### PR TITLE
chore: add protobufs to git index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@
 ## User settings
 xcuserdata/
 
-## Generated Protobufs
-protobufs/
-
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
 *.xccheckout


### PR DESCRIPTION
The protobufs submodule was not properly tracked in the git index due to it being ignored, resulting in the following error (which is now fixed):

```
error: pathspec 'protobufs' did not match any file(s) known to git
```

By tracking the submodule it is now easier to discover from which version of protobufs the Swift definitions were generated.