### PR TITLE
Fix MyInfo persistence that caused bluetooth desyncs

### DIFF
--- a/Meshtastic/Extensions/CoreData/MyInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/MyInfoEntityExtension.swift
@@ -5,10 +5,22 @@
 //  Copyright(c) Garth Vander Houwen 9/3/23.
 //
 
-import Foundation
+import CoreData
+import MeshtasticProtobufs
 
 extension MyInfoEntity {
 
+	convenience init(
+		context: NSManagedObjectContext,
+		myInfo: MyNodeInfo,
+		peripheralId: String
+	) {
+		self.init(context: context)
+		self.peripheralId = peripheralId
+		self.myNodeNum = Int64(myInfo.myNodeNum)
+		self.rebootCount = Int32(myInfo.rebootCount)
+	}
+	
 	var messageList: [MessageEntity] {
 		self.value(forKey: "allMessages") as? [MessageEntity] ?? [MessageEntity]()
 	}

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -133,7 +133,7 @@ public func clearCoreDataDatabase(context: NSManagedObjectContext, includeRoutes
 	}
 }
 
-func upsertNodeInfoPacket (packet: MeshPacket, context: NSManagedObjectContext) {
+func upsertNodeInfoPacket(packet: MeshPacket, context: NSManagedObjectContext) {
 
 	let logString = String.localizedStringWithFormat("mesh.log.nodeinfo.received %@".localized, String(packet.from))
 	MeshLogger.log("📟 \(logString)")
@@ -274,7 +274,7 @@ func upsertNodeInfoPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 			}
 		}
 	} catch {
-		Logger.data.error("💥 Error Fetching NodeInfoEntity for NODEINFO_APP")
+		Logger.data.error("💥 Error Fetching NodeInfoEntity for NODEINFO_APP: \(error.localizedDescription)")
 	}
 }
 

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -176,9 +176,9 @@ struct DisplayConfig: View {
 			setDisplayValues()
 
 			// Need to request a LoRaConfig from the remote node before allowing changes
-			if let connectedPeripheral = bleManager.connectedPeripheral,  node?.displayConfig == nil {
+			if let connectedPeripheral = bleManager.connectedPeripheral, node?.displayConfig == nil {
 				Logger.mesh.info("empty display config")
-				let connectedNode = getNodeInfo(id: bleManager.connectedPeripheral?.num ?? 0, context: context)
+				let connectedNode = getNodeInfo(id: connectedPeripheral.num, context: context)
 				if node != nil && connectedNode != nil {
 					_ = bleManager.requestDisplayConfig(fromUser: connectedNode!.user!, toUser: node!.user!, adminIndex: connectedNode?.myInfo?.adminIndex ?? 0)
 				}


### PR DESCRIPTION
This change tries to address race conditions that occur when repeatedly pairing and unpairing a node via bluetooth. This was caused by the fetch-update code when persisting a `MyInfoEntity` packet instead of relying on CoreData to do the synchronization and merging.

I also factored out a method that updates the appropriate fields on `connectedPeripheral` whenever packets come in, so the node list & bluetooth screen will render correctly.

I also fixed an inverted condition in the message validation logic. We want to make sure messages are _NOT_ empty before we allow them to be sent. 