### PR TITLE
Refactor `NSFetchRequest(entityName:)` to `Entity.fetchRequest()` for type safety

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -437,10 +437,10 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 			success = true
 
 			let traceRoute = TraceRouteEntity(context: context!)
-			let nodes: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+			let nodes = NodeInfoEntity.fetchRequest()
 			nodes.predicate = NSPredicate(format: "num IN %@", [destNum, connectedPeripheral.num])
 			do {
-				guard let fetchedNodes = try context!.fetch(nodes) as? [NodeInfoEntity] else {
+				guard let fetchedNodes = try context?.fetch(nodes) else {
 					return false
 				}
 				let receivingNode = fetchedNodes.first(where: { $0.num == destNum })
@@ -872,10 +872,10 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 				/// MQTT Client Proxy and RangeTest and Store and Forward interest
 				if connectedPeripheral.num > 0 {
 
-					let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+					let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 					fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(connectedPeripheral.num))
 					do {
-						let fetchedNodeInfo = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] ?? []
+						let fetchedNodeInfo = try context.fetch(fetchNodeInfoRequest)
 						if fetchedNodeInfo.count == 1 {
 							// Subscribe to Mqtt Client Proxy if enabled
 							if fetchedNodeInfo[0].mqttConfig != nil && fetchedNodeInfo[0].mqttConfig?.enabled ?? false && fetchedNodeInfo[0].mqttConfig?.proxyToClientEnabled ?? false {
@@ -963,7 +963,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 	
 
 		let fromUserNum: Int64 = connectedPeripheral.num
-		let messageUsers: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "UserEntity")
+		let messageUsers = UserEntity.fetchRequest()
 		messageUsers.predicate = NSPredicate(format: "num IN %@", [fromUserNum, Int64(toUserNum)])
 
 		do {
@@ -1497,7 +1497,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					for cs in channelSet.settings {
 						if addChannels {
 							// We are trying to add a channel so lets get the last index
-							let fetchMyInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "MyInfoEntity")
+							let fetchMyInfoRequest = MyInfoEntity.fetchRequest()
 							fetchMyInfoRequest.predicate = NSPredicate(format: "myNodeNum == %lld", connectedPeripheral.num)
 							do {
 								let fetchedMyInfo = try context?.fetch(fetchMyInfoRequest) as? [MyInfoEntity] ?? []
@@ -3066,7 +3066,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 		guard let connectedPeripheral else { return }
 		let myNodeNum = Int64(connectedPeripheral.num)
 		// Before we get started delete the existing channels from the myNodeInfo
-		let fetchMyInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "MyInfoEntity")
+		let fetchMyInfoRequest = MyInfoEntity.fetchRequest()
 		fetchMyInfoRequest.predicate = NSPredicate(format: "myNodeNum == %lld", myNodeNum)
 
 		do {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -121,13 +121,11 @@ func channelPacket (channel: Channel, fromNum: Int64, context: NSManagedObjectCo
 		let logString = String.localizedStringWithFormat("mesh.log.channel.received %d %@".localized, channel.index, String(fromNum))
 		MeshLogger.log("🎛️ \(logString)")
 
-		let fetchedMyInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "MyInfoEntity")
+		let fetchedMyInfoRequest = MyInfoEntity.fetchRequest()
 		fetchedMyInfoRequest.predicate = NSPredicate(format: "myNodeNum == %lld", fromNum)
 
 		do {
-			guard let fetchedMyInfo = try context.fetch(fetchedMyInfoRequest) as? [MyInfoEntity] else {
-				return
-			}
+			let fetchedMyInfo = try context.fetch(fetchedMyInfoRequest)
 			if fetchedMyInfo.count == 1 {
 				let newChannel = ChannelEntity(
 					context: context,
@@ -179,13 +177,11 @@ func deviceMetadataPacket (metadata: DeviceMetadata, fromNum: Int64, context: NS
 	let logString = String.localizedStringWithFormat("mesh.log.device.metadata.received %@".localized, String(fromNum))
 	MeshLogger.log("🏷️ \(logString)")
 
-	let fetchedNodeRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchedNodeRequest = NodeInfoEntity.fetchRequest()
 	fetchedNodeRequest.predicate = NSPredicate(format: "num == %lld", fromNum)
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchedNodeRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchedNodeRequest)
 		let newMetadata = DeviceMetadataEntity(
 			context: context,
 			metadata: metadata
@@ -265,13 +261,11 @@ func adminAppPacket (packet: MeshPacket, context: NSManagedObjectContext) {
 					let logString = String.localizedStringWithFormat("mesh.log.cannedmessages.messages.received %@".localized, packet.from.toHex())
 					MeshLogger.log("🥫 \(logString)")
 
-					let fetchNodeRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+					let fetchNodeRequest = NodeInfoEntity.fetchRequest()
 					fetchNodeRequest.predicate = NSPredicate(format: "num == %lld", Int64(packet.from))
 
 					do {
-						guard let fetchedNode = try context.fetch(fetchNodeRequest) as? [NodeInfoEntity] else {
-							return
-						}
+						let fetchedNode = try context.fetch(fetchNodeRequest)
 						if fetchedNode.count == 1 {
 							let messages =  String(cmmc.textFormatString())
 								.replacingOccurrences(of: "11: ", with: "")
@@ -347,12 +341,10 @@ func adminAppPacket (packet: MeshPacket, context: NSManagedObjectContext) {
 
 func adminResponseAck (packet: MeshPacket, context: NSManagedObjectContext) {
 
-	let fetchedAdminMessageRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "MessageEntity")
+	let fetchedAdminMessageRequest = MessageEntity.fetchRequest()
 	fetchedAdminMessageRequest.predicate = NSPredicate(format: "messageId == %lld", packet.decoded.requestID)
 	do {
-		guard let fetchedMessage = try context.fetch(fetchedAdminMessageRequest) as? [MessageEntity] else {
-			return
-		}
+		let fetchedMessage = try context.fetch(fetchedAdminMessageRequest)
 		if fetchedMessage.count > 0 {
 			fetchedMessage[0].ackTimestamp = Int32(Date().timeIntervalSince1970)
 			fetchedMessage[0].ackError = Int32(RoutingError.none.rawValue)
@@ -377,11 +369,11 @@ func paxCounterPacket (packet: MeshPacket, context: NSManagedObjectContext) {
 	let logString = String.localizedStringWithFormat("mesh.log.paxcounter %@".localized, String(packet.from))
 	MeshLogger.log("🧑‍🤝‍🧑 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(packet.from))
 
 	do {
-		let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity]
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 
 		if let paxMessage = try? Paxcount(serializedData: packet.decoded.payload) {
 
@@ -391,12 +383,12 @@ func paxCounterPacket (packet: MeshPacket, context: NSManagedObjectContext) {
 			newPax.uptime = Int32(truncatingIfNeeded: paxMessage.uptime)
 			newPax.time = Date()
 
-			if fetchedNode?.count ?? 0 > 0 {
-				guard let mutablePax = fetchedNode?[0].pax!.mutableCopy() as? NSMutableOrderedSet else {
+			if fetchedNode.count > 0 {
+				guard let mutablePax = fetchedNode[0].pax!.mutableCopy() as? NSMutableOrderedSet else {
 					return
 				}
 				mutablePax.add(newPax)
-				fetchedNode![0].pax = mutablePax
+				fetchedNode[0].pax = mutablePax
 				do {
 					try context.save()
 				} catch {
@@ -421,40 +413,40 @@ func routingPacket (packet: MeshPacket, connectedNodeNum: Int64, context: NSMana
 		let logString = String.localizedStringWithFormat("mesh.log.routing.message %@ %@".localized, String(packet.decoded.requestID), routingErrorString)
 		MeshLogger.log("🕸️ \(logString)")
 
-		let fetchMessageRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "MessageEntity")
+		let fetchMessageRequest = MessageEntity.fetchRequest()
 		fetchMessageRequest.predicate = NSPredicate(format: "messageId == %lld", Int64(packet.decoded.requestID))
 
 		do {
-			let fetchedMessage = try context.fetch(fetchMessageRequest) as? [MessageEntity]
-			if fetchedMessage?.count ?? 0 > 0 {
+			let fetchedMessage = try context.fetch(fetchMessageRequest)
+			if fetchedMessage.count > 0 {
 
-				if fetchedMessage![0].toUser != nil {
+				if fetchedMessage[0].toUser != nil {
 					// Real ACK from DM Recipient
 					if packet.to != packet.from {
-						fetchedMessage![0].realACK = true
+						fetchedMessage[0].realACK = true
 					}
 				}
-				fetchedMessage![0].ackError = Int32(routingMessage.errorReason.rawValue)
+				fetchedMessage[0].ackError = Int32(routingMessage.errorReason.rawValue)
 
 				if routingMessage.errorReason == Routing.Error.none {
 
-					fetchedMessage![0].receivedACK = true
+					fetchedMessage[0].receivedACK = true
 				} else {
 					Logger.statistics.error("❗ Routing Error: \(routingErrorString) for a text message packet from Node: \(packet.from)")
 				}
-				fetchedMessage![0].ackSNR = packet.rxSnr
-				fetchedMessage![0].ackTimestamp = Int32(truncatingIfNeeded: packet.rxTime)
+				fetchedMessage[0].ackSNR = packet.rxSnr
+				fetchedMessage[0].ackTimestamp = Int32(truncatingIfNeeded: packet.rxTime)
 
-				if fetchedMessage![0].toUser != nil {
-					fetchedMessage![0].toUser!.objectWillChange.send()
+				if fetchedMessage[0].toUser != nil {
+					fetchedMessage[0].toUser!.objectWillChange.send()
 				} else {
-					let fetchMyInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "MyInfoEntity")
+					let fetchMyInfoRequest = MyInfoEntity.fetchRequest()
 					fetchMyInfoRequest.predicate = NSPredicate(format: "myNodeNum == %lld", connectedNodeNum)
 					do {
-						let fetchedMyInfo = try context.fetch(fetchMyInfoRequest) as? [MyInfoEntity]
-						if fetchedMyInfo?.count ?? 0 > 0 {
+						let fetchedMyInfo = try context.fetch(fetchMyInfoRequest)
+						if fetchedMyInfo.count > 0 {
 
-							for ch in fetchedMyInfo![0].channels!.array as? [ChannelEntity] ?? [] where ch.index == packet.channel {
+							for ch in fetchedMyInfo[0].channels!.array as? [ChannelEntity] ?? [] where ch.index == packet.channel {
 								ch.objectWillChange.send()
 							}
 						}
@@ -488,14 +480,11 @@ func telemetryPacket(packet: MeshPacket, connectedNode: Int64, context: NSManage
 
 		let telemetry = TelemetryEntity(context: context)
 
-		let fetchNodeTelemetryRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+		let fetchNodeTelemetryRequest = NodeInfoEntity.fetchRequest()
 		fetchNodeTelemetryRequest.predicate = NSPredicate(format: "num == %lld", Int64(packet.from))
 
 		do {
-
-			guard let fetchedNode = try context.fetch(fetchNodeTelemetryRequest) as? [NodeInfoEntity] else {
-				return
-			}
+			let fetchedNode = try context.fetch(fetchNodeTelemetryRequest)
 			if fetchedNode.count == 1 {
 				if telemetryMessage.variant == Telemetry.OneOf_Variant.deviceMetrics(telemetryMessage.deviceMetrics) {
 					// Device Metrics
@@ -611,12 +600,10 @@ func textMessageAppPacket(packet: MeshPacket, wantRangeTestPackets: Bool, connec
 
 		MeshLogger.log("💬 \("mesh.log.textmessage.received".localized)")
 
-		let messageUsers: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "UserEntity")
+		let messageUsers = UserEntity.fetchRequest()
 		messageUsers.predicate = NSPredicate(format: "num IN %@", [packet.to, packet.from])
 		do {
-			guard let fetchedUsers = try context.fetch(messageUsers) as? [UserEntity] else {
-				return
-			}
+			let fetchedUsers = try context.fetch(messageUsers)
 			let newMessage = MessageEntity(context: context)
 			newMessage.messageId = Int64(packet.id)
 			newMessage.messageTimestamp = Int32(bitPattern: packet.rxTime)
@@ -687,13 +674,11 @@ func textMessageAppPacket(packet: MeshPacket, wantRangeTestPackets: Bool, connec
 						}
 					} else if newMessage.fromUser != nil && newMessage.toUser == nil {
 
-						let fetchMyInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "MyInfoEntity")
+						let fetchMyInfoRequest = MyInfoEntity.fetchRequest()
 						fetchMyInfoRequest.predicate = NSPredicate(format: "myNodeNum == %lld", Int64(connectedNode))
 
 						do {
-							guard let fetchedMyInfo = try context.fetch(fetchMyInfoRequest) as? [MyInfoEntity] else {
-								return
-							}
+							let fetchedMyInfo = try context.fetch(fetchMyInfoRequest)
 							if !fetchedMyInfo.isEmpty {
 								appState.unreadChannelMessages = fetchedMyInfo[0].unreadMessages
 								UIApplication.shared.applicationIconBadgeNumber = appState.unreadChannelMessages + appState.unreadDirectMessages
@@ -740,15 +725,13 @@ func waypointPacket (packet: MeshPacket, context: NSManagedObjectContext) {
 	let logString = String.localizedStringWithFormat("mesh.log.waypoint.received %@".localized, String(packet.from))
 	MeshLogger.log("📍 \(logString)")
 
-	let fetchWaypointRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "WaypointEntity")
+	let fetchWaypointRequest = WaypointEntity.fetchRequest()
 	fetchWaypointRequest.predicate = NSPredicate(format: "id == %lld", Int64(packet.id))
 
 	do {
 
 		if let waypointMessage = try? Waypoint(serializedData: packet.decoded.payload) {
-			guard let fetchedWaypoint = try context.fetch(fetchWaypointRequest) as? [WaypointEntity] else {
-				return
-			}
+			let fetchedWaypoint = try context.fetch(fetchWaypointRequest)
 			if fetchedWaypoint.isEmpty {
 				let waypoint = WaypointEntity(context: context)
 

--- a/Meshtastic/Persistence/QueryCoreData.swift
+++ b/Meshtastic/Persistence/QueryCoreData.swift
@@ -9,13 +9,11 @@ import CoreData
 
 public func getNodeInfo(id: Int64, context: NSManagedObjectContext) -> NodeInfoEntity? {
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(id))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return nil
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		if fetchedNode.count == 1 {
 			return fetchedNode[0]
 		}
@@ -28,15 +26,13 @@ public func getNodeInfo(id: Int64, context: NSManagedObjectContext) -> NodeInfoE
 public func getStoreAndForwardMessageIds(seconds: Int, context: NSManagedObjectContext) -> [UInt32] {
 
 	let time = seconds * -1
-	let fetchMessagesRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "MessageEntity")
+	let fetchMessagesRequest = MessageEntity.fetchRequest()
 	let timeRange = Calendar.current.date(byAdding: .minute, value: time, to: Date())
 	let milleseconds = Int32(timeRange?.timeIntervalSince1970 ?? 0)
 	fetchMessagesRequest.predicate =  NSPredicate(format: "receivedTimestamp >= %d", milleseconds)
 
 	do {
-		guard let fetchedMessages = try context.fetch(fetchMessagesRequest) as? [MessageEntity] else {
-			return []
-		}
+		let fetchedMessages = try context.fetch(fetchMessagesRequest)
 		if fetchedMessages.count == 1 {
 			return fetchedMessages.map { UInt32($0.messageId) }
 		}
@@ -48,13 +44,11 @@ public func getStoreAndForwardMessageIds(seconds: Int, context: NSManagedObjectC
 
 public func getTraceRoute(id: Int64, context: NSManagedObjectContext) -> TraceRouteEntity? {
 
-	let fetchTraceRouteRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "TraceRouteEntity")
+	let fetchTraceRouteRequest = TraceRouteEntity.fetchRequest()
 	fetchTraceRouteRequest.predicate = NSPredicate(format: "id == %lld", Int64(id))
 
 	do {
-		guard let fetchedTraceRoute = try context.fetch(fetchTraceRouteRequest) as? [TraceRouteEntity] else {
-			return nil
-		}
+		let fetchedTraceRoute = try context.fetch(fetchTraceRouteRequest)
 		if fetchedTraceRoute.count == 1 {
 			return fetchedTraceRoute[0]
 		}
@@ -66,13 +60,11 @@ public func getTraceRoute(id: Int64, context: NSManagedObjectContext) -> TraceRo
 
 public func getUser(id: Int64, context: NSManagedObjectContext) -> UserEntity {
 
-	let fetchUserRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "UserEntity")
+	let fetchUserRequest = UserEntity.fetchRequest()
 	fetchUserRequest.predicate = NSPredicate(format: "num == %lld", Int64(id))
 
 	do {
-		guard let fetchedUser = try context.fetch(fetchUserRequest) as? [UserEntity] else {
-			return UserEntity(context: context)
-		}
+		let fetchedUser = try context.fetch(fetchUserRequest)
 		if fetchedUser.count == 1 {
 			return fetchedUser[0]
 		}
@@ -84,13 +76,11 @@ public func getUser(id: Int64, context: NSManagedObjectContext) -> UserEntity {
 
 public func getWaypoint(id: Int64, context: NSManagedObjectContext) -> WaypointEntity {
 
-	let fetchWaypointRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "WaypointEntity")
+	let fetchWaypointRequest = WaypointEntity.fetchRequest()
 	fetchWaypointRequest.predicate = NSPredicate(format: "id == %lld", Int64(id))
 
 	do {
-		guard let fetchedWaypoint = try context.fetch(fetchWaypointRequest) as? [WaypointEntity] else {
-			return WaypointEntity(context: context)
-		}
+		let fetchedWaypoint = try context.fetch(fetchWaypointRequest)
 		if fetchedWaypoint.count == 1 {
 			return fetchedWaypoint[0]
 		}

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -10,13 +10,11 @@ import OSLog
 
 public func clearPax(destNum: Int64, context: NSManagedObjectContext) -> Bool {
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(destNum))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return false
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		let newPax = [PaxCounterLog]()
 		fetchedNode[0].pax? = NSOrderedSet(array: newPax)
 		do {
@@ -35,13 +33,11 @@ public func clearPax(destNum: Int64, context: NSManagedObjectContext) -> Bool {
 
 public func clearPositions(destNum: Int64, context: NSManagedObjectContext) -> Bool {
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(destNum))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return false
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		let newPostions = [PositionEntity]()
 		fetchedNode[0].positions? = NSOrderedSet(array: newPostions)
 		do {
@@ -60,13 +56,11 @@ public func clearPositions(destNum: Int64, context: NSManagedObjectContext) -> B
 
 public func clearTelemetry(destNum: Int64, metricsType: Int32, context: NSManagedObjectContext) -> Bool {
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(destNum))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return false
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		let emptyTelemetry = [TelemetryEntity]()
 		fetchedNode[0].telemetries? = NSOrderedSet(array: emptyTelemetry)
 		do {
@@ -140,12 +134,12 @@ func upsertNodeInfoPacket(packet: MeshPacket, context: NSManagedObjectContext) {
 
 	guard packet.from > 0 else { return }
 
-	let fetchNodeInfoAppRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoAppRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoAppRequest.predicate = NSPredicate(format: "num == %lld", Int64(packet.from))
 
 	do {
 
-		let fetchedNode = try context.fetch(fetchNodeInfoAppRequest) as? [NodeInfoEntity] ?? []
+		let fetchedNode = try context.fetch(fetchNodeInfoAppRequest)
 		if fetchedNode.count == 0 {
 			// Not Found Insert
 			let newNode = NodeInfoEntity(context: context)
@@ -283,7 +277,7 @@ func upsertPositionPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 	let logString = String.localizedStringWithFormat("mesh.log.position.received %@".localized, packet.from.toHex())
 	MeshLogger.log("📍 \(logString)")
 
-	let fetchNodePositionRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodePositionRequest = NodeInfoEntity.fetchRequest()
 	fetchNodePositionRequest.predicate = NSPredicate(format: "num == %lld", Int64(packet.from))
 
 	do {
@@ -292,18 +286,14 @@ func upsertPositionPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 
 			/// Don't save empty position packets from null island or apple park
 			if (positionMessage.longitudeI != 0 && positionMessage.latitudeI != 0) && (positionMessage.latitudeI != 373346000 && positionMessage.longitudeI != -1220090000) {
-				guard let fetchedNode = try context.fetch(fetchNodePositionRequest) as? [NodeInfoEntity] else {
-					return
-				}
+				let fetchedNode = try context.fetch(fetchNodePositionRequest)
 				if fetchedNode.count == 1 {
 
 					// Unset the current latest position for this node
-					let fetchCurrentLatestPositionsRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "PositionEntity")
+					let fetchCurrentLatestPositionsRequest = PositionEntity.fetchRequest()
 					fetchCurrentLatestPositionsRequest.predicate = NSPredicate(format: "nodePosition.num == %lld && latest = true", Int64(packet.from))
 
-					guard let fetchedPositions = try context.fetch(fetchCurrentLatestPositionsRequest) as? [PositionEntity] else {
-						return
-					}
+					let fetchedPositions = try context.fetch(fetchCurrentLatestPositionsRequest)
 					if fetchedPositions.count > 0 {
 						for position in fetchedPositions {
 							position.latest = false
@@ -384,13 +374,11 @@ func upsertBluetoothConfigPacket(config: Config.BluetoothConfig, nodeNum: Int64,
 	let logString = String.localizedStringWithFormat("mesh.log.bluetooth.config %@".localized, String(nodeNum))
 	MeshLogger.log("📶 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Device Config
 		if !fetchedNode.isEmpty {
 			if fetchedNode[0].bluetoothConfig == nil {
@@ -425,13 +413,11 @@ func upsertDeviceConfigPacket(config: Config.DeviceConfig, nodeNum: Int64, conte
 
 	let logString = String.localizedStringWithFormat("mesh.log.device.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("📟 \(logString)")
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Device Config
 		if !fetchedNode.isEmpty {
 			if fetchedNode[0].deviceConfig == nil {
@@ -481,13 +467,11 @@ func upsertDisplayConfigPacket(config: Config.DisplayConfig, nodeNum: Int64, con
 	let logString = String.localizedStringWithFormat("mesh.log.display.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("🖥️ \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Device Config
 		if !fetchedNode.isEmpty {
 
@@ -547,12 +531,10 @@ func upsertLoRaConfigPacket(config: Config.LoRaConfig, nodeNum: Int64, context: 
 	let logString = String.localizedStringWithFormat("mesh.log.lora.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("📻 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", nodeNum)
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save LoRa Config
 		if fetchedNode.count > 0 {
 			if fetchedNode[0].loRaConfig == nil {
@@ -614,14 +596,11 @@ func upsertNetworkConfigPacket(config: Config.NetworkConfig, nodeNum: Int64, con
 	let logString = String.localizedStringWithFormat("mesh.log.network.config %@".localized, String(nodeNum))
 	MeshLogger.log("🌐 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save WiFi Config
 		if !fetchedNode.isEmpty {
 			if fetchedNode[0].networkConfig == nil {
@@ -661,14 +640,12 @@ func upsertPositionConfigPacket(config: Config.PositionConfig, nodeNum: Int64, c
 	let logString = String.localizedStringWithFormat("mesh.log.position.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("🗺️ \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
 
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save LoRa Config
 		if !fetchedNode.isEmpty {
 			if fetchedNode[0].positionConfig == nil {
@@ -723,13 +700,11 @@ func upsertPowerConfigPacket(config: Config.PowerConfig, nodeNum: Int64, context
 	let logString = String.localizedStringWithFormat("mesh.log.power.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("🗺️ \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Power Config
 		if !fetchedNode.isEmpty {
 			if fetchedNode[0].powerConfig == nil {
@@ -773,14 +748,11 @@ func upsertAmbientLightingModuleConfigPacket(config: ModuleConfig.AmbientLightin
 	let logString = String.localizedStringWithFormat("mesh.log.ambientlighting.config %@".localized, String(nodeNum))
 	MeshLogger.log("🏮 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Ambient Lighting Config
 		if !fetchedNode.isEmpty {
 
@@ -829,14 +801,11 @@ func upsertCannedMessagesModuleConfigPacket(config: ModuleConfig.CannedMessageCo
 	let logString = String.localizedStringWithFormat("mesh.log.cannedmessage.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("🥫 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Canned Message Config
 		if !fetchedNode.isEmpty {
 
@@ -893,14 +862,11 @@ func upsertDetectionSensorModuleConfigPacket(config: ModuleConfig.DetectionSenso
 	let logString = String.localizedStringWithFormat("mesh.log.detectionsensor.config %@".localized, String(nodeNum))
 	MeshLogger.log("🕵️ \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Detection Sensor Config
 		if !fetchedNode.isEmpty {
 
@@ -954,14 +920,11 @@ func upsertExternalNotificationModuleConfigPacket(config: ModuleConfig.ExternalN
 	let logString = String.localizedStringWithFormat("mesh.log.externalnotification.config %@".localized, String(nodeNum))
 	MeshLogger.log("📣 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		
 		guard let node = fetchedNode.first else {
 			return Logger.data.error("💥 No Nodes found in local database matching node \(nodeNum.toHex()) unable to save External Notification Module Config")
@@ -996,14 +959,11 @@ func upsertPaxCounterModuleConfigPacket(config: ModuleConfig.PaxcounterConfig, n
 	let logString = String.localizedStringWithFormat("mesh.log.paxcounter.config %@".localized, String(nodeNum))
 	MeshLogger.log("🧑‍🤝‍🧑 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save PAX Counter Config
 		if !fetchedNode.isEmpty {
 
@@ -1041,14 +1001,11 @@ func upsertRtttlConfigPacket(ringtone: String, nodeNum: Int64, context: NSManage
 	let logString = String.localizedStringWithFormat("mesh.log.ringtone.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("⛰️ \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save RTTTL Config
 		if !fetchedNode.isEmpty {
 			if fetchedNode[0].rtttlConfig == nil {
@@ -1080,14 +1037,11 @@ func upsertMqttModuleConfigPacket(config: ModuleConfig.MQTTConfig, nodeNum: Int6
 	let logString = String.localizedStringWithFormat("mesh.log.mqtt.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("🌉 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		
 		guard let node = fetchedNode.first else {
 			Logger.data.error("No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save MQTT Module Config")
@@ -1123,14 +1077,11 @@ func upsertRangeTestModuleConfigPacket(config: ModuleConfig.RangeTestConfig, nod
 	let logString = String.localizedStringWithFormat("mesh.log.rangetest.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("⛰️ \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Device Config
 		if let node = fetchedNode.first {
 			if let rangeTestConfig = node.rangeTestConfig {
@@ -1162,19 +1113,17 @@ func upsertSerialModuleConfigPacket(config: ModuleConfig.SerialConfig, nodeNum: 
 	let logString = String.localizedStringWithFormat("mesh.log.serial.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("🤖 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		guard let node = fetchedNode.first else {
 			return Logger.data.error("💥 No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Serial Module Config")
 		}
 		
 		// Found a node, save Device Config
-		if let serialConfig = node.serialConfig {
+		if node.serialConfig != nil {
 			node.serialConfig?.update(with: config)
 		} else {
 			node.serialConfig = SerialConfigEntity(
@@ -1202,14 +1151,11 @@ func upsertStoreForwardModuleConfigPacket(config: ModuleConfig.StoreForwardConfi
 	let logString = String.localizedStringWithFormat("mesh.log.storeforward.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("📬 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(nodeNum))
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		guard let node = fetchedNode.first else {
 			Logger.data.error("💥 No Nodes found in local database matching node \(nodeNum.toHex()) unable to save Store & Forward Module Config")
 			return
@@ -1242,14 +1188,11 @@ func upsertTelemetryModuleConfigPacket(config: ModuleConfig.TelemetryConfig, nod
 	let logString = String.localizedStringWithFormat("mesh.log.telemetry.config %@".localized, nodeNum.toHex())
 	MeshLogger.log("📈 \(logString)")
 
-	let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+	let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 	fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", nodeNum)
 
 	do {
-
-		guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {
-			return
-		}
+		let fetchedNode = try context.fetch(fetchNodeInfoRequest)
 		// Found a node, save Telemetry Config
 		if !fetchedNode.isEmpty {
 

--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -314,7 +314,7 @@ struct Connect: View {
 
 			if UserDefaults.preferredPeripheralId.count > 0 && sub {
 
-				let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+				let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 				fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(bleManager.connectedPeripheral?.num ?? -1))
 
 				do {

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -90,7 +90,7 @@ struct Messages: View {
 					self.bleManager.context = context
 				}
 				if UserDefaults.preferredPeripheralId.count > 0 {
-					let fetchNodeInfoRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest.init(entityName: "NodeInfoEntity")
+					let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
 					fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", Int64(UserDefaults.preferredPeripheralNum))
 					do {
 						guard let fetchedNode = try context.fetch(fetchNodeInfoRequest) as? [NodeInfoEntity] else {


### PR DESCRIPTION
This change uses the generated API for constructing fetch requests instead of `NSFetchRequest(entityName: "...")`. This avoids unnecessary typecasts and guards.