### PR TITLE
Remove broken MB tiles funcitionality

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -6815,9 +6815,6 @@
     "Empty" : {
 
     },
-    "Enable MB Tiles" : {
-
-    },
     "Enable Notifications" : {
 
     },
@@ -20900,9 +20897,6 @@
 
     },
     "The last 4 of the device MAC address will be appended to the short name to set the device's BLE Name.  Short name can be up to 4 bytes long." : {
-
-    },
-    "The latest MBTiles file shared with meshtastic will be loaded into the map." : {
 
     },
     "The maximum interval that can elapse without a node broadcasting a position" : {

--- a/Meshtastic/Extensions/UserDefaults.swift
+++ b/Meshtastic/Extensions/UserDefaults.swift
@@ -57,7 +57,6 @@ extension UserDefaults {
 		case enableMapTraffic
 		case enableMapPointsOfInterest
 		case enableOfflineMaps
-		case enableOfflineMapsMBTiles
 		case mapTileServer
 		case enableOverlayServer
 		case mapOverlayServer
@@ -120,9 +119,6 @@ extension UserDefaults {
 
 	@UserDefault(.enableOfflineMaps, defaultValue: false)
 	static var enableOfflineMaps: Bool
-
-	@UserDefault(.enableOfflineMapsMBTiles, defaultValue: false)
-	static var enableOfflineMapsMBTiles: Bool
 
 	@UserDefault(.mapTileServer, defaultValue: .openStreetMap)
 	static var mapTileServer: MapTileServer

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -110,48 +110,6 @@ struct MeshtasticAppleApp: App {
 					Logger.mesh.debug("User wants to open a Channel Settings URL: \(self.incomingUrl?.absoluteString ?? "No QR Code Link")")
 				} else if url.absoluteString.lowercased().contains("meshtastic:///") {
 					appState.router.route(url: url)
-				} else {
-					saveChannels = false
-					Logger.mesh.debug("User wants to import a MBTILES offline map file: \(self.incomingUrl?.absoluteString ?? "No Tiles link")")
-				}
-
-				/// Only do the map tiles stuff if it is enabled
-				if UserDefaults.enableOfflineMapsMBTiles {
-					/// we are expecting a .mbtiles map file that contains raster data
-					/// save it to the documents directory, and name it offline_map.mbtiles
-					let fileManager = FileManager.default
-					let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-					let destination = documentsDirectory.appendingPathComponent("offline_map.mbtiles", isDirectory: false)
-
-					if !self.saveChannels {
-
-						// tell the system we want the file please
-						guard url.startAccessingSecurityScopedResource() else {
-							return
-						}
-
-						// do we need to delete an old one?
-						if fileManager.fileExists(atPath: destination.path) {
-							Logger.mesh.info("Found an old map file.  Deleting it")
-							try? fileManager.removeItem(atPath: destination.path)
-						}
-
-						do {
-							try fileManager.copyItem(at: url, to: destination)
-						} catch {
-							Logger.mesh.error("Copy MB Tile file failed. Error: \(error.localizedDescription)")
-						}
-
-						if fileManager.fileExists(atPath: destination.path) {
-							Logger.mesh.info("Saved the map file")
-
-							// need to tell the map view that it needs to update and try loading the new overlay
-							UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "lastUpdatedLocalMapFile")
-
-						} else {
-							Logger.mesh.error("Didn't save the map file")
-						}
-					}
 				}
 			})
 			.task {

--- a/Meshtastic/Views/Nodes/NodeMap.swift
+++ b/Meshtastic/Views/Nodes/NodeMap.swift
@@ -16,14 +16,12 @@ struct NodeMap: View {
 
 	@ObservedObject
 	var router: Router
-	
 	@State var selectedMapLayer: MapLayer = UserDefaults.mapLayer
 	@State var enableMapRecentering: Bool = UserDefaults.enableMapRecentering
 	@State var enableMapRouteLines: Bool = UserDefaults.enableMapRouteLines
 	@State var enableMapNodeHistoryPins: Bool = UserDefaults.enableMapNodeHistoryPins
 	@State var enableOfflineMaps: Bool = UserDefaults.enableOfflineMaps
 	@State var selectedTileServer: MapTileServer = UserDefaults.mapTileServer
-	@State var enableOfflineMapsMBTiles: Bool = UserDefaults.enableOfflineMapsMBTiles
 	@State var enableOverlayServer: Bool = UserDefaults.enableOverlayServer
 	@State var selectedOverlayServer: MapOverlayServer = UserDefaults.mapOverlayServer
 	@State var mapTilesAboveLabels: Bool = UserDefaults.mapTilesAboveLabels
@@ -172,46 +170,32 @@ struct NodeMap: View {
 							}
 							if enableOfflineMaps {
 								VStack(alignment: .leading) {
-									if !enableOfflineMapsMBTiles {
-										Picker(selection: $selectedTileServer,
-											   label: Text("Tile Server")) {
-											ForEach(MapTileServer.allCases, id: \.self) { tsl in
-												Text(tsl.description)
-											}
-										}
-											   .pickerStyle(DefaultPickerStyle())
-											   .onChange(of: (selectedTileServer)) { newSelectedTileServer in
-												   UserDefaults.mapTileServer = newSelectedTileServer
-											   }
-										Text("Attribution:")
-											.fontWeight(.semibold)
-											.font(.footnote)
-										Text(LocalizedStringKey(selectedTileServer.attribution))
-											.font(.footnote)
-											.foregroundColor(.gray)
-											.padding(0)
-										Divider()
-										Toggle(isOn: $mapTilesAboveLabels) {
-											Text("Tiles above Labels")
-										}
-										.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-										.onTapGesture {
-											self.mapTilesAboveLabels.toggle()
-											UserDefaults.mapTilesAboveLabels = self.mapTilesAboveLabels
+									Picker(selection: $selectedTileServer,
+										   label: Text("Tile Server")) {
+										ForEach(MapTileServer.allCases, id: \.self) { tsl in
+											Text(tsl.description)
 										}
 									}
+										   .pickerStyle(DefaultPickerStyle())
+										   .onChange(of: (selectedTileServer)) { newSelectedTileServer in
+											   UserDefaults.mapTileServer = newSelectedTileServer
+										   }
+									Text("Attribution:")
+										.fontWeight(.semibold)
+										.font(.footnote)
+									Text(LocalizedStringKey(selectedTileServer.attribution))
+										.font(.footnote)
+										.foregroundColor(.gray)
+										.padding(0)
 									Divider()
-									Toggle(isOn: $enableOfflineMapsMBTiles) {
-										Text("Enable MB Tiles")
+									Toggle(isOn: $mapTilesAboveLabels) {
+										Text("Tiles above Labels")
 									}
 									.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 									.onTapGesture {
-										self.enableOfflineMapsMBTiles.toggle()
-										UserDefaults.enableOfflineMapsMBTiles = self.enableOfflineMapsMBTiles
+										self.mapTilesAboveLabels.toggle()
+										UserDefaults.mapTilesAboveLabels = self.mapTilesAboveLabels
 									}
-									Text("The latest MBTiles file shared with meshtastic will be loaded into the map.")
-										.font(.footnote)
-										.foregroundColor(.gray)
 								}
 							}
 						}


### PR DESCRIPTION
The mbtiles functionality is not working and the MapKit map will be removed in the fall anyways so removing this broken functionality. It actually seems to work with an updated mbtiles file, but this whole configuration is hardly used and too complex anyways.