### PR TITLE
2.3.6 working changes

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -1578,7 +1578,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.5;
+				MARKETING_VERSION = 2.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
@@ -1612,7 +1612,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.5;
+				MARKETING_VERSION = 2.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
@@ -1685,7 +1685,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.5;
+				MARKETING_VERSION = 2.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1718,7 +1718,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.5;
+				MARKETING_VERSION = 2.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Meshtastic/Extensions/UserDefaults.swift
+++ b/Meshtastic/Extensions/UserDefaults.swift
@@ -86,7 +86,7 @@ extension UserDefaults {
 	@UserDefault(.provideLocation, defaultValue: false)
 	static var provideLocation: Bool
 
-	@UserDefault(.provideLocationInterval, defaultValue: 0)
+	@UserDefault(.provideLocationInterval, defaultValue: 30)
 	static var provideLocationInterval: Int
 
 	@UserDefault(.mapLayer, defaultValue: .standard)

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -106,14 +106,24 @@ public func deleteUserMessages(user: UserEntity, context: NSManagedObjectContext
 	}
 }
 
-public func clearCoreDataDatabase(context: NSManagedObjectContext) {
+public func clearCoreDataDatabase(context: NSManagedObjectContext, includeRoutes: Bool) {
 
 	let persistenceController = PersistenceController.shared.container
 	for i in 0...persistenceController.managedObjectModel.entities.count-1 {
+		
 		let entity = persistenceController.managedObjectModel.entities[i]
 		let query = NSFetchRequest<NSFetchRequestResult>(entityName: entity.name!)
-		let deleteRequest = NSBatchDeleteRequest(fetchRequest: query)
-
+		var deleteRequest = NSBatchDeleteRequest(fetchRequest: query)
+		let entityName = entity.name ?? "UNK"
+		
+		if includeRoutes {
+			deleteRequest = NSBatchDeleteRequest(fetchRequest: query)
+		} else if !includeRoutes {
+			if !(entityName.contains("RouteEntity") || entityName.contains("LocationEntity")) {
+				print(entity.name?.lowercased())
+				deleteRequest = NSBatchDeleteRequest(fetchRequest: query)
+			}
+		}
 		do {
 			try context.executeAndMergeChanges(using: deleteRequest)
 		} catch let error as NSError {

--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -232,7 +232,7 @@ struct Connect: View {
 									if bleManager.connectedPeripheral != nil && bleManager.connectedPeripheral.peripheral.state == CBPeripheralState.connected {
 										bleManager.disconnectPeripheral()
 									}
-									clearCoreDataDatabase(context: context)
+									clearCoreDataDatabase(context: context, includeRoutes: false)
 									
 									let radio = bleManager.peripherals.first(where: { $0.peripheral.identifier.uuidString == selectedPeripherialId })
 									if radio != nil {

--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -121,6 +121,14 @@ struct Connect: View {
 										Text("Short Name: \(node?.user?.shortName ?? "?")")
 										Text("Long Name: \(node?.user?.longName ?? "unknown".localized)")
 										Text("BLE RSSI: \(bleManager.connectedPeripheral.rssi)")
+										Button {
+											if !bleManager.sendShutdown(fromUser: node!.user!, toUser: node!.user!, adminIndex: node!.myInfo!.adminIndex) {
+												print("Shutdown Failed")
+											}
+											
+										} label: {
+											Label("Power Off", systemImage: "power")
+										}
 									}
 								}
 								if isUnsetRegion {
@@ -234,7 +242,7 @@ struct Connect: View {
 							}
 							.textCase(nil)
 						}
-
+ 
 					} else {
 						Text("bluetooth.off")
 							.foregroundColor(.red)

--- a/Meshtastic/Views/Messages/MessageContextMenuItems.swift
+++ b/Meshtastic/Views/Messages/MessageContextMenuItems.swift
@@ -53,9 +53,14 @@ struct MessageContextMenuItems: View {
 				let messageDate = Date(timeIntervalSince1970: TimeInterval(message.messageTimestamp))
 				Text("\(messageDate.formattedDate(format: MessageText.dateFormatString))").foregroundColor(.gray)
 			}
-			if !isCurrentUser {
+			if !isCurrentUser && !(message.fromUser?.userNode?.viaMqtt ?? false) &&  message.fromUser?.userNode?.hopsAway ?? -1 == 0 {
 				VStack {
 					Text("SNR \(String(format: "%.2f", message.snr)) dB")
+					Text("RSSI \(String(format: "%.2f", message.rssi)) dBm")
+				}
+			} else if !isCurrentUser && !(message.fromUser?.userNode?.viaMqtt ?? false) {
+				VStack {
+					Text("Hops Away \(message.fromUser?.userNode?.hopsAway ?? 0)) dB")
 				}
 			}
 			if isCurrentUser && message.receivedACK {
@@ -77,10 +82,6 @@ struct MessageContextMenuItems: View {
 					let sixMonthsAgo = Calendar.current.date(byAdding: .month, value: -6, to: Date())
 					if ackDate >= sixMonthsAgo! {
 						Text("Ack Time: \(ackDate.formattedDate(format: "h:mm:ss.SSSS a"))")
-							.foregroundColor(.gray)
-					} else {
-						Text("unknown.age")
-							.font(.caption2)
 							.foregroundColor(.gray)
 					}
 				}

--- a/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
@@ -18,7 +18,7 @@ struct TextMessageField: View {
 		HStack {
 			if destination.showAlertButton {
 				Spacer()
-				AlertButton { typingMessage += "🔔 Alert Bell Character! \u{7}" }
+				AlertButton { typingMessage += "🔔 Alert Bell! \u{7}" }
 			}
 			Spacer()
 			RequestPositionButton(action: requestPosition)
@@ -131,7 +131,7 @@ private extension MessageDestination {
 
 	var showAlertButton: Bool {
 		switch self {
-		case .user: return false
+		case .user: return true
 		case .channel: return true
 		}
 	}

--- a/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
@@ -122,12 +122,12 @@ struct DeviceMetricsLog: View {
 				} else {
 					ScrollView {
 						let columns = [
-							GridItem(.flexible(minimum: 25, maximum: 45), spacing: 0.1),
 							GridItem(.flexible(minimum: 25, maximum: 50), spacing: 0.1),
-							GridItem(.flexible(minimum: 30, maximum: 65), spacing: 0.1),
-							GridItem(.flexible(minimum: 30, maximum: 65), spacing: 0.1),
-							GridItem(.flexible(minimum: 30, maximum: 60), spacing: 0.1),
-							GridItem(.flexible(minimum: 130, maximum: 200), spacing: 0.1)
+							GridItem(.flexible(minimum: 25, maximum: 50), spacing: 0.1),
+							GridItem(.flexible(minimum: 25, maximum: 60), spacing: 0.1),
+							GridItem(.flexible(minimum: 25, maximum: 60), spacing: 0.1),
+							GridItem(.flexible(minimum: 25, maximum: 50), spacing: 0.1),
+							GridItem(.flexible(minimum: 130, maximum: 175), spacing: 0.1)
 						]
 						LazyVGrid(columns: columns, alignment: .leading, spacing: 1) {
 							GridRow {

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -75,7 +75,7 @@ struct AppSettings: View {
 					) {
 						Button("Erase all app data?", role: .destructive) {
 							bleManager.disconnectPeripheral()
-							clearCoreDataDatabase(context: context)
+							clearCoreDataDatabase(context: context, includeRoutes: true)
 							context.refreshAllObjects()
 							UserDefaults.standard.reset()
 						}

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -294,9 +294,13 @@ struct Channels: View {
 }
 
 func firstMissingChannelIndex(_ indexes: [Int]) -> Int {
-	for element in 1...indexes.count {
-		if !indexes.contains(element) {
-			return element
+	var smallestIndex = 1
+	if indexes.isEmpty { return smallestIndex }
+	if smallestIndex <= indexes.count {
+		for element in smallestIndex...indexes.count {
+			if !indexes.contains(element) {
+				return element
+			}
 		}
 	}
 	return indexes.count + 1

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -153,7 +153,7 @@ struct DeviceConfig: View {
 							if bleManager.sendNodeDBReset(fromUser: node!.user!, toUser: node!.user!) {
 								DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
 									bleManager.disconnectPeripheral()
-									clearCoreDataDatabase(context: context)
+									clearCoreDataDatabase(context: context, includeRoutes: false)
 								}
 								
 							} else {
@@ -178,7 +178,7 @@ struct DeviceConfig: View {
 							if bleManager.sendFactoryReset(fromUser: node!.user!, toUser: node!.user!) {
 								DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
 									bleManager.disconnectPeripheral()
-									clearCoreDataDatabase(context: context)
+									clearCoreDataDatabase(context: context, includeRoutes: false)
 								}
 							} else {
 								print("Factory Reset Failed")

--- a/Meshtastic/Views/Settings/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware.swift
@@ -12,7 +12,7 @@ struct Firmware: View {
 	@Environment(\.managedObjectContext) var context
 	@EnvironmentObject var bleManager: BLEManager
 	var node: NodeInfoEntity?
-	@State var minimumVersion = "2.3.4"
+	@State var minimumVersion = "2.3.5"
 	@State var version = ""
 	@State private var currentDevice: DeviceHardware?
 	@State private var latestStable: FirmwareRelease?

--- a/Meshtastic/Views/Settings/RouteRecorder.swift
+++ b/Meshtastic/Views/Settings/RouteRecorder.swift
@@ -248,6 +248,7 @@ struct RouteRecorder: View {
 											let nsError = error as NSError
 											print("💥 Error Saving RouteEntity from the Route Recorder \(nsError)")
 										}
+										isShowingDetails = false
 									} label: {
 										Label("finish", systemImage: "flag.checkered")
 									}


### PR DESCRIPTION
*  Fix device metrics grid column sizing
* Show alert bell button on direct messages
* Fix some crashes
* Add power off to connect context menu
* Add hops away to message details, clean up RSSI and SNR visibility
* Set provide location default to 30 seconds
* Only delete routes on factory reset and clear app data
* Close route recorder modal when finished