### PR TITLE
Add share location with mesh feature

### DIFF
--- a/Meshtastic Client.xcodeproj/project.pbxproj
+++ b/Meshtastic Client.xcodeproj/project.pbxproj
@@ -738,7 +738,7 @@
 				CODE_SIGN_ENTITLEMENTS = MeshtasticClient/MeshtasticClient.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_ASSET_PATHS = "\"MeshtasticClient/Preview Content\"";
 				DEVELOPMENT_TEAM = GCH7VS5Y9R;
 				ENABLE_PREVIEWS = YES;
@@ -769,7 +769,7 @@
 				CODE_SIGN_ENTITLEMENTS = MeshtasticClient/MeshtasticClient.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_ASSET_PATHS = "\"MeshtasticClient/Preview Content\"";
 				DEVELOPMENT_TEAM = GCH7VS5Y9R;
 				ENABLE_PREVIEWS = YES;

--- a/MeshtasticClient/Helpers/BLEManager.swift
+++ b/MeshtasticClient/Helpers/BLEManager.swift
@@ -20,6 +20,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 	}
 
 	var context: NSManagedObjectContext?
+	
+	var userSettings: UserSettings?
 
 	private var centralManager: CBCentralManager!
 
@@ -35,6 +37,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
 	var timeoutTimer: Timer?
 	var timeoutTimerCount = 0
+	
+	var positionTimer: Timer?
 
     let broadcastNodeNum: UInt32 = 4294967295
 
@@ -210,7 +214,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
         peripheral.discoverServices([meshtasticServiceCBUUID])
 		if meshLoggingEnabled { MeshLogger.log("✅ BLE Connected: \(peripheral.name ?? "Unknown")") }
         print("✅ BLE Connected: \(peripheral.name ?? "Unknown")")
-
+		
     }
 
 	// Called when a Peripheral fails to connect
@@ -486,6 +490,16 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
 					print("💥 Fetch MyInfo Error")
 				}
+				
+				// Use a timer to keep track of position updates, context to pass the radio name with the timer and the RunLoop to prevent
+				// the timer from running on the main UI thread
+				if self.positionTimer != nil {
+					self.positionTimer!.invalidate()
+				}
+				let context = ["name": "@\(peripheral.name ?? "Unknown")"]
+				self.positionTimer = Timer.scheduledTimer(timeInterval: 30.0, target: self, selector: #selector(positionTimerFired), userInfo: context, repeats: true)
+				RunLoop.current.add(self.positionTimer!, forMode: .common)
+				
 			}
 
 			// MARK: Incoming Node Info Packet
@@ -659,7 +673,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 					if meshLoggingEnabled { MeshLogger.log("💾 BLE FROMRADIO received and nodeInfo saved for \(decodedInfo.nodeInfo.num)") }
 				}
 			}
-			// Handle assorted app packets
+			// Handle other packet types
 			if decodedInfo.packet.id  != 0 {
 
 				do {
@@ -754,6 +768,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 							print("💥 Fetch Message To and From Users Error")
 						}
 					}
+				// MARK: Incoming NODEINFO_APP Packet
 				} else if decodedInfo.packet.decoded.portnum == PortNum.nodeinfoApp {
 
 					let fetchNodeInfoAppRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
@@ -870,7 +885,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
 						print("💥 Error Fetching NodeInfoEntity for POSITION_APP")
 					}
-
+				// MARK: Incoming ROUTING_APP Packet
 				} else if decodedInfo.packet.decoded.portnum == PortNum.routingApp {
 					
 					let currentNodeNum = self.connectedPeripheral.num
@@ -995,7 +1010,8 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 				} else if fetchedUsers.count >= 1 {
 
 					let newMessage = MessageEntity(context: context!)
-					newMessage.messageId = Int64(UInt32.random(in: UInt32(UInt8.max)..<UInt32.max))
+					//newMessage.messageId = Int64(UInt32.random(in: UInt32(UInt8.max)..<UInt32.max))
+					newMessage.messageId = Int64(0xFF | UInt32.random(in: UInt32(UInt8.max)..<UInt32(1147483647)))
 					newMessage.messageTimestamp =  Int32(Date().timeIntervalSince1970)
 					newMessage.receivedACK = false
 					newMessage.direction = "IN"
@@ -1158,11 +1174,26 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 				
 		}
 		
-		
-		
-
-		
 		return success
 	}
 	
+	@objc func positionTimerFired(timer: Timer) {
+		
+		// Check for connected node
+		if connectedPeripheral != nil {
+
+			// Send a position out to the mesh if "share location with the mesh" is enabled in settings
+			if userSettings!.provideLocation {
+				let success = sendPosition(destNum: connectedPeripheral.num, wantResponse: false)
+				if !success {
+					
+					print("Failed to send positon to device")
+					
+				}
+
+			}
+			// Request config to update MyNodeInfo data periodically as well as all nodes
+			
+		}
+	}
 }

--- a/MeshtasticClient/Views/Bluetooth/Connect.swift
+++ b/MeshtasticClient/Views/Bluetooth/Connect.swift
@@ -242,6 +242,7 @@ struct Connect: View {
         .onAppear(perform: {
 
 			self.bleManager.context = context
+			self.bleManager.userSettings = userSettings
 
 			if self.bleManager.connectedPeripheral != nil && userSettings.preferredPeripheralId == self.bleManager.connectedPeripheral.peripheral.identifier.uuidString {
 				isPreferredRadio = true

--- a/MeshtasticClient/Views/Messages/UserMessageList.swift
+++ b/MeshtasticClient/Views/Messages/UserMessageList.swift
@@ -12,6 +12,7 @@ struct UserMessageList: View {
 
 	@Environment(\.managedObjectContext) var context
 	@EnvironmentObject var bleManager: BLEManager
+	@EnvironmentObject var userSettings: UserSettings
 	
 	enum Field: Hashable {
 		case messageText
@@ -35,7 +36,7 @@ struct UserMessageList: View {
     var body: some View {
 		
 		let firmwareVersion = bleManager.lastConnnectionVersion
-		let minimumVersion = "1.3.0"
+		let minimumVersion = "1.3"
 		let hasTapbackSupport = minimumVersion.compare(firmwareVersion, options: .numeric) == .orderedAscending || minimumVersion.compare(firmwareVersion, options: .numeric) == .orderedSame
 		
 		VStack {
@@ -338,6 +339,7 @@ struct UserMessageList: View {
 				.onAppear(perform: {
 					
 					self.bleManager.context = context
+					self.bleManager.userSettings = userSettings
 				
 					if allMessages.count > 2 {
 						
@@ -463,10 +465,5 @@ struct UserMessageList: View {
 				}
 			}
 		}
-		.onAppear(perform: {
-
-			self.bleManager.context = context
-
-		})
     }
 }

--- a/MeshtasticClient/Views/Nodes/NodeDetail.swift
+++ b/MeshtasticClient/Views/Nodes/NodeDetail.swift
@@ -11,6 +11,7 @@ struct NodeDetail: View {
 
 	@Environment(\.managedObjectContext) var context
 	@EnvironmentObject var bleManager: BLEManager
+	@EnvironmentObject var userSettings: UserSettings
 
 	var node: NodeInfoEntity
 
@@ -285,6 +286,7 @@ struct NodeDetail: View {
 		.onAppear(perform: {
 
 			self.bleManager.context = context
+			self.bleManager.userSettings = userSettings
 
 		})
 	}

--- a/MeshtasticClient/Views/Nodes/NodeList.swift
+++ b/MeshtasticClient/Views/Nodes/NodeList.swift
@@ -14,6 +14,7 @@ struct NodeList: View {
 
 	@Environment(\.managedObjectContext) var context
 	@EnvironmentObject var bleManager: BLEManager
+	@EnvironmentObject var userSettings: UserSettings
 
 	@FetchRequest(
 		sortDescriptors: [NSSortDescriptor(key: "lastHeard", ascending: false)],
@@ -115,6 +116,7 @@ struct NodeList: View {
 			.onAppear {
 				// self.nodes.returnsObjectsAsFaults = false
 				self.bleManager.context = context
+				self.bleManager.userSettings = userSettings
 
 				if UIDevice.current.userInterfaceIdiom == .pad {
 					if nodes.count > 0 {

--- a/MeshtasticClient/Views/Nodes/NodeMap.swift
+++ b/MeshtasticClient/Views/Nodes/NodeMap.swift
@@ -15,6 +15,7 @@ struct NodeMap: View {
 
 	@Environment(\.managedObjectContext) var context
 	@EnvironmentObject var bleManager: BLEManager
+	@EnvironmentObject var userSettings: UserSettings
 
 	@AppStorage("meshMapType") var type: String = "hybrid"
 	@AppStorage("meshMapCustomTileServer") var customTileServer: String = "" {
@@ -131,6 +132,7 @@ struct NodeMap: View {
 			.onAppear(perform: {
 
 				self.bleManager.context = context
+				self.bleManager.userSettings = userSettings
 
 			})
         }


### PR DESCRIPTION
Add a timer to the BLEManager that will update the local device position every 30 seconds if the share location setting is on. These portions will be sent to the mesh via existing position update settings on the device