### PR TITLE
fix: don't fetch tiles greater than specified upper bound

### DIFF
--- a/Meshtastic/Helpers/Map/OfflineTileManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineTileManager.swift
@@ -110,7 +110,7 @@ class OfflineTileManager: ObservableObject {
 		if fileManager.fileExists(atPath: tilesUrl.path) {
 			return tilesUrl
 		} else {
-			if UserDefaults.enableOfflineMaps { // Get and persist newTile
+			if UserDefaults.enableOfflineMaps, UserDefaults.mapTileServer.zoomRange.contains(path.z) { // Get and persist newTile
 				return persistLocally(path: path)
 			} else { // Else display empty tile (transparent over Maps tiles)
 				return Bundle.main.url(forResource: "alpha", withExtension: "png")!


### PR DESCRIPTION
Corrects caching to honor zoom range and helps save a bit of network bandwidth, especially when zoomed in past range that the tile server supports (i.e. avoid 404, etc.)