### PR TITLE
Make yellow/Fair RSSI possible

### DIFF
--- a/Meshtastic/Views/Helpers/LoRaSignalStrengthIndicator.swift
+++ b/Meshtastic/Views/Helpers/LoRaSignalStrengthIndicator.swift
@@ -85,7 +85,7 @@ func getRssiColor(rssi: Int32) -> Color {
 	if rssi > -115 {
 		/// Good
 		return .green
-	} else if rssi > -115 && rssi < -120 {
+	} else if rssi > -120 {
 		/// Fair
 		return .yellow
 	} else if rssi > -126 {


### PR DESCRIPTION
I'm guessing a bit, but I suspect this was the intent, but the inequalities are backwards (as clearly no number is both greater than -115 and less than -120).

This should make it so higher than -115 is green, -115 to -120 is yellow, -120 to -125 is orange, and below that is red.