### PR TITLE
Bug Fixes for node info data corruption and node last heard timestamps

### DIFF
--- a/MeshtasticClient/Meshtastic.xcdatamodeld/CoreDataSample.xcdatamodel/contents
+++ b/MeshtasticClient/Meshtastic.xcdatamodeld/CoreDataSample.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21D49" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="MessageEntity" representedClassName="MessageEntity" syncable="YES" codeGenerationType="class">
         <attribute name="direction" attributeType="String"/>
         <attribute name="isTapback" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -20,6 +20,8 @@
         </uniquenessConstraints>
     </entity>
     <entity name="MyInfoEntity" representedClassName="MyInfoEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="bleName" optional="YES" attributeType="String"/>
+        <attribute name="channelUtilization" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="firmwareVersion" attributeType="String"/>
         <attribute name="hasGps" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="maxChannels" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
@@ -74,7 +76,7 @@
     </entity>
     <elements>
         <element name="MessageEntity" positionX="-36" positionY="63" width="128" height="185"/>
-        <element name="MyInfoEntity" positionX="-18" positionY="81" width="128" height="149"/>
+        <element name="MyInfoEntity" positionX="-18" positionY="81" width="128" height="179"/>
         <element name="NodeInfoEntity" positionX="-63" positionY="-18" width="128" height="149"/>
         <element name="PositionEntity" positionX="-54" positionY="54" width="128" height="119"/>
         <element name="UserEntity" positionX="0" positionY="144" width="128" height="200"/>

--- a/MeshtasticClient/Views/Bluetooth/Connect.swift
+++ b/MeshtasticClient/Views/Bluetooth/Connect.swift
@@ -67,11 +67,8 @@ struct Connect: View {
 
 										if bleManager.connectedPeripheral != nil {
 
-											Text(bleManager.connectedPeripheral.longName).font(.title2)
+											Text(bleManager.connectedPeripheral.name).font(.title2)
 
-										} else {
-
-											Text(String(bleManager.connectedPeripheral.peripheral.name ?? "Unknown")).font(.title2)
 										}
 										Text("BLE Name: ").font(.caption)+Text(bleManager.connectedPeripheral.peripheral.name ?? "Unknown")
 											.font(.caption).foregroundColor(Color.gray)

--- a/MeshtasticClient/Views/Messages/UserMessageList.swift
+++ b/MeshtasticClient/Views/Messages/UserMessageList.swift
@@ -34,7 +34,7 @@ struct UserMessageList: View {
     var body: some View {
 		
 		let firmwareVersion = bleManager.lastConnnectionVersion
-		let minimumVersion = "1.2.54"
+		let minimumVersion = "1.2.60"
 		let hasTapbackSupport = minimumVersion.compare(firmwareVersion, options: .numeric) == .orderedAscending || minimumVersion.compare(firmwareVersion, options: .numeric) == .orderedSame
 		
 		VStack {


### PR DESCRIPTION
* Save the same fields for insert and update for node info to prevent data corruption
* Set the last heard timestamp to now if it comes in as unix epoch 