### PR TITLE
Restore the Exchange Positions and TraceRoute button back to the node list context menu

### DIFF
--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -59,7 +59,16 @@ struct NodeList: View {
 				user: user
 			)
 		}
+
 		if let connectedNode {
+			ExchangePositionsButton(
+				bleManager: bleManager,
+				node: node
+			)
+			TraceRouteButton(
+				bleManager: bleManager,
+				node: node
+			)
 			DeleteNodeButton(
 				bleManager: bleManager,
 				context: context,

--- a/MeshtasticProtobufs/Sources/meshtastic/config.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/config.pb.swift
@@ -1087,7 +1087,10 @@ public struct Config {
     ///
     /// When enabled, the `modem_preset` fields will be adhered to, else the `bandwidth`/`spread_factor`/`coding_rate`
     /// will be taked from their respective manually defined fields
-    public var usePreset: Bool = false
+    public var usePreset: Bool {
+      get {return _storage._usePreset}
+      set {_uniqueStorage()._usePreset = newValue}
+    }
 
     ///
     /// Either modem_config or bandwidth/spreading/coding will be specified - NOT BOTH.
@@ -1095,51 +1098,78 @@ public struct Config {
     /// Because protobufs take ZERO space when the value is zero this works out nicely.
     /// This value is replaced by bandwidth/spread_factor/coding_rate.
     /// If you'd like to experiment with other options add them to MeshRadio.cpp in the device code.
-    public var modemPreset: Config.LoRaConfig.ModemPreset = .longFast
+    public var modemPreset: Config.LoRaConfig.ModemPreset {
+      get {return _storage._modemPreset}
+      set {_uniqueStorage()._modemPreset = newValue}
+    }
 
     ///
     /// Bandwidth in MHz
     /// Certain bandwidth numbers are 'special' and will be converted to the
     /// appropriate floating point value: 31 -> 31.25MHz
-    public var bandwidth: UInt32 = 0
+    public var bandwidth: UInt32 {
+      get {return _storage._bandwidth}
+      set {_uniqueStorage()._bandwidth = newValue}
+    }
 
     ///
     /// A number from 7 to 12.
     /// Indicates number of chirps per symbol as 1<<spread_factor.
-    public var spreadFactor: UInt32 = 0
+    public var spreadFactor: UInt32 {
+      get {return _storage._spreadFactor}
+      set {_uniqueStorage()._spreadFactor = newValue}
+    }
 
     ///
     /// The denominator of the coding rate.
     /// ie for 4/5, the value is 5. 4/8 the value is 8.
-    public var codingRate: UInt32 = 0
+    public var codingRate: UInt32 {
+      get {return _storage._codingRate}
+      set {_uniqueStorage()._codingRate = newValue}
+    }
 
     ///
     /// This parameter is for advanced users with advanced test equipment, we do not recommend most users use it.
     /// A frequency offset that is added to to the calculated band center frequency.
     /// Used to correct for crystal calibration errors.
-    public var frequencyOffset: Float = 0
+    public var frequencyOffset: Float {
+      get {return _storage._frequencyOffset}
+      set {_uniqueStorage()._frequencyOffset = newValue}
+    }
 
     ///
     /// The region code for the radio (US, CN, EU433, etc...)
-    public var region: Config.LoRaConfig.RegionCode = .unset
+    public var region: Config.LoRaConfig.RegionCode {
+      get {return _storage._region}
+      set {_uniqueStorage()._region = newValue}
+    }
 
     ///
     /// Maximum number of hops. This can't be greater than 7.
     /// Default of 3
     /// Attempting to set a value > 7 results in the default
-    public var hopLimit: UInt32 = 0
+    public var hopLimit: UInt32 {
+      get {return _storage._hopLimit}
+      set {_uniqueStorage()._hopLimit = newValue}
+    }
 
     ///
     /// Disable TX from the LoRa radio. Useful for hot-swapping antennas and other tests.
     /// Defaults to false
-    public var txEnabled: Bool = false
+    public var txEnabled: Bool {
+      get {return _storage._txEnabled}
+      set {_uniqueStorage()._txEnabled = newValue}
+    }
 
     ///
     /// If zero, then use default max legal continuous power (ie. something that won't
     /// burn out the radio hardware)
     /// In most cases you should use zero here.
     /// Units are in dBm.
-    public var txPower: Int32 = 0
+    public var txPower: Int32 {
+      get {return _storage._txPower}
+      set {_uniqueStorage()._txPower = newValue}
+    }
 
     ///
     /// This controls the actual hardware frequency the radio transmits on.
@@ -1149,17 +1179,26 @@ public struct Config {
     /// algorithm to derive the channel number")
     /// If using the hash algorithm the channel number will be: hash(channel_name) %
     /// NUM_CHANNELS (Where num channels depends on the regulatory region).
-    public var channelNum: UInt32 = 0
+    public var channelNum: UInt32 {
+      get {return _storage._channelNum}
+      set {_uniqueStorage()._channelNum = newValue}
+    }
 
     ///
     /// If true, duty cycle limits will be exceeded and thus you're possibly not following
     /// the local regulations if you're not a HAM.
     /// Has no effect if the duty cycle of the used region is 100%.
-    public var overrideDutyCycle: Bool = false
+    public var overrideDutyCycle: Bool {
+      get {return _storage._overrideDutyCycle}
+      set {_uniqueStorage()._overrideDutyCycle = newValue}
+    }
 
     ///
     /// If true, sets RX boosted gain mode on SX126X based radios
-    public var sx126XRxBoostedGain: Bool = false
+    public var sx126XRxBoostedGain: Bool {
+      get {return _storage._sx126XRxBoostedGain}
+      set {_uniqueStorage()._sx126XRxBoostedGain = newValue}
+    }
 
     ///
     /// This parameter is for advanced users and licensed HAM radio operators.
@@ -1167,17 +1206,33 @@ public struct Config {
     /// will still be applied. This will allow you to use out-of-band frequencies.
     /// Please respect your local laws and regulations. If you are a HAM, make sure you
     /// enable HAM mode and turn off encryption.
-    public var overrideFrequency: Float = 0
+    public var overrideFrequency: Float {
+      get {return _storage._overrideFrequency}
+      set {_uniqueStorage()._overrideFrequency = newValue}
+    }
+
+    ///
+    /// If true, disable the build-in PA FAN using pin define in RF95_FAN_EN.
+    public var paFanDisabled: Bool {
+      get {return _storage._paFanDisabled}
+      set {_uniqueStorage()._paFanDisabled = newValue}
+    }
 
     ///
     /// For testing it is useful sometimes to force a node to never listen to
     /// particular other nodes (simulating radio out of range). All nodenums listed
     /// in ignore_incoming will have packets they send dropped on receive (by router.cpp)
-    public var ignoreIncoming: [UInt32] = []
+    public var ignoreIncoming: [UInt32] {
+      get {return _storage._ignoreIncoming}
+      set {_uniqueStorage()._ignoreIncoming = newValue}
+    }
 
     ///
     /// If true, the device will not process any packets received via LoRa that passed via MQTT anywhere on the path towards it.
-    public var ignoreMqtt: Bool = false
+    public var ignoreMqtt: Bool {
+      get {return _storage._ignoreMqtt}
+      set {_uniqueStorage()._ignoreMqtt = newValue}
+    }
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1391,6 +1446,8 @@ public struct Config {
     }
 
     public init() {}
+
+    fileprivate var _storage = _StorageClass.defaultInstance
   }
 
   public struct BluetoothConfig {
@@ -2443,106 +2500,184 @@ extension Config.LoRaConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     12: .standard(proto: "override_duty_cycle"),
     13: .standard(proto: "sx126x_rx_boosted_gain"),
     14: .standard(proto: "override_frequency"),
+    15: .standard(proto: "pa_fan_disabled"),
     103: .standard(proto: "ignore_incoming"),
     104: .standard(proto: "ignore_mqtt"),
   ]
 
+  fileprivate class _StorageClass {
+    var _usePreset: Bool = false
+    var _modemPreset: Config.LoRaConfig.ModemPreset = .longFast
+    var _bandwidth: UInt32 = 0
+    var _spreadFactor: UInt32 = 0
+    var _codingRate: UInt32 = 0
+    var _frequencyOffset: Float = 0
+    var _region: Config.LoRaConfig.RegionCode = .unset
+    var _hopLimit: UInt32 = 0
+    var _txEnabled: Bool = false
+    var _txPower: Int32 = 0
+    var _channelNum: UInt32 = 0
+    var _overrideDutyCycle: Bool = false
+    var _sx126XRxBoostedGain: Bool = false
+    var _overrideFrequency: Float = 0
+    var _paFanDisabled: Bool = false
+    var _ignoreIncoming: [UInt32] = []
+    var _ignoreMqtt: Bool = false
+
+    #if swift(>=5.10)
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+    #else
+      static let defaultInstance = _StorageClass()
+    #endif
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _usePreset = source._usePreset
+      _modemPreset = source._modemPreset
+      _bandwidth = source._bandwidth
+      _spreadFactor = source._spreadFactor
+      _codingRate = source._codingRate
+      _frequencyOffset = source._frequencyOffset
+      _region = source._region
+      _hopLimit = source._hopLimit
+      _txEnabled = source._txEnabled
+      _txPower = source._txPower
+      _channelNum = source._channelNum
+      _overrideDutyCycle = source._overrideDutyCycle
+      _sx126XRxBoostedGain = source._sx126XRxBoostedGain
+      _overrideFrequency = source._overrideFrequency
+      _paFanDisabled = source._paFanDisabled
+      _ignoreIncoming = source._ignoreIncoming
+      _ignoreMqtt = source._ignoreMqtt
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularBoolField(value: &self.usePreset) }()
-      case 2: try { try decoder.decodeSingularEnumField(value: &self.modemPreset) }()
-      case 3: try { try decoder.decodeSingularUInt32Field(value: &self.bandwidth) }()
-      case 4: try { try decoder.decodeSingularUInt32Field(value: &self.spreadFactor) }()
-      case 5: try { try decoder.decodeSingularUInt32Field(value: &self.codingRate) }()
-      case 6: try { try decoder.decodeSingularFloatField(value: &self.frequencyOffset) }()
-      case 7: try { try decoder.decodeSingularEnumField(value: &self.region) }()
-      case 8: try { try decoder.decodeSingularUInt32Field(value: &self.hopLimit) }()
-      case 9: try { try decoder.decodeSingularBoolField(value: &self.txEnabled) }()
-      case 10: try { try decoder.decodeSingularInt32Field(value: &self.txPower) }()
-      case 11: try { try decoder.decodeSingularUInt32Field(value: &self.channelNum) }()
-      case 12: try { try decoder.decodeSingularBoolField(value: &self.overrideDutyCycle) }()
-      case 13: try { try decoder.decodeSingularBoolField(value: &self.sx126XRxBoostedGain) }()
-      case 14: try { try decoder.decodeSingularFloatField(value: &self.overrideFrequency) }()
-      case 103: try { try decoder.decodeRepeatedUInt32Field(value: &self.ignoreIncoming) }()
-      case 104: try { try decoder.decodeSingularBoolField(value: &self.ignoreMqtt) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularBoolField(value: &_storage._usePreset) }()
+        case 2: try { try decoder.decodeSingularEnumField(value: &_storage._modemPreset) }()
+        case 3: try { try decoder.decodeSingularUInt32Field(value: &_storage._bandwidth) }()
+        case 4: try { try decoder.decodeSingularUInt32Field(value: &_storage._spreadFactor) }()
+        case 5: try { try decoder.decodeSingularUInt32Field(value: &_storage._codingRate) }()
+        case 6: try { try decoder.decodeSingularFloatField(value: &_storage._frequencyOffset) }()
+        case 7: try { try decoder.decodeSingularEnumField(value: &_storage._region) }()
+        case 8: try { try decoder.decodeSingularUInt32Field(value: &_storage._hopLimit) }()
+        case 9: try { try decoder.decodeSingularBoolField(value: &_storage._txEnabled) }()
+        case 10: try { try decoder.decodeSingularInt32Field(value: &_storage._txPower) }()
+        case 11: try { try decoder.decodeSingularUInt32Field(value: &_storage._channelNum) }()
+        case 12: try { try decoder.decodeSingularBoolField(value: &_storage._overrideDutyCycle) }()
+        case 13: try { try decoder.decodeSingularBoolField(value: &_storage._sx126XRxBoostedGain) }()
+        case 14: try { try decoder.decodeSingularFloatField(value: &_storage._overrideFrequency) }()
+        case 15: try { try decoder.decodeSingularBoolField(value: &_storage._paFanDisabled) }()
+        case 103: try { try decoder.decodeRepeatedUInt32Field(value: &_storage._ignoreIncoming) }()
+        case 104: try { try decoder.decodeSingularBoolField(value: &_storage._ignoreMqtt) }()
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.usePreset != false {
-      try visitor.visitSingularBoolField(value: self.usePreset, fieldNumber: 1)
-    }
-    if self.modemPreset != .longFast {
-      try visitor.visitSingularEnumField(value: self.modemPreset, fieldNumber: 2)
-    }
-    if self.bandwidth != 0 {
-      try visitor.visitSingularUInt32Field(value: self.bandwidth, fieldNumber: 3)
-    }
-    if self.spreadFactor != 0 {
-      try visitor.visitSingularUInt32Field(value: self.spreadFactor, fieldNumber: 4)
-    }
-    if self.codingRate != 0 {
-      try visitor.visitSingularUInt32Field(value: self.codingRate, fieldNumber: 5)
-    }
-    if self.frequencyOffset != 0 {
-      try visitor.visitSingularFloatField(value: self.frequencyOffset, fieldNumber: 6)
-    }
-    if self.region != .unset {
-      try visitor.visitSingularEnumField(value: self.region, fieldNumber: 7)
-    }
-    if self.hopLimit != 0 {
-      try visitor.visitSingularUInt32Field(value: self.hopLimit, fieldNumber: 8)
-    }
-    if self.txEnabled != false {
-      try visitor.visitSingularBoolField(value: self.txEnabled, fieldNumber: 9)
-    }
-    if self.txPower != 0 {
-      try visitor.visitSingularInt32Field(value: self.txPower, fieldNumber: 10)
-    }
-    if self.channelNum != 0 {
-      try visitor.visitSingularUInt32Field(value: self.channelNum, fieldNumber: 11)
-    }
-    if self.overrideDutyCycle != false {
-      try visitor.visitSingularBoolField(value: self.overrideDutyCycle, fieldNumber: 12)
-    }
-    if self.sx126XRxBoostedGain != false {
-      try visitor.visitSingularBoolField(value: self.sx126XRxBoostedGain, fieldNumber: 13)
-    }
-    if self.overrideFrequency != 0 {
-      try visitor.visitSingularFloatField(value: self.overrideFrequency, fieldNumber: 14)
-    }
-    if !self.ignoreIncoming.isEmpty {
-      try visitor.visitPackedUInt32Field(value: self.ignoreIncoming, fieldNumber: 103)
-    }
-    if self.ignoreMqtt != false {
-      try visitor.visitSingularBoolField(value: self.ignoreMqtt, fieldNumber: 104)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if _storage._usePreset != false {
+        try visitor.visitSingularBoolField(value: _storage._usePreset, fieldNumber: 1)
+      }
+      if _storage._modemPreset != .longFast {
+        try visitor.visitSingularEnumField(value: _storage._modemPreset, fieldNumber: 2)
+      }
+      if _storage._bandwidth != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._bandwidth, fieldNumber: 3)
+      }
+      if _storage._spreadFactor != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._spreadFactor, fieldNumber: 4)
+      }
+      if _storage._codingRate != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._codingRate, fieldNumber: 5)
+      }
+      if _storage._frequencyOffset != 0 {
+        try visitor.visitSingularFloatField(value: _storage._frequencyOffset, fieldNumber: 6)
+      }
+      if _storage._region != .unset {
+        try visitor.visitSingularEnumField(value: _storage._region, fieldNumber: 7)
+      }
+      if _storage._hopLimit != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._hopLimit, fieldNumber: 8)
+      }
+      if _storage._txEnabled != false {
+        try visitor.visitSingularBoolField(value: _storage._txEnabled, fieldNumber: 9)
+      }
+      if _storage._txPower != 0 {
+        try visitor.visitSingularInt32Field(value: _storage._txPower, fieldNumber: 10)
+      }
+      if _storage._channelNum != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._channelNum, fieldNumber: 11)
+      }
+      if _storage._overrideDutyCycle != false {
+        try visitor.visitSingularBoolField(value: _storage._overrideDutyCycle, fieldNumber: 12)
+      }
+      if _storage._sx126XRxBoostedGain != false {
+        try visitor.visitSingularBoolField(value: _storage._sx126XRxBoostedGain, fieldNumber: 13)
+      }
+      if _storage._overrideFrequency != 0 {
+        try visitor.visitSingularFloatField(value: _storage._overrideFrequency, fieldNumber: 14)
+      }
+      if _storage._paFanDisabled != false {
+        try visitor.visitSingularBoolField(value: _storage._paFanDisabled, fieldNumber: 15)
+      }
+      if !_storage._ignoreIncoming.isEmpty {
+        try visitor.visitPackedUInt32Field(value: _storage._ignoreIncoming, fieldNumber: 103)
+      }
+      if _storage._ignoreMqtt != false {
+        try visitor.visitSingularBoolField(value: _storage._ignoreMqtt, fieldNumber: 104)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Config.LoRaConfig, rhs: Config.LoRaConfig) -> Bool {
-    if lhs.usePreset != rhs.usePreset {return false}
-    if lhs.modemPreset != rhs.modemPreset {return false}
-    if lhs.bandwidth != rhs.bandwidth {return false}
-    if lhs.spreadFactor != rhs.spreadFactor {return false}
-    if lhs.codingRate != rhs.codingRate {return false}
-    if lhs.frequencyOffset != rhs.frequencyOffset {return false}
-    if lhs.region != rhs.region {return false}
-    if lhs.hopLimit != rhs.hopLimit {return false}
-    if lhs.txEnabled != rhs.txEnabled {return false}
-    if lhs.txPower != rhs.txPower {return false}
-    if lhs.channelNum != rhs.channelNum {return false}
-    if lhs.overrideDutyCycle != rhs.overrideDutyCycle {return false}
-    if lhs.sx126XRxBoostedGain != rhs.sx126XRxBoostedGain {return false}
-    if lhs.overrideFrequency != rhs.overrideFrequency {return false}
-    if lhs.ignoreIncoming != rhs.ignoreIncoming {return false}
-    if lhs.ignoreMqtt != rhs.ignoreMqtt {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._usePreset != rhs_storage._usePreset {return false}
+        if _storage._modemPreset != rhs_storage._modemPreset {return false}
+        if _storage._bandwidth != rhs_storage._bandwidth {return false}
+        if _storage._spreadFactor != rhs_storage._spreadFactor {return false}
+        if _storage._codingRate != rhs_storage._codingRate {return false}
+        if _storage._frequencyOffset != rhs_storage._frequencyOffset {return false}
+        if _storage._region != rhs_storage._region {return false}
+        if _storage._hopLimit != rhs_storage._hopLimit {return false}
+        if _storage._txEnabled != rhs_storage._txEnabled {return false}
+        if _storage._txPower != rhs_storage._txPower {return false}
+        if _storage._channelNum != rhs_storage._channelNum {return false}
+        if _storage._overrideDutyCycle != rhs_storage._overrideDutyCycle {return false}
+        if _storage._sx126XRxBoostedGain != rhs_storage._sx126XRxBoostedGain {return false}
+        if _storage._overrideFrequency != rhs_storage._overrideFrequency {return false}
+        if _storage._paFanDisabled != rhs_storage._paFanDisabled {return false}
+        if _storage._ignoreIncoming != rhs_storage._ignoreIncoming {return false}
+        if _storage._ignoreMqtt != rhs_storage._ignoreMqtt {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/MeshtasticProtobufs/Sources/meshtastic/mesh.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/mesh.pb.swift
@@ -2165,26 +2165,20 @@ public struct FromRadio {
   ///
   /// The packet id, used to allow the phone to request missing read packets from the FIFO,
   /// see our bluetooth docs
-  public var id: UInt32 {
-    get {return _storage._id}
-    set {_uniqueStorage()._id = newValue}
-  }
+  public var id: UInt32 = 0
 
   ///
   /// Log levels, chosen to match python logging conventions.
-  public var payloadVariant: OneOf_PayloadVariant? {
-    get {return _storage._payloadVariant}
-    set {_uniqueStorage()._payloadVariant = newValue}
-  }
+  public var payloadVariant: FromRadio.OneOf_PayloadVariant? = nil
 
   ///
   /// Log levels, chosen to match python logging conventions.
   public var packet: MeshPacket {
     get {
-      if case .packet(let v)? = _storage._payloadVariant {return v}
+      if case .packet(let v)? = payloadVariant {return v}
       return MeshPacket()
     }
-    set {_uniqueStorage()._payloadVariant = .packet(newValue)}
+    set {payloadVariant = .packet(newValue)}
   }
 
   ///
@@ -2192,10 +2186,10 @@ public struct FromRadio {
   /// NOTE: This ID must not change - to keep (minimal) compatibility with <1.2 version of android apps.
   public var myInfo: MyNodeInfo {
     get {
-      if case .myInfo(let v)? = _storage._payloadVariant {return v}
+      if case .myInfo(let v)? = payloadVariant {return v}
       return MyNodeInfo()
     }
-    set {_uniqueStorage()._payloadVariant = .myInfo(newValue)}
+    set {payloadVariant = .myInfo(newValue)}
   }
 
   ///
@@ -2203,30 +2197,30 @@ public struct FromRadio {
   /// starts over with the first node in our DB
   public var nodeInfo: NodeInfo {
     get {
-      if case .nodeInfo(let v)? = _storage._payloadVariant {return v}
+      if case .nodeInfo(let v)? = payloadVariant {return v}
       return NodeInfo()
     }
-    set {_uniqueStorage()._payloadVariant = .nodeInfo(newValue)}
+    set {payloadVariant = .nodeInfo(newValue)}
   }
 
   ///
   /// Include a part of the config (was: RadioConfig radio)
   public var config: Config {
     get {
-      if case .config(let v)? = _storage._payloadVariant {return v}
+      if case .config(let v)? = payloadVariant {return v}
       return Config()
     }
-    set {_uniqueStorage()._payloadVariant = .config(newValue)}
+    set {payloadVariant = .config(newValue)}
   }
 
   ///
   /// Set to send debug console output over our protobuf stream
   public var logRecord: LogRecord {
     get {
-      if case .logRecord(let v)? = _storage._payloadVariant {return v}
+      if case .logRecord(let v)? = payloadVariant {return v}
       return LogRecord()
     }
-    set {_uniqueStorage()._payloadVariant = .logRecord(newValue)}
+    set {payloadVariant = .logRecord(newValue)}
   }
 
   ///
@@ -2236,10 +2230,10 @@ public struct FromRadio {
   /// NOTE: This ID must not change - to keep (minimal) compatibility with <1.2 version of android apps.
   public var configCompleteID: UInt32 {
     get {
-      if case .configCompleteID(let v)? = _storage._payloadVariant {return v}
+      if case .configCompleteID(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .configCompleteID(newValue)}
+    set {payloadVariant = .configCompleteID(newValue)}
   }
 
   ///
@@ -2249,80 +2243,80 @@ public struct FromRadio {
   /// NOTE: This ID must not change - to keep (minimal) compatibility with <1.2 version of android apps.
   public var rebooted: Bool {
     get {
-      if case .rebooted(let v)? = _storage._payloadVariant {return v}
+      if case .rebooted(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .rebooted(newValue)}
+    set {payloadVariant = .rebooted(newValue)}
   }
 
   ///
   /// Include module config
   public var moduleConfig: ModuleConfig {
     get {
-      if case .moduleConfig(let v)? = _storage._payloadVariant {return v}
+      if case .moduleConfig(let v)? = payloadVariant {return v}
       return ModuleConfig()
     }
-    set {_uniqueStorage()._payloadVariant = .moduleConfig(newValue)}
+    set {payloadVariant = .moduleConfig(newValue)}
   }
 
   ///
   /// One packet is sent for each channel
   public var channel: Channel {
     get {
-      if case .channel(let v)? = _storage._payloadVariant {return v}
+      if case .channel(let v)? = payloadVariant {return v}
       return Channel()
     }
-    set {_uniqueStorage()._payloadVariant = .channel(newValue)}
+    set {payloadVariant = .channel(newValue)}
   }
 
   ///
   /// Queue status info
   public var queueStatus: QueueStatus {
     get {
-      if case .queueStatus(let v)? = _storage._payloadVariant {return v}
+      if case .queueStatus(let v)? = payloadVariant {return v}
       return QueueStatus()
     }
-    set {_uniqueStorage()._payloadVariant = .queueStatus(newValue)}
+    set {payloadVariant = .queueStatus(newValue)}
   }
 
   ///
   /// File Transfer Chunk
   public var xmodemPacket: XModem {
     get {
-      if case .xmodemPacket(let v)? = _storage._payloadVariant {return v}
+      if case .xmodemPacket(let v)? = payloadVariant {return v}
       return XModem()
     }
-    set {_uniqueStorage()._payloadVariant = .xmodemPacket(newValue)}
+    set {payloadVariant = .xmodemPacket(newValue)}
   }
 
   ///
   /// Device metadata message
   public var metadata: DeviceMetadata {
     get {
-      if case .metadata(let v)? = _storage._payloadVariant {return v}
+      if case .metadata(let v)? = payloadVariant {return v}
       return DeviceMetadata()
     }
-    set {_uniqueStorage()._payloadVariant = .metadata(newValue)}
+    set {payloadVariant = .metadata(newValue)}
   }
 
   ///
   /// MQTT Client Proxy Message (device sending to client / phone for publishing to MQTT)
   public var mqttClientProxyMessage: MqttClientProxyMessage {
     get {
-      if case .mqttClientProxyMessage(let v)? = _storage._payloadVariant {return v}
+      if case .mqttClientProxyMessage(let v)? = payloadVariant {return v}
       return MqttClientProxyMessage()
     }
-    set {_uniqueStorage()._payloadVariant = .mqttClientProxyMessage(newValue)}
+    set {payloadVariant = .mqttClientProxyMessage(newValue)}
   }
 
   ///
   /// File system manifest messages
   public var fileInfo: FileInfo {
     get {
-      if case .fileInfo(let v)? = _storage._payloadVariant {return v}
+      if case .fileInfo(let v)? = payloadVariant {return v}
       return FileInfo()
     }
-    set {_uniqueStorage()._payloadVariant = .fileInfo(newValue)}
+    set {payloadVariant = .fileInfo(newValue)}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2450,8 +2444,6 @@ public struct FromRadio {
   }
 
   public init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 ///
@@ -4303,305 +4295,263 @@ extension FromRadio: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementation
     15: .same(proto: "fileInfo"),
   ]
 
-  fileprivate class _StorageClass {
-    var _id: UInt32 = 0
-    var _payloadVariant: FromRadio.OneOf_PayloadVariant?
-
-    #if swift(>=5.10)
-      // This property is used as the initial default value for new instances of the type.
-      // The type itself is protecting the reference to its storage via CoW semantics.
-      // This will force a copy to be made of this reference when the first mutation occurs;
-      // hence, it is safe to mark this as `nonisolated(unsafe)`.
-      static nonisolated(unsafe) let defaultInstance = _StorageClass()
-    #else
-      static let defaultInstance = _StorageClass()
-    #endif
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _id = source._id
-      _payloadVariant = source._payloadVariant
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try { try decoder.decodeSingularUInt32Field(value: &_storage._id) }()
-        case 2: try {
-          var v: MeshPacket?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .packet(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .packet(v)
-          }
-        }()
-        case 3: try {
-          var v: MyNodeInfo?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .myInfo(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .myInfo(v)
-          }
-        }()
-        case 4: try {
-          var v: NodeInfo?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .nodeInfo(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .nodeInfo(v)
-          }
-        }()
-        case 5: try {
-          var v: Config?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .config(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .config(v)
-          }
-        }()
-        case 6: try {
-          var v: LogRecord?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .logRecord(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .logRecord(v)
-          }
-        }()
-        case 7: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .configCompleteID(v)
-          }
-        }()
-        case 8: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .rebooted(v)
-          }
-        }()
-        case 9: try {
-          var v: ModuleConfig?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .moduleConfig(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .moduleConfig(v)
-          }
-        }()
-        case 10: try {
-          var v: Channel?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .channel(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .channel(v)
-          }
-        }()
-        case 11: try {
-          var v: QueueStatus?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .queueStatus(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .queueStatus(v)
-          }
-        }()
-        case 12: try {
-          var v: XModem?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .xmodemPacket(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .xmodemPacket(v)
-          }
-        }()
-        case 13: try {
-          var v: DeviceMetadata?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .metadata(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .metadata(v)
-          }
-        }()
-        case 14: try {
-          var v: MqttClientProxyMessage?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .mqttClientProxyMessage(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .mqttClientProxyMessage(v)
-          }
-        }()
-        case 15: try {
-          var v: FileInfo?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .fileInfo(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .fileInfo(v)
-          }
-        }()
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self.id) }()
+      case 2: try {
+        var v: MeshPacket?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .packet(let m) = current {v = m}
         }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .packet(v)
+        }
+      }()
+      case 3: try {
+        var v: MyNodeInfo?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .myInfo(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .myInfo(v)
+        }
+      }()
+      case 4: try {
+        var v: NodeInfo?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .nodeInfo(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .nodeInfo(v)
+        }
+      }()
+      case 5: try {
+        var v: Config?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .config(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .config(v)
+        }
+      }()
+      case 6: try {
+        var v: LogRecord?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .logRecord(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .logRecord(v)
+        }
+      }()
+      case 7: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .configCompleteID(v)
+        }
+      }()
+      case 8: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .rebooted(v)
+        }
+      }()
+      case 9: try {
+        var v: ModuleConfig?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .moduleConfig(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .moduleConfig(v)
+        }
+      }()
+      case 10: try {
+        var v: Channel?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .channel(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .channel(v)
+        }
+      }()
+      case 11: try {
+        var v: QueueStatus?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .queueStatus(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .queueStatus(v)
+        }
+      }()
+      case 12: try {
+        var v: XModem?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .xmodemPacket(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .xmodemPacket(v)
+        }
+      }()
+      case 13: try {
+        var v: DeviceMetadata?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .metadata(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .metadata(v)
+        }
+      }()
+      case 14: try {
+        var v: MqttClientProxyMessage?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .mqttClientProxyMessage(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .mqttClientProxyMessage(v)
+        }
+      }()
+      case 15: try {
+        var v: FileInfo?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .fileInfo(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .fileInfo(v)
+        }
+      }()
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every if/case branch local when no optimizations
-      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-      // https://github.com/apple/swift-protobuf/issues/1182
-      if _storage._id != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._id, fieldNumber: 1)
-      }
-      switch _storage._payloadVariant {
-      case .packet?: try {
-        guard case .packet(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }()
-      case .myInfo?: try {
-        guard case .myInfo(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      }()
-      case .nodeInfo?: try {
-        guard case .nodeInfo(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }()
-      case .config?: try {
-        guard case .config(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      }()
-      case .logRecord?: try {
-        guard case .logRecord(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }()
-      case .configCompleteID?: try {
-        guard case .configCompleteID(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 7)
-      }()
-      case .rebooted?: try {
-        guard case .rebooted(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 8)
-      }()
-      case .moduleConfig?: try {
-        guard case .moduleConfig(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-      }()
-      case .channel?: try {
-        guard case .channel(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-      }()
-      case .queueStatus?: try {
-        guard case .queueStatus(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      }()
-      case .xmodemPacket?: try {
-        guard case .xmodemPacket(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-      }()
-      case .metadata?: try {
-        guard case .metadata(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-      }()
-      case .mqttClientProxyMessage?: try {
-        guard case .mqttClientProxyMessage(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
-      }()
-      case .fileInfo?: try {
-        guard case .fileInfo(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-      }()
-      case nil: break
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.id != 0 {
+      try visitor.visitSingularUInt32Field(value: self.id, fieldNumber: 1)
+    }
+    switch self.payloadVariant {
+    case .packet?: try {
+      guard case .packet(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case .myInfo?: try {
+      guard case .myInfo(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }()
+    case .nodeInfo?: try {
+      guard case .nodeInfo(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }()
+    case .config?: try {
+      guard case .config(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    }()
+    case .logRecord?: try {
+      guard case .logRecord(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
+    case .configCompleteID?: try {
+      guard case .configCompleteID(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 7)
+    }()
+    case .rebooted?: try {
+      guard case .rebooted(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 8)
+    }()
+    case .moduleConfig?: try {
+      guard case .moduleConfig(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    }()
+    case .channel?: try {
+      guard case .channel(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    }()
+    case .queueStatus?: try {
+      guard case .queueStatus(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+    }()
+    case .xmodemPacket?: try {
+      guard case .xmodemPacket(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+    }()
+    case .metadata?: try {
+      guard case .metadata(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+    }()
+    case .mqttClientProxyMessage?: try {
+      guard case .mqttClientProxyMessage(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+    }()
+    case .fileInfo?: try {
+      guard case .fileInfo(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+    }()
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: FromRadio, rhs: FromRadio) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._id != rhs_storage._id {return false}
-        if _storage._payloadVariant != rhs_storage._payloadVariant {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.id != rhs.id {return false}
+    if lhs.payloadVariant != rhs.payloadVariant {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/MeshtasticProtobufs/Sources/meshtastic/module_config.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/module_config.pb.swift
@@ -758,6 +758,9 @@ public struct ModuleConfig {
 
       /// NMEA messages specifically tailored for CalTopo
       case caltopo // = 5
+
+      /// Ecowitt WS85 weather station
+      case ws85 // = 6
       case UNRECOGNIZED(Int)
 
       public init() {
@@ -772,6 +775,7 @@ public struct ModuleConfig {
         case 3: self = .textmsg
         case 4: self = .nmea
         case 5: self = .caltopo
+        case 6: self = .ws85
         default: self = .UNRECOGNIZED(rawValue)
         }
       }
@@ -784,6 +788,7 @@ public struct ModuleConfig {
         case .textmsg: return 3
         case .nmea: return 4
         case .caltopo: return 5
+        case .ws85: return 6
         case .UNRECOGNIZED(let i): return i
         }
       }
@@ -1208,6 +1213,7 @@ extension ModuleConfig.SerialConfig.Serial_Mode: CaseIterable {
     .textmsg,
     .nmea,
     .caltopo,
+    .ws85,
   ]
 }
 
@@ -2081,6 +2087,7 @@ extension ModuleConfig.SerialConfig.Serial_Mode: SwiftProtobuf._ProtoNameProvidi
     3: .same(proto: "TEXTMSG"),
     4: .same(proto: "NMEA"),
     5: .same(proto: "CALTOPO"),
+    6: .same(proto: "WS85"),
   ]
 }
 

--- a/MeshtasticProtobufs/Sources/meshtastic/telemetry.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/telemetry.pb.swift
@@ -277,69 +277,130 @@ public struct EnvironmentMetrics {
 
   ///
   /// Temperature measured
-  public var temperature: Float = 0
+  public var temperature: Float {
+    get {return _storage._temperature}
+    set {_uniqueStorage()._temperature = newValue}
+  }
 
   ///
   /// Relative humidity percent measured
-  public var relativeHumidity: Float = 0
+  public var relativeHumidity: Float {
+    get {return _storage._relativeHumidity}
+    set {_uniqueStorage()._relativeHumidity = newValue}
+  }
 
   ///
   /// Barometric pressure in hPA measured
-  public var barometricPressure: Float = 0
+  public var barometricPressure: Float {
+    get {return _storage._barometricPressure}
+    set {_uniqueStorage()._barometricPressure = newValue}
+  }
 
   ///
   /// Gas resistance in MOhm measured
-  public var gasResistance: Float = 0
+  public var gasResistance: Float {
+    get {return _storage._gasResistance}
+    set {_uniqueStorage()._gasResistance = newValue}
+  }
 
   ///
   /// Voltage measured (To be depreciated in favor of PowerMetrics in Meshtastic 3.x)
-  public var voltage: Float = 0
+  public var voltage: Float {
+    get {return _storage._voltage}
+    set {_uniqueStorage()._voltage = newValue}
+  }
 
   ///
   /// Current measured (To be depreciated in favor of PowerMetrics in Meshtastic 3.x)
-  public var current: Float = 0
+  public var current: Float {
+    get {return _storage._current}
+    set {_uniqueStorage()._current = newValue}
+  }
 
   /// 
   /// relative scale IAQ value as measured by Bosch BME680 . value 0-500.
   /// Belongs to Air Quality but is not particle but VOC measurement. Other VOC values can also be put in here.
-  public var iaq: UInt32 = 0
+  public var iaq: UInt32 {
+    get {return _storage._iaq}
+    set {_uniqueStorage()._iaq = newValue}
+  }
 
   ///
   /// RCWL9620 Doppler Radar Distance Sensor, used for water level detection. Float value in mm.
-  public var distance: Float = 0
+  public var distance: Float {
+    get {return _storage._distance}
+    set {_uniqueStorage()._distance = newValue}
+  }
 
   ///
   /// VEML7700 high accuracy ambient light(Lux) digital 16-bit resolution sensor.
-  public var lux: Float = 0
+  public var lux: Float {
+    get {return _storage._lux}
+    set {_uniqueStorage()._lux = newValue}
+  }
 
   ///
   /// VEML7700 high accuracy white light(irradiance) not calibrated digital 16-bit resolution sensor.
-  public var whiteLux: Float = 0
+  public var whiteLux: Float {
+    get {return _storage._whiteLux}
+    set {_uniqueStorage()._whiteLux = newValue}
+  }
 
   ///
   /// Infrared lux
-  public var irLux: Float = 0
+  public var irLux: Float {
+    get {return _storage._irLux}
+    set {_uniqueStorage()._irLux = newValue}
+  }
 
   ///
   /// Ultraviolet lux
-  public var uvLux: Float = 0
+  public var uvLux: Float {
+    get {return _storage._uvLux}
+    set {_uniqueStorage()._uvLux = newValue}
+  }
 
   ///
   /// Wind direction in degrees
   /// 0 degrees = North, 90 = East, etc...
-  public var windDirection: UInt32 = 0
+  public var windDirection: UInt32 {
+    get {return _storage._windDirection}
+    set {_uniqueStorage()._windDirection = newValue}
+  }
 
   ///
   /// Wind speed in m/s
-  public var windSpeed: Float = 0
+  public var windSpeed: Float {
+    get {return _storage._windSpeed}
+    set {_uniqueStorage()._windSpeed = newValue}
+  }
 
   ///
   /// Weight in KG
-  public var weight: Float = 0
+  public var weight: Float {
+    get {return _storage._weight}
+    set {_uniqueStorage()._weight = newValue}
+  }
+
+  ///
+  /// Wind gust in m/s
+  public var windGust: Float {
+    get {return _storage._windGust}
+    set {_uniqueStorage()._windGust = newValue}
+  }
+
+  ///
+  /// Wind lull in m/s
+  public var windLull: Float {
+    get {return _storage._windLull}
+    set {_uniqueStorage()._windLull = newValue}
+  }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 ///
@@ -678,99 +739,183 @@ extension EnvironmentMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     13: .standard(proto: "wind_direction"),
     14: .standard(proto: "wind_speed"),
     15: .same(proto: "weight"),
+    16: .standard(proto: "wind_gust"),
+    17: .standard(proto: "wind_lull"),
   ]
 
+  fileprivate class _StorageClass {
+    var _temperature: Float = 0
+    var _relativeHumidity: Float = 0
+    var _barometricPressure: Float = 0
+    var _gasResistance: Float = 0
+    var _voltage: Float = 0
+    var _current: Float = 0
+    var _iaq: UInt32 = 0
+    var _distance: Float = 0
+    var _lux: Float = 0
+    var _whiteLux: Float = 0
+    var _irLux: Float = 0
+    var _uvLux: Float = 0
+    var _windDirection: UInt32 = 0
+    var _windSpeed: Float = 0
+    var _weight: Float = 0
+    var _windGust: Float = 0
+    var _windLull: Float = 0
+
+    #if swift(>=5.10)
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+    #else
+      static let defaultInstance = _StorageClass()
+    #endif
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _temperature = source._temperature
+      _relativeHumidity = source._relativeHumidity
+      _barometricPressure = source._barometricPressure
+      _gasResistance = source._gasResistance
+      _voltage = source._voltage
+      _current = source._current
+      _iaq = source._iaq
+      _distance = source._distance
+      _lux = source._lux
+      _whiteLux = source._whiteLux
+      _irLux = source._irLux
+      _uvLux = source._uvLux
+      _windDirection = source._windDirection
+      _windSpeed = source._windSpeed
+      _weight = source._weight
+      _windGust = source._windGust
+      _windLull = source._windLull
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularFloatField(value: &self.temperature) }()
-      case 2: try { try decoder.decodeSingularFloatField(value: &self.relativeHumidity) }()
-      case 3: try { try decoder.decodeSingularFloatField(value: &self.barometricPressure) }()
-      case 4: try { try decoder.decodeSingularFloatField(value: &self.gasResistance) }()
-      case 5: try { try decoder.decodeSingularFloatField(value: &self.voltage) }()
-      case 6: try { try decoder.decodeSingularFloatField(value: &self.current) }()
-      case 7: try { try decoder.decodeSingularUInt32Field(value: &self.iaq) }()
-      case 8: try { try decoder.decodeSingularFloatField(value: &self.distance) }()
-      case 9: try { try decoder.decodeSingularFloatField(value: &self.lux) }()
-      case 10: try { try decoder.decodeSingularFloatField(value: &self.whiteLux) }()
-      case 11: try { try decoder.decodeSingularFloatField(value: &self.irLux) }()
-      case 12: try { try decoder.decodeSingularFloatField(value: &self.uvLux) }()
-      case 13: try { try decoder.decodeSingularUInt32Field(value: &self.windDirection) }()
-      case 14: try { try decoder.decodeSingularFloatField(value: &self.windSpeed) }()
-      case 15: try { try decoder.decodeSingularFloatField(value: &self.weight) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularFloatField(value: &_storage._temperature) }()
+        case 2: try { try decoder.decodeSingularFloatField(value: &_storage._relativeHumidity) }()
+        case 3: try { try decoder.decodeSingularFloatField(value: &_storage._barometricPressure) }()
+        case 4: try { try decoder.decodeSingularFloatField(value: &_storage._gasResistance) }()
+        case 5: try { try decoder.decodeSingularFloatField(value: &_storage._voltage) }()
+        case 6: try { try decoder.decodeSingularFloatField(value: &_storage._current) }()
+        case 7: try { try decoder.decodeSingularUInt32Field(value: &_storage._iaq) }()
+        case 8: try { try decoder.decodeSingularFloatField(value: &_storage._distance) }()
+        case 9: try { try decoder.decodeSingularFloatField(value: &_storage._lux) }()
+        case 10: try { try decoder.decodeSingularFloatField(value: &_storage._whiteLux) }()
+        case 11: try { try decoder.decodeSingularFloatField(value: &_storage._irLux) }()
+        case 12: try { try decoder.decodeSingularFloatField(value: &_storage._uvLux) }()
+        case 13: try { try decoder.decodeSingularUInt32Field(value: &_storage._windDirection) }()
+        case 14: try { try decoder.decodeSingularFloatField(value: &_storage._windSpeed) }()
+        case 15: try { try decoder.decodeSingularFloatField(value: &_storage._weight) }()
+        case 16: try { try decoder.decodeSingularFloatField(value: &_storage._windGust) }()
+        case 17: try { try decoder.decodeSingularFloatField(value: &_storage._windLull) }()
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.temperature != 0 {
-      try visitor.visitSingularFloatField(value: self.temperature, fieldNumber: 1)
-    }
-    if self.relativeHumidity != 0 {
-      try visitor.visitSingularFloatField(value: self.relativeHumidity, fieldNumber: 2)
-    }
-    if self.barometricPressure != 0 {
-      try visitor.visitSingularFloatField(value: self.barometricPressure, fieldNumber: 3)
-    }
-    if self.gasResistance != 0 {
-      try visitor.visitSingularFloatField(value: self.gasResistance, fieldNumber: 4)
-    }
-    if self.voltage != 0 {
-      try visitor.visitSingularFloatField(value: self.voltage, fieldNumber: 5)
-    }
-    if self.current != 0 {
-      try visitor.visitSingularFloatField(value: self.current, fieldNumber: 6)
-    }
-    if self.iaq != 0 {
-      try visitor.visitSingularUInt32Field(value: self.iaq, fieldNumber: 7)
-    }
-    if self.distance != 0 {
-      try visitor.visitSingularFloatField(value: self.distance, fieldNumber: 8)
-    }
-    if self.lux != 0 {
-      try visitor.visitSingularFloatField(value: self.lux, fieldNumber: 9)
-    }
-    if self.whiteLux != 0 {
-      try visitor.visitSingularFloatField(value: self.whiteLux, fieldNumber: 10)
-    }
-    if self.irLux != 0 {
-      try visitor.visitSingularFloatField(value: self.irLux, fieldNumber: 11)
-    }
-    if self.uvLux != 0 {
-      try visitor.visitSingularFloatField(value: self.uvLux, fieldNumber: 12)
-    }
-    if self.windDirection != 0 {
-      try visitor.visitSingularUInt32Field(value: self.windDirection, fieldNumber: 13)
-    }
-    if self.windSpeed != 0 {
-      try visitor.visitSingularFloatField(value: self.windSpeed, fieldNumber: 14)
-    }
-    if self.weight != 0 {
-      try visitor.visitSingularFloatField(value: self.weight, fieldNumber: 15)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      if _storage._temperature != 0 {
+        try visitor.visitSingularFloatField(value: _storage._temperature, fieldNumber: 1)
+      }
+      if _storage._relativeHumidity != 0 {
+        try visitor.visitSingularFloatField(value: _storage._relativeHumidity, fieldNumber: 2)
+      }
+      if _storage._barometricPressure != 0 {
+        try visitor.visitSingularFloatField(value: _storage._barometricPressure, fieldNumber: 3)
+      }
+      if _storage._gasResistance != 0 {
+        try visitor.visitSingularFloatField(value: _storage._gasResistance, fieldNumber: 4)
+      }
+      if _storage._voltage != 0 {
+        try visitor.visitSingularFloatField(value: _storage._voltage, fieldNumber: 5)
+      }
+      if _storage._current != 0 {
+        try visitor.visitSingularFloatField(value: _storage._current, fieldNumber: 6)
+      }
+      if _storage._iaq != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._iaq, fieldNumber: 7)
+      }
+      if _storage._distance != 0 {
+        try visitor.visitSingularFloatField(value: _storage._distance, fieldNumber: 8)
+      }
+      if _storage._lux != 0 {
+        try visitor.visitSingularFloatField(value: _storage._lux, fieldNumber: 9)
+      }
+      if _storage._whiteLux != 0 {
+        try visitor.visitSingularFloatField(value: _storage._whiteLux, fieldNumber: 10)
+      }
+      if _storage._irLux != 0 {
+        try visitor.visitSingularFloatField(value: _storage._irLux, fieldNumber: 11)
+      }
+      if _storage._uvLux != 0 {
+        try visitor.visitSingularFloatField(value: _storage._uvLux, fieldNumber: 12)
+      }
+      if _storage._windDirection != 0 {
+        try visitor.visitSingularUInt32Field(value: _storage._windDirection, fieldNumber: 13)
+      }
+      if _storage._windSpeed != 0 {
+        try visitor.visitSingularFloatField(value: _storage._windSpeed, fieldNumber: 14)
+      }
+      if _storage._weight != 0 {
+        try visitor.visitSingularFloatField(value: _storage._weight, fieldNumber: 15)
+      }
+      if _storage._windGust != 0 {
+        try visitor.visitSingularFloatField(value: _storage._windGust, fieldNumber: 16)
+      }
+      if _storage._windLull != 0 {
+        try visitor.visitSingularFloatField(value: _storage._windLull, fieldNumber: 17)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: EnvironmentMetrics, rhs: EnvironmentMetrics) -> Bool {
-    if lhs.temperature != rhs.temperature {return false}
-    if lhs.relativeHumidity != rhs.relativeHumidity {return false}
-    if lhs.barometricPressure != rhs.barometricPressure {return false}
-    if lhs.gasResistance != rhs.gasResistance {return false}
-    if lhs.voltage != rhs.voltage {return false}
-    if lhs.current != rhs.current {return false}
-    if lhs.iaq != rhs.iaq {return false}
-    if lhs.distance != rhs.distance {return false}
-    if lhs.lux != rhs.lux {return false}
-    if lhs.whiteLux != rhs.whiteLux {return false}
-    if lhs.irLux != rhs.irLux {return false}
-    if lhs.uvLux != rhs.uvLux {return false}
-    if lhs.windDirection != rhs.windDirection {return false}
-    if lhs.windSpeed != rhs.windSpeed {return false}
-    if lhs.weight != rhs.weight {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._temperature != rhs_storage._temperature {return false}
+        if _storage._relativeHumidity != rhs_storage._relativeHumidity {return false}
+        if _storage._barometricPressure != rhs_storage._barometricPressure {return false}
+        if _storage._gasResistance != rhs_storage._gasResistance {return false}
+        if _storage._voltage != rhs_storage._voltage {return false}
+        if _storage._current != rhs_storage._current {return false}
+        if _storage._iaq != rhs_storage._iaq {return false}
+        if _storage._distance != rhs_storage._distance {return false}
+        if _storage._lux != rhs_storage._lux {return false}
+        if _storage._whiteLux != rhs_storage._whiteLux {return false}
+        if _storage._irLux != rhs_storage._irLux {return false}
+        if _storage._uvLux != rhs_storage._uvLux {return false}
+        if _storage._windDirection != rhs_storage._windDirection {return false}
+        if _storage._windSpeed != rhs_storage._windSpeed {return false}
+        if _storage._weight != rhs_storage._weight {return false}
+        if _storage._windGust != rhs_storage._windGust {return false}
+        if _storage._windLull != rhs_storage._windLull {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }


### PR DESCRIPTION
This change restores the Exchange Positions & Trace Route buttons back in the node list's context menu.

Unfortunately, the context menu doesn't render the alerts after a position packet is sent because the view is already removed from the render. It would take some refactoring to restore that to the node list, but the position packet and traceroute is still sent, and this should be functional enough for now.

Longer term, it would be cool to use a non-blocking UI action sheet-type of toast message for a lot of these confirmation dialog things. 
