### PR TITLE
Made New Node notifications off by default

### DIFF
--- a/Settings.bundle/Root.plist
+++ b/Settings.bundle/Root.plist
@@ -92,7 +92,7 @@
 			<key>Key</key>
 			<string>newNodeNotifications</string>
 			<key>DefaultValue</key>
-			<true/>
+			<false/>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
The new node notification behavior should be optional as users will most likely start complaining about a large amount of notifications in large meshes. These notifications are intended more for power users.