### PR TITLE
feature: add power configuration

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		D93068D52B812B700066FBC8 /* MessageDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068D42B812B700066FBC8 /* MessageDestination.swift */; };
 		D93068D72B8146690066FBC8 /* MessageText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068D62B8146690066FBC8 /* MessageText.swift */; };
 		D93068D92B81509C0066FBC8 /* TapbackResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068D82B81509C0066FBC8 /* TapbackResponses.swift */; };
+		D93068DD2B81CA820066FBC8 /* ConfigHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */; };
 		D9BC22DB2B7DE8E2006A37D5 /* TileDownloadStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BC22DA2B7DE8E2006A37D5 /* TileDownloadStatus.swift */; };
 		D9C9839D2B79CFD700BDBE6A /* TextMessageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C9839C2B79CFD700BDBE6A /* TextMessageSize.swift */; };
 		D9C983A02B79D0E800BDBE6A /* AlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C9839F2B79D0E800BDBE6A /* AlertButton.swift */; };
@@ -243,6 +244,7 @@
 		D93068D42B812B700066FBC8 /* MessageDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDestination.swift; sourceTree = "<group>"; };
 		D93068D62B8146690066FBC8 /* MessageText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageText.swift; sourceTree = "<group>"; };
 		D93068D82B81509C0066FBC8 /* TapbackResponses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapbackResponses.swift; sourceTree = "<group>"; };
+		D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigHeader.swift; sourceTree = "<group>"; };
 		D9BC22DA2B7DE8E2006A37D5 /* TileDownloadStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileDownloadStatus.swift; sourceTree = "<group>"; };
 		D9C9839C2B79CFD700BDBE6A /* TextMessageSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMessageSize.swift; sourceTree = "<group>"; };
 		D9C9839F2B79D0E800BDBE6A /* AlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertButton.swift; sourceTree = "<group>"; };
@@ -636,6 +638,7 @@
 		DD61937A2863876A00E59241 /* Config */ = {
 			isa = PBXGroup;
 			children = (
+				D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */,
 				DDB6ABD528AE742000384BA1 /* BluetoothConfig.swift */,
 				DD41582528582E9B009B0E59 /* DeviceConfig.swift */,
 				DD8EBF42285058FA00426DCA /* DisplayConfig.swift */,
@@ -1268,6 +1271,7 @@
 				DDDB444029F79AB000EE2349 /* UserDefaults.swift in Sources */,
 				DDB6ABE028B13AC700384BA1 /* DeviceEnums.swift in Sources */,
 				DD86D40C287F401000BAEB7A /* SaveChannelQRCode.swift in Sources */,
+				D93068DD2B81CA820066FBC8 /* ConfigHeader.swift in Sources */,
 				DDA1C48E28DB49D3009933EC /* ChannelRoles.swift in Sources */,
 				D9BC22DB2B7DE8E2006A37D5 /* TileDownloadStatus.swift in Sources */,
 				DD8ED9C8289CE4B900B3B0AB /* RoutingError.swift in Sources */,

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -18,7 +18,9 @@
 		D93068D52B812B700066FBC8 /* MessageDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068D42B812B700066FBC8 /* MessageDestination.swift */; };
 		D93068D72B8146690066FBC8 /* MessageText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068D62B8146690066FBC8 /* MessageText.swift */; };
 		D93068D92B81509C0066FBC8 /* TapbackResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068D82B81509C0066FBC8 /* TapbackResponses.swift */; };
+		D93068DB2B81C85E0066FBC8 /* PowerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068DA2B81C85E0066FBC8 /* PowerConfig.swift */; };
 		D93068DD2B81CA820066FBC8 /* ConfigHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */; };
+		D93069082B81DF040066FBC8 /* SaveConfigButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93069072B81DF040066FBC8 /* SaveConfigButton.swift */; };
 		D9BC22DB2B7DE8E2006A37D5 /* TileDownloadStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BC22DA2B7DE8E2006A37D5 /* TileDownloadStatus.swift */; };
 		D9C9839D2B79CFD700BDBE6A /* TextMessageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C9839C2B79CFD700BDBE6A /* TextMessageSize.swift */; };
 		D9C983A02B79D0E800BDBE6A /* AlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C9839F2B79D0E800BDBE6A /* AlertButton.swift */; };
@@ -244,7 +246,10 @@
 		D93068D42B812B700066FBC8 /* MessageDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDestination.swift; sourceTree = "<group>"; };
 		D93068D62B8146690066FBC8 /* MessageText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageText.swift; sourceTree = "<group>"; };
 		D93068D82B81509C0066FBC8 /* TapbackResponses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapbackResponses.swift; sourceTree = "<group>"; };
+		D93068DA2B81C85E0066FBC8 /* PowerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerConfig.swift; sourceTree = "<group>"; };
 		D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigHeader.swift; sourceTree = "<group>"; };
+		D93069062B81D8900066FBC8 /* MeshtasticDataModelV 27.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 27.xcdatamodel"; sourceTree = "<group>"; };
+		D93069072B81DF040066FBC8 /* SaveConfigButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveConfigButton.swift; sourceTree = "<group>"; };
 		D9BC22DA2B7DE8E2006A37D5 /* TileDownloadStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileDownloadStatus.swift; sourceTree = "<group>"; };
 		D9C9839C2B79CFD700BDBE6A /* TextMessageSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMessageSize.swift; sourceTree = "<group>"; };
 		D9C9839F2B79D0E800BDBE6A /* AlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertButton.swift; sourceTree = "<group>"; };
@@ -639,12 +644,14 @@
 			isa = PBXGroup;
 			children = (
 				D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */,
+				D93069072B81DF040066FBC8 /* SaveConfigButton.swift */,
 				DDB6ABD528AE742000384BA1 /* BluetoothConfig.swift */,
 				DD41582528582E9B009B0E59 /* DeviceConfig.swift */,
 				DD8EBF42285058FA00426DCA /* DisplayConfig.swift */,
 				DD2553562855B02500E55709 /* LoRaConfig.swift */,
 				DD2553582855B52700E55709 /* PositionConfig.swift */,
 				DD8ED9C42898D51F00B3B0AB /* NetworkConfig.swift */,
+				D93068DA2B81C85E0066FBC8 /* PowerConfig.swift */,
 				DD61937B2863877A00E59241 /* Module */,
 			);
 			path = Config;
@@ -1178,6 +1185,7 @@
 				DD457188293C7E63000C49FB /* BLESignalStrengthIndicator.swift in Sources */,
 				DDFEB3BB29900C1200EE7472 /* CurrentConditionsCompact.swift in Sources */,
 				DD836AE726F6B38600ABCC23 /* Connect.swift in Sources */,
+				D93069082B81DF040066FBC8 /* SaveConfigButton.swift in Sources */,
 				DD5E523F298F5A9E00D21B61 /* AirQualityIndexCompact.swift in Sources */,
 				DD964FBF296E76EF007C176F /* WaypointFormMapKit.swift in Sources */,
 				DD3501892852FC3B000FC853 /* Settings.swift in Sources */,
@@ -1257,6 +1265,7 @@
 				DD94B7402ACCE3BE00DCD1D1 /* MapSettingsForm.swift in Sources */,
 				DD964FC2297272AE007C176F /* WaypointEntityExtension.swift in Sources */,
 				6DA39D8E2A92DC52007E311C /* MeshtasticAppDelegate.swift in Sources */,
+				D93068DB2B81C85E0066FBC8 /* PowerConfig.swift in Sources */,
 				D93068D32B8129510066FBC8 /* MessageContextMenuItems.swift in Sources */,
 				DD5E520A298EE33B00D21B61 /* channel.pb.swift in Sources */,
 				DD8EBF43285058FA00426DCA /* DisplayConfig.swift in Sources */,
@@ -1849,6 +1858,7 @@
 		DD3CC6BA28E366DF00FA9159 /* Meshtastic.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				D93069062B81D8900066FBC8 /* MeshtasticDataModelV 27.xcdatamodel */,
 				DD05296F2B77F454008E44CD /* MeshtasticDataModelV 26.xcdatamodel */,
 				DD23D9AB2B7133F6003F5CBE /* MeshtasticDataModelV 25.xcdatamodel */,
 				DDB234392B5CA9B000DA6FB1 /* MeshtasticDataModelV 24.xcdatamodel */,
@@ -1876,7 +1886,7 @@
 				DD5D0A9A2931AD6B00F7EA61 /* MeshtasticDataModelV2.xcdatamodel */,
 				DD3CC6BB28E366DF00FA9159 /* MeshtasticDataModel.xcdatamodel */,
 			);
-			currentVersion = DD05296F2B77F454008E44CD /* MeshtasticDataModelV 26.xcdatamodel */;
+			currentVersion = D93069062B81D8900066FBC8 /* MeshtasticDataModelV 27.xcdatamodel */;
 			name = Meshtastic.xcdatamodeld;
 			path = Meshtastic/Meshtastic.xcdatamodeld;
 			sourceTree = "<group>";

--- a/Meshtastic/Enums/IntervalEnums.swift
+++ b/Meshtastic/Enums/IntervalEnums.swift
@@ -165,3 +165,5 @@ enum UpdateIntervals: Int, CaseIterable, Identifiable {
 		}
 	}
 }
+
+typealias PowerIntervals = UpdateIntervals

--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -1513,7 +1513,35 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 		
 		return 0
 	}
-	
+
+	public func savePowerConfig(config: Config.PowerConfig, fromUser: UserEntity, toUser: UserEntity, adminIndex: Int32) -> Int64 {
+
+		var adminPacket = AdminMessage()
+		adminPacket.setConfig.power = config
+
+		var meshPacket: MeshPacket = MeshPacket()
+		meshPacket.to = UInt32(toUser.num)
+		meshPacket.from	= UInt32(fromUser.num)
+		meshPacket.channel = UInt32(adminIndex)
+		meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+		meshPacket.priority =  MeshPacket.Priority.reliable
+		meshPacket.wantAck = true
+		var dataMessage = DataMessage()
+		dataMessage.payload = try! adminPacket.serializedData()
+		dataMessage.portnum = PortNum.adminApp
+
+		meshPacket.decoded = dataMessage
+
+		let messageDescription = "🛟 Saved Power Config for \(toUser.longName ?? "unknown".localized)"
+
+		if sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription, fromUser: fromUser, toUser: toUser) {
+			upsertPowerConfigPacket(config: config, nodeNum: toUser.num, context: context!)
+			return Int64(meshPacket.id)
+		}
+
+		return 0
+	}
+
 	public func saveNetworkConfig(config: Config.NetworkConfig, fromUser: UserEntity, toUser: UserEntity, adminIndex: Int32) -> Int64 {
 		
 		var adminPacket = AdminMessage()
@@ -2067,7 +2095,34 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 		}
 		return false
 	}
-	
+
+	public func requestPowerConfig(fromUser: UserEntity, toUser: UserEntity, adminIndex: Int32) -> Bool {
+
+		var adminPacket = AdminMessage()
+		adminPacket.getConfigRequest = AdminMessage.ConfigType.powerConfig
+
+		var meshPacket: MeshPacket = MeshPacket()
+		meshPacket.to = UInt32(toUser.num)
+		meshPacket.from	= UInt32(fromUser.num)
+		meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+		meshPacket.priority =  MeshPacket.Priority.reliable
+		meshPacket.channel = UInt32(adminIndex)
+		meshPacket.wantAck = true
+
+		var dataMessage = DataMessage()
+		dataMessage.payload = try! adminPacket.serializedData()
+		dataMessage.portnum = PortNum.adminApp
+		dataMessage.wantResponse = true
+
+		meshPacket.decoded = dataMessage
+
+		let messageDescription = "🛎️ Requested Power Config on admin channel \(adminIndex) for node: \(toUser.longName ?? "unknown".localized)"
+		if sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription, fromUser: fromUser, toUser: toUser) {
+			return true
+		}
+		return false
+	}
+
 	public func requestAmbientLightingConfig(fromUser: UserEntity, toUser: UserEntity, adminIndex: Int32) -> Bool {
 		
 		var adminPacket = AdminMessage()

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -51,6 +51,8 @@ func localConfig (config: Config, context: NSManagedObjectContext, nodeNum: Int6
 		upsertNetworkConfigPacket(config: config.network, nodeNum: nodeNum, context: context)
 	} else if config.payloadVariant == Config.OneOf_PayloadVariant.position(config.position) {
 		upsertPositionConfigPacket(config: config.position, nodeNum: nodeNum, context: context)
+	} else if config.payloadVariant == Config.OneOf_PayloadVariant.power(config.power) {
+		upsertPowerConfigPacket(config: config.power, nodeNum: nodeNum, context: context)
 	}
 }
 
@@ -478,6 +480,8 @@ func adminAppPacket (packet: MeshPacket, context: NSManagedObjectContext) {
 				upsertNetworkConfigPacket(config: config.network, nodeNum: Int64(packet.from), context: context)
 			} else if config.payloadVariant == Config.OneOf_PayloadVariant.position(config.position) {
 				upsertPositionConfigPacket(config: config.position, nodeNum: Int64(packet.from), context: context)
+			} else if config.payloadVariant == Config.OneOf_PayloadVariant.power(config.power) {
+				upsertPowerConfigPacket(config: config.power, nodeNum: Int64(packet.from), context: context)
 			}
 		} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getModuleConfigResponse(adminMessage.getModuleConfigResponse) {
 			let moduleConfig = adminMessage.getModuleConfigResponse

--- a/Meshtastic/Meshtastic.xcdatamodeld/.xccurrentversion
+++ b/Meshtastic/Meshtastic.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>MeshtasticDataModelV 26.xcdatamodel</string>
+	<string>MeshtasticDataModelV 27.xcdatamodel</string>
 </dict>
 </plist>

--- a/Meshtastic/Meshtastic.xcdatamodeld/MeshtasticDataModelV 27.xcdatamodel/contents
+++ b/Meshtastic/Meshtastic.xcdatamodeld/MeshtasticDataModelV 27.xcdatamodel/contents
@@ -1,0 +1,426 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23D60" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="AmbientLightingConfigEntity" representedClassName="AmbientLightingConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="blue" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="current" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="green" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ledState" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="red" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="ambientLightingConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="ambientLightingConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="BluetoothConfigEntity" representedClassName="BluetoothConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="enabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="fixedPin" optional="YES" attributeType="Integer 32" defaultValueString="123456" usesScalarValueType="YES"/>
+        <attribute name="mode" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="bluetoothConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="bluetoothConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="CannedMessageConfigEntity" representedClassName="CannedMessageConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="enabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="inputbrokerEventCcw" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="inputbrokerEventCw" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="inputbrokerEventPress" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="inputbrokerPinA" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="inputbrokerPinB" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <attribute name="inputbrokerPinPress" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <attribute name="messages" optional="YES" attributeType="String" minValueString="0" maxValueString="198"/>
+        <attribute name="rotary1Enabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="sendBell" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="updown1Enabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="cannedMessagesConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="cannedMessageConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="ChannelEntity" representedClassName="ChannelEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="downlinkEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="index" attributeType="Integer 32" minValueString="0" maxValueString="13" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="mute" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="psk" optional="YES" attributeType="Binary"/>
+        <attribute name="role" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="uplinkEnabled" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="myInfoChannel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MyInfoEntity" inverseName="channels" inverseEntity="MyInfoEntity"/>
+        <fetchedProperty name="allPrivateMessages" optional="YES">
+            <fetchRequest name="fetchedPropertyFetchRequest" entity="MessageEntity" predicateString="channel == $FETCH_SOURCE.index &amp;&amp;  toUser == nil AND isEmoji == false"/>
+        </fetchedProperty>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="index"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="DetectionSensorConfigEntity" representedClassName="DetectionSensorConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="detectionTriggeredHigh" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="enabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="minimumBroadcastSecs" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="monitorPin" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="sendBell" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="stateBroadcastSecs" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usePullup" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="detectionSensorConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="detectionSensorConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="DeviceConfigEntity" representedClassName="DeviceConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="buttonGpio" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="buzzerGpio" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="debugLogEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="disableTripleClick" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="doubleTapAsButtonPress" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isManaged" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="nodeInfoBroadcastSecs" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rebroadcastMode" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="role" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="serialEnabled" optional="YES" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="deviceConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="deviceConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="DeviceMetadataEntity" representedClassName="DeviceMetadataEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="canShutdown" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="deviceStateVersion" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="firmwareVersion" optional="YES" attributeType="String"/>
+        <attribute name="hasBluetooth" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hasEthernet" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hasWifi" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="hwModel" optional="YES" attributeType="String"/>
+        <attribute name="positionFlags" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="role" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="metadataNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="metadata" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="DisplayConfigEntity" representedClassName="DisplayConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="compassNorthTop" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="displayMode" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="flipScreen" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="gpsFormat" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="headingBold" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="oledType" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="screenCarouselInterval" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="screenOnSeconds" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="units" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="wakeOnTapOrMotion" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="displayConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="displayConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="ExternalNotificationConfigEntity" representedClassName="ExternalNotificationConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="active" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="alertBell" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="alertBellBuzzer" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="alertBellVibra" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="alertMessage" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="alertMessageBuzzer" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="alertMessageVibra" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="enabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="nagTimeout" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="output" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="outputBuzzer" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="outputMilliseconds" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="outputVibra" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="useI2SAsBuzzer" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="usePWM" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <relationship name="externalNotificationConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="externalNotificationConfig" inverseEntity="NodeInfoEntity"/>
+        <fetchedProperty name="fetchedProperty" optional="YES">
+            <fetchRequest name="fetchedPropertyFetchRequest" entity="ExternalNotificationConfigEntity"/>
+        </fetchedProperty>
+    </entity>
+    <entity name="LocationEntity" representedClassName="LocationEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="altitude" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="heading" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <attribute name="latitudeI" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="longitudeI" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="speed" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="routeLocation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RouteEntity" inverseName="locations" inverseEntity="RouteEntity"/>
+    </entity>
+    <entity name="LoRaConfigEntity" representedClassName="LoRaConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="bandwidth" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="channelNum" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="codingRate" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="frequencyOffset" optional="YES" attributeType="Float" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="hopLimit" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ignoreMqtt" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="modemPreset" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="overrideDutyCycle" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="overrideFrequency" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="regionCode" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="spreadFactor" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sx126xRxBoostedGain" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="txEnabled" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="txPower" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usePreset" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <relationship name="loRaConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="loRaConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="MessageEntity" representedClassName="MessageEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="ackError" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ackSNR" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="ackTimestamp" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="admin" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="adminDescription" optional="YES" attributeType="String"/>
+        <attribute name="channel" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isEmoji" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="messageId" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="messagePayload" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="messagePayloadMarkdown" optional="YES" attributeType="String"/>
+        <attribute name="messageTimestamp" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="portNum" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="read" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="realACK" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="receivedACK" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="receivedTimestamp" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="replyID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rssi" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="snr" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="fromUser" optional="YES" maxCount="1" deletionRule="Nullify" ordered="YES" destinationEntity="UserEntity" inverseName="sentMessages" inverseEntity="UserEntity"/>
+        <relationship name="toUser" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserEntity" inverseName="receivedMessages" inverseEntity="UserEntity"/>
+        <fetchedProperty name="tapbacks" optional="YES">
+            <fetchRequest name="fetchedPropertyFetchRequest" entity="MessageEntity" predicateString="replyID == $FETCH_SOURCE.messageId AND isEmoji == true"/>
+        </fetchedProperty>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="messageId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="MQTTConfigEntity" representedClassName="MQTTConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="address" optional="YES" attributeType="String" maxValueString="30"/>
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="encryptionEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="jsonEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="password" optional="YES" attributeType="String" maxValueString="30"/>
+        <attribute name="proxyToClientEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="root" optional="YES" attributeType="String" defaultValueString="msh"/>
+        <attribute name="tlsEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="username" optional="YES" attributeType="String" maxValueString="30"/>
+        <relationship name="mqttConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="mqttConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="MyInfoEntity" representedClassName="MyInfoEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="adminIndex" optional="YES" attributeType="Integer 32" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="bleName" optional="YES" attributeType="String"/>
+        <attribute name="minAppVersion" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="myNodeNum" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="peripheralId" optional="YES" attributeType="String"/>
+        <attribute name="rebootCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="channels" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ChannelEntity" inverseName="myInfoChannel" inverseEntity="ChannelEntity"/>
+        <relationship name="myInfoNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="myInfo" inverseEntity="NodeInfoEntity"/>
+        <fetchedProperty name="allMessages" optional="YES">
+            <fetchRequest name="fetchedPropertyFetchRequest" entity="MessageEntity" predicateString="toUser == nil"/>
+        </fetchedProperty>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="myNodeNum"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="NetworkConfigEntity" representedClassName="NetworkConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="dns" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ethEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="gateway" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ip" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ntpServer" optional="YES" attributeType="String"/>
+        <attribute name="subnet" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="wifiEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="wifiMode" optional="YES" attributeType="Integer 32" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="wifiPsk" optional="YES" attributeType="String" minValueString="0" maxValueString="60"/>
+        <attribute name="wifiSsid" optional="YES" attributeType="String" minValueString="0" maxValueString="30"/>
+        <relationship name="networkConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="networkConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="NodeInfoEntity" representedClassName="NodeInfoEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="bleName" optional="YES" attributeType="String"/>
+        <attribute name="channel" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="detection" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="environment" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="lastHeard" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="num" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="peripheralId" optional="YES" attributeType="String"/>
+        <attribute name="rssi" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="snr" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="viaMqtt" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="ambientLightingConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AmbientLightingConfigEntity" inverseName="ambientLightingConfigNode" inverseEntity="AmbientLightingConfigEntity"/>
+        <relationship name="bluetoothConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BluetoothConfigEntity" inverseName="bluetoothConfigNode" inverseEntity="BluetoothConfigEntity"/>
+        <relationship name="cannedMessageConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CannedMessageConfigEntity" inverseName="cannedMessagesConfigNode" inverseEntity="CannedMessageConfigEntity"/>
+        <relationship name="detectionSensorConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DetectionSensorConfigEntity" inverseName="detectionSensorConfigNode" inverseEntity="DetectionSensorConfigEntity"/>
+        <relationship name="deviceConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DeviceConfigEntity" inverseName="deviceConfigNode" inverseEntity="DeviceConfigEntity"/>
+        <relationship name="displayConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DisplayConfigEntity" inverseName="displayConfigNode" inverseEntity="DisplayConfigEntity"/>
+        <relationship name="externalNotificationConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ExternalNotificationConfigEntity" inverseName="externalNotificationConfigNode" inverseEntity="ExternalNotificationConfigEntity"/>
+        <relationship name="loRaConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LoRaConfigEntity" inverseName="loRaConfigNode" inverseEntity="LoRaConfigEntity"/>
+        <relationship name="metadata" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DeviceMetadataEntity" inverseName="metadataNode" inverseEntity="DeviceMetadataEntity"/>
+        <relationship name="mqttConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MQTTConfigEntity" inverseName="mqttConfigNode" inverseEntity="MQTTConfigEntity"/>
+        <relationship name="myInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MyInfoEntity" inverseName="myInfoNode" inverseEntity="MyInfoEntity"/>
+        <relationship name="networkConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NetworkConfigEntity" inverseName="networkConfigNode" inverseEntity="NetworkConfigEntity"/>
+        <relationship name="positionConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PositionConfigEntity" inverseName="positionConfigNode" inverseEntity="PositionConfigEntity"/>
+        <relationship name="positions" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="PositionEntity" inverseName="nodePosition" inverseEntity="PositionEntity"/>
+        <relationship name="powerConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PowerConfigEntity" inverseName="powerConfigNode" inverseEntity="PowerConfigEntity"/>
+        <relationship name="rangeTestConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RangeTestConfigEntity" inverseName="rangeTestConfigNode" inverseEntity="RangeTestConfigEntity"/>
+        <relationship name="rtttlConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RTTTLConfigEntity" inverseName="rtttlConfigNode" inverseEntity="RTTTLConfigEntity"/>
+        <relationship name="serialConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SerialConfigEntity" inverseName="serialConfigNode" inverseEntity="SerialConfigEntity"/>
+        <relationship name="storeForwardConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StoreForwardConfigEntity" inverseName="storeForwardConfigNode" inverseEntity="StoreForwardConfigEntity"/>
+        <relationship name="telemetries" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="TelemetryEntity" inverseName="nodeTelemetry" inverseEntity="TelemetryEntity"/>
+        <relationship name="telemetryConfig" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TelemetryConfigEntity" inverseName="telemetryConfigNode" inverseEntity="TelemetryConfigEntity"/>
+        <relationship name="traceRoutes" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="TraceRouteEntity" inverseName="node" inverseEntity="TraceRouteEntity"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserEntity" inverseName="userNode" inverseEntity="UserEntity"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="num"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="PositionConfigEntity" representedClassName="PositionConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="broadcastSmartMinimumDistance" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="broadcastSmartMinimumIntervalSecs" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="deviceGpsEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="fixedPosition" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="gpsAttemptTime" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="gpsEnGpio" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="gpsMode" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="gpsUpdateInterval" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="positionBroadcastSeconds" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="positionFlags" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rxGpio" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="smartPositionEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="txGpio" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="positionConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="positionConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="PositionEntity" representedClassName="PositionEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="altitude" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="heading" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="latest" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="latitudeI" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="longitudeI" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rssi" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="satsInView" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="seqNo" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="snr" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="speed" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="time" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="nodePosition" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="positions" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="PowerConfigEntity" representedClassName="PowerConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="adcMultiplierOverride" optional="YES" attributeType="Float" usesScalarValueType="YES"/>
+        <attribute name="deviceBatteryInaAddress" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isPowerSaving" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lsSecs" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="minWakeSecs" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="onBatteryShutdownAfterSecs" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="waitBluetoothSecs" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="powerConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="powerConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="RangeTestConfigEntity" representedClassName="RangeTestConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="enabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="save" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="sender" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <relationship name="rangeTestConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="rangeTestConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="RouteEntity" representedClassName="RouteEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="color" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="enabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="notes" optional="YES" attributeType="String"/>
+        <relationship name="locations" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="LocationEntity" inverseName="routeLocation" inverseEntity="LocationEntity"/>
+    </entity>
+    <entity name="RTTTLConfigEntity" representedClassName="RTTTLConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="ringtone" optional="YES" attributeType="String" maxValueString="228" defaultValueString=""/>
+        <relationship name="rtttlConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="rtttlConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="SerialConfigEntity" representedClassName="SerialConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="baudRate" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="echo" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="enabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="mode" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="overrideConsoleSerialPort" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="rxd" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeout" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="txd" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="serialConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="serialConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="StoreForwardConfigEntity" representedClassName="StoreForwardConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="heartbeat" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="historyReturnMax" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="historyReturnWindow" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isRouter" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastHeartbeat" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastRequest" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="records" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="storeForwardConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="storeForwardConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="TelemetryConfigEntity" representedClassName="TelemetryConfigEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="deviceUpdateInterval" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="environmentDisplayFahrenheit" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="environmentMeasurementEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="environmentScreenEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="environmentUpdateInterval" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="telemetryConfigNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="telemetryConfig" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="TelemetryEntity" representedClassName="TelemetryEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="airUtilTx" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="barometricPressure" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="batteryLevel" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="channelUtilization" optional="YES" attributeType="Float" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="current" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="gasResistance" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="metricsType" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="relativeHumidity" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="rssi" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="snr" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="temperature" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="time" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="voltage" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="nodeTelemetry" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="telemetries" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="TraceRouteEntity" representedClassName="TraceRouteEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="altitude" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="hasPositions" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="latitudeI" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="longitudeI" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="num" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="response" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="route" optional="YES" attributeType="Transformable" customClassName="[UInt32]"/>
+        <attribute name="routeText" optional="YES" attributeType="String"/>
+        <attribute name="time" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="hops" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="TraceRouteHopEntity" inverseName="traceRoute" inverseEntity="TraceRouteHopEntity"/>
+        <relationship name="node" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="traceRoutes" inverseEntity="NodeInfoEntity"/>
+    </entity>
+    <entity name="TraceRouteHopEntity" representedClassName="TraceRouteHopEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="altitude" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="latitudeI" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="longitudeI" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="num" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="time" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="traceRoute" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TraceRouteEntity" inverseName="hops" inverseEntity="TraceRouteEntity"/>
+    </entity>
+    <entity name="UserEntity" representedClassName="UserEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="hwModel" attributeType="String"/>
+        <attribute name="isLicensed" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastMessage" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="longName" attributeType="String"/>
+        <attribute name="mute" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="num" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="role" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="shortName" attributeType="String"/>
+        <attribute name="userId" attributeType="String"/>
+        <attribute name="vip" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="receivedMessages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="MessageEntity" inverseName="toUser" inverseEntity="MessageEntity"/>
+        <relationship name="sentMessages" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="MessageEntity" inverseName="fromUser" inverseEntity="MessageEntity"/>
+        <relationship name="userNode" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NodeInfoEntity" inverseName="user" inverseEntity="NodeInfoEntity"/>
+        <fetchedProperty name="adminMessages" optional="YES">
+            <fetchRequest name="fetchedPropertyFetchRequest" entity="MessageEntity" predicateString="(fromUser.num == $FETCH_SOURCE.num) AND isEmoji == false AND admin = true"/>
+        </fetchedProperty>
+        <fetchedProperty name="allMessages" optional="YES">
+            <fetchRequest name="fetchedPropertyFetchRequest" entity="MessageEntity" predicateString="((toUser.num == $FETCH_SOURCE.num) OR (fromUser.num == $FETCH_SOURCE.num)) AND toUser != nil AND fromUser != nil AND isEmoji == false AND admin = false AND portNum != 10 "/>
+        </fetchedProperty>
+        <fetchedProperty name="detectionSensorMessages" optional="YES">
+            <fetchRequest name="fetchedPropertyFetchRequest" entity="MessageEntity" predicateString="(fromUser.num == $FETCH_SOURCE.num) AND portNum = 10"/>
+        </fetchedProperty>
+    </entity>
+    <entity name="WaypointEntity" representedClassName="WaypointEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="expire" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="icon" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="latitudeI" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="locked" attributeType="Integer 64" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="longDescription" optional="YES" attributeType="String" maxValueString="100"/>
+        <attribute name="longitudeI" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" minValueString="1" maxValueString="30"/>
+    </entity>
+</model>

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -645,6 +645,55 @@ func upsertPositionConfigPacket(config: Meshtastic.Config.PositionConfig, nodeNu
 	}
 }
 
+func upsertPowerConfigPacket(config: Meshtastic.Config.PowerConfig, nodeNum: Int64, context: NSManagedObjectContext) {
+	let logString = String.localizedStringWithFormat("mesh.log.power.config %@".localized, String(nodeNum))
+	MeshLogger.log("🗺️ \(logString)")
+
+	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
+
+	do {
+		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
+			return
+		}
+		// Found a node, save Power Config
+		if !fetchedNode.isEmpty {
+			if fetchedNode[0].powerConfig == nil {
+				let newPowerConfig = PowerConfigEntity(context: context)
+				newPowerConfig.adcMultiplierOverride = config.adcMultiplierOverride
+				newPowerConfig.deviceBatteryInaAddress = Int32(config.deviceBatteryInaAddress)
+				newPowerConfig.isPowerSaving = config.isPowerSaving
+				newPowerConfig.lsSecs = Int32(config.lsSecs)
+				newPowerConfig.minWakeSecs = Int32(config.minWakeSecs)
+				newPowerConfig.onBatteryShutdownAfterSecs = Int32(config.onBatteryShutdownAfterSecs)
+				newPowerConfig.waitBluetoothSecs = Int32(config.waitBluetoothSecs)
+				fetchedNode[0].powerConfig = newPowerConfig
+			} else {
+				fetchedNode[0].powerConfig?.adcMultiplierOverride = config.adcMultiplierOverride
+				fetchedNode[0].powerConfig?.deviceBatteryInaAddress = Int32(config.deviceBatteryInaAddress)
+				fetchedNode[0].powerConfig?.isPowerSaving = config.isPowerSaving
+				fetchedNode[0].powerConfig?.lsSecs = Int32(config.lsSecs)
+				fetchedNode[0].powerConfig?.minWakeSecs = Int32(config.minWakeSecs)
+				fetchedNode[0].powerConfig?.onBatteryShutdownAfterSecs = Int32(config.onBatteryShutdownAfterSecs)
+				fetchedNode[0].powerConfig?.waitBluetoothSecs = Int32(config.waitBluetoothSecs)
+			}
+			do {
+				try context.save()
+				print("💾 Updated Power Config for node number: \(String(nodeNum))")
+			} catch {
+				context.rollback()
+				let nsError = error as NSError
+				print("💥 Error Updating Core Data PowerConfigEntity: \(nsError)")
+			}
+		} else {
+			print("💥 No Nodes found in local database matching node number \(nodeNum) unable to save Power Config")
+		}
+	} catch {
+		let nsError = error as NSError
+		print("💥 Fetching node for core data PowerConfigEntity failed: \(nsError)")
+	}
+}
+
 func upsertAmbientLightingModuleConfigPacket(config: Meshtastic.ModuleConfig.AmbientLightingConfig, nodeNum: Int64, context: NSManagedObjectContext) {
 
 	let logString = String.localizedStringWithFormat("mesh.log.ambientlighting.config %@".localized, String(nodeNum))

--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -26,31 +26,8 @@ struct BluetoothConfig: View {
 	}()
 	var body: some View {
 		Form {
-			if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-				Text("There has been no response to a request for device metadata over the admin channel for this node.")
-					.font(.callout)
-					.foregroundColor(.orange)
+			ConfigHeader(title: "Bluetooth", config: \.bluetoothConfig, node: node, onAppear: setBluetoothValues)
 
-			} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-				// Let users know what is going on if they are using remote admin and don't have the config yet
-				if node?.bluetoothConfig == nil {
-					Text("Bluetooth config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				} else {
-					Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-						.font(.title3)
-						.onAppear {
-							setBluetoothValues()
-						}
-				}
-			} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? -1 {
-				Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-			} else {
-				Text("Please connect to a radio to configure settings.")
-					.font(.callout)
-					.foregroundColor(.orange)
-			}
 			Section(header: Text("options")) {
 				Toggle(isOn: $enabled) {
 					Label("enabled", systemImage: "antenna.radiowaves.left.and.right")

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import CoreData
+
+struct ConfigHeader<T>: View {
+	@EnvironmentObject var bleManager: BLEManager
+
+	let title: String
+	let config: KeyPath<NodeInfoEntity, T?>
+	let node: NodeInfoEntity?
+	let onAppear: () -> Void
+
+	var body: some View {
+		if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
+			Text("There has been no response to a request for device metadata over the admin channel for this node.")
+				.font(.callout)
+				.foregroundColor(.orange)
+
+		} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
+			// Let users know what is going on if they are using remote admin and don't have the config yet
+			if node?[keyPath: config] == nil {
+				Text("\(title) config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
+					.font(.callout)
+					.foregroundColor(.orange)
+			} else {
+				Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
+					.font(.title3)
+					.onAppear(perform: onAppear)
+			}
+		} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? -1 {
+			Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
+		} else {
+			Text("Please connect to a radio to configure settings.")
+				.font(.callout)
+				.foregroundColor(.orange)
+		}
+	}
+}

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -32,30 +32,8 @@ struct DeviceConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.deviceConfig == nil {
-						Text("Device config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setDeviceValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Device", config: \.deviceConfig, node: node, onAppear: setDeviceValues)
+
 				Section(header: Text("options")) {
 					Picker("Device Role", selection: $deviceRole ) {
 						ForEach(DeviceRoles.allCases) { dr in

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -16,9 +16,7 @@ struct DeviceConfig: View {
 
 	@State private var isPresentingNodeDBResetConfirm = false
 	@State private var isPresentingFactoryResetConfirm = false
-	@State private var isPresentingSaveConfirm = false
 	@State var hasChanges = false
-
 	@State var deviceRole = 0
 	@State var buzzerGPIO = 0
 	@State var buttonGPIO = 0
@@ -167,49 +165,28 @@ struct DeviceConfig: View {
 				}
 			}
 			HStack {
-				Button {
-					isPresentingSaveConfirm = true
-				} label: {
-					Label("save", systemImage: "square.and.arrow.down")
-				}
-				.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-				.buttonStyle(.bordered)
-				.buttonBorderShape(.capsule)
-				.controlSize(.large)
-				.padding()
-				.confirmationDialog(
-					"are.you.sure",
-					isPresented: $isPresentingSaveConfirm,
-					titleVisibility: .visible
-				) {
-					let nodeName = node?.user?.longName ?? "unknown".localized
-					let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-					Button(buttonText) {
-						let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-						if connectedNode != nil {
-							var dc = Config.DeviceConfig()
-							dc.role = DeviceRoles(rawValue: deviceRole)!.protoEnumValue()
-							dc.serialEnabled = serialEnabled
-							dc.debugLogEnabled = debugLogEnabled
-							dc.buttonGpio = UInt32(buttonGPIO)
-							dc.buzzerGpio = UInt32(buzzerGPIO)
-							dc.rebroadcastMode = RebroadcastModes(rawValue: rebroadcastMode)?.protoEnumValue() ?? RebroadcastModes.all.protoEnumValue()
-							dc.nodeInfoBroadcastSecs = UInt32(nodeInfoBroadcastSecs)
-							dc.doubleTapAsButtonPress = doubleTapAsButtonPress
-							dc.isManaged = isManaged
-							let adminMessageId = bleManager.saveDeviceConfig(config: dc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-							if adminMessageId > 0 {
-								// Should show a saved successfully alert once I know that to be true
-								// for now just disable the button after a successful save
-								hasChanges = false
-								goBack()
-							}
+				SaveConfigButton(node: node, hasChanges: $hasChanges) {
+					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
+					if connectedNode != nil {
+						var dc = Config.DeviceConfig()
+						dc.role = DeviceRoles(rawValue: deviceRole)!.protoEnumValue()
+						dc.serialEnabled = serialEnabled
+						dc.debugLogEnabled = debugLogEnabled
+						dc.buttonGpio = UInt32(buttonGPIO)
+						dc.buzzerGpio = UInt32(buzzerGPIO)
+						dc.rebroadcastMode = RebroadcastModes(rawValue: rebroadcastMode)?.protoEnumValue() ?? RebroadcastModes.all.protoEnumValue()
+						dc.nodeInfoBroadcastSecs = UInt32(nodeInfoBroadcastSecs)
+						dc.doubleTapAsButtonPress = doubleTapAsButtonPress
+						dc.isManaged = isManaged
+						let adminMessageId = bleManager.saveDeviceConfig(config: dc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+						if adminMessageId > 0 {
+							// Should show a saved successfully alert once I know that to be true
+							// for now just disable the button after a successful save
+							hasChanges = false
+							goBack()
 						}
 					}
 				}
-			message: {
-				Text("config.save.confirm")
-			}
 			}
 			Spacer()
 		}

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -29,33 +29,9 @@ struct DisplayConfig: View {
 	@State var units = 0
 
 	var body: some View {
-
 		Form {
-			if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-				Text("There has been no response to a request for device metadata over the admin channel for this node.")
-					.font(.callout)
-					.foregroundColor(.orange)
+			ConfigHeader(title: "Display", config: \.displayConfig, node: node, onAppear: setDisplayValues)
 
-			} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-				// Let users know what is going on if they are using remote admin and don't have the config yet
-				if node?.displayConfig == nil {
-					Text("Display config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				} else {
-					Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-						.font(.title3)
-						.onAppear {
-							setDisplayValues()
-						}
-				}
-			} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-				Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-			} else {
-				Text("Please connect to a radio to configure settings.")
-					.font(.callout)
-					.foregroundColor(.orange)
-			}
 			Section(header: Text("Device Screen")) {
 				Picker("Display Mode", selection: $displayMode ) {
 					ForEach(DisplayModes.allCases) { dm in

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -29,7 +29,6 @@ struct LoRaConfig: View {
 
 	var node: NodeInfoEntity?
 
-	@State var isPresentingSaveConfirm = false
 	@State var hasChanges = false
 	@State var region: Int = 0
 	@State var modemPreset = 0
@@ -55,7 +54,7 @@ struct LoRaConfig: View {
 		VStack {
 			Form {
 				ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues)
-				
+
 				Section(header: Text("Options")) {
 
 					Picker("Region", selection: $region ) {
@@ -176,51 +175,31 @@ struct LoRaConfig: View {
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.loRaConfig == nil)
 
-			Button {
-				isPresentingSaveConfirm = true
-			} label: {
-				Label("save", systemImage: "square.and.arrow.down")
-			}
-			.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding()
-			.confirmationDialog(
-				"are.you.sure",
-				isPresented: $isPresentingSaveConfirm,
-				titleVisibility: .visible
-			) {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
-					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? 0, context: context)
-					if connectedNode != nil {
-						var lc = Config.LoRaConfig()
-						lc.hopLimit = UInt32(hopLimit)
-						lc.region = RegionCodes(rawValue: region)!.protoEnumValue()
-						lc.modemPreset = ModemPresets(rawValue: modemPreset)!.protoEnumValue()
-						lc.usePreset = usePreset
-						lc.txEnabled = txEnabled
-						lc.txPower = Int32(txPower)
-						lc.channelNum = UInt32(channelNum)
-						lc.bandwidth = UInt32(bandwidth)
-						lc.codingRate = UInt32(codingRate)
-						lc.spreadFactor = UInt32(spreadFactor)
-						lc.sx126XRxBoostedGain = rxBoostedGain
-						lc.overrideFrequency = overrideFrequency
-						lc.ignoreMqtt = ignoreMqtt
-						let adminMessageId = bleManager.saveLoRaConfig(config: lc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-						if adminMessageId > 0 {
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							hasChanges = false
-							goBack()
-						}
+			SaveConfigButton(node: node, hasChanges: $hasChanges) {
+				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? 0, context: context)
+				if connectedNode != nil {
+					var lc = Config.LoRaConfig()
+					lc.hopLimit = UInt32(hopLimit)
+					lc.region = RegionCodes(rawValue: region)!.protoEnumValue()
+					lc.modemPreset = ModemPresets(rawValue: modemPreset)!.protoEnumValue()
+					lc.usePreset = usePreset
+					lc.txEnabled = txEnabled
+					lc.txPower = Int32(txPower)
+					lc.channelNum = UInt32(channelNum)
+					lc.bandwidth = UInt32(bandwidth)
+					lc.codingRate = UInt32(codingRate)
+					lc.spreadFactor = UInt32(spreadFactor)
+					lc.sx126XRxBoostedGain = rxBoostedGain
+					lc.overrideFrequency = overrideFrequency
+					lc.ignoreMqtt = ignoreMqtt
+					let adminMessageId = bleManager.saveLoRaConfig(config: lc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					if adminMessageId > 0 {
+						// Should show a saved successfully alert once I know that to be true
+						// for now just disable the button after a successful save
+						hasChanges = false
+						goBack()
 					}
 				}
-			} message: {
-				Text("config.save.confirm")
 			}
 		}
 		.navigationTitle("lora.config")

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -52,34 +52,10 @@ struct LoRaConfig: View {
 	}()
 
 	var body: some View {
-
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.loRaConfig == nil {
-						Text("LoRa config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setLoRaValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues)
+				
 				Section(header: Text("Options")) {
 
 					Picker("Region", selection: $region ) {

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -57,48 +57,27 @@ struct AmbientLightingConfig: View {
 				}
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.ambientLightingConfig == nil)
-			Button {
-				isPresentingSaveConfirm = true
-			} label: {
-				Label("save", systemImage: "square.and.arrow.down")
-			}
-			.disabled(self.bleManager.connectedPeripheral == nil || !hasChanges)
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding()
-			.confirmationDialog(
-				"are.you.sure",
-				isPresented: $isPresentingSaveConfirm,
-				titleVisibility: .visible
-			) {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
 
+			SaveConfigButton(node: node, hasChanges: $hasChanges) {
 				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if connectedNode != nil {
-						var al = ModuleConfig.AmbientLightingConfig()
-						al.ledState = ledState
-						al.current = UInt32(current)
-						if let components {
-							al.red = UInt32(components.red * 255)
-							al.green = UInt32(components.green * 255)
-							al.blue = UInt32(components.blue * 255)
-						}
+				if connectedNode != nil {
+					var al = ModuleConfig.AmbientLightingConfig()
+					al.ledState = ledState
+					al.current = UInt32(current)
+					if let components {
+						al.red = UInt32(components.red * 255)
+						al.green = UInt32(components.green * 255)
+						al.blue = UInt32(components.blue * 255)
+					}
 
-						let adminMessageId =  bleManager.saveAmbientLightingModuleConfig(config: al, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-						if adminMessageId > 0 {
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							hasChanges = false
-							goBack()
-						}
+					let adminMessageId =  bleManager.saveAmbientLightingModuleConfig(config: al, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					if adminMessageId > 0 {
+						// Should show a saved successfully alert once I know that to be true
+						// for now just disable the button after a successful save
+						hasChanges = false
+						goBack()
 					}
 				}
-			}
-			message: {
-				Text("config.save.confirm")
 			}
 			.navigationTitle("ambient.lighting.config")
 			.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -27,31 +27,8 @@ struct AmbientLightingConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.rtttlConfig == nil {
-						Text("Ambient Lighting config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setAmbientLightingConfigValue()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Ambient Lighting", config: \.ambientLightingConfig, node: node, onAppear: setAmbientLightingConfigValue)
+				
 				Section(header: Text("options")) {
 					Toggle(isOn: $ledState) {
 						Label("LED State", systemImage: ledState ? "lightbulb.led.fill" : "lightbulb.led")

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -167,72 +167,52 @@ struct CannedMessagesConfig: View {
 			}
 			.scrollDismissesKeyboard(.immediately)
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.cannedMessageConfig == nil)
-			Button {
-				isPresentingSaveConfirm = true
-			} label: {
-				Label("save", systemImage: "square.and.arrow.down")
-			}
-			.disabled(bleManager.connectedPeripheral == nil || (!hasChanges && !hasMessagesChanges))
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding()
-			.confirmationDialog(
-				"are.you.sure",
-				isPresented: $isPresentingSaveConfirm,
-				titleVisibility: .visible
-			) {
-				let nodeName = bleManager.connectedPeripheral != nil ? bleManager.connectedPeripheral.longName : "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
-					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? -1, context: context)
-					if hasChanges {
-						if connectedNode != nil {
-							var cmc = ModuleConfig.CannedMessageConfig()
-							cmc.enabled = enabled
-							cmc.sendBell = sendBell
-							cmc.rotary1Enabled = rotary1Enabled
-							cmc.updown1Enabled = updown1Enabled
-							if rotary1Enabled {
-								/// Input event origin accepted by the canned messages
-								/// Can be e.g. "rotEnc1", "upDownEnc1",  "cardkb",  or keyword "_any"
-								cmc.allowInputSource = "rotEnc1"
-							} else if updown1Enabled {
-								cmc.allowInputSource = "upDown1"
-							} else {
-								cmc.allowInputSource = "_any"
-							}
-							cmc.inputbrokerPinA = UInt32(inputbrokerPinA)
-							cmc.inputbrokerPinB = UInt32(inputbrokerPinB)
-							cmc.inputbrokerPinPress = UInt32(inputbrokerPinPress)
-							cmc.inputbrokerEventCw = InputEventChars(rawValue: inputbrokerEventCw)!.protoEnumValue()
-							cmc.inputbrokerEventCcw = InputEventChars(rawValue: inputbrokerEventCcw)!.protoEnumValue()
-							cmc.inputbrokerEventPress = InputEventChars(rawValue: inputbrokerEventPress)!.protoEnumValue()
-							let adminMessageId =  bleManager.saveCannedMessageModuleConfig(config: cmc, fromUser: node!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-							if adminMessageId > 0 {
-								// Should show a saved successfully alert once I know that to be true
-								// for now just disable the button after a successful save
-								hasChanges = false
-								goBack()
-							}
+
+			SaveConfigButton(node: node, hasChanges: $hasChanges) {
+				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? -1, context: context)
+				if hasChanges {
+					if connectedNode != nil {
+						var cmc = ModuleConfig.CannedMessageConfig()
+						cmc.enabled = enabled
+						cmc.sendBell = sendBell
+						cmc.rotary1Enabled = rotary1Enabled
+						cmc.updown1Enabled = updown1Enabled
+						if rotary1Enabled {
+							/// Input event origin accepted by the canned messages
+							/// Can be e.g. "rotEnc1", "upDownEnc1",  "cardkb",  or keyword "_any"
+							cmc.allowInputSource = "rotEnc1"
+						} else if updown1Enabled {
+							cmc.allowInputSource = "upDown1"
+						} else {
+							cmc.allowInputSource = "_any"
 						}
-					}
-					if hasMessagesChanges {
-						let adminMessageId =  bleManager.saveCannedMessageModuleMessages(messages: messages, fromUser: node!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+						cmc.inputbrokerPinA = UInt32(inputbrokerPinA)
+						cmc.inputbrokerPinB = UInt32(inputbrokerPinB)
+						cmc.inputbrokerPinPress = UInt32(inputbrokerPinPress)
+						cmc.inputbrokerEventCw = InputEventChars(rawValue: inputbrokerEventCw)!.protoEnumValue()
+						cmc.inputbrokerEventCcw = InputEventChars(rawValue: inputbrokerEventCcw)!.protoEnumValue()
+						cmc.inputbrokerEventPress = InputEventChars(rawValue: inputbrokerEventPress)!.protoEnumValue()
+						let adminMessageId =  bleManager.saveCannedMessageModuleConfig(config: cmc, fromUser: node!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
 						if adminMessageId > 0 {
 							// Should show a saved successfully alert once I know that to be true
 							// for now just disable the button after a successful save
-							hasMessagesChanges = false
-							if !hasChanges {
-								bleManager.sendWantConfig()
-								goBack()
-							}
+							hasChanges = false
+							goBack()
 						}
 					}
 				}
-			}
-			message: {
-				Text("config.save.confirm")
+				if hasMessagesChanges {
+					let adminMessageId =  bleManager.saveCannedMessageModuleMessages(messages: messages, fromUser: node!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					if adminMessageId > 0 {
+						// Should show a saved successfully alert once I know that to be true
+						// for now just disable the button after a successful save
+						hasMessagesChanges = false
+						if !hasChanges {
+							bleManager.sendWantConfig()
+							goBack()
+						}
+					}
+				}
 			}
 			.navigationTitle("canned.messages.config")
 			.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -38,31 +38,8 @@ struct CannedMessagesConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.cannedMessageConfig == nil {
-						Text("Canned messages config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setCannedMessagesValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Canned messages", config: \.cannedMessageConfig, node: node, onAppear: setCannedMessagesValues)
+				
 				Section(header: Text("options")) {
 					Toggle(isOn: $enabled) {
 

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -43,31 +43,8 @@ struct DetectionSensorConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-					
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.detectionSensorConfig == nil {
-						Text("Detection Sensor config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setDetectionSensorValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Detection Sensor", config: \.detectionSensorConfig, node: node, onAppear: setDetectionSensorValues)
+				
 				Section(header: Text("options")) {
 					
 					Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -168,47 +168,26 @@ struct DetectionSensorConfig: View {
 		.scrollDismissesKeyboard(.interactively)
 		.disabled(self.bleManager.connectedPeripheral == nil || node?.detectionSensorConfig == nil)
 
-		Button {
-			isPresentingSaveConfirm = true
-		} label: {
-			Label("save", systemImage: "square.and.arrow.down")
-		}
-		.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-		.buttonStyle(.bordered)
-		.buttonBorderShape(.capsule)
-		.controlSize(.large)
-		.padding()
-		.confirmationDialog(
-			"are.you.sure",
-			isPresented: $isPresentingSaveConfirm,
-			titleVisibility: .visible
-		) {
+		SaveConfigButton(node: node, hasChanges: $hasChanges) {
 			let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? -1, context: context)
 			if connectedNode != nil {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
-					var dsc = ModuleConfig.DetectionSensorConfig()
-					dsc.enabled = self.enabled
-					dsc.sendBell = self.sendBell
-					dsc.name = self.name
-					dsc.monitorPin = UInt32(self.monitorPin)
-					dsc.detectionTriggeredHigh = self.detectionTriggeredHigh
-					dsc.usePullup = self.usePullup
-					dsc.minimumBroadcastSecs = UInt32(self.minimumBroadcastSecs)
-					dsc.stateBroadcastSecs = UInt32(self.stateBroadcastSecs)
-					let adminMessageId = bleManager.saveDetectionSensorModuleConfig(config: dsc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-					if adminMessageId > 0 {
-						// Should show a saved successfully alert once I know that to be true
-						// for now just disable the button after a successful save
-						hasChanges = false
-						goBack()
-					}
+				var dsc = ModuleConfig.DetectionSensorConfig()
+				dsc.enabled = self.enabled
+				dsc.sendBell = self.sendBell
+				dsc.name = self.name
+				dsc.monitorPin = UInt32(self.monitorPin)
+				dsc.detectionTriggeredHigh = self.detectionTriggeredHigh
+				dsc.usePullup = self.usePullup
+				dsc.minimumBroadcastSecs = UInt32(self.minimumBroadcastSecs)
+				dsc.stateBroadcastSecs = UInt32(self.stateBroadcastSecs)
+				let adminMessageId = bleManager.saveDetectionSensorModuleConfig(config: dsc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				if adminMessageId > 0 {
+					// Should show a saved successfully alert once I know that to be true
+					// for now just disable the button after a successful save
+					hasChanges = false
+					goBack()
 				}
 			}
-		}
-		message: {
-			Text("config.save.confirm")
 		}
 		.navigationTitle("detection.sensor.config")
 		.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -147,54 +147,34 @@ struct ExternalNotificationConfig: View {
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.externalNotificationConfig == nil)
 		}
-		Button {
-			isPresentingSaveConfirm = true
-		} label: {
-			Label("save", systemImage: "square.and.arrow.down")
-		}
-		.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-		.buttonStyle(.bordered)
-		.buttonBorderShape(.capsule)
-		.controlSize(.large)
-		.padding()
-		.confirmationDialog(
-			"are.you.sure",
-			isPresented: $isPresentingSaveConfirm,
-			titleVisibility: .visible
-		) {
+
+		SaveConfigButton(node: node, hasChanges: $hasChanges) {
 			let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? -1, context: context)
 			if connectedNode != nil {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
-					var enc = ModuleConfig.ExternalNotificationConfig()
-					enc.enabled = enabled
-					enc.alertBell = alertBell
-					enc.alertBellBuzzer = alertBellBuzzer
-					enc.alertBellVibra = alertBellVibra
-					enc.alertMessage = alertMessage
-					enc.alertMessageBuzzer = alertMessageBuzzer
-					enc.alertMessageVibra = alertMessageVibra
-					enc.active = active
-					enc.output = UInt32(output)
-					enc.nagTimeout = UInt32(nagTimeout)
-					enc.outputBuzzer = UInt32(outputBuzzer)
-					enc.outputVibra = UInt32(outputVibra)
-					enc.outputMs = UInt32(outputMilliseconds)
-					enc.usePwm = usePWM
-					enc.useI2SAsBuzzer = useI2SAsBuzzer
-					let adminMessageId =  bleManager.saveExternalNotificationModuleConfig(config: enc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-					if adminMessageId > 0 {
-						// Should show a saved successfully alert once I know that to be true
-						// for now just disable the button after a successful save
-						hasChanges = false
-						goBack()
-					}
+				var enc = ModuleConfig.ExternalNotificationConfig()
+				enc.enabled = enabled
+				enc.alertBell = alertBell
+				enc.alertBellBuzzer = alertBellBuzzer
+				enc.alertBellVibra = alertBellVibra
+				enc.alertMessage = alertMessage
+				enc.alertMessageBuzzer = alertMessageBuzzer
+				enc.alertMessageVibra = alertMessageVibra
+				enc.active = active
+				enc.output = UInt32(output)
+				enc.nagTimeout = UInt32(nagTimeout)
+				enc.outputBuzzer = UInt32(outputBuzzer)
+				enc.outputVibra = UInt32(outputVibra)
+				enc.outputMs = UInt32(outputMilliseconds)
+				enc.usePwm = usePWM
+				enc.useI2SAsBuzzer = useI2SAsBuzzer
+				let adminMessageId =  bleManager.saveExternalNotificationModuleConfig(config: enc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				if adminMessageId > 0 {
+					// Should show a saved successfully alert once I know that to be true
+					// for now just disable the button after a successful save
+					hasChanges = false
+					goBack()
 				}
 			}
-		}
-		message: {
-			Text("config.save.confirm")
 		}
 		.navigationTitle("external.notification.config")
 		.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -35,31 +35,8 @@ struct ExternalNotificationConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-					
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.externalNotificationConfig == nil {
-						Text("External notification config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setExternalNotificationValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "External notification", config: \.externalNotificationConfig, node: node, onAppear: setExternalNotificationValues)
+
 				Section(header: Text("options")) {
 					Toggle(isOn: $enabled) {
 						Label("enabled", systemImage: "megaphone")

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -191,48 +191,28 @@ struct MQTTConfig: View {
 			.scrollDismissesKeyboard(.interactively)
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.mqttConfig == nil)
 		}
-		Button {
-			isPresentingSaveConfirm = true
-		} label: {
-			Label("save", systemImage: "square.and.arrow.down")
-		}
-		.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-		.buttonStyle(.bordered)
-		.buttonBorderShape(.capsule)
-		.controlSize(.large)
-		.padding()
-		.confirmationDialog(
-			"are.you.sure",
-			isPresented: $isPresentingSaveConfirm,
-			titleVisibility: .visible
-		) {
+
+		SaveConfigButton(node: node, hasChanges: $hasChanges) {
 			let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? -1, context: context)
 			if connectedNode != nil {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
-					var mqtt = ModuleConfig.MQTTConfig()
-					mqtt.enabled = self.enabled
-					mqtt.proxyToClientEnabled = self.proxyToClientEnabled
-					mqtt.address = self.address
-					mqtt.username = self.username
-					mqtt.password = self.password
-					mqtt.root = self.root
-					mqtt.encryptionEnabled = self.encryptionEnabled
-					mqtt.jsonEnabled = self.jsonEnabled
-					mqtt.tlsEnabled = self.tlsEnabled
-					let adminMessageId =  bleManager.saveMQTTConfig(config: mqtt, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-					if adminMessageId > 0 {
-						// Should show a saved successfully alert once I know that to be true
-						// for now just disable the button after a successful save
-						hasChanges = false
-						goBack()
-					}
+				var mqtt = ModuleConfig.MQTTConfig()
+				mqtt.enabled = self.enabled
+				mqtt.proxyToClientEnabled = self.proxyToClientEnabled
+				mqtt.address = self.address
+				mqtt.username = self.username
+				mqtt.password = self.password
+				mqtt.root = self.root
+				mqtt.encryptionEnabled = self.encryptionEnabled
+				mqtt.jsonEnabled = self.jsonEnabled
+				mqtt.tlsEnabled = self.tlsEnabled
+				let adminMessageId =  bleManager.saveMQTTConfig(config: mqtt, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				if adminMessageId > 0 {
+					// Should show a saved successfully alert once I know that to be true
+					// for now just disable the button after a successful save
+					hasChanges = false
+					goBack()
 				}
 			}
-		}
-		message: {
-			Text("config.save.confirm")
 		}
 		.navigationTitle("mqtt.config")
 		.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -38,32 +38,9 @@ struct MQTTConfig: View {
 							.foregroundColor(.red)
 					}
 				}
-					
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-					
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.mqttConfig == nil {
-						Text("MQTT config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setMqttValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+
+				ConfigHeader(title: "MQTT", config: \.mqttConfig, node: node, onAppear: setMqttValues)
+
 				Section(header: Text("options")) {
 					
 					Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -49,43 +49,22 @@ struct RangeTestConfig: View {
 				}
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.rangeTestConfig == nil)
-			Button {
-				isPresentingSaveConfirm = true
-			} label: {
-				Label("save", systemImage: "square.and.arrow.down")
-			}
-			.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding()
-			.confirmationDialog(
-				"are.you.sure",
-				isPresented: $isPresentingSaveConfirm,
-				titleVisibility: .visible
-			) {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
 
+			SaveConfigButton(node: node, hasChanges: $hasChanges) {
 				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if connectedNode != nil {
-						var rtc = ModuleConfig.RangeTestConfig()
-						rtc.enabled = enabled
-						rtc.save = save
-						rtc.sender = UInt32(sender)
-						let adminMessageId =  bleManager.saveRangeTestModuleConfig(config: rtc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-						if adminMessageId > 0 {
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							hasChanges = false
-							goBack()
-						}
+				if connectedNode != nil {
+					var rtc = ModuleConfig.RangeTestConfig()
+					rtc.enabled = enabled
+					rtc.save = save
+					rtc.sender = UInt32(sender)
+					let adminMessageId =  bleManager.saveRangeTestModuleConfig(config: rtc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					if adminMessageId > 0 {
+						// Should show a saved successfully alert once I know that to be true
+						// for now just disable the button after a successful save
+						hasChanges = false
+						goBack()
 					}
 				}
-			}
-			message: {
-				Text("config.save.confirm")
 			}
 			.navigationTitle("range.test.config")
 			.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -23,31 +23,8 @@ struct RangeTestConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.rangeTestConfig == nil {
-						Text("Range test config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setRangeTestValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Range", config: \.rangeTestConfig, node: node, onAppear: setRangeTestValues)
+				
 				Section(header: Text("options")) {
 					Toggle(isOn: $enabled) {
 

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -21,31 +21,8 @@ struct RtttlConfig: View {
     var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.rtttlConfig == nil {
-						Text("RTTTL Ringtone config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setRtttLConfigValue()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "RTTTL Ringtone", config: \.rtttlConfig, node: node, onAppear: setRtttLConfigValue)
+				
 				Section(header: Text("options")) {
 					HStack {
 						Label("ringtone", systemImage: "music.quarternote.3")

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -51,39 +51,18 @@ struct RtttlConfig: View {
 				}
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.rtttlConfig == nil)
-			Button {
-				isPresentingSaveConfirm = true
-			} label: {
-				Label("save", systemImage: "square.and.arrow.down")
-			}
-			.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding()
-			.confirmationDialog(
-				"are.you.sure",
-				isPresented: $isPresentingSaveConfirm,
-				titleVisibility: .visible
-			) {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
 
+			SaveConfigButton(node: node, hasChanges: $hasChanges) {
 				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if connectedNode != nil {
-						let adminMessageId =  bleManager.saveRtttlConfig(ringtone: ringtone.trimmingCharacters(in: .whitespacesAndNewlines), fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-						if adminMessageId > 0 {
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							hasChanges = false
-							goBack()
-						}
+				if connectedNode != nil {
+					let adminMessageId =  bleManager.saveRtttlConfig(ringtone: ringtone.trimmingCharacters(in: .whitespacesAndNewlines), fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					if adminMessageId > 0 {
+						// Should show a saved successfully alert once I know that to be true
+						// for now just disable the button after a successful save
+						hasChanges = false
+						goBack()
 					}
 				}
-			}
-			message: {
-				Text("config.save.confirm")
 			}
 			.navigationTitle("ringtone.config")
 			.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -31,31 +31,8 @@ struct SerialConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.serialConfig == nil {
-						Text("Serial config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setSerialValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Serial", config: \.serialConfig, node: node, onAppear: setSerialValues)
+				
 				Section(header: Text("options")) {
 
 					Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -101,53 +101,28 @@ struct SerialConfig: View {
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.serialConfig == nil)
 
-			Button {
+			SaveConfigButton(node: node, hasChanges: $hasChanges) {
+				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
+				if connectedNode != nil {
+					var sc = ModuleConfig.SerialConfig()
+					sc.enabled = enabled
+					sc.echo = echo
+					sc.rxd = UInt32(rxd)
+					sc.txd = UInt32(txd)
+					sc.baud = SerialBaudRates(rawValue: baudRate)!.protoEnumValue()
+					sc.timeout = UInt32(timeout)
+					sc.overrideConsoleSerialPort = overrideConsoleSerialPort
+					sc.mode	= SerialModeTypes(rawValue: mode)!.protoEnumValue()
 
-				isPresentingSaveConfirm = true
+					let adminMessageId =  bleManager.saveSerialModuleConfig(config: sc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
 
-			} label: {
-
-				Label("save", systemImage: "square.and.arrow.down")
-			}
-			.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding()
-			.confirmationDialog(
-
-				"are.you.sure",
-				isPresented: $isPresentingSaveConfirm,
-				titleVisibility: .visible
-			) {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
-					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if connectedNode != nil {
-						var sc = ModuleConfig.SerialConfig()
-						sc.enabled = enabled
-						sc.echo = echo
-						sc.rxd = UInt32(rxd)
-						sc.txd = UInt32(txd)
-						sc.baud = SerialBaudRates(rawValue: baudRate)!.protoEnumValue()
-						sc.timeout = UInt32(timeout)
-						sc.overrideConsoleSerialPort = overrideConsoleSerialPort
-						sc.mode	= SerialModeTypes(rawValue: mode)!.protoEnumValue()
-
-						let adminMessageId =  bleManager.saveSerialModuleConfig(config: sc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-
-						if adminMessageId > 0 {
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							hasChanges = false
-							goBack()
-						}
+					if adminMessageId > 0 {
+						// Should show a saved successfully alert once I know that to be true
+						// for now just disable the button after a successful save
+						hasChanges = false
+						goBack()
 					}
 				}
-			}
-			message: {
-				Text("config.save.confirm")
 			}
 			.navigationTitle("serial.config")
 			.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -31,31 +31,8 @@ struct StoreForwardConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-					
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.storeForwardConfig == nil {
-						Text("Store and forward config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setStoreAndForwardValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Store and forward", config: \.storeForwardConfig, node: node, onAppear: setStoreAndForwardValues)
+				
 				Section(header: Text("options")) {
 					
 					Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -104,56 +104,35 @@ struct StoreForwardConfig: View {
 			.scrollDismissesKeyboard(.interactively)
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.storeForwardConfig == nil)
 		}
-		Button {
-			isPresentingSaveConfirm = true
-		} label: {
-			Label("save", systemImage: "square.and.arrow.down")
-		}
-		.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-		.buttonStyle(.bordered)
-		.buttonBorderShape(.capsule)
-		.controlSize(.large)
-		.padding()
-		.confirmationDialog(
-			"are.you.sure",
-			isPresented: $isPresentingSaveConfirm,
-			titleVisibility: .visible
-		) {
+
+		SaveConfigButton(node: node, hasChanges: $hasChanges) {
 			let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? -1, context: context)
 			if connectedNode != nil {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
-					
-					/// Let the user set isRouter for the connected node, for nodes on the mesh set isRouter based
-					/// on receipt of a primary heartbeat
-					if connectedNode?.num ?? 0 == node?.num ?? -1 {
-						connectedNode?.storeForwardConfig?.isRouter = isRouter
-						do {
-							try context.save()
-						} catch {
-							print("Failed to save isRouter")
-						}
-					}
-					
-					var sfc = ModuleConfig.StoreForwardConfig()
-					sfc.enabled = self.enabled
-					sfc.heartbeat = self.heartbeat
-					sfc.records = UInt32(self.records)
-					sfc.historyReturnMax = UInt32(self.historyReturnMax)
-					sfc.historyReturnWindow = UInt32(self.historyReturnWindow)
-					let adminMessageId = bleManager.saveStoreForwardModuleConfig(config: sfc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-					if adminMessageId > 0 {
-						// Should show a saved successfully alert once I know that to be true
-						// for now just disable the button after a successful save
-						hasChanges = false
-						goBack()
+				/// Let the user set isRouter for the connected node, for nodes on the mesh set isRouter based
+				/// on receipt of a primary heartbeat
+				if connectedNode?.num ?? 0 == node?.num ?? -1 {
+					connectedNode?.storeForwardConfig?.isRouter = isRouter
+					do {
+						try context.save()
+					} catch {
+						print("Failed to save isRouter")
 					}
 				}
+				
+				var sfc = ModuleConfig.StoreForwardConfig()
+				sfc.enabled = self.enabled
+				sfc.heartbeat = self.heartbeat
+				sfc.records = UInt32(self.records)
+				sfc.historyReturnMax = UInt32(self.historyReturnMax)
+				sfc.historyReturnWindow = UInt32(self.historyReturnWindow)
+				let adminMessageId = bleManager.saveStoreForwardModuleConfig(config: sfc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				if adminMessageId > 0 {
+					// Should show a saved successfully alert once I know that to be true
+					// for now just disable the button after a successful save
+					hasChanges = false
+					goBack()
+				}
 			}
-		}
-		message: {
-			Text("config.save.confirm")
 		}
 		.navigationTitle("storeforward.config")
 		.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -63,44 +63,24 @@ struct TelemetryConfig: View {
 				}
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.telemetryConfig == nil)
-			Button {
-				isPresentingSaveConfirm = true
-			} label: {
-				Label("save", systemImage: "square.and.arrow.down")
-			}
-			.disabled(bleManager.connectedPeripheral == nil || !hasChanges || node!.telemetryConfig == nil)
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding()
-			.confirmationDialog(
-				"are.you.sure",
-				isPresented: $isPresentingSaveConfirm,
-				titleVisibility: .visible
-			) {
+
+			SaveConfigButton(node: node, hasChanges: $hasChanges) {
 				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? -1, context: context)
 				if connectedNode != nil {
-					let nodeName = node?.user?.longName ?? "unknown".localized
-					let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-					Button(buttonText) {
-						var tc = ModuleConfig.TelemetryConfig()
-						tc.deviceUpdateInterval = UInt32(deviceUpdateInterval)
-						tc.environmentUpdateInterval = UInt32(environmentUpdateInterval)
-						tc.environmentMeasurementEnabled = environmentMeasurementEnabled
-						tc.environmentScreenEnabled = environmentScreenEnabled
-						tc.environmentDisplayFahrenheit = environmentDisplayFahrenheit
-						let adminMessageId = bleManager.saveTelemetryModuleConfig(config: tc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-						if adminMessageId > 0 {
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							hasChanges = false
-							goBack()
-						}
+					var tc = ModuleConfig.TelemetryConfig()
+					tc.deviceUpdateInterval = UInt32(deviceUpdateInterval)
+					tc.environmentUpdateInterval = UInt32(environmentUpdateInterval)
+					tc.environmentMeasurementEnabled = environmentMeasurementEnabled
+					tc.environmentScreenEnabled = environmentScreenEnabled
+					tc.environmentDisplayFahrenheit = environmentDisplayFahrenheit
+					let adminMessageId = bleManager.saveTelemetryModuleConfig(config: tc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					if adminMessageId > 0 {
+						// Should show a saved successfully alert once I know that to be true
+						// for now just disable the button after a successful save
+						hasChanges = false
+						goBack()
 					}
 				}
-			}
-			message: {
-				Text("config.save.confirm")
 			}
 			.navigationTitle("telemetry.config")
 			.navigationBarItems(trailing:

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -25,31 +25,8 @@ struct TelemetryConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.telemetryConfig == nil {
-						Text("Telemetry config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setTelemetryValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Telemetry", config: \.telemetryConfig, node: node, onAppear: setTelemetryValues)
+				
 				Section(header: Text("update.interval")) {
 					Picker("Device Metrics", selection: $deviceUpdateInterval ) {
 						ForEach(UpdateIntervals.allCases) { ui in

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -15,7 +15,6 @@ struct NetworkConfig: View {
 
 	var node: NodeInfoEntity?
 
-	@State private var isPresentingSaveConfirm: Bool = false
 	@State var hasChanges: Bool = false
 	@State var wifiEnabled = false
 	@State var wifiSsid = ""
@@ -95,44 +94,25 @@ struct NetworkConfig: View {
 			}
 			.scrollDismissesKeyboard(.interactively)
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.networkConfig == nil)
-			Button {
-				isPresentingSaveConfirm = true
-			} label: {
-				Label("save", systemImage: "square.and.arrow.down")
-			}
-			.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding()
-			.confirmationDialog(
-				"are.you.sure",
-				isPresented: $isPresentingSaveConfirm,
-				titleVisibility: .visible
-			) {
-				let nodeName = node?.user?.longName ?? "unknown".localized
-				let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
-				Button(buttonText) {
-					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if connectedNode != nil {
-						var network = Config.NetworkConfig()
-						network.wifiEnabled = self.wifiEnabled
-						network.wifiSsid = self.wifiSsid
-						network.wifiPsk = self.wifiPsk
-						network.ethEnabled = self.ethEnabled
-						// network.addressMode = Config.NetworkConfig.AddressMode.dhcp
 
-						let adminMessageId =  bleManager.saveNetworkConfig(config: network, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-						if adminMessageId > 0 {
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							hasChanges = false
-							goBack()
-						}
+			SaveConfigButton(node: node, hasChanges: $hasChanges) {
+				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
+				if connectedNode != nil {
+					var network = Config.NetworkConfig()
+					network.wifiEnabled = self.wifiEnabled
+					network.wifiSsid = self.wifiSsid
+					network.wifiPsk = self.wifiPsk
+					network.ethEnabled = self.ethEnabled
+					// network.addressMode = Config.NetworkConfig.AddressMode.dhcp
+
+					let adminMessageId =  bleManager.saveNetworkConfig(config: network, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					if adminMessageId > 0 {
+						// Should show a saved successfully alert once I know that to be true
+						// for now just disable the button after a successful save
+						hasChanges = false
+						goBack()
 					}
 				}
-			} message: {
-				Text("config.save.confirm")
 			}
 		}
 		.navigationTitle("network.config")

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -26,34 +26,10 @@ struct NetworkConfig: View {
 	@State var ethMode = 0
 
 	var body: some View {
-
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.networkConfig == nil {
-						Text("Network config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setNetworkValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Network", config: \.networkConfig, node: node, onAppear: setNetworkValues)
+				
 				if (node != nil && node?.metadata?.hasWifi ?? false) {
 					Section(header: Text("WiFi Options")) {
 						Toggle(isOn: $wifiEnabled) {

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -74,34 +74,9 @@ struct PositionConfig: View {
 	@State var includeHeading = false
 
 	var body: some View {
-
 		VStack {
 			Form {
-				if node != nil && node?.metadata == nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					Text("There has been no response to a request for device metadata over the admin channel for this node.")
-						.font(.callout)
-						.foregroundColor(.orange)
-
-				} else if node != nil && node?.num ?? 0 != bleManager.connectedPeripheral?.num ?? 0 {
-					// Let users know what is going on if they are using remote admin and don't have the config yet
-					if node?.positionConfig == nil {
-						Text("Position config data was requested over the admin channel but no response has been returned from the remote node. You can check the status of admin message requests in the admin message log.")
-							.font(.callout)
-							.foregroundColor(.orange)
-					} else {
-						Text("Remote administration for: \(node?.user?.longName ?? "Unknown")")
-							.font(.title3)
-							.onAppear {
-								setPositionValues()
-							}
-					}
-				} else if node != nil && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? 0 {
-					Text("Configuration for: \(node?.user?.longName ?? "Unknown")")
-				} else {
-					Text("Please connect to a radio to configure settings.")
-						.font(.callout)
-						.foregroundColor(.orange)
-				}
+				ConfigHeader(title: "Position", config: \.positionConfig, node: node, onAppear: setPositionValues)
 
 				Section(header: Text("Position Packet")) {
 

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+
+struct PowerConfig: View {
+	@Environment(\.managedObjectContext) private var context
+	@EnvironmentObject private var bleManager: BLEManager
+	@Environment(\.dismiss) private var goBack
+
+	let node: NodeInfoEntity?
+
+	@State private var isPowerSaving = false
+
+	@State private var shutdownOnPowerLoss = false
+	@State private var shutdownAfterSecs = 0
+	@State private var adcOverride = false
+	@State private var adcMultiplier: Float = 0.0
+
+	@State private var waitBluetoothSecs = 60
+	@State private var lsSecs = 300
+	@State private var minWakeSecs = 10
+
+	@State private var hasChanges: Bool = false
+	@FocusState private var isFocused: Bool
+
+	var body: some View {
+		Form {
+			ConfigHeader(title: "Power", config: \.powerConfig, node: node, onAppear: setPowerValues)
+
+			Section(header: Text("power")) {
+				Toggle(isOn: $isPowerSaving) {
+					Text("power.save")
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+			}
+
+			Section {
+				Toggle(isOn: $shutdownOnPowerLoss) {
+					Text("power.shutdown.on.power.loss")
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+				if shutdownOnPowerLoss {
+					Picker("power.shutdown.after.secs", selection: $shutdownAfterSecs) {
+						ForEach(PowerIntervals.allCases) { at in
+							Text(at.description)
+						}
+					}
+					.pickerStyle(DefaultPickerStyle())
+				}
+			} header: {
+				Text("Shutdown")
+			}
+
+			Section {
+				Toggle(isOn: $adcOverride) {
+					Text("power.adc.override")
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+				if adcOverride {
+					HStack {
+						Text("power.adc.multiplier")
+						Spacer()
+						FloatField(title: "power.adc.multiplier", number: $adcMultiplier) {
+							(2.0 ... 6.0).contains($0)
+						}
+						.focused($isFocused)
+						Spacer()
+					}
+				}
+			} header: {
+				Text("Battery")
+			}
+
+			Section {
+				Picker("power.wait.bluetooth.secs", selection: $waitBluetoothSecs) {
+					ForEach(PowerIntervals.allCases) {
+						Text($0.description)
+					}
+				}
+				.pickerStyle(DefaultPickerStyle())
+
+				Picker("power.ls.secs", selection: $lsSecs) {
+					ForEach(PowerIntervals.allCases) {
+						Text($0.description)
+					}
+				}
+				.pickerStyle(DefaultPickerStyle())
+
+				Picker("power.min.wake.secs", selection: $minWakeSecs) {
+					ForEach(PowerIntervals.allCases) {
+						Text($0.description)
+					}
+				}
+				.pickerStyle(DefaultPickerStyle())
+			} header: {
+				Text("Sleep")
+			}
+		}
+		.disabled(self.bleManager.connectedPeripheral == nil || node?.powerConfig == nil)
+		.navigationTitle("power.config")
+		.navigationBarItems(trailing: ZStack {
+			ConnectedDevice(
+				bluetoothOn: bleManager.isSwitchedOn,
+				deviceConnected: bleManager.connectedPeripheral != nil,
+				name: "\(bleManager.connectedPeripheral?.shortName ?? "?")"
+			)
+		})
+		.toolbar {
+			ToolbarItemGroup(placement: .keyboard) {
+				Spacer()
+				Button("dismiss.keyboard") {
+					isFocused = false
+				}
+				.font(.subheadline)
+			}
+		}
+		.onAppear {
+			if self.bleManager.context == nil {
+				self.bleManager.context = context
+			}
+			setPowerValues()
+
+			// Need to request a Power config from the remote node before allowing changes
+			if bleManager.connectedPeripheral != nil && node?.powerConfig == nil {
+				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? 0, context: context)
+				if node != nil && connectedNode != nil {
+					_ = bleManager.requestPowerConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				}
+			}
+		}
+		.onChange(of: isPowerSaving) {
+			if let val = node?.powerConfig?.isPowerSaving {
+				hasChanges = $0 != val
+			}
+		}
+		.onChange(of: shutdownOnPowerLoss) { _ in
+			hasChanges = true
+		}
+		.onChange(of: shutdownAfterSecs) {
+			if let val = node?.powerConfig?.onBatteryShutdownAfterSecs {
+				hasChanges = $0 != val
+			}
+		}
+		.onChange(of: adcOverride) { _ in
+			hasChanges = true
+		}
+		.onChange(of: adcMultiplier) {
+			if let val = node?.powerConfig?.adcMultiplierOverride {
+				hasChanges = $0 != val
+			}
+		}
+		.onChange(of: waitBluetoothSecs) {
+			if let val = node?.powerConfig?.waitBluetoothSecs {
+				hasChanges = $0 != val
+			}
+		}
+		.onChange(of: lsSecs) {
+			if let val = node?.powerConfig?.lsSecs {
+				hasChanges = $0 != val
+			}
+		}
+		.onChange(of: minWakeSecs) {
+			if let val = node?.powerConfig?.minWakeSecs {
+				hasChanges = $0 != val
+			}
+		}
+
+		SaveConfigButton(node: node, hasChanges: $hasChanges) {
+			guard let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context),
+				  let fromUser = connectedNode.user,
+				  let toUser = node?.user else {
+				return
+			}
+
+			var config = Config.PowerConfig()
+			config.isPowerSaving = isPowerSaving
+			config.onBatteryShutdownAfterSecs = shutdownOnPowerLoss ? UInt32(shutdownAfterSecs) : 0
+			config.adcMultiplierOverride = adcOverride ? adcMultiplier : 0
+			config.waitBluetoothSecs = UInt32(waitBluetoothSecs)
+			config.lsSecs = UInt32(lsSecs)
+			config.minWakeSecs = UInt32(minWakeSecs)
+
+			let adminMessageId = bleManager.savePowerConfig(
+				config: config,
+				fromUser: fromUser,
+				toUser: toUser,
+				adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+			)
+			if adminMessageId > 0 {
+				// Should show a saved successfully alert once I know that to be true
+				// for now just disable the button after a successful save
+				hasChanges = false
+				goBack()
+			}
+		}
+	}
+
+	private func setPowerValues() {
+		isPowerSaving = node?.powerConfig?.isPowerSaving ?? isPowerSaving
+
+		shutdownAfterSecs = Int(node?.powerConfig?.onBatteryShutdownAfterSecs ?? Int32(shutdownAfterSecs))
+		shutdownOnPowerLoss = shutdownAfterSecs != 0
+
+		adcMultiplier = node?.powerConfig?.adcMultiplierOverride ?? adcMultiplier
+		adcOverride = adcMultiplier != 0
+
+		waitBluetoothSecs = Int(node?.powerConfig?.waitBluetoothSecs ?? Int32(waitBluetoothSecs))
+		lsSecs = Int(node?.powerConfig?.lsSecs ?? Int32(lsSecs))
+		minWakeSecs = Int(node?.powerConfig?.minWakeSecs ?? Int32(minWakeSecs))
+	}
+}
+
+/// Helper view for isolating user float input that can be validated before being applied.
+private struct FloatField: View {
+	let title: String
+	@Binding var number: Float
+	var isValid: (Float) -> Bool = { _ in true }
+
+	@State private var typingNumber: Float = 0.0
+
+	var body: some View {
+		TextField(title.localized, value: $typingNumber, format: .number)
+			.foregroundColor(.gray)
+			.multilineTextAlignment(.trailing)
+			.onChange(of: typingNumber, perform: { _ in
+				if isValid(typingNumber) {
+					number = typingNumber
+				} else {
+					typingNumber = number
+				}
+			})
+			.keyboardType(.decimalPad)
+			.onAppear {
+				typingNumber = number
+			}
+	}
+}

--- a/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
+++ b/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct SaveConfigButton: View {
+	@EnvironmentObject var bleManager: BLEManager
+
+	@State private var isPresentingSaveConfirm = false
+	let node: NodeInfoEntity?
+	@Binding var hasChanges: Bool
+	let onConfirmation: () -> Void
+
+	var body: some View {
+		Button {
+			isPresentingSaveConfirm = true
+		} label: {
+			Label("save", systemImage: "square.and.arrow.down")
+		}
+		.disabled(bleManager.connectedPeripheral == nil || !hasChanges)
+		.buttonStyle(.bordered)
+		.buttonBorderShape(.capsule)
+		.controlSize(.large)
+		.padding()
+		.confirmationDialog(
+			"are.you.sure",
+			isPresented: $isPresentingSaveConfirm,
+			titleVisibility: .visible
+		) {
+			let nodeName = node?.user?.longName ?? "unknown".localized
+			let buttonText = String.localizedStringWithFormat("save.config %@".localized, nodeName)
+			Button(buttonText) {
+				onConfirmation()
+			}
+		} message: {
+			Text("config.save.confirm")
+		}
+	}
+}

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -28,6 +28,7 @@ struct Settings: View {
 		case displayConfig
 		case networkConfig
 		case positionConfig
+		case powerConfig
 		case ambientLightingConfig
 		case cannedMessagesConfig
 		case detectionSensorConfig
@@ -223,6 +224,15 @@ struct Settings: View {
 							Text("position")
 						}
 						.tag(SettingsSidebar.positionConfig)
+
+						NavigationLink {
+							PowerConfig(node: nodes.first(where: { $0.num == selectedNode }))
+						} label: {
+							Image(systemName: "bolt.fill")
+								.symbolRenderingMode(.hierarchical)
+							Text("power")
+						}
+						.tag(SettingsSidebar.powerConfig)
 					}
 					Section("module.configuration") {
 						if #available(iOS 17.0, macOS 14.0, *) {

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -185,6 +185,7 @@
 "mesh.log.nodeinfo.received %@"="Node info received for: %@";
 "mesh.log.position.config %@"="Positon config received: %@";
 "mesh.log.position.received %@"="Position Packet received from node: %@";
+"mesh.log.power.config %@"="Power config received: %@";
 "mesh.log.rangetest.config %@"="Range Test module config received: %@";
 "mesh.log.ringtone.config %@"="RTTTL Ringtone config received: %@";
 "mesh.log.routing.message %@ %@"="Routing received for RequestID: %@ Ack Status: %@";
@@ -231,6 +232,16 @@
 "phone.gps.interval.description"="How frequently your phone will send your location to the device, location updates to the mesh are managed by the device.";
 "position"="Position";
 "position.config"="Position Config";
+"power"="Power";
+"power.adc.override"="ADC Override";
+"power.adc.multiplier"="Multiplier";
+"power.config"="Power Config";
+"power.ls.secs"="Light Sleep Interval";
+"power.min.wake.secs"="Minimum Wake Interval";
+"power.save"="Power Save";
+"power.shutdown.on.power.loss"="Shutdown on Power Loss";
+"power.shutdown.after.secs"="After";
+"power.wait.bluetooth.secs"="Bluetooth Off After";
 "preferred.radio"="Preferred Radio";
 "radio.configuration"="Radio Configuration";
 "range.test"="Range Test";


### PR DESCRIPTION
Adds ability to configure power settings in the app. Also refactors two shared config views to greatly reduce lines of code: `ConfigHeader` and `SaveConfigButton`. I recommend reviewing without whitespace changes visible.

![IMG_FD41C01F4170-1](https://github.com/meshtastic/Meshtastic-Apple/assets/7528924/aa3a8295-1e7f-4c18-8ffa-cfc250927dd3)
![IMG_FD41C01F4170-2](https://github.com/meshtastic/Meshtastic-Apple/assets/7528924/00ae754a-a089-4095-aa3a-703e6d10b295)
