### PR TITLE
Fix minor comma typo

### DIFF
--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -234,7 +234,7 @@ struct PositionConfig: View {
 
 					if includeDop {
 						Toggle(isOn: $includeHvdop) {
-							Text("If DOP is set use, HDOP / VDOP values instead of PDOP")
+							Text("If DOP is set, use HDOP / VDOP values instead of PDOP")
 						}
 						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 					}


### PR DESCRIPTION
Minor typo, comma was in the wrong place, corrected.