### PR TITLE
Fix Lint & Compiler Warnings

### DIFF
--- a/Meshtastic/Export/LogDocument.swift
+++ b/Meshtastic/Export/LogDocument.swift
@@ -11,12 +11,10 @@ struct LogDocument: FileDocument {
 	}
 
 	init(configuration: ReadConfiguration) throws {
-		guard let data = configuration.file.regularFileContents,
-			  let string = String(data: data, encoding: .utf8)
-		else {
+		guard let data = configuration.file.regularFileContents else {
 			throw CocoaError(.fileReadCorruptFile)
 		}
-		logFile = string
+		logFile = String(decoding: data, as: UTF8.self)
 	}
 
 	func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {

--- a/Meshtastic/Helpers/MeshLogger.swift
+++ b/Meshtastic/Helpers/MeshLogger.swift
@@ -32,7 +32,7 @@ class MeshLogger {
 				fileHandle.closeFile()
 			} else {
 				try data.write(to: logFile, options: .atomicWrite)
-				let log = String(data: data, encoding: .utf8) ?? "unknown".localized
+				let log = String(decoding: data, as: UTF8.self)
 				Logger.mesh.notice("\(log)")
 			}
 		} catch {

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -73,7 +73,6 @@ struct Messages: View {
 
 					if let urlComponent = URLComponents(string: newPath ?? "") {
 						let queryItems = urlComponent.queryItems
-						let messageId = queryItems?.first(where: { $0.name == "messageId" })?.value
 						let channel = queryItems?.first(where: { $0.name == "channel" })?.value
 
 						if let channel {

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -76,7 +76,7 @@ struct MeshMapContent: MapContent {
 						}
 					}
 				}
-				.onTapGesture { location in
+				.onTapGesture { _ in
 					selectedPosition = (selectedPosition == position ? nil : position)
 				}
 			}

--- a/Meshtastic/Views/Settings/Routes.swift
+++ b/Meshtastic/Views/Settings/Routes.swift
@@ -58,21 +58,22 @@ struct Routes: View {
 						}
 
 						do {
-							guard let fileContent = String(data: try Data(contentsOf: selectedFile), encoding: .utf8) else { return }
+							let data = try Data(contentsOf: selectedFile)
+							let fileContent = String(decoding: data, as: UTF8.self)
 							let routeName = selectedFile.lastPathComponent.dropLast(4)
 							let lines = fileContent.components(separatedBy: "\n")
-							let headers = lines.first?.components(separatedBy: ",")
-							var latIndex = -1
-							var longIndex = -1
-							for index in headers!.indices {
-								Logger.services.debug("\(index): \( headers![index])")
-								if headers![index].trimmingCharacters(in: .whitespaces) == "Latitude" {
+							guard let headers = lines.first?.components(separatedBy: ",") else { return }
+							var latIndex: Int?
+							var longIndex: Int?
+							for index in headers.indices {
+								Logger.services.debug("\(index): \(headers[index])")
+								if headers[index].trimmingCharacters(in: .whitespaces) == "Latitude" {
 									latIndex = index
-								} else if headers![index].trimmingCharacters(in: .whitespaces) == "Longitude" {
+								} else if headers[index].trimmingCharacters(in: .whitespaces) == "Longitude" {
 									longIndex = index
 								}
 							}
-							if latIndex >= 0 && longIndex >= 0 {
+							if let latIndex, let longIndex {
 								let newRoute = RouteEntity(context: context)
 								newRoute.name = String(routeName)
 								newRoute.id = Int32.random(in: Int32(Int8.max) ... Int32.max)
@@ -83,8 +84,8 @@ struct Routes: View {
 								lines.dropFirst().forEach { line in
 									let data = line.components(separatedBy: ",")
 									if data.count > 1 {
-										let latitude = latIndex >= 0 ? data[latIndex].trimmingCharacters(in: .whitespaces) : "0"
-										let longitude = longIndex >= 0 ? data[longIndex].trimmingCharacters(in: .whitespaces) : "0"
+										let latitude = data[latIndex].trimmingCharacters(in: .whitespaces)
+										let longitude = data[longIndex].trimmingCharacters(in: .whitespaces)
 										let loc = LocationEntity(context: context)
 										loc.latitudeI = Int32((Double(latitude) ?? 0) * 1e7)
 										loc.longitudeI = Int32((Double(longitude) ?? 0) * 1e7)


### PR DESCRIPTION
This change addresses a few lint warnings and removes an unresolved closure parameter. 

While fixing the warning in `Route.swift`, I've also cleaned up the way that Lat / Long were handled with a -1 sentinel value, and converted those local variables to `Optional`s