### PR TITLE
Add First Heard and Last Heard times to node details

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -10798,6 +10798,9 @@
         }
       }
     },
+    "Last heard" : {
+
+    },
     "Latitude" : {
 
     },
@@ -21713,7 +21716,6 @@
 
     },
     "unknown" : {
-      "extractionState" : "migrated",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -7366,6 +7366,9 @@
         }
       }
     },
+    "First heard" : {
+
+    },
     "Five Minutes" : {
 
     },

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -145,8 +145,10 @@ func upsertNodeInfoPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 			let newNode = NodeInfoEntity(context: context)
 			newNode.id = Int64(packet.from)
 			newNode.num = Int64(packet.from)
-			newNode.firstHeard = Date(timeIntervalSince1970: TimeInterval(Int64(packet.rxTime)))
-			newNode.lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(packet.rxTime)))
+			if packet.rxTime != 0 {
+				newNode.firstHeard = Date(timeIntervalSince1970: TimeInterval(Int64(packet.rxTime)))
+				newNode.lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(packet.rxTime)))
+			}
 			newNode.snr = packet.rxSnr
 			newNode.rssi = packet.rxRssi
 			newNode.viaMqtt = packet.viaMqtt

--- a/Meshtastic/Views/Helpers/LastHeardText.swift
+++ b/Meshtastic/Views/Helpers/LastHeardText.swift
@@ -15,8 +15,8 @@ struct LastHeardText: View {
 	}()
 
 	var body: some View {
-		if let lastHeard, lastHeard.timeIntervalSince1970 > 0 {
-			Text(lastHeard.formatted())
+		if let lastHeard, lastHeard.timeIntervalSince1970 > 0, let text = Self.formatter.string(for: lastHeard) {
+			Text(text)
 		} else {
 			Text("unknown")
 		}

--- a/Meshtastic/Views/Helpers/LastHeardText.swift
+++ b/Meshtastic/Views/Helpers/LastHeardText.swift
@@ -7,7 +7,6 @@ import SwiftUI
 //
 struct LastHeardText: View {
 	var lastHeard: Date?
-	let sixMonthsAgo = Calendar.current.date(byAdding: .month, value: -6, to: Date())
 
 	static let formatter: RelativeDateTimeFormatter = {
 		let formatter = RelativeDateTimeFormatter()
@@ -16,10 +15,10 @@ struct LastHeardText: View {
 	}()
 
 	var body: some View {
-		if lastHeard != nil && lastHeard! >= sixMonthsAgo! {
-			Text(lastHeard?.formatted() ?? "unknown.age".localized)
+		if let lastHeard, lastHeard.timeIntervalSince1970 > 0 {
+			Text(lastHeard.formatted())
 		} else {
-			Text("unknown.age")
+			Text("unknown")
 		}
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -18,11 +18,11 @@ struct NodeDetail: View {
 
 	// The node the device is currently connected to
 	var connectedNode: NodeInfoEntity?
-	
+
 	// The node information being displayed on the detail screen
 	@ObservedObject
 	var node: NodeInfoEntity
-	
+
 	var columnVisibility = NavigationSplitViewVisibility.all
 
 	var favoriteNodeAction: some View {
@@ -96,6 +96,20 @@ struct NodeDetail: View {
 						.textSelection(.enabled)
 					}
 
+					if let metadata = node.metadata {
+						HStack {
+							Label {
+								Text("firmware.version")
+							} icon: {
+								Image(systemName: "memorychip")
+									.symbolRenderingMode(.multicolor)
+							}
+							Spacer()
+
+							Text(metadata.firmwareVersion ?? "unknown".localized)
+						}
+					}
+
 					if let dm = node.telemetries?.filtered(using: NSPredicate(format: "metricsType == 0")).lastObject as? TelemetryEntity, dm.uptimeSeconds > 0 {
 						HStack {
 							Label {
@@ -111,21 +125,22 @@ struct NodeDetail: View {
 							let later = now + TimeInterval(dm.uptimeSeconds)
 							let uptime = (now..<later).formatted(.components(style: .narrow))
 							Text(uptime)
-							.textSelection(.enabled)
+								.textSelection(.enabled)
 						}
 					}
 
-					if let metadata = node.metadata {
+					if let lastHeard = node.lastHeard {
 						HStack {
 							Label {
-								Text("firmware.version")
+								Text("Last heard")
 							} icon: {
-								Image(systemName: "memorychip")
+								Image(systemName: "clock.arrow.circlepath")
 									.symbolRenderingMode(.multicolor)
 							}
 							Spacer()
 
-							Text(metadata.firmwareVersion ?? "unknown".localized)
+							LastHeardText(lastHeard: lastHeard)
+								.textSelection(.enabled)
 						}
 					}
 				}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -129,6 +129,21 @@ struct NodeDetail: View {
 						}
 					}
 
+					if let firstHeard = node.firstHeard {
+						HStack {
+							Label {
+								Text("First heard")
+							} icon: {
+								Image(systemName: "clock")
+									.symbolRenderingMode(.multicolor)
+							}
+							Spacer()
+
+							LastHeardText(lastHeard: firstHeard)
+								.textSelection(.enabled)
+						}
+					}
+
 					if let lastHeard = node.lastHeard {
 						HStack {
 							Label {


### PR DESCRIPTION
This change adds the last heard date to the node details screen. Unfortunately, it seems much of this data is buggy for me, and I have several nodes with lastHeard dates on Jan 1 1970, so I can't really validate that the change works on the happy path.

![IMG_D7578A3F43FE-1](https://github.com/meshtastic/Meshtastic-Apple/assets/17112724/64332079-26c2-4ad1-bd07-3d784a9ed9e3)


