### PR TITLE
Text formatting fix for Hops Away

### DIFF
--- a/Meshtastic/Views/Messages/MessageContextMenuItems.swift
+++ b/Meshtastic/Views/Messages/MessageContextMenuItems.swift
@@ -60,7 +60,7 @@ struct MessageContextMenuItems: View {
 				}
 			} else if !isCurrentUser && !(message.fromUser?.userNode?.viaMqtt ?? false) {
 				VStack {
-					Text("Hops Away \(message.fromUser?.userNode?.hopsAway ?? 0)) dB")
+					Text("Hops Away: \(message.fromUser?.userNode?.hopsAway ?? 0)")
 				}
 			}
 			if isCurrentUser && message.receivedACK {


### PR DESCRIPTION
The 'Hops Away' contextual menu item for messages was suffixed with a close bracket and 'dB'.
But hops are not measured in dB.

I believe this is a copy/paste bug.
