### PR TITLE
fix: inverted map options sheet resizing

### DIFF
--- a/Meshtastic/Views/Nodes/NodeMap.swift
+++ b/Meshtastic/Views/Nodes/NodeMap.swift
@@ -223,7 +223,7 @@ struct NodeMap: View {
 					.padding(.bottom)
 					#endif
 				}
-				.presentationDetents([UserDefaults.enableOfflineMaps || UserDefaults.enableOverlayServer ? .large : .medium])
+				.presentationDetents([enableOfflineMaps || enableOverlayServer ? .large : .medium])
 				.presentationDragIndicator(.visible)
 			}
 		}


### PR DESCRIPTION
Similar to https://github.com/meshtastic/Meshtastic-Apple/pull/475 fixes an issue where map options sheet sizing was inverted when enabling/disabling offline maps.

Before:

https://github.com/meshtastic/Meshtastic-Apple/assets/7528924/a332106a-e59d-4fa7-8381-c02e8d6768c8

After:

https://github.com/meshtastic/Meshtastic-Apple/assets/7528924/964b5b8c-7b50-42ab-b733-a687b384f05a