### PR TITLE
Add mqtt status icon in channels with uplink/downlink enabled

### DIFF
--- a/Meshtastic/Views/Helpers/ConnectedDevice.swift
+++ b/Meshtastic/Views/Helpers/ConnectedDevice.swift
@@ -9,6 +9,7 @@ struct ConnectedDevice: View {
     var bluetoothOn: Bool
     var deviceConnected: Bool
     var name: String
+	var mqttProxyEnabled: Bool = false
 	var mqttProxyConnected: Bool = false
 	var phoneOnly: Bool = false
 
@@ -18,11 +19,11 @@ struct ConnectedDevice: View {
 			
 			if (phoneOnly && UIDevice.current.userInterfaceIdiom == .phone) || !phoneOnly {
 				if bluetoothOn {
-					if deviceConnected && mqttProxyConnected {
-						if mqttProxyConnected {
+					if deviceConnected && (mqttProxyEnabled || mqttProxyConnected) {
+						if (mqttProxyConnected || mqttProxyEnabled) {
 							Image(systemName: "iphone.gen3.radiowaves.left.and.right.circle.fill")
 								.imageScale(.large)
-								.foregroundColor(.green)
+								.foregroundColor(mqttProxyConnected ? .green : .gray)
 								.symbolRenderingMode(.hierarchical)
 						}
 					}

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -156,7 +156,10 @@ struct ChannelMessageList: View {
 					ConnectedDevice(
 						bluetoothOn: bleManager.isSwitchedOn,
 						deviceConnected: bleManager.connectedPeripheral != nil,
-						name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
+						name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?",
+						mqttProxyEnabled: channel.uplinkEnabled || channel.downlinkEnabled,
+						mqttProxyConnected: channel.uplinkEnabled || channel.downlinkEnabled ? bleManager.mqttProxyConnected : false
+					)
 				}
 			}
 		}

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -289,7 +289,7 @@ struct MQTTConfig: View {
 		.navigationTitle("mqtt.config")
 		.navigationBarItems(trailing:
 			ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?", mqttProxyConnected: bleManager.mqttProxyConnected)
+			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?", mqttProxyEnabled: self.enabled, mqttProxyConnected: bleManager.mqttProxyConnected)
 		})
 		.onChange(of: address) { newAddress in
 			if node != nil && node?.mqttConfig != nil {


### PR DESCRIPTION
First and foremost, please let me know if there are any styling issues with my code, I'm very rusty on iOS code generally and a relative newbie when it comes to SwiftUI.

This PR adds an icon in the channels detail view when uplink or downlink is enabled and also adds the status of the connection in the color of the icon as well.
This also adds the same connection icon in the MQT config settings screen

Here are some screenshots:  

![Frame 1](https://github.com/meshtastic/Meshtastic-Apple/assets/2348508/5353c373-fb4d-48db-b056-45ff2eb8d377)
