### PR TITLE
invalidate existing timer before creating a new one

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -168,6 +168,9 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 
 		self.centralManager?.connect(peripheral)
 
+		// Invalidate any existing timer
+		self.timeoutTimer?.invalidate()
+
 		// Use a timer to keep track of connecting peripherals, context to pass the radio name with the timer and the RunLoop to prevent
 		// the timer from running on the main UI thread
 		let context = ["name": "@\(peripheral.name ?? "Unknown")"]


### PR DESCRIPTION
Prevent race condition where the timer doesn't invalidate so it keeps disconnecting subsequent successful connections.


https://user-images.githubusercontent.com/662419/183272856-c8ef1b15-d834-4f72-9e9a-459daa531180.mov


