### PR TITLE
Refactor how packets are parsed and persisted to the data model

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		25A978592C124FA70003AAE7 /* NodeInfoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25A978572C124FA70003AAE7 /* NodeInfoExtensions.swift */; };
 		6DA39D8E2A92DC52007E311C /* MeshtasticAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA39D8D2A92DC52007E311C /* MeshtasticAppDelegate.swift */; };
 		6DEDA55A2A957B8E00321D2E /* DetectionSensorLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEDA5592A957B8E00321D2E /* DetectionSensorLog.swift */; };
 		6DEDA55C2A9592F900321D2E /* MessageEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEDA55B2A9592F900321D2E /* MessageEntityExtension.swift */; };
@@ -240,6 +241,7 @@
 
 /* Begin PBXFileReference section */
 		258EE1262C0E833D0025A5FB /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		25A978572C124FA70003AAE7 /* NodeInfoExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeInfoExtensions.swift; sourceTree = "<group>"; };
 		6DA39D8D2A92DC52007E311C /* MeshtasticAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshtasticAppDelegate.swift; sourceTree = "<group>"; };
 		6DEDA5592A957B8E00321D2E /* DetectionSensorLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectionSensorLog.swift; sourceTree = "<group>"; };
 		6DEDA55B2A9592F900321D2E /* MessageEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEntityExtension.swift; sourceTree = "<group>"; };
@@ -513,6 +515,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		25A978582C124FA70003AAE7 /* Protobufs */ = {
+			isa = PBXGroup;
+			children = (
+				25A978572C124FA70003AAE7 /* NodeInfoExtensions.swift */,
+			);
+			path = Protobufs;
+			sourceTree = "<group>";
+		};
 		C9483F6B2773016700998F6B /* MapKitMap */ = {
 			isa = PBXGroup;
 			children = (
@@ -951,6 +961,7 @@
 		DDDB443E29F79A9400EE2349 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				25A978582C124FA70003AAE7 /* Protobufs */,
 				DD007BB12AA59B9A00F5FA12 /* CoreData */,
 				DDFFA7462B3A7F3C004730DB /* Bundle.swift */,
 				DDDB444529F8A96500EE2349 /* Character.swift */,
@@ -1314,6 +1325,7 @@
 				DD0F791B28713C8A00A6FDAD /* AdminMessageList.swift in Sources */,
 				DD3CC6BC28E366DF00FA9159 /* Meshtastic.xcdatamodeld in Sources */,
 				DDC4C9FF2A8D982900CE201C /* DetectionSensorConfig.swift in Sources */,
+				25A978592C124FA70003AAE7 /* NodeInfoExtensions.swift in Sources */,
 				D9C983A22B79D1A600BDBE6A /* RequestPositionButton.swift in Sources */,
 				DDDB26442AAC0206003AFCB7 /* NodeDetail.swift in Sources */,
 				DD5E5210298EE33B00D21B61 /* telemetry.pb.swift in Sources */,

--- a/Meshtastic/Extensions/CoreData/PositionEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/PositionEntityExtension.swift
@@ -11,7 +11,22 @@ import MapKit
 import SwiftUI
 
 extension PositionEntity {
-
+	convenience init(
+		context: NSManagedObjectContext,
+		nodeInfo: NodeInfo
+	) {
+		self.init(context: context)
+		self.latest = true
+		self.seqNo = Int32(nodeInfo.position.seqNumber)
+		self.latitudeI = nodeInfo.position.latitudeI
+		self.longitudeI = nodeInfo.position.longitudeI
+		self.altitude = nodeInfo.position.altitude
+		self.satsInView = Int32(nodeInfo.position.satsInView)
+		self.speed = Int32(nodeInfo.position.groundSpeed)
+		self.heading = Int32(nodeInfo.position.groundTrack)
+		self.time = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.position.time)))
+	}
+	
 	static func allPositionsFetchRequest() -> NSFetchRequest<PositionEntity> {
 		let request: NSFetchRequest<PositionEntity> = PositionEntity.fetchRequest()
 		request.fetchLimit = 1000

--- a/Meshtastic/Extensions/CoreData/UserEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/UserEntityExtension.swift
@@ -9,6 +9,31 @@ import Foundation
 import CoreData
 
 extension UserEntity {
+	convenience init(
+		context: NSManagedObjectContext,
+		user: User,
+		num: Int
+	) {
+		self.init(context: context)
+		self.userId = user.id
+		self.num = Int64(num)
+		self.longName = user.longName
+		self.shortName = user.shortName
+		self.hwModel = String(describing: user.hwModel).uppercased()
+		self.isLicensed = user.isLicensed
+		self.role = Int32(user.role.rawValue)
+	}
+	
+	convenience init(context: NSManagedObjectContext, num: Int) {
+		self.init(context: context)
+		self.num = Int64(num)
+		let userId = String(format: "!%2X", num)
+		self.userId = userId
+		let last4 = String(userId.suffix(4))
+		self.longName = "Meshtastic \(last4)"
+		self.shortName = last4
+		self.hwModel = "UNSET"
+	}
 
 	var messageList: [MessageEntity] {
 		self.value(forKey: "allMessages") as? [MessageEntity] ?? [MessageEntity]()
@@ -26,16 +51,4 @@ extension UserEntity {
 		let unreadMessages = messageList.filter { ($0 as AnyObject).read == false }
 		return unreadMessages.count
 	}
-}
-
-public func createUser(num: Int64, context: NSManagedObjectContext) -> UserEntity {
-	let newUser = UserEntity(context: context)
-	newUser.num = Int64(num)
-	let userId = String(format: "%2X", num)
-	newUser.userId = "!\(userId)"
-	let last4 = String(userId.suffix(4))
-	newUser.longName = "Meshtastic \(last4)"
-	newUser.shortName = last4
-	newUser.hwModel = "UNSET"
-	return newUser
 }

--- a/Meshtastic/Extensions/Protobufs/NodeInfoExtensions.swift
+++ b/Meshtastic/Extensions/Protobufs/NodeInfoExtensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension NodeInfo {
+	var isValidPosition: Bool {
+		hasPosition &&
+			position.longitudeI != 0 &&
+			position.latitudeI != 0 &&
+			position.latitudeI != 373346000 &&
+			position.longitudeI != -1220090000
+	}
+}

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -166,20 +166,14 @@ func upsertNodeInfoPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 
 			if let newUserMessage = try? User(serializedData: packet.decoded.payload) {
 
-				if newUserMessage.id.isEmpty {
-					if packet.from > Int16.max {
-						let newUser = createUser(num: Int64(packet.from), context: context)
-						newNode.user = newUser
-					}
+				if newUserMessage.id.isEmpty, packet.from > Int16.max {
+					newNode.user = UserEntity(context: context, num: Int(packet.from))
 				} else {
-
-					let newUser = UserEntity(context: context)
-					newUser.userId = newUserMessage.id
-					newUser.num = Int64(packet.from)
-					newUser.longName = newUserMessage.longName
-					newUser.shortName = newUserMessage.shortName
-					newUser.role = Int32(newUserMessage.role.rawValue)
-					newUser.hwModel = String(describing: newUserMessage.hwModel).uppercased()
+					let newUser = UserEntity(
+						context: context,
+						user: newUserMessage,
+						num: Int(packet.from)
+					)
 					newNode.user = newUser
 
 					if UserDefaults.newNodeNotifications {
@@ -199,13 +193,13 @@ func upsertNodeInfoPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 				}
 			} else {
 				if packet.from > Int16.max {
-					let newUser = createUser(num: Int64(packet.from), context: context)
+					let newUser = UserEntity(context: context, num: Int(packet.from))
 					fetchedNode[0].user = newUser
 				}
 			}
 
 			if newNode.user == nil && packet.from > Int16.max {
-				newNode.user = createUser(num: Int64(packet.from), context: context)
+				newNode.user = UserEntity(context: context, num: Int(packet.from))
 			}
 
 			let myInfoEntity = MyInfoEntity(context: context)
@@ -265,8 +259,8 @@ func upsertNodeInfoPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 				fetchedNode[0].hopsAway = Int32(packet.hopStart - packet.hopLimit)
 			}
 			if fetchedNode[0].user == nil {
-				let newUser = createUser(num: Int64(packet.from), context: context)
-				fetchedNode[0].user! = newUser
+				let newUser = UserEntity(context: context, num: Int(packet.from))
+				fetchedNode[0].user = newUser
 			}
 			do {
 				try context.save()


### PR DESCRIPTION
## What?

This change extracts several repeated segments of code that map the fields in a mesh packet onto a CoreData model into convenience initializers on the CoreData models. 

## Why?

By using these new convenience initializers, the field mapping is only done in one place, and can prevent a developer from accidentally missing a field when persisting data.

## How is this tested?

I ran a debug build on an iPhone 15 Pro Max connected to a Heltec V3, and hooked up MQTT. I was able to detect another local node (mine) and many more over MQTT. I let the app run for a while, and continue to populate the node list over MQTT.

I noticed that some of the "LoRa" nodes weren't actually detected via my radio, so I'm thinking there is another underlying issue about where and how that field is set.

## Screenshots

|  | List | Filter | 
|:-:|:-:|:-:|
| LoRa | ![IMG_3397](https://github.com/meshtastic/Meshtastic-Apple/assets/17112724/d2abbd90-aaae-4485-adb4-555678bcffb7)  | ![IMG_3398](https://github.com/meshtastic/Meshtastic-Apple/assets/17112724/45a956db-9761-4f10-bf33-6b617f0dde30) |
| MQTT | ![IMG_3399](https://github.com/meshtastic/Meshtastic-Apple/assets/17112724/d220e648-b1f4-44fe-b6cd-73a9ed42cb43) | ![IMG_3400](https://github.com/meshtastic/Meshtastic-Apple/assets/17112724/474dbd87-2cd1-4e41-9d55-6b9eda76b09e) |
