### PR TITLE
Fixed NRF first pair issue

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -409,7 +409,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeriph
 		}
     }
 	
-	@objc func sendWantConfig() {
+	func sendWantConfig() {
 		guard (connectedPeripheral!.peripheral.state == CBPeripheralState.connected) else { return }
 
 		MeshLogger.log("ℹ️ Issuing wantConfig to \(connectedPeripheral!.peripheral.name ?? "Unknown")")


### PR DESCRIPTION
New strategy is to wait until all characteristics are registered, and then issue our wantConfig followed by a read from radio. 
Seems to work on both NRF and Esp32 on my Macbook.