### PR TITLE
Updated readme to include git submodule command and gen_protos.sh to check the directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ SwiftUI client applications for iOS, iPadOS and macOS.
   brew install swift-protobuf
   ```
 - check out the latest protobuf commit from the master branch
+  ```bash
+  git submodule update --init
+  ```
 - run:
   ```bash
   ./gen_proto.sh

--- a/gen_protos.sh
+++ b/gen_protos.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # simple sanity checking for repo
-if [ ! -d "../protobufs" ]; then
-   echo "Please check out the protobuf submodule by running: `git submodule update --init`"
+if [ ! -d "./protobufs" ]; then
+   echo 'Please check out the protobuf submodule by running: `git submodule update --init`'
   exit
 fi
 
 # simple sanity checking for executable
 if [ ! -x "$(which protoc)" ]; then
-  echo "Please install swift-protobuf by running: brew install swift-protobuf"
+  echo 'Please install swift-protobuf by running: `brew install swift-protobuf`'
   exit
 fi
 


### PR DESCRIPTION
I just set up the project for the first time and noticed a couple minor things:

I updated README.md to include a command for initializing the protobufs submodule
I also updated `gen_protos.sh` to check the right directory (`./protobufs`, not `../protobufs`)
Additionally updated the same to echo the git submodule command and added ``` to the second echo