### PR TITLE
Fix Contact List Duplicates

### DIFF
--- a/Meshtastic/Meshtastic.xcdatamodeld/MeshtasticDataModelV 37.xcdatamodel/contents
+++ b/Meshtastic/Meshtastic.xcdatamodeld/MeshtasticDataModelV 37.xcdatamodel/contents
@@ -443,6 +443,11 @@
         <fetchedProperty name="detectionSensorMessages" optional="YES">
             <fetchRequest name="fetchedPropertyFetchRequest" entity="MessageEntity" predicateString="(fromUser.num == $FETCH_SOURCE.num) AND portNum = 10"/>
         </fetchedProperty>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="num"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
     </entity>
     <entity name="WaypointEntity" representedClassName="WaypointEntity" syncable="YES" codeGenerationType="class">
         <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>


### PR DESCRIPTION
## What?

This change adds a constraint on `UserEntity` `num` field, so that the Contacts list won't populate with duplicate entries.

## How is it tested?

I have a 2 node mesh where i caused one node to send a bunch of packets by powering off and on repeatedly, and saw that it created several user entities before these changes.

After this change, only one entry shows up in the Messages -> Direct Messages section