### PR TITLE
Add interactive selection line to device metrics chart

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -14632,6 +14632,9 @@
     "Mininum time between detection broadcasts. Default is 45 seconds." : {
 
     },
+    "Minute" : {
+
+    },
     "mode" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
Allows for chart selection from both the table below the chart and the chart itself.

There is an annotation that I commented out, not sure what it would display here.

@RCGV1 I got the start of some interactivity going.