### PR TITLE
Adding scripts to setup linting as a pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ SwiftUI client applications for iOS, iPadOS and macOS.
 This project is currently using **Xcode 15.4**. 
 
 1. Clone the repo.
+2. Set up git hooks to automatically lint the project when you commit changes.
 2. Open `Meshtastic.xcworkspace`
 2. Build and run the `Meshtastic` target.
 
 ```sh
 git clone git@github.com:meshtastic/Meshtastic-Apple.git
 cd Meshtastic-Apple
+./scripts/setup-hooks.sh
 open Meshtastic.xcworkspace
 ```
 

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./scripts/lint/lint-fix-changes.sh

--- a/scripts/lint/lint-fix-changes.sh
+++ b/scripts/lint/lint-fix-changes.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Path to swiftlint
+SWIFT_LINT=$(which swiftlint)
+
+# Check if SwiftLint is installed
+if [[ -e "${SWIFT_LINT}" ]]; then
+    count=0
+    for file_path in $(git ls-files -m --exclude-from=.gitignore | grep ".swift$"); do
+        export SCRIPT_INPUT_FILE_$count=$file_path
+        count=$((count + 1))
+    done
+
+    ##### Check for modified files in unstaged/Staged area #####
+    for file_path in $(git diff --name-only --cached | grep ".swift$"); do
+        export SCRIPT_INPUT_FILE_$count=$file_path
+        count=$((count + 1))
+    done
+
+    ##### Make the count available as global variable #####
+    export SCRIPT_INPUT_FILE_COUNT=$count
+
+    ##### Fix files or exit if no files found for fixing #####
+    if [ "$count" -ne 0 ]; then
+        echo "Found files to fix! Running swiftLint --fix..."
+        
+        # Run SwiftLint --fix on each file
+        for ((i = 0; i < count; i++)); do
+            file_var="SCRIPT_INPUT_FILE_$i"
+            file_path=${!file_var}
+            echo "Fixing $file_path"
+            $SWIFT_LINT --fix --path "$file_path"
+        done
+        
+        # Add the fixed files back to staging
+        for ((i = 0; i < count; i++)); do
+            file_var="SCRIPT_INPUT_FILE_$i"
+            file_path=${!file_var}
+            git add "$file_path"
+        done
+        
+        echo "swiftLint --fix completed and files re-staged."
+
+        # Optionally lint the fixed files
+        echo "Linting fixed files..."
+        $SWIFT_LINT lint --use-script-input-files
+    else
+        exit 0
+    fi
+
+    RESULT=$?
+
+    if [ $RESULT -eq 0 ]; then
+        exit 0
+    else
+        echo ""
+        echo "⛔️ Violation found of the type ERROR! Please fix these issues before continuing!"
+    fi
+    exit $RESULT
+
+else
+    echo "SwiftLint not installed. Please install from https://github.com/realm/SwiftLint"
+    exit -1
+fi

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Define the source and destination paths
+SOURCE_PATH="./scripts/hooks/pre-commit"
+HOOKS_DIR=".git/hooks"
+DEST_PATH="$HOOKS_DIR/pre-commit"
+
+# Check if the hooks directory exists
+if [ ! -d "$HOOKS_DIR" ]; then
+  echo "Error: .git/hooks directory not found. Make sure you're in the root of a Git repository."
+  exit 1
+fi
+
+# Copy the script to the hooks directory
+cp "$SOURCE_PATH" "$DEST_PATH"
+
+# Make the hook script executable
+chmod +x "$DEST_PATH"
+
+echo "Pre-commit hooks have been set up successfully."


### PR DESCRIPTION
This change adds a few scripts that will automatically set up a `pre-commit` hook to run `swiftlint --fix` on changed files. This will help keep the project's codebase cleaner, and remove a bunch of noise around the more pesky lint errors.

Please test this out on your own machines to help catch any edge cases.

## Testing

1. Run `./scripts/setup-hooks.sh`
2. Make some changes & commit them.
3. ???
4. Profit

## Cleanup

If you need to revert the changes to your local machine from this PR, run this

```
rm .git/hooks/pre-commit
```