### PR TITLE
add now missing value label

### DIFF
--- a/Meshtastic/Views/MapKitMap/Custom/LocalMBTileOverlay.swift
+++ b/Meshtastic/Views/MapKitMap/Custom/LocalMBTileOverlay.swift
@@ -56,8 +56,8 @@ class LocalMBTileOverlay: MKTileOverlay {
 			self.mb = try Connection(self.path, readonly: true)
 			let metadata = Table("metadata")
 
-			let name = Expression<String>("name")
-			let value = Expression<String>("value")
+			let name = Expression<String>(value: "name")
+			let value = Expression<String>(value: "value")
 
 			// make sure it's raster
 			let formatQuery = try mb.pluck(metadata.select(value).filter(name == "format"))


### PR DESCRIPTION
On Sonoma these items were throwing errors in Xcode cloud and in Xcode 16 beta, made the suggested changes to fix the build both places