### PR TITLE
Fix bug where MQTT was showing connected even if down/up was not enabled

### DIFF
--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -260,7 +260,7 @@ struct Connect: View {
 			.navigationTitle("bluetooth")
 			.navigationBarItems(leading: MeshtasticLogo(), trailing:
 									ZStack {
-				ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
+				ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?", mqttProxyConnected: bleManager.mqttProxyConnected, mqttTopic: bleManager.mqttManager.topic)
 			})
 		}
 		.sheet(isPresented: $invalidFirmwareVersion, onDismiss: didDismissSheet) {

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -159,7 +159,7 @@ struct ChannelMessageList: View {
 						name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?",
 
 						// mqttProxyConnected defaults to false, so if it's not enabled it will still be false
-						mqttProxyConnected: bleManager.mqttProxyConnected,
+						mqttProxyConnected: bleManager.mqttProxyConnected && (channel.uplinkEnabled || channel.downlinkEnabled),
 						mqttUplinkEnabled: channel.uplinkEnabled,
 						mqttDownlinkEnabled: channel.downlinkEnabled,
 						mqttTopic: bleManager.mqttManager.topic


### PR DESCRIPTION
The MQTT indicator was always showing connected on all channels, fixed that
Also added/fixed the connect screen so the indicator both shows the current connection status as well as the current topic