### PR TITLE
Fix CoreData crash

### DIFF
--- a/Meshtastic/Extensions/CoreData/ExternalNotificationConfigEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/ExternalNotificationConfigEntityExtension.swift
@@ -5,7 +5,7 @@ extension ExternalNotificationConfigEntity {
 		context: NSManagedObjectContext,
 		config: ModuleConfig.ExternalNotificationConfig
 	) {
-		self.init()
+		self.init(context: context)
 		self.enabled = config.enabled
 		self.usePWM = config.usePwm
 		self.alertBell = config.alertBell


### PR DESCRIPTION
Forgot to call the designated initializer during the refactor