### PR TITLE
Fix Issues With Empty User Information

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -556,20 +556,23 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 						let newConnection = UserDefaults.preferredPeripheralNum != Int(myInfo?.myNodeNum ?? 0)
 											
 						if newConnection {
-							let container = NSPersistentContainer(name : "Meshtastic")
-							guard let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-								Logger.data.error("nil File path for back")
-								return
-							}
-							do {
-								disconnectPeripheral(reconnect: false)
-								try container.restorePersistentStore(from: url.appendingPathComponent("backups").appendingPathComponent("\(UserDefaults.preferredPeripheralNum)").appendingPathComponent("Meshtastic.sqlite"))
-								UserDefaults.preferredPeripheralNum = Int(myInfo?.myNodeNum ?? 0)
-								context?.reset()
-								connectTo(peripheral: peripheral)
-								Logger.data.notice("🗂️ Restored Core data for /\(UserDefaults.preferredPeripheralNum)")
-							} catch {
-								Logger.data.error("Copy error: \(error)")
+							let container = NSPersistentContainer(name: "Meshtastic")
+							if let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+								let databasePath = url.appendingPathComponent("backups")
+									.appendingPathComponent("\(UserDefaults.preferredPeripheralNum)")
+									.appendingPathComponent("Meshtastic.sqlite")
+								if FileManager.default.fileExists(atPath: databasePath.path) {
+									do {
+										disconnectPeripheral(reconnect: false)
+										try container.restorePersistentStore(from: databasePath)
+										UserDefaults.preferredPeripheralNum = Int(myInfo?.myNodeNum ?? 0)
+										context?.reset()
+										connectTo(peripheral: peripheral)
+										Logger.data.notice("🗂️ Restored Core data for /\(UserDefaults.preferredPeripheralNum)")
+									} catch {
+										Logger.data.error("Copy error: \(error)")
+									}
+								}
 							}
 						}
 						


### PR DESCRIPTION
This change fixes an issue where the node list would sometimes show "Unknown" for several nodes. This was happening because we were relying on outdated objects from the CoreData object graph.

This change also adds a check for a file path before attempting a backup & restore, since this action could sometimes cause bluetooth devices to never successfully reconnect.