### PR TITLE
Code Cleanup: Refactor a bunch of force_unwrapping and nil checks to use `if let`

### DIFF
--- a/Meshtastic.xcodeproj/xcshareddata/xcschemes/WidgetsExtension.xcscheme
+++ b/Meshtastic.xcodeproj/xcshareddata/xcschemes/WidgetsExtension.xcscheme
@@ -89,7 +89,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
-      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Meshtastic/Views/MapKitMap/NodeMapMapkit.swift
+++ b/Meshtastic/Views/MapKitMap/NodeMapMapkit.swift
@@ -150,13 +150,15 @@ struct NodeMapMapkit: View {
 						.presentationDragIndicator(.automatic)
 				})
 				.navigationBarTitle(String(node.user?.longName ?? "unknown".localized), displayMode: .inline)
-				.navigationBarItems(trailing:
-					ZStack {
-					ConnectedDevice(
-						bluetoothOn: bleManager.isSwitchedOn,
-						deviceConnected: bleManager.connectedPeripheral != nil,
-						name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-				})
+				.navigationBarItems(
+					trailing: ZStack {
+						ConnectedDevice(
+							bluetoothOn: bleManager.isSwitchedOn,
+							deviceConnected: bleManager.connectedPeripheral != nil,
+							name: bleManager.connectedPeripheral?.shortName ?? "?"
+						)
+					}
+				)
 			}
 			.padding(.bottom, 2)
 		}

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -28,8 +28,8 @@ struct ChannelMessageList: View {
 			ScrollViewReader { scrollView in
 				ScrollView {
 					LazyVStack {
-						ForEach( channel.allPrivateMessages ) { (message: MessageEntity) in
-							let currentUser: Bool = (Int64(preferredPeripheralNum) == message.fromUser?.num ? true : false)
+						ForEach(channel.allPrivateMessages) { (message: MessageEntity) in
+							let currentUser: Bool = Int64(preferredPeripheralNum) == message.fromUser?.num
 							if message.replyID > 0 {
 								let messageReply = channel.allPrivateMessages.first(where: { $0.messageId == message.replyID })
 								HStack {
@@ -46,8 +46,9 @@ struct ChannelMessageList: View {
 								}
 							}
 							HStack(alignment: .bottom) {
-								if currentUser { Spacer(minLength: 50) }
-								if !currentUser {
+								if currentUser {
+									Spacer(minLength: 50)
+								} else {
 									CircleText(text: message.fromUser?.shortName ?? "?", color: Color(UIColor(hex: UInt32(message.fromUser?.num ?? 0))), circleSize: 44)
 										.padding(.all, 5)
 										.offset(y: -7)
@@ -56,8 +57,8 @@ struct ChannelMessageList: View {
 								VStack(alignment: currentUser ? .trailing : .leading) {
 									let isDetectionSensorMessage = message.portNum == Int32(PortNum.detectionSensorApp.rawValue)
 
-									if !currentUser && message.fromUser != nil {
-										Text("\(message.fromUser?.longName ?? "unknown".localized ) (\(message.fromUser?.userId ?? "?"))")
+									if !currentUser, let fromUser = message.fromUser {
+										Text("\(fromUser.longName ?? "unknown".localized) (\(fromUser.userId ?? "?"))")
 											.font(.caption)
 											.foregroundColor(.gray)
 											.offset(y: 8)
@@ -166,8 +167,7 @@ struct ChannelMessageList: View {
 					ConnectedDevice(
 						bluetoothOn: bleManager.isSwitchedOn,
 						deviceConnected: bleManager.connectedPeripheral != nil,
-						name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?",
-
+						name: bleManager.connectedPeripheral?.shortName ?? "?",
 						// mqttProxyConnected defaults to false, so if it's not enabled it will still be false
 						mqttProxyConnected: bleManager.mqttProxyConnected && (channel.uplinkEnabled || channel.downlinkEnabled),
 						mqttUplinkEnabled: channel.uplinkEnabled,

--- a/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
@@ -83,7 +83,7 @@ struct TextMessageField: View {
 	}
 
 	private func requestPosition() {
-		let userLongName = bleManager.connectedPeripheral != nil ? bleManager.connectedPeripheral.longName : "Unknown"
+		let userLongName = bleManager.connectedPeripheral?.longName ?? "Unknown"
 		sendPositionWithMessage = true
 		typingMessage =  "📍 " + userLongName + " \(destination.positionShareMessage)."
 	}

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -150,7 +150,8 @@ struct UserMessageList: View {
 					ConnectedDevice(
 						bluetoothOn: bleManager.isSwitchedOn,
 						deviceConnected: bleManager.connectedPeripheral != nil,
-						name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
+						name: bleManager.connectedPeripheral?.shortName ?? "?"
+					)
 				}
 			}
 		}

--- a/Meshtastic/Views/Nodes/DetectionSensorLog.swift
+++ b/Meshtastic/Views/Nodes/DetectionSensorLog.swift
@@ -120,10 +120,15 @@ struct DetectionSensorLog: View {
 		}
 		.navigationTitle("detection.sensor.log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-				ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context

--- a/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
@@ -218,10 +218,15 @@ struct DeviceMetricsLog: View {
 		}
 		.navigationTitle("device.metrics.log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-				ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context

--- a/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
@@ -201,10 +201,15 @@ struct EnvironmentMetricsLog: View {
 
 		.navigationTitle("Environment Metrics Log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context

--- a/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
@@ -122,7 +122,7 @@ struct NodeMapSwiftUI: View {
 		ConnectedDevice(
 			bluetoothOn: bleManager.isSwitchedOn,
 			deviceConnected: bleManager.connectedPeripheral != nil,
-			name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?"
+			name: bleManager.connectedPeripheral?.shortName ?? "?"
 		)
 	}
 

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -163,9 +163,16 @@ struct MeshMap: View {
 				.padding(5)
 			}
 		}
-		.navigationBarItems(leading: MeshtasticLogo(), trailing: ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			leading: MeshtasticLogo(),
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			UIApplication.shared.isIdleTimerDisabled = true
 

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -54,15 +54,14 @@ struct NodeList: View {
 //				}
 //			}
 
-			let connectedNodeNum = Int(bleManager.connectedPeripheral != nil ? bleManager.connectedPeripheral?.num ?? 0 : 0)
+			let connectedNodeNum = Int(bleManager.connectedPeripheral?.num ?? 0)
 			let connectedNode = nodes.first(where: { $0.num == connectedNodeNum })
 			List(nodes, id: \.self, selection: $selectedNode) { node in
 
 				NodeListItem(node: node,
-							 connected: bleManager.connectedPeripheral != nil && bleManager.connectedPeripheral?.num ?? -1 == node.num,
-							 connectedNode: (bleManager.connectedPeripheral != nil ? bleManager.connectedPeripheral?.num ?? -1 : -1))
+							 connected: (bleManager.connectedPeripheral?.num ?? -1) == node.num,
+							 connectedNode: bleManager.connectedPeripheral?.num ?? -1)
 				.contextMenu {
-
 					Button {
 						if !node.favorite {
 
@@ -107,7 +106,7 @@ struct NodeList: View {
 						} label: {
 							Label(node.user!.mute ? "Show Alerts" : "Hide Alerts", systemImage: node.user!.mute ? "bell" : "bell.slash")
 						}
-						if bleManager.connectedPeripheral != nil && node.num != connectedNodeNum {
+						if bleManager.connectedPeripheral != nil, node.num != connectedNodeNum {
 							Button {
 								let positionSent = bleManager.sendPosition(
 									channel: node.channel,
@@ -123,8 +122,7 @@ struct NodeList: View {
 							} label: {
 								Label("Exchange Positions", systemImage: "arrow.triangle.2.circlepath")
 							}
-						}
-						if bleManager.connectedPeripheral != nil && connectedNodeNum != node.num {
+							
 							Button {
 								let success = bleManager.sendTraceRouteRequest(destNum: node.user?.num ?? 0, wantResponse: true)
 								if success {
@@ -234,15 +232,17 @@ struct NodeList: View {
 				}
 			}
 			.navigationSplitViewColumnWidth(min: 100, ideal: 250, max: 500)
-			.navigationBarItems(leading:
-				MeshtasticLogo(),
-				trailing:
-					ZStack {
+			.navigationBarItems(
+				leading: MeshtasticLogo(),
+				trailing: ZStack {
 					ConnectedDevice(
 						bluetoothOn: bleManager.isSwitchedOn,
 						deviceConnected: bleManager.connectedPeripheral != nil,
-						name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?", phoneOnly: true)
-				})
+						name: bleManager.connectedPeripheral?.shortName ?? "?",
+						phoneOnly: true
+					)
+				}
+			)
 		} content: {
 			if let node = selectedNode {
 				NavigationStack {
@@ -250,8 +250,7 @@ struct NodeList: View {
 						.edgesIgnoringSafeArea([.leading, .trailing])
 						.navigationBarTitle(String(node.user?.longName ?? "unknown".localized), displayMode: .inline)
 						.navigationBarItems(
-							trailing:
-							ZStack {
+							trailing: ZStack {
 								if UIDevice.current.userInterfaceIdiom != .phone {
 									Button {
 										columnVisibility = .detailOnly
@@ -262,8 +261,11 @@ struct NodeList: View {
 								ConnectedDevice(
 									bluetoothOn: bleManager.isSwitchedOn,
 									deviceConnected: bleManager.connectedPeripheral != nil,
-									name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?", phoneOnly: true)
-						})
+									name: bleManager.connectedPeripheral?.shortName ?? "?",
+									phoneOnly: true
+								)
+							}
+						)
 				}
 
 			 } else {

--- a/Meshtastic/Views/Nodes/NodeMap.swift
+++ b/Meshtastic/Views/Nodes/NodeMap.swift
@@ -229,15 +229,16 @@ struct NodeMap: View {
 				.presentationDragIndicator(.visible)
 			}
 		}
-		.navigationBarItems(leading:
-								MeshtasticLogo(), trailing:
-								ZStack {
-			ConnectedDevice(
-				bluetoothOn: bleManager.isSwitchedOn,
-				deviceConnected: bleManager.connectedPeripheral != nil,
-				name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName :
-					"?")
-		})
+		.navigationBarItems(
+			leading: MeshtasticLogo(),
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear(perform: {
 			UIApplication.shared.isIdleTimerDisabled = true
 			if self.bleManager.context == nil {

--- a/Meshtastic/Views/Nodes/PaxCounterLog.swift
+++ b/Meshtastic/Views/Nodes/PaxCounterLog.swift
@@ -205,10 +205,15 @@ struct PaxCounterLog: View {
 		}
 		.navigationTitle("paxcounter.log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-				ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context

--- a/Meshtastic/Views/Nodes/PositionLog.swift
+++ b/Meshtastic/Views/Nodes/PositionLog.swift
@@ -175,10 +175,14 @@ struct PositionLog: View {
 		}
 		.navigationTitle("Position Log \(node.positions?.count ?? 0) Points")
 		.navigationBarItems(
-			trailing:
-				ZStack {
-					ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context

--- a/Meshtastic/Views/Nodes/TraceRouteLog.swift
+++ b/Meshtastic/Views/Nodes/TraceRouteLog.swift
@@ -141,10 +141,15 @@ struct TraceRouteLog: View {
 			}
 			.navigationTitle("Trace Route Log")
 		}
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -109,10 +109,15 @@ struct AppSettings: View {
 			})
 		}
 		.navigationTitle("appsettings")
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -282,10 +282,15 @@ struct Channels: View {
 			}
 		}
 		.navigationTitle("channels")
-		.navigationBarItems(trailing:
-		ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -31,277 +31,290 @@ struct DeviceConfig: View {
 	@State var ledHeartbeatEnabled = true
 	@State var isManaged = false
 	@State var tzdef = ""
+	
+	var optionsSection: some View {
+		Section(header: Text("options")) {
+			VStack(alignment: .leading) {
+				Picker("Device Role", selection: $deviceRole ) {
+					ForEach(DeviceRoles.allCases) { dr in
+						Text(dr.name)
+					}
+				}
+				Text(DeviceRoles(rawValue: deviceRole)?.description ?? "")
+					.foregroundColor(.gray)
+					.font(.callout)
+			}
+			.pickerStyle(DefaultPickerStyle())
+
+			VStack(alignment: .leading) {
+				Picker("Rebroadcast Mode", selection: $rebroadcastMode ) {
+					ForEach(RebroadcastModes.allCases) { rm in
+						Text(rm.name)
+					}
+				}
+				Text(RebroadcastModes(rawValue: rebroadcastMode)?.description ?? "")
+					.foregroundColor(.gray)
+					.font(.callout)
+			}
+			.pickerStyle(DefaultPickerStyle())
+
+			Toggle(isOn: $isManaged) {
+				Label("Managed Device", systemImage: "gearshape.arrow.triangle.2.circlepath")
+				Text("Enabling Managed mode will restrict access to all radio configurations, such as short/long names, regions, channels, modules, etc. and will only be accessible through the Admin channel. To avoid being locked out, make sure the Admin channel is working properly before enabling it.")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			Picker("Node Info Broadcast Interval", selection: $nodeInfoBroadcastSecs ) {
+				ForEach(UpdateIntervals.allCases) { ui in
+					if ui.rawValue >= 3600 {
+						Text(ui.description)
+					}
+				}
+			}
+			.pickerStyle(DefaultPickerStyle())
+		}
+	}
+	
+	var hardwareSection: some View {
+		Section(header: Text("Hardware")) {
+
+			Toggle(isOn: $doubleTapAsButtonPress) {
+				Label("Double Tap as Button", systemImage: "hand.tap")
+				Text("Treat double tap on supported accelerometers as a user button press.")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			Toggle(isOn: $ledHeartbeatEnabled) {
+				Label("LED Heartbeat", systemImage: "waveform.path.ecg")
+				Text("Controls the blinking LED on the device.  For most devices this will control one of the up to 4 LEDS, the charger and GPS LEDs are not controllable.")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+		}
+	}
+	
+	var debugSection: some View {
+		Section(header: Text("Debug")) {
+			Toggle(isOn: $serialEnabled) {
+				Label("Serial Console", systemImage: "terminal")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+			Toggle(isOn: $debugLogEnabled) {
+				Label("Debug Log", systemImage: "ant.fill")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+			VStack(alignment: .leading) {
+				HStack {
+					Label("Time Zone", systemImage: "clock.badge.exclamationmark")
+					TextField("Time Zone", text: $tzdef, axis: .vertical)
+						.foregroundColor(.gray)
+						.onChange(of: tzdef, perform: { _ in
+							let totalBytes = tzdef.utf8.count
+							// Only mess with the value if it is too big
+							if totalBytes > 63 {
+								tzdef = String(tzdef.dropLast())
+							}
+						})
+						.foregroundColor(.gray)
+
+				}
+				.keyboardType(.default)
+				.disableAutocorrection(true)
+				Text("Time zone for dates on the device screen and log.")
+					.foregroundColor(.gray)
+					.font(.callout)
+			}
+		}
+	}
+	
+	var gpioSection: some View {
+		Section(header: Text("GPIO")) {
+			Picker("Button GPIO", selection: $buttonGPIO) {
+				ForEach(0..<49) {
+					if $0 == 0 {
+						Text("unset")
+					} else {
+						Text("Pin \($0)")
+					}
+				}
+			}
+			.pickerStyle(DefaultPickerStyle())
+			Picker("Buzzer GPIO", selection: $buzzerGPIO) {
+				ForEach(0..<49) {
+					if $0 == 0 {
+						Text("unset")
+					} else {
+						Text("Pin \($0)")
+					}
+				}
+			}
+			.pickerStyle(DefaultPickerStyle())
+		}
+	}
+	
+	var resetSection: some View {
+		HStack {
+			if let connectedPeripheral = bleManager.connectedPeripheral, let node, node.num == connectedPeripheral.num {
+				Button("Reset NodeDB", role: .destructive) {
+					isPresentingNodeDBResetConfirm = true
+				}
+				.disabled(node.user == nil)
+				.buttonStyle(.bordered)
+				.buttonBorderShape(.capsule)
+				.controlSize(.large)
+				.padding(.leading)
+				.confirmationDialog(
+					"are.you.sure",
+					isPresented: $isPresentingNodeDBResetConfirm,
+					titleVisibility: .visible
+				) {
+					Button("Erase all device and app data?", role: .destructive) {
+						if bleManager.sendNodeDBReset(fromUser: node.user!, toUser: node.user!) {
+							DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+								bleManager.disconnectPeripheral()
+								clearCoreDataDatabase(context: context, includeRoutes: false)
+							}
+
+						} else {
+							Logger.mesh.error("NodeDB Reset Failed")
+						}
+					}
+				}
+				
+				Button("Factory Reset", role: .destructive) {
+					isPresentingFactoryResetConfirm = true
+				}
+				.disabled(node.user == nil)
+				.buttonStyle(.bordered)
+				.buttonBorderShape(.capsule)
+				.controlSize(.large)
+				.padding(.trailing)
+				.confirmationDialog(
+					"All device and app data will be deleted. You will also need to forget your devices under Settings > Bluetooth.",
+					isPresented: $isPresentingFactoryResetConfirm,
+					titleVisibility: .visible
+				) {
+					Button("Factory reset your device and app? ", role: .destructive) {
+						if bleManager.sendFactoryReset(fromUser: node.user!, toUser: node.user!) {
+							DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+								bleManager.disconnectPeripheral()
+								clearCoreDataDatabase(context: context, includeRoutes: false)
+							}
+						} else {
+							Logger.mesh.error("Factory Reset Failed")
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	var saveConfigButton: some View {
+		HStack {
+		   SaveConfigButton(node: node, hasChanges: $hasChanges) {
+			   if let connectedPeripheral = bleManager.connectedPeripheral,
+				   let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context) {
+				   var dc = Config.DeviceConfig()
+				   dc.role = DeviceRoles(rawValue: deviceRole)!.protoEnumValue()
+				   dc.serialEnabled = serialEnabled
+				   dc.debugLogEnabled = debugLogEnabled
+				   dc.buttonGpio = UInt32(buttonGPIO)
+				   dc.buzzerGpio = UInt32(buzzerGPIO)
+				   dc.rebroadcastMode = RebroadcastModes(rawValue: rebroadcastMode)?.protoEnumValue() ?? RebroadcastModes.all.protoEnumValue()
+				   dc.nodeInfoBroadcastSecs = UInt32(nodeInfoBroadcastSecs)
+				   dc.doubleTapAsButtonPress = doubleTapAsButtonPress
+				   dc.isManaged = isManaged
+				   dc.tzdef = tzdef
+				   dc.ledHeartbeatDisabled = !ledHeartbeatEnabled
+				   if isManaged {
+					   serialEnabled = false
+					   debugLogEnabled = false
+				   }
+				   let adminMessageId = bleManager.saveDeviceConfig(
+					   config: dc,
+					   fromUser: connectedNode.user!,
+					   toUser: node!.user!,
+					   adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+				   )
+				   if adminMessageId > 0 {
+					   // Should show a saved successfully alert once I know that to be true
+					   // for now just disable the button after a successful save
+					   hasChanges = false
+					   goBack()
+				   }
+			   }
+		   }
+	   }
+	}
 
 	var body: some View {
 		VStack {
 			Form {
 				ConfigHeader(title: "Device", config: \.deviceConfig, node: node, onAppear: setDeviceValues)
 
-				Section(header: Text("options")) {
-					VStack(alignment: .leading) {
-						Picker("Device Role", selection: $deviceRole ) {
-							ForEach(DeviceRoles.allCases) { dr in
-								Text(dr.name)
-							}
-						}
-						Text(DeviceRoles(rawValue: deviceRole)?.description ?? "")
-							.foregroundColor(.gray)
-							.font(.callout)
-					}
-					.pickerStyle(DefaultPickerStyle())
-
-					VStack(alignment: .leading) {
-						Picker("Rebroadcast Mode", selection: $rebroadcastMode ) {
-							ForEach(RebroadcastModes.allCases) { rm in
-								Text(rm.name)
-							}
-						}
-						Text(RebroadcastModes(rawValue: rebroadcastMode)?.description ?? "")
-							.foregroundColor(.gray)
-							.font(.callout)
-					}
-					.pickerStyle(DefaultPickerStyle())
-
-					Toggle(isOn: $isManaged) {
-						Label("Managed Device", systemImage: "gearshape.arrow.triangle.2.circlepath")
-						Text("Enabling Managed mode will restrict access to all radio configurations, such as short/long names, regions, channels, modules, etc. and will only be accessible through the Admin channel. To avoid being locked out, make sure the Admin channel is working properly before enabling it.")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					Picker("Node Info Broadcast Interval", selection: $nodeInfoBroadcastSecs ) {
-						ForEach(UpdateIntervals.allCases) { ui in
-							if ui.rawValue >= 3600 {
-								Text(ui.description)
-							}
-						}
-					}
-					.pickerStyle(DefaultPickerStyle())
-				}
-				Section(header: Text("Hardware")) {
-
-					Toggle(isOn: $doubleTapAsButtonPress) {
-						Label("Double Tap as Button", systemImage: "hand.tap")
-						Text("Treat double tap on supported accelerometers as a user button press.")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					Toggle(isOn: $ledHeartbeatEnabled) {
-						Label("LED Heartbeat", systemImage: "waveform.path.ecg")
-						Text("Controls the blinking LED on the device.  For most devices this will control one of the up to 4 LEDS, the charger and GPS LEDs are not controllable.")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-				}
-				Section(header: Text("Debug")) {
-					Toggle(isOn: $serialEnabled) {
-						Label("Serial Console", systemImage: "terminal")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					Toggle(isOn: $debugLogEnabled) {
-						Label("Debug Log", systemImage: "ant.fill")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					VStack(alignment: .leading) {
-						HStack {
-							Label("Time Zone", systemImage: "clock.badge.exclamationmark")
-							TextField("Time Zone", text: $tzdef, axis: .vertical)
-								.foregroundColor(.gray)
-								.onChange(of: tzdef, perform: { _ in
-									let totalBytes = tzdef.utf8.count
-									// Only mess with the value if it is too big
-									if totalBytes > 63 {
-										tzdef = String(tzdef.dropLast())
-									}
-								})
-								.foregroundColor(.gray)
-
-						}
-						.keyboardType(.default)
-						.disableAutocorrection(true)
-						Text("Time zone for dates on the device screen and log.")
-							.foregroundColor(.gray)
-							.font(.callout)
-					}
-				}
-				Section(header: Text("GPIO")) {
-					Picker("Button GPIO", selection: $buttonGPIO) {
-						ForEach(0..<49) {
-							if $0 == 0 {
-								Text("unset")
-							} else {
-								Text("Pin \($0)")
-							}
-						}
-					}
-					.pickerStyle(DefaultPickerStyle())
-					Picker("Buzzer GPIO", selection: $buzzerGPIO) {
-						ForEach(0..<49) {
-							if $0 == 0 {
-								Text("unset")
-							} else {
-								Text("Pin \($0)")
-							}
-						}
-					}
-					.pickerStyle(DefaultPickerStyle())
-				}
+				optionsSection
+				hardwareSection
+				debugSection
+				gpioSection
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.deviceConfig == nil)
 			// Only show these buttons for the BLE connected node
-			if bleManager.connectedPeripheral != nil && node?.num ?? -1  == bleManager.connectedPeripheral.num {
-				HStack {
-					Button("Reset NodeDB", role: .destructive) {
-						isPresentingNodeDBResetConfirm = true
-					}
-					.disabled(node?.user == nil)
-					.buttonStyle(.bordered)
-					.buttonBorderShape(.capsule)
-					.controlSize(.large)
-					.padding(.leading)
-					.confirmationDialog(
-						"are.you.sure",
-						isPresented: $isPresentingNodeDBResetConfirm,
-						titleVisibility: .visible
-					) {
-						Button("Erase all device and app data?", role: .destructive) {
-							if bleManager.sendNodeDBReset(fromUser: node!.user!, toUser: node!.user!) {
-								DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-									bleManager.disconnectPeripheral()
-									clearCoreDataDatabase(context: context, includeRoutes: false)
-								}
-
-							} else {
-								Logger.mesh.error("NodeDB Reset Failed")
-							}
-						}
-					}
-					Button("Factory Reset", role: .destructive) {
-						isPresentingFactoryResetConfirm = true
-					}
-					.disabled(node?.user == nil)
-					.buttonStyle(.bordered)
-					.buttonBorderShape(.capsule)
-					.controlSize(.large)
-					.padding(.trailing)
-					.confirmationDialog(
-						"All device and app data will be deleted. You will also need to forget your devices under Settings > Bluetooth.",
-						isPresented: $isPresentingFactoryResetConfirm,
-						titleVisibility: .visible
-					) {
-						Button("Factory reset your device and app? ", role: .destructive) {
-							if bleManager.sendFactoryReset(fromUser: node!.user!, toUser: node!.user!) {
-								DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-									bleManager.disconnectPeripheral()
-									clearCoreDataDatabase(context: context, includeRoutes: false)
-								}
-							} else {
-								Logger.mesh.error("Factory Reset Failed")
-							}
-						}
-					}
-				}
-			}
-			HStack {
-				SaveConfigButton(node: node, hasChanges: $hasChanges) {
-					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if connectedNode != nil {
-						var dc = Config.DeviceConfig()
-						dc.role = DeviceRoles(rawValue: deviceRole)!.protoEnumValue()
-						dc.serialEnabled = serialEnabled
-						dc.debugLogEnabled = debugLogEnabled
-						dc.buttonGpio = UInt32(buttonGPIO)
-						dc.buzzerGpio = UInt32(buzzerGPIO)
-						dc.rebroadcastMode = RebroadcastModes(rawValue: rebroadcastMode)?.protoEnumValue() ?? RebroadcastModes.all.protoEnumValue()
-						dc.nodeInfoBroadcastSecs = UInt32(nodeInfoBroadcastSecs)
-						dc.doubleTapAsButtonPress = doubleTapAsButtonPress
-						dc.isManaged = isManaged
-						dc.tzdef = tzdef
-						dc.ledHeartbeatDisabled = !ledHeartbeatEnabled
-						if isManaged {
-							serialEnabled = false
-							debugLogEnabled = false
-						}
-						let adminMessageId = bleManager.saveDeviceConfig(config: dc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-						if adminMessageId > 0 {
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							hasChanges = false
-							goBack()
-						}
-					}
-				}
-			}
+			resetSection
+			saveConfigButton
 			Spacer()
 		}
 		.navigationTitle("device.config")
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context
 			}
 			setDeviceValues()
 			// Need to request a LoRaConfig from the remote node before allowing changes
-			if bleManager.connectedPeripheral != nil && node?.deviceConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral, node?.deviceConfig == nil {
 				Logger.mesh.info("empty device config")
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? -1, context: context)
+				let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
 				if node != nil && connectedNode != nil && connectedNode?.user != nil {
 					_ = bleManager.requestDeviceConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
 				}
 			}
 		}
-		.onChange(of: deviceRole) { newRole in
-			if node != nil && node?.deviceConfig != nil {
-				if newRole != node!.deviceConfig!.role { hasChanges = true }
-			}
-		}
-		.onChange(of: serialEnabled) { newSerial in
-			if node != nil && node?.deviceConfig != nil {
-				if newSerial != node!.deviceConfig!.serialEnabled { hasChanges = true }
-			}
-		}
-		.onChange(of: debugLogEnabled) { newDebugLog in
-			if node != nil && node?.deviceConfig != nil {
-				if newDebugLog != node!.deviceConfig!.debugLogEnabled {	hasChanges = true }
-			}
-		}
-		.onChange(of: buttonGPIO) { newButtonGPIO in
-			if node != nil && node?.deviceConfig != nil {
-				if newButtonGPIO != node!.deviceConfig!.buttonGpio { hasChanges = true }
-			}
-		}
-		.onChange(of: buzzerGPIO) { newBuzzerGPIO in
-			if node != nil && node?.deviceConfig != nil {
-				if newBuzzerGPIO != node!.deviceConfig!.buttonGpio { hasChanges = true }
-			}
-		}
-		.onChange(of: rebroadcastMode) { newRebroadcastMode in
-			if node != nil && node?.deviceConfig != nil {
-				if newRebroadcastMode != node!.deviceConfig!.rebroadcastMode { hasChanges = true }
-			}
-		}
-		.onChange(of: nodeInfoBroadcastSecs) { newNodeInfoBroadcastSecs in
-			if node != nil && node?.deviceConfig != nil {
-				if newNodeInfoBroadcastSecs != node!.deviceConfig!.nodeInfoBroadcastSecs { hasChanges = true }
-			}
-		}
-		.onChange(of: doubleTapAsButtonPress) { newDoubleTapAsButtonPress in
-			if node != nil && node?.deviceConfig != nil {
-				if newDoubleTapAsButtonPress != node!.deviceConfig!.doubleTapAsButtonPress { hasChanges = true }
-			}
-		}
-		.onChange(of: isManaged) { newIsManaged in
-			if node != nil && node?.deviceConfig != nil {
-				if newIsManaged != node!.deviceConfig!.isManaged { hasChanges = true }
-			}
-		}
-		.onChange(of: tzdef) { newTzdef in
-			if node != nil && node?.deviceConfig != nil {
-				if newTzdef != node!.deviceConfig!.tzdef { hasChanges = true }
-			}
+		.onChange(of: deviceRole) { _ in handleChanges() }
+		.onChange(of: serialEnabled) { _ in handleChanges() }
+		.onChange(of: debugLogEnabled) { _ in handleChanges() }
+		.onChange(of: buttonGPIO) { _ in handleChanges() }
+		.onChange(of: buzzerGPIO) { _ in handleChanges() }
+		.onChange(of: rebroadcastMode) { _ in handleChanges() }
+		.onChange(of: nodeInfoBroadcastSecs) { _ in handleChanges() }
+		.onChange(of: doubleTapAsButtonPress) { _ in handleChanges() }
+		.onChange(of: isManaged) { _ in handleChanges() }
+		.onChange(of: tzdef) { _ in handleChanges() }
+	}
+	
+	func handleChanges() {
+		guard let deviceConfig = node?.deviceConfig else { return }
+		if deviceConfig.role != deviceRole ||
+			deviceConfig.serialEnabled != serialEnabled ||
+			deviceConfig.debugLogEnabled != debugLogEnabled ||
+			deviceConfig.buttonGpio != buttonGPIO ||
+			deviceConfig.buzzerGpio != buzzerGPIO ||
+			deviceConfig.rebroadcastMode != rebroadcastMode ||
+			deviceConfig.nodeInfoBroadcastSecs != nodeInfoBroadcastSecs ||
+			deviceConfig.doubleTapAsButtonPress != doubleTapAsButtonPress ||
+			deviceConfig.isManaged != isManaged ||
+			deviceConfig.tzdef != tzdef
+		{
+			hasChanges = true
 		}
 	}
+	
 	func setDeviceValues() {
 		self.deviceRole = Int(node?.deviceConfig?.role ?? 0)
 		self.serialEnabled = (node?.deviceConfig?.serialEnabled ?? true)

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -221,21 +221,30 @@ struct LoRaConfig: View {
 			}
 		}
 		.navigationTitle("lora.config")
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context
 			}
 			setLoRaValues()
 			// Need to request a LoRaConfig from the remote node before allowing changes
-			if bleManager.connectedPeripheral != nil && node?.loRaConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral,  node?.loRaConfig == nil {
 				Logger.mesh.info("empty lora config")
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-				if node != nil && connectedNode != nil {
-					_ = bleManager.requestLoRaConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
+				if let node, let connectedNode {
+					_ = bleManager.requestLoRaConfig(
+						fromUser: connectedNode.user!,
+						toUser: node.user!,
+						adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+					)
 				}
 			}
 		}

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -180,21 +180,30 @@ struct DetectionSensorConfig: View {
 			}
 		}
 		.navigationTitle("detection.sensor.config")
-		.navigationBarItems(trailing:
-			ZStack {
-				ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context
 			}
 			setDetectionSensorValues()
 			// Need to request a Detection Sensor Module Config from the remote node before allowing changes
-			if bleManager.connectedPeripheral != nil && node?.detectionSensorConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral, let node, node.detectionSensorConfig == nil {
 				Logger.mesh.info("empty detection sensor module config")
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-				if node != nil && connectedNode != nil {
-					_ = bleManager.requestDetectionSensorModuleConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
+				if let connectedNode {
+					_ = bleManager.requestDetectionSensorModuleConfig(
+						fromUser: connectedNode.user!,
+						toUser: node.user!,
+						adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+					)
 				}
 			}
 		}

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -190,19 +190,24 @@ struct ExternalNotificationConfig: View {
 			}
 		}
 		.navigationTitle("external.notification.config")
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context
 			}
 			setExternalNotificationValues()
 			// Need to request a TelemetryModuleConfig from the remote node before allowing changes
-			if bleManager.connectedPeripheral != nil && node?.externalNotificationConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral,  node?.externalNotificationConfig == nil {
 				Logger.mesh.info("empty external notification module config")
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
+				let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
 				if node != nil && connectedNode != nil {
 					_ = bleManager.requestExternalNotificationModuleConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
 				}

--- a/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
@@ -54,7 +54,7 @@ struct PaxCounterConfig: View {
 			ConnectedDevice(
 				bluetoothOn: bleManager.isSwitchedOn,
 				deviceConnected: bleManager.connectedPeripheral != nil,
-				name: "\(bleManager.connectedPeripheral?.shortName ?? "?")"
+				name: bleManager.connectedPeripheral?.shortName ?? "?"
 			)
 		})
 		.onAppear {
@@ -64,7 +64,7 @@ struct PaxCounterConfig: View {
 
 			setPaxValues()
 			// Need to request a PAX Counter module config from the remote node before allowing changes
-			if bleManager.connectedPeripheral != nil && node?.paxCounterConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral, node?.paxCounterConfig == nil {
 				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? 0, context: context)
 				if node != nil && connectedNode != nil {
 					_ = bleManager.requestPaxCounterModuleConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
@@ -83,7 +83,8 @@ struct PaxCounterConfig: View {
 		}
 
 		SaveConfigButton(node: node, hasChanges: $hasChanges) {
-			guard let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context),
+			guard let connectedPeripheral = bleManager.connectedPeripheral,
+			      let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context),
 				  let fromUser = connectedNode.user,
 				  let toUser = node?.user else {
 				return

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -56,13 +56,19 @@ struct RangeTestConfig: View {
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.rangeTestConfig == nil)
 
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-				if connectedNode != nil {
+				
+				if let connectedPeripheral = bleManager.connectedPeripheral,
+				    let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context) {
 					var rtc = ModuleConfig.RangeTestConfig()
 					rtc.enabled = enabled
 					rtc.save = save
 					rtc.sender = UInt32(sender)
-					let adminMessageId =  bleManager.saveRangeTestModuleConfig(config: rtc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					let adminMessageId = bleManager.saveRangeTestModuleConfig(
+						config: rtc,
+						fromUser: connectedNode.user!,
+						toUser: node!.user!,
+						adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+					)
 					if adminMessageId > 0 {
 						// Should show a saved successfully alert once I know that to be true
 						// for now just disable the button after a successful save
@@ -72,21 +78,26 @@ struct RangeTestConfig: View {
 				}
 			}
 			.navigationTitle("range.test.config")
-			.navigationBarItems(trailing:
-				ZStack {
-					ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-			})
+			.navigationBarItems(
+				trailing: ZStack {
+					ConnectedDevice(
+						bluetoothOn: bleManager.isSwitchedOn,
+						deviceConnected: bleManager.connectedPeripheral != nil,
+						name: bleManager.connectedPeripheral?.shortName ?? "?"
+					)
+				}
+			)
 			.onAppear {
 				if self.bleManager.context == nil {
 					self.bleManager.context = context
 				}
 				setRangeTestValues()
 				// Need to request a RangeTestModule Config from the remote node before allowing changes
-				if bleManager.connectedPeripheral != nil && node?.rangeTestConfig == nil {
+				if let connectedPeripheral = bleManager.connectedPeripheral, node?.rangeTestConfig == nil {
 					Logger.mesh.debug("empty range test module config")
-					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if node != nil && connectedNode != nil {
-						_ = bleManager.requestRangeTestModuleConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
+					if let node, let connectedNode {
+						_ = bleManager.requestRangeTestModuleConfig(fromUser: connectedNode.user!, toUser: node.user!, adminIndex: connectedNode.myInfo?.adminIndex ?? 0)
 					}
 				}
 			}

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -50,9 +50,14 @@ struct RtttlConfig: View {
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.rtttlConfig == nil)
 
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-				if connectedNode != nil {
-					let adminMessageId =  bleManager.saveRtttlConfig(ringtone: ringtone.trimmingCharacters(in: .whitespacesAndNewlines), fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				if let peripheralNum = bleManager.connectedPeripheral?.num,
+					let connectedNode = getNodeInfo(id: peripheralNum, context: context) {
+					let adminMessageId = bleManager.saveRtttlConfig(
+						ringtone: ringtone.trimmingCharacters(in: .whitespacesAndNewlines),
+						fromUser: connectedNode.user!,
+						toUser: node!.user!,
+						adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+					)
 					if adminMessageId > 0 {
 						// Should show a saved successfully alert once I know that to be true
 						// for now just disable the button after a successful save
@@ -62,21 +67,30 @@ struct RtttlConfig: View {
 				}
 			}
 			.navigationTitle("config.ringtone.title")
-			.navigationBarItems(trailing:
-				ZStack {
-					ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-			})
+			.navigationBarItems(
+				trailing: ZStack {
+					ConnectedDevice(
+						bluetoothOn: bleManager.isSwitchedOn,
+						deviceConnected: bleManager.connectedPeripheral != nil,
+						name: bleManager.connectedPeripheral?.shortName ?? "?"
+					)
+				}
+			)
 			.onAppear {
 				if self.bleManager.context == nil {
 					self.bleManager.context = context
 				}
 				setRtttLConfigValue()
 				// Need to request a Rtttl Config from the remote node before allowing changes
-				if bleManager.connectedPeripheral != nil && (node?.rtttlConfig == nil || node?.rtttlConfig?.ringtone?.count ?? 0 == 0) {
-					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if node != nil && connectedNode != nil {
-						_ = bleManager.requestRtttlConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-					}
+				if let connectedPeripheral = bleManager.connectedPeripheral,
+					let node,
+					let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context),
+					(node.rtttlConfig == nil || node.rtttlConfig?.ringtone?.isEmpty ?? false) {
+					_ = bleManager.requestRtttlConfig(
+						fromUser: connectedNode.user!,
+						toUser: node.user!,
+						adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+					)
 				}
 			}
 			.onChange(of: ringtone) { newRingtone in

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -137,21 +137,30 @@ struct StoreForwardConfig: View {
 			}
 		}
 		.navigationTitle("storeforward.config")
-		.navigationBarItems(trailing:
-			ZStack {
-				ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context
 			}
 
 			// Need to request a Detection Sensor Module Config from the remote node before allowing changes
-			if bleManager.connectedPeripheral != nil && node?.storeForwardConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral, let node, node.storeForwardConfig == nil {
 				Logger.mesh.debug("empty store and forward module config")
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-				if node != nil && connectedNode != nil {
-					_ = bleManager.requestStoreAndForwardModuleConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
+				if let connectedNode {
+					_ = bleManager.requestStoreAndForwardModuleConfig(
+						fromUser: connectedNode.user!,
+						toUser: node.user!,
+						adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+					)
 				}
 			}
 			setStoreAndForwardValues()

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -127,19 +127,24 @@ struct TelemetryConfig: View {
 			.navigationTitle("telemetry.config")
 			.navigationBarItems(trailing:
 				ZStack {
-					ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-			})
+					ConnectedDevice(
+						bluetoothOn: bleManager.isSwitchedOn,
+						deviceConnected: bleManager.connectedPeripheral != nil,
+						name: bleManager.connectedPeripheral?.shortName ?? "?"
+					)
+				}
+			)
 			.onAppear {
 				if self.bleManager.context == nil {
 					self.bleManager.context = context
 				}
 				setTelemetryValues()
 				// Need to request a TelemetryModuleConfig from the remote node before allowing changes
-				if bleManager.connectedPeripheral != nil && node?.telemetryConfig == nil {
+				if let connectedPeripheral = bleManager.connectedPeripheral, node?.telemetryConfig == nil {
 					Logger.mesh.info("empty telemetry module config")
-					let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-					if node != nil && connectedNode != nil {
-						_ = bleManager.requestTelemetryModuleConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+					let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
+					if let node, let connectedNode {
+						_ = bleManager.requestTelemetryModuleConfig(fromUser: connectedNode.user!, toUser: node.user!, adminIndex: connectedNode.myInfo?.adminIndex ?? 0)
 					}
 				}
 			}

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -80,299 +80,311 @@ struct PositionConfig: View {
 	@State private var showingSetFixedAlert = false
 	// @State private var showingRemoveFixedAlert = false
 
+	@ViewBuilder
+	var positionPacketSection: some View {
+		Section(header: Text("Position Packet")) {
+
+			VStack(alignment: .leading) {
+				Picker("Broadcast Interval", selection: $positionBroadcastSeconds) {
+					ForEach(UpdateIntervals.allCases) { at in
+						if at.rawValue >= 300 {
+							Text(at.description)
+						}
+					}
+				}
+				.pickerStyle(DefaultPickerStyle())
+				Text("The maximum interval that can elapse without a node broadcasting a position")
+					.foregroundColor(.gray)
+					.font(.callout)
+			}
+
+			Toggle(isOn: $smartPositionEnabled) {
+				Label("Smart Position", systemImage: "brain")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			if smartPositionEnabled {
+				VStack(alignment: .leading) {
+					Picker("Minimum Interval", selection: $broadcastSmartMinimumIntervalSecs) {
+						ForEach(UpdateIntervals.allCases) { at in
+							Text(at.description)
+						}
+					}
+					.pickerStyle(DefaultPickerStyle())
+					Text("The fastest that position updates will be sent if the minimum distance has been satisfied")
+						.foregroundColor(.gray)
+						.font(.callout)
+				}
+				VStack(alignment: .leading) {
+					Picker("Minimum Distance", selection: $broadcastSmartMinimumDistance) {
+						ForEach(10..<151) {
+							if $0 == 0 {
+								Text("unset")
+							} else {
+								if $0.isMultiple(of: 5) {
+									Text("\($0)")
+										.tag($0)
+								}
+							}
+						}
+					}
+					.pickerStyle(DefaultPickerStyle())
+					Text("The minimum distance change in meters to be considered for a smart position broadcast.")
+						.foregroundColor(.gray)
+						.font(.callout)
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	var deviceGPSSection: some View {
+		Section(header: Text("Device GPS")) {
+			Picker("", selection: $gpsMode) {
+				ForEach(GpsMode.allCases, id: \.self) { at in
+					Text(at.description)
+						.tag(at.id)
+						
+				}
+			}
+			.pickerStyle(SegmentedPickerStyle())
+			.padding(.top, 5)
+			.padding(.bottom, 5)
+			.disabled(fixedPosition && !(gpsMode == 1))
+			if gpsMode == 1 {
+				Text("Positions will be provided by your device GPS, if you select disabled or not present you can set a fixed position.")
+					.foregroundColor(.gray)
+					.font(.callout)
+				VStack(alignment: .leading) {
+					Picker("Update Interval", selection: $gpsUpdateInterval) {
+						ForEach(GpsUpdateIntervals.allCases) { ui in
+							Text(ui.description)
+						}
+					}
+					Text("How often should we try to get a GPS position.")
+						.foregroundColor(.gray)
+						.font(.callout)
+				}
+			}
+			if (gpsMode != 1 && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? -1) || fixedPosition {
+				VStack(alignment: .leading) {
+					Toggle(isOn: $fixedPosition) {
+						Label("Fixed Position", systemImage: "location.square.fill")
+						if !(node?.positionConfig?.fixedPosition ?? false) {
+							Text("Your current location will be set as the fixed position and broadcast over the mesh on the position interval.")
+						} else {
+
+						}
+					}
+					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	var positionFlagsSection: some View {
+		Section(header: Text("Position Flags")) {
+
+			Text("Optional fields to include when assembling position messages. the more fields are included, the larger the message will be - leading to longer airtime and a higher risk of packet loss")
+				.foregroundColor(.gray)
+				.font(.callout)
+
+			Toggle(isOn: $includeAltitude) {
+				Label("Altitude", systemImage: "arrow.up")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			Toggle(isOn: $includeSatsinview) {
+				Label("Number of satellites", systemImage: "skew")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			Toggle(isOn: $includeSeqNo) { // 64
+				Label("Sequence number", systemImage: "number")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			Toggle(isOn: $includeTimestamp) { // 128
+				Label("timestamp", systemImage: "clock")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			Toggle(isOn: $includeHeading) { // 128
+				Label("Vehicle heading", systemImage: "location.circle")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			Toggle(isOn: $includeSpeed) { // 128
+
+				Label("Vehicle speed", systemImage: "speedometer")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+		}
+	}
+
+	@ViewBuilder
+	var advancedPositionFlagsSection: some View {
+		Section(header: Text("Advanced Position Flags")) {
+
+			if includeAltitude {
+				Toggle(isOn: $includeAltitudeMsl) {
+					Label("Altitude is Mean Sea Level", systemImage: "arrow.up.to.line.compact")
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+				Toggle(isOn: $includeGeoidalSeparation) {
+					Label("Altitude Geoidal Separation", systemImage: "globe.americas")
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+			}
+
+			Toggle(isOn: $includeDop) {
+				Text("Dilution of precision (DOP) PDOP used by default")
+			}
+			.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+			if includeDop {
+				Toggle(isOn: $includeHvdop) {
+					Text("If DOP is set, use HDOP / VDOP values instead of PDOP")
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+			}
+		}
+	}
+	
+	@ViewBuilder
+	var advancedDeviceGPSSection: some View {
+		Section(header: Text("Advanced Device GPS")) {
+			Picker("GPS Receive GPIO", selection: $rxGpio) {
+				ForEach(0..<49) {
+					if $0 == 0 {
+						Text("unset")
+					} else {
+						Text("Pin \($0)")
+					}
+				}
+			}
+			.pickerStyle(DefaultPickerStyle())
+			Picker("GPS Transmit GPIO", selection: $txGpio) {
+				ForEach(0..<49) {
+					if $0 == 0 {
+						Text("unset")
+					} else {
+						Text("Pin \($0)")
+					}
+				}
+			}
+			.pickerStyle(DefaultPickerStyle())
+			Picker("GPS EN GPIO", selection: $gpsEnGpio) {
+				ForEach(0..<49) {
+					if $0 == 0 {
+						Text("unset")
+					} else {
+						Text("Pin \($0)")
+					}
+				}
+			}
+			.pickerStyle(DefaultPickerStyle())
+			Text("(Re)define PIN_GPS_EN for your board.")
+				.font(.caption)
+		}
+	}
+	
+	var saveButton: some View {
+		SaveConfigButton(node: node, hasChanges: $hasChanges) {
+			if fixedPosition && !supportedVersion {
+				_ = bleManager.sendPosition(channel: 0, destNum: node?.num ?? 0, wantResponse: true)
+			}
+			let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral!.num, context: context)
+
+			if connectedNode != nil {
+				var pc = Config.PositionConfig()
+				pc.positionBroadcastSmartEnabled = smartPositionEnabled
+				pc.gpsEnabled = gpsMode == 1
+				pc.gpsMode = Config.PositionConfig.GpsMode(rawValue: gpsMode) ?? Config.PositionConfig.GpsMode.notPresent
+				pc.fixedPosition = fixedPosition
+				pc.gpsUpdateInterval = UInt32(gpsUpdateInterval)
+				pc.positionBroadcastSecs = UInt32(positionBroadcastSeconds)
+				pc.broadcastSmartMinimumIntervalSecs = UInt32(broadcastSmartMinimumIntervalSecs)
+				pc.broadcastSmartMinimumDistance = UInt32(broadcastSmartMinimumDistance)
+				pc.rxGpio = UInt32(rxGpio)
+				pc.txGpio = UInt32(txGpio)
+				pc.gpsEnGpio = UInt32(gpsEnGpio)
+				var pf: PositionFlags = []
+				if includeAltitude { pf.insert(.Altitude) }
+				if includeAltitudeMsl { pf.insert(.AltitudeMsl) }
+				if includeGeoidalSeparation { pf.insert(.GeoidalSeparation) }
+				if includeDop { pf.insert(.Dop) }
+				if includeHvdop { pf.insert(.Hvdop) }
+				if includeSatsinview { pf.insert(.Satsinview) }
+				if includeSeqNo { pf.insert(.SeqNo) }
+				if includeTimestamp { pf.insert(.Timestamp) }
+				if includeSpeed { pf.insert(.Speed) }
+				if includeHeading { pf.insert(.Heading) }
+				pc.positionFlags = UInt32(pf.rawValue)
+				let adminMessageId =  bleManager.savePositionConfig(config: pc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				if adminMessageId > 0 {
+					// Disable the button after a successful save
+					hasChanges = false
+					goBack()
+				}
+			}
+		}
+	}
+	
+	var setFixedAlertTitle: String {
+		if node?.positionConfig?.fixedPosition == true {
+			return "Remove Fixed Position"
+		} else {
+			return "Set Fixed Position"
+		}
+	}
+	
+	
 	var body: some View {
 		VStack {
 			Form {
 				ConfigHeader(title: "Position", config: \.positionConfig, node: node, onAppear: setPositionValues)
 
-				Section(header: Text("Position Packet")) {
-
-					VStack(alignment: .leading) {
-						Picker("Broadcast Interval", selection: $positionBroadcastSeconds) {
-							ForEach(UpdateIntervals.allCases) { at in
-								if at.rawValue >= 300 {
-									Text(at.description)
-								}
-							}
-						}
-						.pickerStyle(DefaultPickerStyle())
-						Text("The maximum interval that can elapse without a node broadcasting a position")
-							.foregroundColor(.gray)
-							.font(.callout)
-					}
-
-					Toggle(isOn: $smartPositionEnabled) {
-						Label("Smart Position", systemImage: "brain")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					if smartPositionEnabled {
-						VStack(alignment: .leading) {
-							Picker("Minimum Interval", selection: $broadcastSmartMinimumIntervalSecs) {
-								ForEach(UpdateIntervals.allCases) { at in
-									Text(at.description)
-								}
-							}
-							.pickerStyle(DefaultPickerStyle())
-							Text("The fastest that position updates will be sent if the minimum distance has been satisfied")
-								.foregroundColor(.gray)
-								.font(.callout)
-						}
-						VStack(alignment: .leading) {
-							Picker("Minimum Distance", selection: $broadcastSmartMinimumDistance) {
-								ForEach(10..<151) {
-									if $0 == 0 {
-										Text("unset")
-									} else {
-										if $0.isMultiple(of: 5) {
-											Text("\($0)")
-												.tag($0)
-										}
-									}
-								}
-							}
-							.pickerStyle(DefaultPickerStyle())
-							Text("The minimum distance change in meters to be considered for a smart position broadcast.")
-								.foregroundColor(.gray)
-								.font(.callout)
-						}
-					}
-				}
-				Section(header: Text("Device GPS")) {
-					Picker("", selection: $gpsMode) {
-						ForEach(GpsMode.allCases, id: \.self) { at in
-							Text(at.description)
-								.tag(at.id)
-								
-						}
-					}
-					.pickerStyle(SegmentedPickerStyle())
-					.padding(.top, 5)
-					.padding(.bottom, 5)
-					.disabled(fixedPosition && !(gpsMode == 1))
-					if gpsMode == 1 {
-						Text("Positions will be provided by your device GPS, if you select disabled or not present you can set a fixed position.")
-							.foregroundColor(.gray)
-							.font(.callout)
-						VStack(alignment: .leading) {
-							Picker("Update Interval", selection: $gpsUpdateInterval) {
-								ForEach(GpsUpdateIntervals.allCases) { ui in
-									Text(ui.description)
-								}
-							}
-							Text("How often should we try to get a GPS position.")
-								.foregroundColor(.gray)
-								.font(.callout)
-						}
-					}
-					if (gpsMode != 1 && node?.num ?? 0 == bleManager.connectedPeripheral?.num ?? -1) || fixedPosition {
-						VStack(alignment: .leading) {
-							Toggle(isOn: $fixedPosition) {
-								Label("Fixed Position", systemImage: "location.square.fill")
-								if !(node?.positionConfig?.fixedPosition ?? false) {
-									Text("Your current location will be set as the fixed position and broadcast over the mesh on the position interval.")
-								} else {
-
-								}
-							}
-							.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-						}
-					}
-				}
-				Section(header: Text("Position Flags")) {
-
-					Text("Optional fields to include when assembling position messages. the more fields are included, the larger the message will be - leading to longer airtime and a higher risk of packet loss")
-						.foregroundColor(.gray)
-						.font(.callout)
-
-					Toggle(isOn: $includeAltitude) {
-						Label("Altitude", systemImage: "arrow.up")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					Toggle(isOn: $includeSatsinview) {
-						Label("Number of satellites", systemImage: "skew")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					Toggle(isOn: $includeSeqNo) { // 64
-						Label("Sequence number", systemImage: "number")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					Toggle(isOn: $includeTimestamp) { // 128
-						Label("timestamp", systemImage: "clock")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					Toggle(isOn: $includeHeading) { // 128
-						Label("Vehicle heading", systemImage: "location.circle")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					Toggle(isOn: $includeSpeed) { // 128
-
-						Label("Vehicle speed", systemImage: "speedometer")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-				}
-				Section(header: Text("Advanced Position Flags")) {
-
-					if includeAltitude {
-						Toggle(isOn: $includeAltitudeMsl) {
-							Label("Altitude is Mean Sea Level", systemImage: "arrow.up.to.line.compact")
-						}
-						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-						Toggle(isOn: $includeGeoidalSeparation) {
-							Label("Altitude Geoidal Separation", systemImage: "globe.americas")
-						}
-						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					}
-
-					Toggle(isOn: $includeDop) {
-						Text("Dilution of precision (DOP) PDOP used by default")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					if includeDop {
-						Toggle(isOn: $includeHvdop) {
-							Text("If DOP is set, use HDOP / VDOP values instead of PDOP")
-						}
-						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					}
-				}
+				positionPacketSection
+				deviceGPSSection
+				positionFlagsSection
+				advancedPositionFlagsSection
 
 				if gpsMode == 1 {
-					Section(header: Text("Advanced Device GPS")) {
-						Picker("GPS Receive GPIO", selection: $rxGpio) {
-							ForEach(0..<49) {
-								if $0 == 0 {
-									Text("unset")
-								} else {
-									Text("Pin \($0)")
-								}
-							}
-						}
-						.pickerStyle(DefaultPickerStyle())
-						Picker("GPS Transmit GPIO", selection: $txGpio) {
-							ForEach(0..<49) {
-								if $0 == 0 {
-									Text("unset")
-								} else {
-									Text("Pin \($0)")
-								}
-							}
-						}
-						.pickerStyle(DefaultPickerStyle())
-						Picker("GPS EN GPIO", selection: $gpsEnGpio) {
-							ForEach(0..<49) {
-								if $0 == 0 {
-									Text("unset")
-								} else {
-									Text("Pin \($0)")
-								}
-							}
-						}
-						.pickerStyle(DefaultPickerStyle())
-						Text("(Re)define PIN_GPS_EN for your board.")
-							.font(.caption)
-					}
+					advancedDeviceGPSSection
 				}
 			}
 			.disabled(self.bleManager.connectedPeripheral == nil || node?.positionConfig == nil)
-			.alert(node?.positionConfig?.fixedPosition ?? false ? "Remove Fixed Position" : "Set Fixed Position", isPresented: $showingSetFixedAlert) {
+			.alert(setFixedAlertTitle, isPresented: $showingSetFixedAlert) {
 				Button("Cancel", role: .cancel) {
 					fixedPosition = !fixedPosition
 				}
 				if node?.positionConfig?.fixedPosition ?? false {
 					Button("Remove", role: .destructive) {
-						if bleManager.connectedPeripheral.num > 0 {
-							if !bleManager.removeFixedPosition(fromUser: node!.user!, channel: 0) {
-								Logger.mesh.error("Remove Fixed Position Failed")
-							}
-							let mutablePositions = node?.positions?.mutableCopy() as? NSMutableOrderedSet
-							mutablePositions?.removeAllObjects()
-							node?.positions = mutablePositions
-							node?.positionConfig?.fixedPosition = false
-							do {
-								try context.save()
-								Logger.data.info("💾 Updated Position Config with Fixed Position = false")
-							} catch {
-								context.rollback()
-								let nsError = error as NSError
-								Logger.data.error("Error Saving Position Config Entity \(nsError)")
-							}
-						}
+						removeFixedPosition()
 					}
 				} else {
 					Button("Set") {
-						if bleManager.connectedPeripheral.num > 0 {
-							if !bleManager.setFixedPosition(fromUser: node!.user!, channel: 0) {
-								Logger.mesh.error("Set Position Failed")
-							}
-							node?.positionConfig?.fixedPosition = true
-							do {
-								try context.save()
-								Logger.data.info("💾 Updated Position Config with Fixed Position = true")
-							} catch {
-								context.rollback()
-								let nsError = error as NSError
-								Logger.data.error("Error Saving Position Config Entity \(nsError)")
-							}
-						}
+						setFixedPosition()
 					}
 				}
 			} message: {
 				Text(node?.positionConfig?.fixedPosition ?? false ? "This will disable fixed position and remove the currently set position." : "This will send a current position from your phone and enable fixed position.")
 			}
 
-			SaveConfigButton(node: node, hasChanges: $hasChanges) {
-				if fixedPosition && !supportedVersion {
-					_ = bleManager.sendPosition(channel: 0, destNum: node?.num ?? 0, wantResponse: true)
-				}
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-
-				if connectedNode != nil {
-					var pc = Config.PositionConfig()
-					pc.positionBroadcastSmartEnabled = smartPositionEnabled
-					pc.gpsEnabled = gpsMode == 1
-					pc.gpsMode = Config.PositionConfig.GpsMode(rawValue: gpsMode) ?? Config.PositionConfig.GpsMode.notPresent
-					pc.fixedPosition = fixedPosition
-					pc.gpsUpdateInterval = UInt32(gpsUpdateInterval)
-					pc.positionBroadcastSecs = UInt32(positionBroadcastSeconds)
-					pc.broadcastSmartMinimumIntervalSecs = UInt32(broadcastSmartMinimumIntervalSecs)
-					pc.broadcastSmartMinimumDistance = UInt32(broadcastSmartMinimumDistance)
-					pc.rxGpio = UInt32(rxGpio)
-					pc.txGpio = UInt32(txGpio)
-					pc.gpsEnGpio = UInt32(gpsEnGpio)
-					var pf: PositionFlags = []
-					if includeAltitude { pf.insert(.Altitude) }
-					if includeAltitudeMsl { pf.insert(.AltitudeMsl) }
-					if includeGeoidalSeparation { pf.insert(.GeoidalSeparation) }
-					if includeDop { pf.insert(.Dop) }
-					if includeHvdop { pf.insert(.Hvdop) }
-					if includeSatsinview { pf.insert(.Satsinview) }
-					if includeSeqNo { pf.insert(.SeqNo) }
-					if includeTimestamp { pf.insert(.Timestamp) }
-					if includeSpeed { pf.insert(.Speed) }
-					if includeHeading { pf.insert(.Heading) }
-					pc.positionFlags = UInt32(pf.rawValue)
-					let adminMessageId =  bleManager.savePositionConfig(config: pc, fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
-					if adminMessageId > 0 {
-						// Disable the button after a successful save
-						hasChanges = false
-						goBack()
-					}
-				}
-			}
+			saveButton
 		}
 		.navigationTitle("position.config")
-		.navigationBarItems(trailing:
-
-			ZStack {
-
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			if self.bleManager.context == nil {
 				self.bleManager.context = context
@@ -380,133 +392,88 @@ struct PositionConfig: View {
 			setPositionValues()
 			supportedVersion = bleManager.connectedVersion == "0.0.0" ||  self.minimumVersion.compare(bleManager.connectedVersion, options: .numeric) == .orderedAscending || minimumVersion.compare(bleManager.connectedVersion, options: .numeric) == .orderedSame
 			// Need to request a PositionConfig from the remote node before allowing changes
-			if bleManager.connectedPeripheral != nil && node?.positionConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral, node?.positionConfig == nil {
 				Logger.mesh.info("empty position config")
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context)
-				if node != nil && connectedNode != nil {
-					_ = bleManager.requestPositionConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
+				let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
+				if let node, let connectedNode {
+					_ = bleManager.requestPositionConfig(
+						fromUser: connectedNode.user!,
+						toUser: node.user!,
+						adminIndex: connectedNode.myInfo?.adminIndex ?? 0
+					)
 				}
 			}
 		}
 		.onChange(of: fixedPosition) { newFixed in
 			if supportedVersion {
-				if node != nil && node!.positionConfig != nil {
+				if let positionConfig = node?.positionConfig {
 					/// Fixed Position is off to start
-					if !node!.positionConfig!.fixedPosition && newFixed {
+					if !positionConfig.fixedPosition && newFixed {
 						showingSetFixedAlert = true
-					} else if node!.positionConfig!.fixedPosition && !newFixed {
+					} else if positionConfig.fixedPosition && !newFixed {
 						/// Fixed Position is on to start
 						showingSetFixedAlert = true
 					}
 				}
 			}
 		}
-		.onChange(of: deviceGpsEnabled) { newDeviceGps in
-			if node != nil && node!.positionConfig != nil {
-				if newDeviceGps != node!.positionConfig!.deviceGpsEnabled { hasChanges = true }
-			}
+		.onChange(of: gpsMode) { _ in
+			handleChanges()
 		}
-		.onChange(of: gpsMode) { newGpsMode in
-			if node != nil && node!.positionConfig != nil {
-				if newGpsMode != node!.positionConfig!.gpsMode { hasChanges = true }
-			}
+		.onChange(of: rxGpio) { _ in
+			handleChanges()
 		}
-		.onChange(of: rxGpio) { newRxGpio in
-			if node != nil && node!.positionConfig != nil {
-				if newRxGpio != node!.positionConfig!.rxGpio { hasChanges = true }
-			}
+		.onChange(of: txGpio) { _ in
+			handleChanges()
 		}
-		.onChange(of: txGpio) { newTxGpio in
-			if node != nil && node!.positionConfig != nil {
-				if newTxGpio != node!.positionConfig!.txGpio { hasChanges = true }
-			}
+		.onChange(of: gpsEnGpio) { _ in
+			handleChanges()
 		}
-		.onChange(of: txGpio) { newGpsEnGpio in
-			if node != nil && node!.positionConfig != nil {
-				if newGpsEnGpio != node!.positionConfig!.gpsEnGpio { hasChanges = true }
-			}
+		.onChange(of: smartPositionEnabled) { _ in
+			handleChanges()
 		}
-		.onChange(of: smartPositionEnabled) { newSmartPositionEnabled in
-			if node != nil && node!.positionConfig != nil {
-				if newSmartPositionEnabled != node!.positionConfig!.smartPositionEnabled { hasChanges = true }
-			}
+		.onChange(of: positionBroadcastSeconds) { _ in
+			handleChanges()
 		}
-		.onChange(of: positionBroadcastSeconds) { newPositionBroadcastSeconds in
-			if node != nil && node!.positionConfig != nil {
-				if newPositionBroadcastSeconds != node!.positionConfig!.positionBroadcastSeconds { hasChanges = true }
-			}
+		.onChange(of: broadcastSmartMinimumIntervalSecs) { _ in
+			handleChanges()
 		}
-		.onChange(of: broadcastSmartMinimumIntervalSecs) { newBroadcastSmartMinimumIntervalSecs in
-			if node != nil && node!.positionConfig != nil {
-				if newBroadcastSmartMinimumIntervalSecs != node!.positionConfig!.broadcastSmartMinimumIntervalSecs { hasChanges = true }
-			}
+		.onChange(of: broadcastSmartMinimumDistance) { _ in
+			handleChanges()
 		}
-		.onChange(of: broadcastSmartMinimumDistance) { newBroadcastSmartMinimumDistance in
-			if node != nil && node!.positionConfig != nil {
-				if newBroadcastSmartMinimumDistance != node!.positionConfig!.broadcastSmartMinimumDistance { hasChanges = true }
-			}
+		.onChange(of: gpsUpdateInterval) { _ in
+			handleChanges()
 		}
-		.onChange(of: gpsUpdateInterval) { newGpsUpdateInterval in
-			if node != nil && node!.positionConfig != nil {
-				if newGpsUpdateInterval != node!.positionConfig!.gpsUpdateInterval { hasChanges = true }
-			}
-		}
-		.onChange(of: includeAltitude) { altFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.Altitude)
-			if existingValue != altFlag { hasChanges = true }
-		}
-		.onChange(of: includeAltitudeMsl) { altMslFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.AltitudeMsl)
-			if existingValue != altMslFlag { hasChanges = true }
-		}
-		.onChange(of: includeSatsinview) { satsFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.Satsinview)
-			if existingValue != satsFlag { hasChanges = true }
-		}
-		.onChange(of: includeSeqNo) { seqFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.SeqNo)
-			if existingValue != seqFlag { hasChanges = true }
-		}
-		.onChange(of: includeTimestamp) { timestampFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.Timestamp)
-			if existingValue != timestampFlag { hasChanges = true }
-		}
-		.onChange(of: includeTimestamp) { timestampFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.Timestamp)
-			if existingValue != timestampFlag { hasChanges = true }
-		}
-		.onChange(of: includeSpeed) { speedFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.Speed)
-			if existingValue != speedFlag { hasChanges = true }
-		}
-		.onChange(of: includeHeading) { headingFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.Heading)
-			if existingValue != headingFlag { hasChanges = true }
-		}
-		.onChange(of: includeGeoidalSeparation) { geoSepFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.GeoidalSeparation)
-			if existingValue != geoSepFlag { hasChanges = true }
-		}
-		.onChange(of: includeDop) { dopFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.Dop)
-			if existingValue != dopFlag { hasChanges = true }
-		}
-		.onChange(of: includeHvdop) { hvdopFlag in
-			let pf = PositionFlags(rawValue: self.positionFlags)
-			let existingValue = pf.contains(.Hvdop)
-			if existingValue != hvdopFlag { hasChanges = true }
+		.onChange(of: positionFlags) { _ in
+			handleChanges()
 		}
 	}
+
+	func handleChanges() {
+		guard let positionConfig = node?.positionConfig else { return }
+		let pf = PositionFlags(rawValue: self.positionFlags)
+		hasChanges = positionConfig.deviceGpsEnabled != deviceGpsEnabled ||
+			positionConfig.gpsMode != gpsMode ||
+			positionConfig.rxGpio != rxGpio ||
+			positionConfig.txGpio != txGpio ||
+			positionConfig.gpsEnGpio != gpsEnGpio ||
+			positionConfig.smartPositionEnabled != smartPositionEnabled ||
+			positionConfig.positionBroadcastSeconds != positionBroadcastSeconds ||
+			positionConfig.broadcastSmartMinimumIntervalSecs != broadcastSmartMinimumIntervalSecs ||
+			positionConfig.broadcastSmartMinimumDistance != broadcastSmartMinimumDistance ||
+			positionConfig.gpsUpdateInterval != gpsUpdateInterval ||
+			pf.contains(.Altitude) ||
+			pf.contains(.AltitudeMsl) ||
+			pf.contains(.Satsinview) ||
+			pf.contains(.SeqNo) ||
+			pf.contains(.Timestamp) ||
+			pf.contains(.Speed) ||
+			pf.contains(.Heading) ||
+			pf.contains(.GeoidalSeparation) ||
+			pf.contains(.Dop) ||
+			pf.contains(.Hvdop)
+	}
+	
 	func setPositionValues() {
 		self.smartPositionEnabled = node?.positionConfig?.smartPositionEnabled ?? true
 		self.deviceGpsEnabled = node?.positionConfig?.deviceGpsEnabled ?? false
@@ -525,17 +492,54 @@ struct PositionConfig: View {
 		self.positionFlags = Int(node?.positionConfig?.positionFlags ?? 3)
 
 		let pf = PositionFlags(rawValue: self.positionFlags)
-		if pf.contains(.Altitude) { self.includeAltitude = true } else { self.includeAltitude = false }
-		if pf.contains(.AltitudeMsl) { self.includeAltitudeMsl = true } else { self.includeAltitudeMsl = false }
-		if pf.contains(.GeoidalSeparation) { self.includeGeoidalSeparation = true } else { self.includeGeoidalSeparation = false }
-		if pf.contains(.Dop) { self.includeDop = true  } else { self.includeDop = false }
-		if pf.contains(.Hvdop) { self.includeHvdop = true } else { self.includeHvdop = false }
-		if pf.contains(.Satsinview) { self.includeSatsinview = true } else { self.includeSatsinview = false }
-		if pf.contains(.SeqNo) { self.includeSeqNo = true } else { self.includeSeqNo = false }
-		if pf.contains(.Timestamp) { self.includeTimestamp = true } else { self.includeTimestamp = false }
-		if pf.contains(.Speed) { self.includeSpeed = true } else { self.includeSpeed = false }
-		if pf.contains(.Heading) { self.includeHeading = true } else { self.includeHeading = false }
+		self.includeAltitude = pf.contains(.Altitude)
+		self.includeAltitudeMsl = pf.contains(.AltitudeMsl)
+		self.includeGeoidalSeparation = pf.contains(.GeoidalSeparation)
+		self.includeDop = pf.contains(.Dop)
+		self.includeHvdop = pf.contains(.Hvdop)
+		self.includeSatsinview = pf.contains(.Satsinview)
+		self.includeSeqNo = pf.contains(.SeqNo)
+		self.includeTimestamp = pf.contains(.Timestamp)
+		self.includeSpeed = pf.contains(.Speed)
+		self.includeHeading = pf.contains(.Heading)
 
 		self.hasChanges = false
+	}
+	
+	private func setFixedPosition() {
+		guard let nodeNum = bleManager.connectedPeripheral?.num,
+			  nodeNum > 0 else { return }
+		if !bleManager.setFixedPosition(fromUser: node!.user!, channel: 0) {
+			Logger.mesh.error("Set Position Failed")
+		}
+		node?.positionConfig?.fixedPosition = true
+		do {
+			try context.save()
+			Logger.data.info("💾 Updated Position Config with Fixed Position = true")
+		} catch {
+			context.rollback()
+			let nsError = error as NSError
+			Logger.data.error("Error Saving Position Config Entity \(nsError)")
+		}
+	}
+	
+	private func removeFixedPosition() {
+		guard let nodeNum = bleManager.connectedPeripheral?.num,
+			  nodeNum > 0 else { return }
+		if !bleManager.removeFixedPosition(fromUser: node!.user!, channel: 0) {
+			Logger.mesh.error("Remove Fixed Position Failed")
+		}
+		let mutablePositions = node?.positions?.mutableCopy() as? NSMutableOrderedSet
+		mutablePositions?.removeAllObjects()
+		node?.positions = mutablePositions
+		node?.positionConfig?.fixedPosition = false
+		do {
+			try context.save()
+			Logger.data.info("💾 Updated Position Config with Fixed Position = false")
+		} catch {
+			context.rollback()
+			let nsError = error as NSError
+			Logger.data.error("Error Saving Position Config Entity \(nsError)")
+		}
 	}
 }

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -105,7 +105,7 @@ struct PowerConfig: View {
 			ConnectedDevice(
 				bluetoothOn: bleManager.isSwitchedOn,
 				deviceConnected: bleManager.connectedPeripheral != nil,
-				name: "\(bleManager.connectedPeripheral?.shortName ?? "?")"
+				name: bleManager.connectedPeripheral?.shortName ?? "?"
 			)
 		})
 		.toolbar {
@@ -135,7 +135,7 @@ struct PowerConfig: View {
 			setPowerValues()
 
 			// Need to request a Power config from the remote node before allowing changes
-			if bleManager.connectedPeripheral != nil && node?.powerConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral,  node?.powerConfig == nil {
 				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? 0, context: context)
 				if node != nil && connectedNode != nil {
 					_ = bleManager.requestPowerConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
@@ -180,7 +180,8 @@ struct PowerConfig: View {
 		}
 
 		SaveConfigButton(node: node, hasChanges: $hasChanges) {
-			guard let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral.num, context: context),
+			guard let connectedPeripheral = bleManager.connectedPeripheral,
+				  let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context),
 				  let fromUser = connectedNode.user,
 				  let toUser = node?.user else {
 				return

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -101,7 +101,7 @@ struct Settings: View {
 				let hasAdmin = node?.myInfo?.adminIndex ?? 0 > 0 ? true : false
 
 				if !(node?.deviceConfig?.isManaged ?? false) {
-					if bleManager.connectedPeripheral != nil {
+					if let connectedPeripheral = bleManager.connectedPeripheral{
 						Section("Configure") {
 							if hasAdmin {
 								Picker("Configuring Node", selection: $selectedNode) {
@@ -110,7 +110,7 @@ struct Settings: View {
 									}
 
 									ForEach(nodes) { node in
-										if node.num == bleManager.connectedPeripheral?.num ?? 0 {
+										if node.num == connectedPeripheral.num {
 											Label {
 												Text("BLE: \(node.user?.longName ?? "unknown".localized)")
 											} icon: {
@@ -477,9 +477,7 @@ struct Settings: View {
 			}
 			.listStyle(GroupedListStyle())
 			.navigationTitle("settings")
-			.navigationBarItems(leading:
-				MeshtasticLogo()
-			)
+			.navigationBarItems(leading: MeshtasticLogo())
 		}
 		detail: {
 			if #available (iOS 17, *) {

--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -233,10 +233,15 @@ struct ShareChannels: View {
 			}
 			.navigationTitle("generate.qr.code")
 			.navigationBarTitleDisplayMode(.inline)
-			.navigationBarItems(trailing:
-			ZStack {
-				ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-			})
+			.navigationBarItems(
+				trailing: ZStack {
+					ConnectedDevice(
+						bluetoothOn: bleManager.isSwitchedOn,
+						deviceConnected: bleManager.connectedPeripheral != nil,
+						name: bleManager.connectedPeripheral?.shortName ?? "?"
+					)
+				}
+			)
 			.onAppear {
 				bleManager.context = context
 				generateChannelSet()

--- a/Meshtastic/Views/Settings/UserConfig.swift
+++ b/Meshtastic/Views/Settings/UserConfig.swift
@@ -184,10 +184,15 @@ struct UserConfig: View {
 			Spacer()
 		}
 		.navigationTitle("user.config")
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(bluetoothOn: bleManager.isSwitchedOn, deviceConnected: bleManager.connectedPeripheral != nil, name: (bleManager.connectedPeripheral != nil) ? bleManager.connectedPeripheral.shortName : "?")
-		})
+		.navigationBarItems(
+			trailing: ZStack {
+				ConnectedDevice(
+					bluetoothOn: bleManager.isSwitchedOn,
+					deviceConnected: bleManager.connectedPeripheral != nil,
+					name: bleManager.connectedPeripheral?.shortName ?? "?"
+				)
+			}
+		)
 		.onAppear {
 			self.shortName = node?.user?.shortName ?? ""
 			self.longName = node?.user?.longName ?? ""


### PR DESCRIPTION
This change fixes a bunch of code quality issues using nil checks instead `if let`.

* Changed `BLEManager.connectedPeripheral` to an optional instead of an implicitly unwrapped optional. This caused a huge number of callsites to change, so those callsites were updated with `if let` syntax
* After this change, I ran into some compile time issues with some of the more complicated views. I split those up into `@ViewBuilder`s and computed properties, and extracted large blocks of code into methods.

I'm worried that I might have clobbered some of the changes Garth made around where the peripheral name gets set, so don't merge this unless you validate that fix is still working.