### PR TITLE
Adding project documentation to formalize development and release management

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What changed?
+<!-- Provide a clear description for the change -->
+
+## Why did it change?
+<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
+
+## How is this tested?
+<!-- Describe your approach to testing the feature. -->
+
+## Screenshots/Videos (when applicable)
+
+<!-- Attach screenshots or videos demonstrating the new feature in action. -->
+
+## Checklist
+
+- [ ] My code adheres to the project's coding and style guidelines.
+- [ ] I have conducted a self-review of my code.
+- [ ] I have commented my code, particularly in complex areas.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have tested the change to ensure that it works as intended.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,128 @@
+# Contributing to Meshtastic
+
+Thank you for considering contributing to Meshtastic! We appreciate your time and effort in helping to improve the project. This document outlines the guidelines for contributing to the project.
+
+## Table of Contents
+
+1. [Getting Started](#getting-started)
+2. [Development Workflow](#development-workflow)
+   - [Targeting `main`](#targeting-main)
+   - [Small, Incremental Changes](#small-incremental-changes)
+   - [Rebase Commits](#rebase-commits)
+3. [Creating a Branch](#creating-a-branch)
+4. [Making Changes](#making-changes)
+5. [Commit Messages](#commit-messages)
+6. [Merging Changes](#merging-changes)
+7. [Testing](#testing)
+8. [Code Review](#code-review)
+9. [Documentation](#documentation)
+10. [Style Guides](#style-guides)
+    - [Git Commit Messages](#git-commit-messages)
+    - [Code Style](#code-style)
+11. [Community](#community)
+
+## Getting Started
+
+1. Fork the repository on GitLab.
+2. Clone your fork to your local machine:
+   ```sh
+   git clone https://gitlab.com/<your-username>/Meshtastic-Apple.git
+   ```
+3. Navigate to the project directory:
+   ```sh
+   cd Meshtastic-Apple
+   ```
+4. Open the Meshtastic.xcworkspace
+   ```sh
+   open Meshtastic.xcworkspace
+   ```
+
+## Development Workflow
+
+### Targeting `main`
+
+In accordance with trunk-based development, all changes should target the `main` branch.
+
+### Small, Incremental Changes
+
+To facilitate easy code reviews and minimize merge conflicts, we encourage making small, incremental changes. Each change should be a self-contained, logically coherent unit of work that addresses a specific task or fixes a particular issue.
+
+### Rebase Commits
+
+To keep the project history clean, please use rebasing over merging when incorporating changes from the `main` branch into your feature branches. To rebase your branch on `main`, you can perform the following steps.
+
+```sh
+git fetch
+git rebase main
+```
+
+To enable pulls to rebase by default, you can use this git configuration option.
+
+```sh
+git config pull.rebase true
+```
+
+## Creating a Branch
+
+1. Always create a new branch for your work. Use a descriptive name for your branch:
+   ```sh
+   git checkout -b your-branch-name
+   ```
+
+## Making Changes
+
+1. Make your changes in the new branch.
+2. Ensure your changes adhere to the project’s coding standards and conventions.
+3. Keep your changes focused and avoid combining multiple unrelated tasks in a single branch.
+
+## Commit Messages
+
+1. Write clear and concise commit messages following the guidelines in [Git Commit Messages](#git-commit-messages).
+
+## Merging Changes
+
+1. Push your changes to your fork:
+   ```sh
+   git push origin your-branch-name
+   ```
+2. Create a pull request (PR) targeting the `main` branch.
+3. Ensure your PR adheres to the project's guidelines and includes a clear description of the changes.
+4. Request a code review from the project maintainers.
+
+## Testing
+
+1. Ensure all existing tests pass before submitting your PR.
+2. Write new tests for any new features or bug fixes.
+3. Run the tests locally
+
+## Code Review
+
+1. Address any feedback or changes requested by the reviewers.
+2. Once approved, the PR will be merged into the `main` branch by a project maintainer.
+
+## Documentation
+
+1. Update the documentation to reflect any changes you have made.
+2. Ensure the documentation is clear and concise.
+
+## Style Guides
+
+### Git Commit Messages
+
+- Use the imperative mood in the subject line (e.g., "Fix bug" instead of "Fixed bug").
+- Use the body to explain what and why, not how.
+
+### Code Style
+
+- This project requires swiftLint - see https://github.com/realm/SwiftLint
+- Use SwiftUI
+- Use SFSymbols for icons
+- Use Core Data for persistence
+- Ensure your code is clean and well-documented.
+
+## Community
+
+- Join our community on [Discord](https://discord.com/invite/ktMAKGBnBs).
+- Participate in discussions and share your ideas.
+
+Thank you for contributing to Meshtastic!

--- a/README.md
+++ b/README.md
@@ -8,40 +8,27 @@
 
 SwiftUI client applications for iOS, iPadOS and macOS.
 
-## Getting Started
+## OS Requirements
 
-This project is currently using **Xcode 15.4**. 
+* iOS App Requires iOS 16 +
+* iPadOS App Requires iPadOS 16 +
+* Mac App Reguires macOS 13 +
 
-1. Clone the repo.
-2. Open `Meshtastic.xcworkspace`
-2. Build and run the `Meshtastic` target.
+## Contributing
 
-```sh
-git clone git@github.com:meshtastic/Meshtastic-Apple.git
-cd Meshtastic-Apple
-open Meshtastic.xcworkspace
-```
-
-## Technical Standards
-
-### Supported Operating Systems
-
-* iOS 16+
-* iPadOS 16+
-* macOS 13+
-
-### Code Standards
-
-- Use SwiftUI
-- Use SFSymbols for icons
-- Use Core Data for persistence
+For information on how to contribute to Meshtastic-Apple, please read [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Updating Protobufs:
-- run:
-  ```bash
-  scripts/gen_protos.sh
-  ```
-- build, test, commit changes
+
+1. run
+```bash
+./scripts/gen_protos.sh
+```
+2. Build, test, and commit the changes.
+
+## Release Process
+
+For more information on how a new release of Meshtastic is managed, please refer to [RELEASING.md](./RELEASING.md)
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing Meshtastic
+
+This document outlines the process for preparing and making a release for Meshtastic.
+
+## Table of Contents
+
+1. [Branching Strategy](#branching-strategy)
+2. [Preparing for a Release](#preparing-for-a-release)
+3. [Creating a Release Branch](#creating-a-release-branch)
+4. [Finalizing the Release](#finalizing-the-release)
+
+## Branching Strategy
+
+- **Main Branch (`main`)**: This is the main development branch where daily development occurs. 
+- **Release Branch (`X.YY.ZZ-release`)**: This branch is created from `main` for preparing a specific release version.
+
+## Preparing for a Release
+
+1. Ensure all desired features and fixes are merged into the `main` branch.
+2. Update the version number in the relevant files.
+3. Update the project documentation to reflect the upcoming release.
+
+## Creating a Release Branch
+
+1. Create a release branch from `main`.
+   ```sh
+   ./scripts/create-release-branch.sh
+   ```
+
+## Finalizing the Release
+
+1. Perform final testing and quality checks on the `X.YY.ZZ-release` branch.
+    a. If any hotfix changes are required, merge those changes into `X.YY.ZZ-release`.
+    b. After merging these changes into the release branch, cherry-pick the changes onto `main`.
+2. Once everything is ready, create a final tag for the release:
+   ```sh
+   git tag -a X.YY.ZZ -m "Release version X.Y.Z"
+   git push origin X.YY.ZZ
+   ```
+
+Thank you for following the release process and helping to ensure the stability and quality of Meshtastic!
+
+---
+
+Feel free to modify this template to better fit your project's specific needs.

--- a/scripts/create-release-branch.sh
+++ b/scripts/create-release-branch.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Check if the release version number is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <release-version>"
+  exit 1
+fi
+
+# Set the release version number
+RELEASE_VERSION=$1
+
+# Check if the release branch already exists on the remote repository
+if git ls-remote --exit-code --heads origin $RELEASE_BRANCH; then
+  echo "The branch $RELEASE_BRANCH already exists on the remote repository."
+  exit 1
+fi
+
+# Prompt the user for confirmation
+echo "You are about to create and push the release branch ${RELEASE_VERSION}-release."
+read -p "Are you sure you want to proceed? (Y/n): " confirmation
+
+# Check the user's response
+if [[ ! "$confirmation" =~ ^[Yy]$ ]]; then
+  echo "Operation cancelled."
+  exit 0
+fi
+
+# Check out the main branch and pull the latest changes
+git checkout main
+git pull origin main
+
+# Create a new branch for the release
+RELEASE_BRANCH="${RELEASE_VERSION}-release"
+git checkout -b $RELEASE_BRANCH
+
+# Push the new release branch to the remote repository
+git push origin $RELEASE_BRANCH
+
+echo "Release branch $RELEASE_BRANCH created and pushed successfully."


### PR DESCRIPTION
This change institutes several new development lifecycle changes across the project. The major changes are outlined below.

1. Start using trunk-based development by encouraging contributors to target `main` with their changes.
2. Formalize a release process by documenting the steps for managing released versions on GitHub. 
3. Adds a PR template so that pull requests follow a standardized format

This is a big shift in how things are currently managed, and I wanna make sure we're all good with this before accepting these changes.