### PR TITLE
Bump Protos

### DIFF
--- a/Meshtastic.xcodeproj/xcshareddata/xcschemes/WidgetsExtension.xcscheme
+++ b/Meshtastic.xcodeproj/xcshareddata/xcschemes/WidgetsExtension.xcscheme
@@ -89,7 +89,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
-      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/MeshtasticProtobufs/Sources/meshtastic/admin.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/admin.pb.swift
@@ -24,7 +24,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// This message is handled by the Admin module and is responsible for all settings/channel read/write operations.
 /// This message is used to do settings operations to both remote AND local nodes.
 /// (Prior to 1.2 these operations were done via special ToRadio operations)
-public struct AdminMessage {
+public struct AdminMessage: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -456,7 +456,7 @@ public struct AdminMessage {
 
   ///
   /// TODO: REPLACE
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, Sendable {
     ///
     /// Send the specified channel in the response to this message
     /// NOTE: This field is sent with the channel index + 1 (to ensure we never try to send 'zero' - which protobufs treats as not present)
@@ -590,185 +590,11 @@ public struct AdminMessage {
     /// Tell the node to reset the nodedb.
     case nodedbReset(Int32)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: AdminMessage.OneOf_PayloadVariant, rhs: AdminMessage.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.getChannelRequest, .getChannelRequest): return {
-        guard case .getChannelRequest(let l) = lhs, case .getChannelRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getChannelResponse, .getChannelResponse): return {
-        guard case .getChannelResponse(let l) = lhs, case .getChannelResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getOwnerRequest, .getOwnerRequest): return {
-        guard case .getOwnerRequest(let l) = lhs, case .getOwnerRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getOwnerResponse, .getOwnerResponse): return {
-        guard case .getOwnerResponse(let l) = lhs, case .getOwnerResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getConfigRequest, .getConfigRequest): return {
-        guard case .getConfigRequest(let l) = lhs, case .getConfigRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getConfigResponse, .getConfigResponse): return {
-        guard case .getConfigResponse(let l) = lhs, case .getConfigResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getModuleConfigRequest, .getModuleConfigRequest): return {
-        guard case .getModuleConfigRequest(let l) = lhs, case .getModuleConfigRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getModuleConfigResponse, .getModuleConfigResponse): return {
-        guard case .getModuleConfigResponse(let l) = lhs, case .getModuleConfigResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getCannedMessageModuleMessagesRequest, .getCannedMessageModuleMessagesRequest): return {
-        guard case .getCannedMessageModuleMessagesRequest(let l) = lhs, case .getCannedMessageModuleMessagesRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getCannedMessageModuleMessagesResponse, .getCannedMessageModuleMessagesResponse): return {
-        guard case .getCannedMessageModuleMessagesResponse(let l) = lhs, case .getCannedMessageModuleMessagesResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getDeviceMetadataRequest, .getDeviceMetadataRequest): return {
-        guard case .getDeviceMetadataRequest(let l) = lhs, case .getDeviceMetadataRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getDeviceMetadataResponse, .getDeviceMetadataResponse): return {
-        guard case .getDeviceMetadataResponse(let l) = lhs, case .getDeviceMetadataResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getRingtoneRequest, .getRingtoneRequest): return {
-        guard case .getRingtoneRequest(let l) = lhs, case .getRingtoneRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getRingtoneResponse, .getRingtoneResponse): return {
-        guard case .getRingtoneResponse(let l) = lhs, case .getRingtoneResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getDeviceConnectionStatusRequest, .getDeviceConnectionStatusRequest): return {
-        guard case .getDeviceConnectionStatusRequest(let l) = lhs, case .getDeviceConnectionStatusRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getDeviceConnectionStatusResponse, .getDeviceConnectionStatusResponse): return {
-        guard case .getDeviceConnectionStatusResponse(let l) = lhs, case .getDeviceConnectionStatusResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setHamMode, .setHamMode): return {
-        guard case .setHamMode(let l) = lhs, case .setHamMode(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getNodeRemoteHardwarePinsRequest, .getNodeRemoteHardwarePinsRequest): return {
-        guard case .getNodeRemoteHardwarePinsRequest(let l) = lhs, case .getNodeRemoteHardwarePinsRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.getNodeRemoteHardwarePinsResponse, .getNodeRemoteHardwarePinsResponse): return {
-        guard case .getNodeRemoteHardwarePinsResponse(let l) = lhs, case .getNodeRemoteHardwarePinsResponse(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.enterDfuModeRequest, .enterDfuModeRequest): return {
-        guard case .enterDfuModeRequest(let l) = lhs, case .enterDfuModeRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.deleteFileRequest, .deleteFileRequest): return {
-        guard case .deleteFileRequest(let l) = lhs, case .deleteFileRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setScale, .setScale): return {
-        guard case .setScale(let l) = lhs, case .setScale(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setOwner, .setOwner): return {
-        guard case .setOwner(let l) = lhs, case .setOwner(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setChannel, .setChannel): return {
-        guard case .setChannel(let l) = lhs, case .setChannel(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setConfig, .setConfig): return {
-        guard case .setConfig(let l) = lhs, case .setConfig(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setModuleConfig, .setModuleConfig): return {
-        guard case .setModuleConfig(let l) = lhs, case .setModuleConfig(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setCannedMessageModuleMessages, .setCannedMessageModuleMessages): return {
-        guard case .setCannedMessageModuleMessages(let l) = lhs, case .setCannedMessageModuleMessages(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setRingtoneMessage, .setRingtoneMessage): return {
-        guard case .setRingtoneMessage(let l) = lhs, case .setRingtoneMessage(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.removeByNodenum, .removeByNodenum): return {
-        guard case .removeByNodenum(let l) = lhs, case .removeByNodenum(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setFavoriteNode, .setFavoriteNode): return {
-        guard case .setFavoriteNode(let l) = lhs, case .setFavoriteNode(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.removeFavoriteNode, .removeFavoriteNode): return {
-        guard case .removeFavoriteNode(let l) = lhs, case .removeFavoriteNode(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.setFixedPosition, .setFixedPosition): return {
-        guard case .setFixedPosition(let l) = lhs, case .setFixedPosition(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.removeFixedPosition, .removeFixedPosition): return {
-        guard case .removeFixedPosition(let l) = lhs, case .removeFixedPosition(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.beginEditSettings, .beginEditSettings): return {
-        guard case .beginEditSettings(let l) = lhs, case .beginEditSettings(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.commitEditSettings, .commitEditSettings): return {
-        guard case .commitEditSettings(let l) = lhs, case .commitEditSettings(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.rebootOtaSeconds, .rebootOtaSeconds): return {
-        guard case .rebootOtaSeconds(let l) = lhs, case .rebootOtaSeconds(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.exitSimulator, .exitSimulator): return {
-        guard case .exitSimulator(let l) = lhs, case .exitSimulator(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.rebootSeconds, .rebootSeconds): return {
-        guard case .rebootSeconds(let l) = lhs, case .rebootSeconds(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.shutdownSeconds, .shutdownSeconds): return {
-        guard case .shutdownSeconds(let l) = lhs, case .shutdownSeconds(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.factoryReset, .factoryReset): return {
-        guard case .factoryReset(let l) = lhs, case .factoryReset(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.nodedbReset, .nodedbReset): return {
-        guard case .nodedbReset(let l) = lhs, case .nodedbReset(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   ///
   /// TODO: REPLACE
-  public enum ConfigType: SwiftProtobuf.Enum {
+  public enum ConfigType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -830,11 +656,22 @@ public struct AdminMessage {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [AdminMessage.ConfigType] = [
+      .deviceConfig,
+      .positionConfig,
+      .powerConfig,
+      .networkConfig,
+      .displayConfig,
+      .loraConfig,
+      .bluetoothConfig,
+    ]
+
   }
 
   ///
   /// TODO: REPLACE
-  public enum ModuleConfigType: SwiftProtobuf.Enum {
+  public enum ModuleConfigType: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -932,50 +769,31 @@ public struct AdminMessage {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [AdminMessage.ModuleConfigType] = [
+      .mqttConfig,
+      .serialConfig,
+      .extnotifConfig,
+      .storeforwardConfig,
+      .rangetestConfig,
+      .telemetryConfig,
+      .cannedmsgConfig,
+      .audioConfig,
+      .remotehardwareConfig,
+      .neighborinfoConfig,
+      .ambientlightingConfig,
+      .detectionsensorConfig,
+      .paxcounterConfig,
+    ]
+
   }
 
   public init() {}
 }
 
-#if swift(>=4.2)
-
-extension AdminMessage.ConfigType: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [AdminMessage.ConfigType] = [
-    .deviceConfig,
-    .positionConfig,
-    .powerConfig,
-    .networkConfig,
-    .displayConfig,
-    .loraConfig,
-    .bluetoothConfig,
-  ]
-}
-
-extension AdminMessage.ModuleConfigType: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [AdminMessage.ModuleConfigType] = [
-    .mqttConfig,
-    .serialConfig,
-    .extnotifConfig,
-    .storeforwardConfig,
-    .rangetestConfig,
-    .telemetryConfig,
-    .cannedmsgConfig,
-    .audioConfig,
-    .remotehardwareConfig,
-    .neighborinfoConfig,
-    .ambientlightingConfig,
-    .detectionsensorConfig,
-    .paxcounterConfig,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
 ///
 /// Parameters for setting up Meshtastic for ameteur radio usage
-public struct HamParameters {
+public struct HamParameters: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1005,7 +823,7 @@ public struct HamParameters {
 
 ///
 /// Response envelope for node_remote_hardware_pins
-public struct NodeRemoteHardwarePinsResponse {
+public struct NodeRemoteHardwarePinsResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1018,15 +836,6 @@ public struct NodeRemoteHardwarePinsResponse {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension AdminMessage: @unchecked Sendable {}
-extension AdminMessage.OneOf_PayloadVariant: @unchecked Sendable {}
-extension AdminMessage.ConfigType: @unchecked Sendable {}
-extension AdminMessage.ModuleConfigType: @unchecked Sendable {}
-extension HamParameters: @unchecked Sendable {}
-extension NodeRemoteHardwarePinsResponse: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -1725,7 +1534,7 @@ extension HamParameters: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     if self.txPower != 0 {
       try visitor.visitSingularInt32Field(value: self.txPower, fieldNumber: 2)
     }
-    if self.frequency != 0 {
+    if self.frequency.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.frequency, fieldNumber: 3)
     }
     if !self.shortName.isEmpty {

--- a/MeshtasticProtobufs/Sources/meshtastic/apponly.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/apponly.pb.swift
@@ -26,7 +26,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// any SECONDARY channels.
 /// No DISABLED channels are included.
 /// This abstraction is used only on the the 'app side' of the world (ie python, javascript and android etc) to show a group of Channels as a (long) URL
-public struct ChannelSet {
+public struct ChannelSet: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -52,10 +52,6 @@ public struct ChannelSet {
 
   fileprivate var _loraConfig: Config.LoRaConfig? = nil
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension ChannelSet: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/atak.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/atak.pb.swift
@@ -20,7 +20,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public enum Team: SwiftProtobuf.Enum {
+public enum Team: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -130,11 +130,6 @@ public enum Team: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Team: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [Team] = [
     .unspecifedColor,
@@ -153,13 +148,12 @@ extension Team: CaseIterable {
     .darkGreen,
     .brown,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 ///
 /// Role of the group member
-public enum MemberRole: SwiftProtobuf.Enum {
+public enum MemberRole: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -233,11 +227,6 @@ public enum MemberRole: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension MemberRole: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [MemberRole] = [
     .unspecifed,
@@ -250,13 +239,12 @@ extension MemberRole: CaseIterable {
     .rto,
     .k9,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 ///
 /// Packets for the official ATAK Plugin
-public struct TAKPacket {
+public struct TAKPacket: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -326,7 +314,7 @@ public struct TAKPacket {
 
   ///
   /// The payload of the packet
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, Sendable {
     ///
     /// TAK position report
     case pli(PLI)
@@ -334,24 +322,6 @@ public struct TAKPacket {
     /// ATAK GeoChat message
     case chat(GeoChat)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: TAKPacket.OneOf_PayloadVariant, rhs: TAKPacket.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.pli, .pli): return {
-        guard case .pli(let l) = lhs, case .pli(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.chat, .chat): return {
-        guard case .chat(let l) = lhs, case .chat(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -363,7 +333,7 @@ public struct TAKPacket {
 
 ///
 /// ATAK GeoChat message
-public struct GeoChat {
+public struct GeoChat: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -405,7 +375,7 @@ public struct GeoChat {
 ///
 /// ATAK Group
 /// <__group role='Team Member' name='Cyan'/>
-public struct Group {
+public struct Group: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -427,7 +397,7 @@ public struct Group {
 ///
 /// ATAK EUD Status
 /// <status battery='100' />
-public struct Status {
+public struct Status: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -444,7 +414,7 @@ public struct Status {
 ///
 /// ATAK Contact
 /// <contact endpoint='0.0.0.0:4242:tcp' phone='+12345678' callsign='FALKE'/>
-public struct Contact {
+public struct Contact: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -464,7 +434,7 @@ public struct Contact {
 
 ///
 /// Position Location Information from ATAK
-public struct PLI {
+public struct PLI: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -495,18 +465,6 @@ public struct PLI {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Team: @unchecked Sendable {}
-extension MemberRole: @unchecked Sendable {}
-extension TAKPacket: @unchecked Sendable {}
-extension TAKPacket.OneOf_PayloadVariant: @unchecked Sendable {}
-extension GeoChat: @unchecked Sendable {}
-extension Group: @unchecked Sendable {}
-extension Status: @unchecked Sendable {}
-extension Contact: @unchecked Sendable {}
-extension PLI: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/cannedmessages.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/cannedmessages.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 ///
 /// Canned message module configuration.
-public struct CannedMessageModuleConfig {
+public struct CannedMessageModuleConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -35,10 +35,6 @@ public struct CannedMessageModuleConfig {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension CannedMessageModuleConfig: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/channel.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/channel.pb.swift
@@ -36,13 +36,15 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// FIXME: Add description of multi-channel support and how primary vs secondary channels are used.
 /// FIXME: explain how apps use channels for security.
 /// explain how remote settings and remote gpio are managed as an example
-public struct ChannelSettings {
+public struct ChannelSettings: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   ///
   /// Deprecated in favor of LoraConfig.channel_num
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var channelNum: UInt32 = 0
 
   ///
@@ -111,7 +113,7 @@ public struct ChannelSettings {
 
 ///
 /// This message is specifically for modules to store per-channel configuration data.
-public struct ModuleSettings {
+public struct ModuleSettings: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -132,7 +134,7 @@ public struct ModuleSettings {
 
 ///
 /// A pair of a channel number, mode and the (sharable) settings for that channel
-public struct Channel {
+public struct Channel: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -170,7 +172,7 @@ public struct Channel {
   /// cross band routing as needed.
   /// If a device has only a single radio (the common case) only one channel can be PRIMARY at a time
   /// (but any number of SECONDARY channels can't be sent received on that common frequency)
-  public enum Role: SwiftProtobuf.Enum {
+  public enum Role: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -209,32 +211,19 @@ public struct Channel {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Channel.Role] = [
+      .disabled,
+      .primary,
+      .secondary,
+    ]
+
   }
 
   public init() {}
 
   fileprivate var _settings: ChannelSettings? = nil
 }
-
-#if swift(>=4.2)
-
-extension Channel.Role: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Channel.Role] = [
-    .disabled,
-    .primary,
-    .secondary,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension ChannelSettings: @unchecked Sendable {}
-extension ModuleSettings: @unchecked Sendable {}
-extension Channel: @unchecked Sendable {}
-extension Channel.Role: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/clientonly.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/clientonly.pb.swift
@@ -23,7 +23,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 ///
 /// This abstraction is used to contain any configuration for provisioning a node on any client.
 /// It is useful for importing and exporting configurations.
-public struct DeviceProfile {
+public struct DeviceProfile: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -93,10 +93,6 @@ public struct DeviceProfile {
   fileprivate var _config: LocalConfig? = nil
   fileprivate var _moduleConfig: LocalModuleConfig? = nil
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension DeviceProfile: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/config.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/config.pb.swift
@@ -20,7 +20,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public struct Config {
+public struct Config: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -89,7 +89,7 @@ public struct Config {
 
   ///
   /// Payload Variant
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, Sendable {
     case device(Config.DeviceConfig)
     case position(Config.PositionConfig)
     case power(Config.PowerConfig)
@@ -98,49 +98,11 @@ public struct Config {
     case lora(Config.LoRaConfig)
     case bluetooth(Config.BluetoothConfig)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: Config.OneOf_PayloadVariant, rhs: Config.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.device, .device): return {
-        guard case .device(let l) = lhs, case .device(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.position, .position): return {
-        guard case .position(let l) = lhs, case .position(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.power, .power): return {
-        guard case .power(let l) = lhs, case .power(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.network, .network): return {
-        guard case .network(let l) = lhs, case .network(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.display, .display): return {
-        guard case .display(let l) = lhs, case .display(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.lora, .lora): return {
-        guard case .lora(let l) = lhs, case .lora(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.bluetooth, .bluetooth): return {
-        guard case .bluetooth(let l) = lhs, case .bluetooth(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   ///
   /// Configuration
-  public struct DeviceConfig {
+  public struct DeviceConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -202,7 +164,7 @@ public struct Config {
 
     ///
     /// Defines the device's role on the Mesh network
-    public enum Role: SwiftProtobuf.Enum {
+    public enum Role: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -220,6 +182,8 @@ public struct Config {
       ///   The wifi radio and the oled screen will be put to sleep.
       ///   This mode may still potentially have higher power usage due to it's preference in message rebroadcasting on the mesh.
       case router // = 2
+
+      /// NOTE: This enum value was marked as deprecated in the .proto file
       case routerClient // = 3
 
       ///
@@ -310,11 +274,26 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.DeviceConfig.Role] = [
+        .client,
+        .clientMute,
+        .router,
+        .routerClient,
+        .repeater,
+        .tracker,
+        .sensor,
+        .tak,
+        .clientHidden,
+        .lostAndFound,
+        .takTracker,
+      ]
+
     }
 
     ///
     /// Defines the device's behavior for how messages are rebroadcast
-    public enum RebroadcastMode: SwiftProtobuf.Enum {
+    public enum RebroadcastMode: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -362,6 +341,14 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.DeviceConfig.RebroadcastMode] = [
+        .all,
+        .allSkipDecoding,
+        .localOnly,
+        .knownOnly,
+      ]
+
     }
 
     public init() {}
@@ -369,7 +356,7 @@ public struct Config {
 
   ///
   /// Position Config
-  public struct PositionConfig {
+  public struct PositionConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -391,6 +378,8 @@ public struct Config {
 
     ///
     /// Is GPS enabled for this node?
+    ///
+    /// NOTE: This field was marked as deprecated in the .proto file.
     public var gpsEnabled: Bool = false
 
     ///
@@ -401,6 +390,8 @@ public struct Config {
 
     ///
     /// Deprecated in favor of using smart / regular broadcast intervals as implicit attempt time
+    ///
+    /// NOTE: This field was marked as deprecated in the .proto file.
     public var gpsAttemptTime: UInt32 = 0
 
     ///
@@ -441,7 +432,7 @@ public struct Config {
     /// are always included (also time if GPS-synced)
     /// NOTE: the more fields are included, the larger the message will be -
     ///   leading to longer airtime and a higher risk of packet loss
-    public enum PositionFlags: SwiftProtobuf.Enum {
+    public enum PositionFlags: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -531,9 +522,24 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.PositionConfig.PositionFlags] = [
+        .unset,
+        .altitude,
+        .altitudeMsl,
+        .geoidalSeparation,
+        .dop,
+        .hvdop,
+        .satinview,
+        .seqNo,
+        .timestamp,
+        .heading,
+        .speed,
+      ]
+
     }
 
-    public enum GpsMode: SwiftProtobuf.Enum {
+    public enum GpsMode: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -571,6 +577,13 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.PositionConfig.GpsMode] = [
+        .disabled,
+        .enabled,
+        .notPresent,
+      ]
+
     }
 
     public init() {}
@@ -579,7 +592,7 @@ public struct Config {
   ///
   /// Power Config\
   /// See [Power Config](/docs/settings/config/power) for additional power config details.
-  public struct PowerConfig {
+  public struct PowerConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -639,7 +652,7 @@ public struct Config {
 
   ///
   /// Network Config
-  public struct NetworkConfig {
+  public struct NetworkConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -686,7 +699,7 @@ public struct Config {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum AddressMode: SwiftProtobuf.Enum {
+    public enum AddressMode: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -718,9 +731,15 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.NetworkConfig.AddressMode] = [
+        .dhcp,
+        .static,
+      ]
+
     }
 
-    public struct IpV4Config {
+    public struct IpV4Config: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
       // methods supported on all messages.
@@ -753,7 +772,7 @@ public struct Config {
 
   ///
   /// Display Config
-  public struct DisplayConfig {
+  public struct DisplayConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -809,7 +828,7 @@ public struct Config {
 
     ///
     /// How the GPS coordinates are displayed on the OLED screen.
-    public enum GpsCoordinateFormat: SwiftProtobuf.Enum {
+    public enum GpsCoordinateFormat: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -872,11 +891,21 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.DisplayConfig.GpsCoordinateFormat] = [
+        .dec,
+        .dms,
+        .utm,
+        .mgrs,
+        .olc,
+        .osgr,
+      ]
+
     }
 
     ///
     /// Unit display preference
-    public enum DisplayUnits: SwiftProtobuf.Enum {
+    public enum DisplayUnits: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -908,11 +937,17 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.DisplayConfig.DisplayUnits] = [
+        .metric,
+        .imperial,
+      ]
+
     }
 
     ///
     /// Override OLED outo detect with this if it fails.
-    public enum OledType: SwiftProtobuf.Enum {
+    public enum OledType: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -956,9 +991,17 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.DisplayConfig.OledType] = [
+        .oledAuto,
+        .oledSsd1306,
+        .oledSh1106,
+        .oledSh1107,
+      ]
+
     }
 
-    public enum DisplayMode: SwiftProtobuf.Enum {
+    public enum DisplayMode: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -1002,9 +1045,17 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.DisplayConfig.DisplayMode] = [
+        .default,
+        .twocolor,
+        .inverted,
+        .color,
+      ]
+
     }
 
-    public enum CompassOrientation: SwiftProtobuf.Enum {
+    public enum CompassOrientation: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -1072,6 +1123,18 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.DisplayConfig.CompassOrientation] = [
+        .degrees0,
+        .degrees90,
+        .degrees180,
+        .degrees270,
+        .degrees0Inverted,
+        .degrees90Inverted,
+        .degrees180Inverted,
+        .degrees270Inverted,
+      ]
+
     }
 
     public init() {}
@@ -1079,7 +1142,7 @@ public struct Config {
 
   ///
   /// Lora Config
-  public struct LoRaConfig {
+  public struct LoRaConfig: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1236,7 +1299,7 @@ public struct Config {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum RegionCode: SwiftProtobuf.Enum {
+    public enum RegionCode: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -1370,12 +1433,35 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.LoRaConfig.RegionCode] = [
+        .unset,
+        .us,
+        .eu433,
+        .eu868,
+        .cn,
+        .jp,
+        .anz,
+        .kr,
+        .tw,
+        .ru,
+        .in,
+        .nz865,
+        .th,
+        .lora24,
+        .ua433,
+        .ua868,
+        .my433,
+        .my919,
+        .sg923,
+      ]
+
     }
 
     ///
     /// Standard predefined channel settings
     /// Note: these mappings must match ModemPreset Choice in the device code.
-    public enum ModemPreset: SwiftProtobuf.Enum {
+    public enum ModemPreset: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -1443,6 +1529,18 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.LoRaConfig.ModemPreset] = [
+        .longFast,
+        .longSlow,
+        .veryLongSlow,
+        .mediumSlow,
+        .mediumFast,
+        .shortSlow,
+        .shortFast,
+        .longModerate,
+      ]
+
     }
 
     public init() {}
@@ -1450,7 +1548,7 @@ public struct Config {
     fileprivate var _storage = _StorageClass.defaultInstance
   }
 
-  public struct BluetoothConfig {
+  public struct BluetoothConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1473,7 +1571,7 @@ public struct Config {
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public enum PairingMode: SwiftProtobuf.Enum {
+    public enum PairingMode: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -1511,6 +1609,13 @@ public struct Config {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [Config.BluetoothConfig.PairingMode] = [
+        .randomPin,
+        .fixedPin,
+        .noPin,
+      ]
+
     }
 
     public init() {}
@@ -1518,199 +1623,6 @@ public struct Config {
 
   public init() {}
 }
-
-#if swift(>=4.2)
-
-extension Config.DeviceConfig.Role: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.DeviceConfig.Role] = [
-    .client,
-    .clientMute,
-    .router,
-    .routerClient,
-    .repeater,
-    .tracker,
-    .sensor,
-    .tak,
-    .clientHidden,
-    .lostAndFound,
-    .takTracker,
-  ]
-}
-
-extension Config.DeviceConfig.RebroadcastMode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.DeviceConfig.RebroadcastMode] = [
-    .all,
-    .allSkipDecoding,
-    .localOnly,
-    .knownOnly,
-  ]
-}
-
-extension Config.PositionConfig.PositionFlags: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.PositionConfig.PositionFlags] = [
-    .unset,
-    .altitude,
-    .altitudeMsl,
-    .geoidalSeparation,
-    .dop,
-    .hvdop,
-    .satinview,
-    .seqNo,
-    .timestamp,
-    .heading,
-    .speed,
-  ]
-}
-
-extension Config.PositionConfig.GpsMode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.PositionConfig.GpsMode] = [
-    .disabled,
-    .enabled,
-    .notPresent,
-  ]
-}
-
-extension Config.NetworkConfig.AddressMode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.NetworkConfig.AddressMode] = [
-    .dhcp,
-    .static,
-  ]
-}
-
-extension Config.DisplayConfig.GpsCoordinateFormat: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.DisplayConfig.GpsCoordinateFormat] = [
-    .dec,
-    .dms,
-    .utm,
-    .mgrs,
-    .olc,
-    .osgr,
-  ]
-}
-
-extension Config.DisplayConfig.DisplayUnits: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.DisplayConfig.DisplayUnits] = [
-    .metric,
-    .imperial,
-  ]
-}
-
-extension Config.DisplayConfig.OledType: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.DisplayConfig.OledType] = [
-    .oledAuto,
-    .oledSsd1306,
-    .oledSh1106,
-    .oledSh1107,
-  ]
-}
-
-extension Config.DisplayConfig.DisplayMode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.DisplayConfig.DisplayMode] = [
-    .default,
-    .twocolor,
-    .inverted,
-    .color,
-  ]
-}
-
-extension Config.DisplayConfig.CompassOrientation: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.DisplayConfig.CompassOrientation] = [
-    .degrees0,
-    .degrees90,
-    .degrees180,
-    .degrees270,
-    .degrees0Inverted,
-    .degrees90Inverted,
-    .degrees180Inverted,
-    .degrees270Inverted,
-  ]
-}
-
-extension Config.LoRaConfig.RegionCode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.LoRaConfig.RegionCode] = [
-    .unset,
-    .us,
-    .eu433,
-    .eu868,
-    .cn,
-    .jp,
-    .anz,
-    .kr,
-    .tw,
-    .ru,
-    .in,
-    .nz865,
-    .th,
-    .lora24,
-    .ua433,
-    .ua868,
-    .my433,
-    .my919,
-    .sg923,
-  ]
-}
-
-extension Config.LoRaConfig.ModemPreset: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.LoRaConfig.ModemPreset] = [
-    .longFast,
-    .longSlow,
-    .veryLongSlow,
-    .mediumSlow,
-    .mediumFast,
-    .shortSlow,
-    .shortFast,
-    .longModerate,
-  ]
-}
-
-extension Config.BluetoothConfig.PairingMode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Config.BluetoothConfig.PairingMode] = [
-    .randomPin,
-    .fixedPin,
-    .noPin,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Config: @unchecked Sendable {}
-extension Config.OneOf_PayloadVariant: @unchecked Sendable {}
-extension Config.DeviceConfig: @unchecked Sendable {}
-extension Config.DeviceConfig.Role: @unchecked Sendable {}
-extension Config.DeviceConfig.RebroadcastMode: @unchecked Sendable {}
-extension Config.PositionConfig: @unchecked Sendable {}
-extension Config.PositionConfig.PositionFlags: @unchecked Sendable {}
-extension Config.PositionConfig.GpsMode: @unchecked Sendable {}
-extension Config.PowerConfig: @unchecked Sendable {}
-extension Config.NetworkConfig: @unchecked Sendable {}
-extension Config.NetworkConfig.AddressMode: @unchecked Sendable {}
-extension Config.NetworkConfig.IpV4Config: @unchecked Sendable {}
-extension Config.DisplayConfig: @unchecked Sendable {}
-extension Config.DisplayConfig.GpsCoordinateFormat: @unchecked Sendable {}
-extension Config.DisplayConfig.DisplayUnits: @unchecked Sendable {}
-extension Config.DisplayConfig.OledType: @unchecked Sendable {}
-extension Config.DisplayConfig.DisplayMode: @unchecked Sendable {}
-extension Config.DisplayConfig.CompassOrientation: @unchecked Sendable {}
-extension Config.LoRaConfig: @unchecked Sendable {}
-extension Config.LoRaConfig.RegionCode: @unchecked Sendable {}
-extension Config.LoRaConfig.ModemPreset: @unchecked Sendable {}
-extension Config.BluetoothConfig: @unchecked Sendable {}
-extension Config.BluetoothConfig.PairingMode: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -2168,7 +2080,7 @@ extension Config.PowerConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     if self.onBatteryShutdownAfterSecs != 0 {
       try visitor.visitSingularUInt32Field(value: self.onBatteryShutdownAfterSecs, fieldNumber: 2)
     }
-    if self.adcMultiplierOverride != 0 {
+    if self.adcMultiplierOverride.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.adcMultiplierOverride, fieldNumber: 3)
     }
     if self.waitBluetoothSecs != 0 {
@@ -2612,7 +2524,7 @@ extension Config.LoRaConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       if _storage._codingRate != 0 {
         try visitor.visitSingularUInt32Field(value: _storage._codingRate, fieldNumber: 5)
       }
-      if _storage._frequencyOffset != 0 {
+      if _storage._frequencyOffset.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._frequencyOffset, fieldNumber: 6)
       }
       if _storage._region != .unset {
@@ -2636,7 +2548,7 @@ extension Config.LoRaConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       if _storage._sx126XRxBoostedGain != false {
         try visitor.visitSingularBoolField(value: _storage._sx126XRxBoostedGain, fieldNumber: 13)
       }
-      if _storage._overrideFrequency != 0 {
+      if _storage._overrideFrequency.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._overrideFrequency, fieldNumber: 14)
       }
       if _storage._paFanDisabled != false {

--- a/MeshtasticProtobufs/Sources/meshtastic/connection_status.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/connection_status.pb.swift
@@ -20,7 +20,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public struct DeviceConnectionStatus {
+public struct DeviceConnectionStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -81,7 +81,7 @@ public struct DeviceConnectionStatus {
 
 ///
 /// WiFi connection status
-public struct WifiConnectionStatus {
+public struct WifiConnectionStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -114,7 +114,7 @@ public struct WifiConnectionStatus {
 
 ///
 /// Ethernet connection status
-public struct EthernetConnectionStatus {
+public struct EthernetConnectionStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -139,7 +139,7 @@ public struct EthernetConnectionStatus {
 
 ///
 /// Ethernet or WiFi connection status
-public struct NetworkConnectionStatus {
+public struct NetworkConnectionStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -167,7 +167,7 @@ public struct NetworkConnectionStatus {
 
 ///
 /// Bluetooth connection status
-public struct BluetoothConnectionStatus {
+public struct BluetoothConnectionStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -191,7 +191,7 @@ public struct BluetoothConnectionStatus {
 
 ///
 /// Serial connection status
-public struct SerialConnectionStatus {
+public struct SerialConnectionStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -208,15 +208,6 @@ public struct SerialConnectionStatus {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension DeviceConnectionStatus: @unchecked Sendable {}
-extension WifiConnectionStatus: @unchecked Sendable {}
-extension EthernetConnectionStatus: @unchecked Sendable {}
-extension NetworkConnectionStatus: @unchecked Sendable {}
-extension BluetoothConnectionStatus: @unchecked Sendable {}
-extension SerialConnectionStatus: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/deviceonly.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/deviceonly.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 ///
 /// Font sizes for the device screen
-public enum ScreenFonts: SwiftProtobuf.Enum {
+public enum ScreenFonts: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -60,24 +60,18 @@ public enum ScreenFonts: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension ScreenFonts: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [ScreenFonts] = [
     .fontSmall,
     .fontMedium,
     .fontLarge,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 ///
 /// Position with static location information only for NodeDBLite
-public struct PositionLite {
+public struct PositionLite: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -112,7 +106,7 @@ public struct PositionLite {
   public init() {}
 }
 
-public struct NodeInfoLite {
+public struct NodeInfoLite: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -215,7 +209,7 @@ public struct NodeInfoLite {
 /// FIXME, since we write this each time we enter deep sleep (and have infinite
 /// flash) it would be better to use some sort of append only data structure for
 /// the receive queue and use the preferences store for the other stuff
-public struct DeviceState {
+public struct DeviceState: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -275,6 +269,8 @@ public struct DeviceState {
   /// Used only during development.
   /// Indicates developer is testing and changes should never be saved to flash.
   /// Deprecated in 2.3.1
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var noSave: Bool {
     get {return _storage._noSave}
     set {_uniqueStorage()._noSave = newValue}
@@ -323,7 +319,7 @@ public struct DeviceState {
 
 ///
 /// The on-disk saved channels
-public struct ChannelFile {
+public struct ChannelFile: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -346,7 +342,7 @@ public struct ChannelFile {
 ///
 /// This can be used for customizing the firmware distribution. If populated,
 /// show a secondary bootup screen with custom logo and text for 2.5 seconds.
-public struct OEMStore {
+public struct OEMStore: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -404,15 +400,6 @@ public struct OEMStore {
   fileprivate var _oemLocalConfig: LocalConfig? = nil
   fileprivate var _oemLocalModuleConfig: LocalModuleConfig? = nil
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension ScreenFonts: @unchecked Sendable {}
-extension PositionLite: @unchecked Sendable {}
-extension NodeInfoLite: @unchecked Sendable {}
-extension DeviceState: @unchecked Sendable {}
-extension ChannelFile: @unchecked Sendable {}
-extension OEMStore: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -581,7 +568,7 @@ extension NodeInfoLite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
       try { if let v = _storage._position {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
       } }()
-      if _storage._snr != 0 {
+      if _storage._snr.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._snr, fieldNumber: 4)
       }
       if _storage._lastHeard != 0 {

--- a/MeshtasticProtobufs/Sources/meshtastic/localonly.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/localonly.pb.swift
@@ -20,7 +20,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public struct LocalConfig {
+public struct LocalConfig: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -118,7 +118,7 @@ public struct LocalConfig {
   fileprivate var _storage = _StorageClass.defaultInstance
 }
 
-public struct LocalModuleConfig {
+public struct LocalModuleConfig: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -281,11 +281,6 @@ public struct LocalModuleConfig {
 
   fileprivate var _storage = _StorageClass.defaultInstance
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension LocalConfig: @unchecked Sendable {}
-extension LocalModuleConfig: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/mesh.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/mesh.pb.swift
@@ -25,7 +25,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// bin/build-all.sh script.
 /// Because they will be used to find firmware filenames in the android app for OTA updates.
 /// To match the old style filenames, _ is converted to -, p is converted to .
-public enum HardwareModel: SwiftProtobuf.Enum {
+public enum HardwareModel: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -496,11 +496,6 @@ public enum HardwareModel: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension HardwareModel: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [HardwareModel] = [
     .unset,
@@ -576,13 +571,12 @@ extension HardwareModel: CaseIterable {
     .trackerT1000E,
     .privateHw,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 ///
 /// Shared constants between device and phone
-public enum Constants: SwiftProtobuf.Enum {
+public enum Constants: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -617,26 +611,20 @@ public enum Constants: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension Constants: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [Constants] = [
     .zero,
     .dataPayloadLen,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 ///
 /// Error codes for critical errors
 /// The device might report these fault codes on the screen.
 /// If you encounter a fault code, please post on the meshtastic.discourse.group
 /// and we'll try to help.
-public enum CriticalErrorCode: SwiftProtobuf.Enum {
+public enum CriticalErrorCode: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -730,11 +718,6 @@ public enum CriticalErrorCode: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension CriticalErrorCode: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [CriticalErrorCode] = [
     .none,
@@ -750,13 +733,12 @@ extension CriticalErrorCode: CaseIterable {
     .sx1262Failure,
     .radioSpiBug,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 ///
 /// a gps position
-public struct Position {
+public struct Position: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -945,7 +927,7 @@ public struct Position {
 
   ///
   /// How the location was acquired: manual, onboard GPS, external (EUD) GPS
-  public enum LocSource: SwiftProtobuf.Enum {
+  public enum LocSource: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -989,12 +971,20 @@ public struct Position {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Position.LocSource] = [
+      .locUnset,
+      .locManual,
+      .locInternal,
+      .locExternal,
+    ]
+
   }
 
   ///
   /// How the altitude was acquired: manual, GPS int/ext, etc
   /// Default: same as location_source if present
-  public enum AltSource: SwiftProtobuf.Enum {
+  public enum AltSource: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -1044,37 +1034,21 @@ public struct Position {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Position.AltSource] = [
+      .altUnset,
+      .altManual,
+      .altInternal,
+      .altExternal,
+      .altBarometric,
+    ]
+
   }
 
   public init() {}
 
   fileprivate var _storage = _StorageClass.defaultInstance
 }
-
-#if swift(>=4.2)
-
-extension Position.LocSource: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Position.LocSource] = [
-    .locUnset,
-    .locManual,
-    .locInternal,
-    .locExternal,
-  ]
-}
-
-extension Position.AltSource: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Position.AltSource] = [
-    .altUnset,
-    .altManual,
-    .altInternal,
-    .altExternal,
-    .altBarometric,
-  ]
-}
-
-#endif  // swift(>=4.2)
 
 ///
 /// Broadcast when a newly powered mesh node wants to find a node num it can use
@@ -1097,7 +1071,7 @@ extension Position.AltSource: CaseIterable {
 /// A few nodenums are reserved and will never be requested:
 /// 0xff - broadcast
 /// 0 through 3 - for future use
-public struct User {
+public struct User: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1122,6 +1096,8 @@ public struct User {
   /// Deprecated in Meshtastic 2.1.x
   /// This is the addr of the radio.
   /// Not populated by the phone, but added by the esp32 when broadcasting
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var macaddr: Data = Data()
 
   ///
@@ -1148,7 +1124,7 @@ public struct User {
 
 ///
 /// A message used in our Dynamic Source Routing protocol (RFC 4728 based)
-public struct RouteDiscovery {
+public struct RouteDiscovery: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1164,7 +1140,7 @@ public struct RouteDiscovery {
 
 ///
 /// A Routing control Data packet handled by the routing module
-public struct Routing {
+public struct Routing: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1204,7 +1180,7 @@ public struct Routing {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_Variant: Equatable {
+  public enum OneOf_Variant: Equatable, Sendable {
     ///
     /// A route request going from the requester
     case routeRequest(RouteDiscovery)
@@ -1216,34 +1192,12 @@ public struct Routing {
     /// in addition to ack.fail_id to provide details on the type of failure).
     case errorReason(Routing.Error)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: Routing.OneOf_Variant, rhs: Routing.OneOf_Variant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.routeRequest, .routeRequest): return {
-        guard case .routeRequest(let l) = lhs, case .routeRequest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.routeReply, .routeReply): return {
-        guard case .routeReply(let l) = lhs, case .routeReply(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.errorReason, .errorReason): return {
-        guard case .errorReason(let l) = lhs, case .errorReason(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   ///
   /// A failure in delivering a message (usually used for routing control messages, but might be provided in addition to ack.fail_id to provide
   /// details on the type of failure).
-  public enum Error: SwiftProtobuf.Enum {
+  public enum Error: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -1337,38 +1291,32 @@ public struct Routing {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [Routing.Error] = [
+      .none,
+      .noRoute,
+      .gotNak,
+      .timeout,
+      .noInterface,
+      .maxRetransmit,
+      .noChannel,
+      .tooLarge,
+      .noResponse,
+      .dutyCycleLimit,
+      .badRequest,
+      .notAuthorized,
+    ]
+
   }
 
   public init() {}
 }
 
-#if swift(>=4.2)
-
-extension Routing.Error: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Routing.Error] = [
-    .none,
-    .noRoute,
-    .gotNak,
-    .timeout,
-    .noInterface,
-    .maxRetransmit,
-    .noChannel,
-    .tooLarge,
-    .noResponse,
-    .dutyCycleLimit,
-    .badRequest,
-    .notAuthorized,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
 ///
 /// (Formerly called SubPacket)
 /// The payload portion fo a packet, this is the actual bytes that are sent
 /// inside a radio packet (because from/to are broken out by the comms library)
-public struct DataMessage {
+public struct DataMessage: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1422,7 +1370,7 @@ public struct DataMessage {
 
 ///
 /// Waypoint message, used to share arbitrary locations across the mesh
-public struct Waypoint {
+public struct Waypoint: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1467,7 +1415,7 @@ public struct Waypoint {
 
 ///
 /// This message will be proxied over the PhoneAPI for the client to deliver to the MQTT server
-public struct MqttClientProxyMessage {
+public struct MqttClientProxyMessage: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1508,7 +1456,7 @@ public struct MqttClientProxyMessage {
 
   ///
   /// The actual service envelope payload or text for mqtt pub / sub
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, @unchecked Sendable {
     ///
     /// Bytes
     case data(Data)
@@ -1516,24 +1464,6 @@ public struct MqttClientProxyMessage {
     /// Text
     case text(String)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: MqttClientProxyMessage.OneOf_PayloadVariant, rhs: MqttClientProxyMessage.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.data, .data): return {
-        guard case .data(let l) = lhs, case .data(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.text, .text): return {
-        guard case .text(let l) = lhs, case .text(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -1543,7 +1473,7 @@ public struct MqttClientProxyMessage {
 /// A packet envelope sent/received over the mesh
 /// only payload_variant is sent in the payload portion of the LORA packet.
 /// The other fields are either not sent at all, or sent in the special 16 byte LORA header.
-public struct MeshPacket {
+public struct MeshPacket: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1677,6 +1607,8 @@ public struct MeshPacket {
 
   ///
   /// Describe if this message is delayed
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var delayed: MeshPacket.Delayed {
     get {return _storage._delayed}
     set {_uniqueStorage()._delayed = newValue}
@@ -1699,7 +1631,7 @@ public struct MeshPacket {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, @unchecked Sendable {
     ///
     /// TODO: REPLACE
     case decoded(DataMessage)
@@ -1707,24 +1639,6 @@ public struct MeshPacket {
     /// TODO: REPLACE
     case encrypted(Data)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: MeshPacket.OneOf_PayloadVariant, rhs: MeshPacket.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.decoded, .decoded): return {
-        guard case .decoded(let l) = lhs, case .decoded(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.encrypted, .encrypted): return {
-        guard case .encrypted(let l) = lhs, case .encrypted(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   ///
@@ -1746,7 +1660,7 @@ public struct MeshPacket {
   /// So I bit the bullet and implemented a new (internal - not sent over the air)
   /// field in MeshPacket called 'priority'.
   /// And the transmission queue in the router object is now a priority queue.
-  public enum Priority: SwiftProtobuf.Enum {
+  public enum Priority: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -1811,11 +1725,22 @@ public struct MeshPacket {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [MeshPacket.Priority] = [
+      .unset,
+      .min,
+      .background,
+      .default,
+      .reliable,
+      .ack,
+      .max,
+    ]
+
   }
 
   ///
   /// Identify if this is a delayed packet
-  public enum Delayed: SwiftProtobuf.Enum {
+  public enum Delayed: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -1853,38 +1778,19 @@ public struct MeshPacket {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [MeshPacket.Delayed] = [
+      .noDelay,
+      .broadcast,
+      .direct,
+    ]
+
   }
 
   public init() {}
 
   fileprivate var _storage = _StorageClass.defaultInstance
 }
-
-#if swift(>=4.2)
-
-extension MeshPacket.Priority: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [MeshPacket.Priority] = [
-    .unset,
-    .min,
-    .background,
-    .default,
-    .reliable,
-    .ack,
-    .max,
-  ]
-}
-
-extension MeshPacket.Delayed: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [MeshPacket.Delayed] = [
-    .noDelay,
-    .broadcast,
-    .direct,
-  ]
-}
-
-#endif  // swift(>=4.2)
 
 ///
 /// The bluetooth to device link:
@@ -1903,7 +1809,7 @@ extension MeshPacket.Delayed: CaseIterable {
 /// level etc) SET_CONFIG (switches device to a new set of radio params and
 /// preshared key, drops all existing nodes, force our node to rejoin this new group)
 /// Full information about a node on the mesh
-public struct NodeInfo {
+public struct NodeInfo: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2004,7 +1910,7 @@ public struct NodeInfo {
 /// Unique local debugging info for this node
 /// Note: we don't include position or the user info, because that will come in the
 /// Sent to the phone in response to WantNodes.
-public struct MyNodeInfo {
+public struct MyNodeInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2035,7 +1941,7 @@ public struct MyNodeInfo {
 /// on the message it is assumed to be a continuation of the previously sent message.
 /// This allows the device code to use fixed maxlen 64 byte strings for messages,
 /// and then extend as needed by emitting multiple records.
-public struct LogRecord {
+public struct LogRecord: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2060,7 +1966,7 @@ public struct LogRecord {
 
   ///
   /// Log levels, chosen to match python logging conventions.
-  public enum Level: SwiftProtobuf.Enum {
+  public enum Level: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -2122,29 +2028,23 @@ public struct LogRecord {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [LogRecord.Level] = [
+      .unset,
+      .critical,
+      .error,
+      .warning,
+      .info,
+      .debug,
+      .trace,
+    ]
+
   }
 
   public init() {}
 }
 
-#if swift(>=4.2)
-
-extension LogRecord.Level: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [LogRecord.Level] = [
-    .unset,
-    .critical,
-    .error,
-    .warning,
-    .info,
-    .debug,
-    .trace,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-public struct QueueStatus {
+public struct QueueStatus: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2171,7 +2071,7 @@ public struct QueueStatus {
 /// It will support READ and NOTIFY. When a new packet arrives the device will BLE notify?
 /// It will sit in that descriptor until consumed by the phone,
 /// at which point the next item in the FIFO will be populated.
-public struct FromRadio {
+public struct FromRadio: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2337,7 +2237,7 @@ public struct FromRadio {
 
   ///
   /// Log levels, chosen to match python logging conventions.
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, Sendable {
     ///
     /// Log levels, chosen to match python logging conventions.
     case packet(MeshPacket)
@@ -2389,72 +2289,6 @@ public struct FromRadio {
     /// File system manifest messages
     case fileInfo(FileInfo)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: FromRadio.OneOf_PayloadVariant, rhs: FromRadio.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.packet, .packet): return {
-        guard case .packet(let l) = lhs, case .packet(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.myInfo, .myInfo): return {
-        guard case .myInfo(let l) = lhs, case .myInfo(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.nodeInfo, .nodeInfo): return {
-        guard case .nodeInfo(let l) = lhs, case .nodeInfo(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.config, .config): return {
-        guard case .config(let l) = lhs, case .config(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.logRecord, .logRecord): return {
-        guard case .logRecord(let l) = lhs, case .logRecord(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.configCompleteID, .configCompleteID): return {
-        guard case .configCompleteID(let l) = lhs, case .configCompleteID(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.rebooted, .rebooted): return {
-        guard case .rebooted(let l) = lhs, case .rebooted(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.moduleConfig, .moduleConfig): return {
-        guard case .moduleConfig(let l) = lhs, case .moduleConfig(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.channel, .channel): return {
-        guard case .channel(let l) = lhs, case .channel(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.queueStatus, .queueStatus): return {
-        guard case .queueStatus(let l) = lhs, case .queueStatus(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.xmodemPacket, .xmodemPacket): return {
-        guard case .xmodemPacket(let l) = lhs, case .xmodemPacket(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.metadata, .metadata): return {
-        guard case .metadata(let l) = lhs, case .metadata(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.mqttClientProxyMessage, .mqttClientProxyMessage): return {
-        guard case .mqttClientProxyMessage(let l) = lhs, case .mqttClientProxyMessage(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.fileInfo, .fileInfo): return {
-        guard case .fileInfo(let l) = lhs, case .fileInfo(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -2462,7 +2296,7 @@ public struct FromRadio {
 
 ///
 /// Individual File info for the device
-public struct FileInfo {
+public struct FileInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2483,7 +2317,7 @@ public struct FileInfo {
 ///
 /// Packets/commands to the radio will be written (reliably) to the toRadio characteristic.
 /// Once the write completes the phone can assume it is handled.
-public struct ToRadio {
+public struct ToRadio: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2563,7 +2397,7 @@ public struct ToRadio {
 
   ///
   /// Log levels, chosen to match python logging conventions.
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, Sendable {
     ///
     /// Send this packet on the mesh
     case packet(MeshPacket)
@@ -2590,40 +2424,6 @@ public struct ToRadio {
     /// Heartbeat message (used to keep the device connection awake on serial)
     case heartbeat(Heartbeat)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: ToRadio.OneOf_PayloadVariant, rhs: ToRadio.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.packet, .packet): return {
-        guard case .packet(let l) = lhs, case .packet(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.wantConfigID, .wantConfigID): return {
-        guard case .wantConfigID(let l) = lhs, case .wantConfigID(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.disconnect, .disconnect): return {
-        guard case .disconnect(let l) = lhs, case .disconnect(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.xmodemPacket, .xmodemPacket): return {
-        guard case .xmodemPacket(let l) = lhs, case .xmodemPacket(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.mqttClientProxyMessage, .mqttClientProxyMessage): return {
-        guard case .mqttClientProxyMessage(let l) = lhs, case .mqttClientProxyMessage(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.heartbeat, .heartbeat): return {
-        guard case .heartbeat(let l) = lhs, case .heartbeat(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -2631,7 +2431,7 @@ public struct ToRadio {
 
 ///
 /// Compressed message payload
-public struct Compressed {
+public struct Compressed: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2651,7 +2451,7 @@ public struct Compressed {
 
 ///
 /// Full info on edges for a single node
-public struct NeighborInfo {
+public struct NeighborInfo: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2679,7 +2479,7 @@ public struct NeighborInfo {
 
 ///
 /// A single edge in the mesh
-public struct Neighbor {
+public struct Neighbor: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2709,7 +2509,7 @@ public struct Neighbor {
 
 ///
 /// Device metadata response
-public struct DeviceMetadata {
+public struct DeviceMetadata: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2762,7 +2562,7 @@ public struct DeviceMetadata {
 ///
 /// A heartbeat message is sent to the node from the client to keep the connection alive.
 /// This is currently only needed to keep serial connections alive, but can be used by any PhoneAPI.
-public struct Heartbeat {
+public struct Heartbeat: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2774,7 +2574,7 @@ public struct Heartbeat {
 
 ///
 /// RemoteHardwarePins associated with a node
-public struct NodeRemoteHardwarePin {
+public struct NodeRemoteHardwarePin: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2801,7 +2601,7 @@ public struct NodeRemoteHardwarePin {
   fileprivate var _pin: RemoteHardwarePin? = nil
 }
 
-public struct ChunkedPayload {
+public struct ChunkedPayload: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2829,7 +2629,7 @@ public struct ChunkedPayload {
 
 ///
 /// Wrapper message for broken repeated oneof support
-public struct resend_chunks {
+public struct resend_chunks: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2843,7 +2643,7 @@ public struct resend_chunks {
 
 ///
 /// Responses to a ChunkedPayload request
-public struct ChunkedPayloadResponse {
+public struct ChunkedPayloadResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -2886,7 +2686,7 @@ public struct ChunkedPayloadResponse {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, Sendable {
     ///
     /// Request to transfer chunked payload
     case requestTransfer(Bool)
@@ -2897,74 +2697,10 @@ public struct ChunkedPayloadResponse {
     /// Request missing indexes in the chunked payload
     case resendChunks(resend_chunks)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: ChunkedPayloadResponse.OneOf_PayloadVariant, rhs: ChunkedPayloadResponse.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.requestTransfer, .requestTransfer): return {
-        guard case .requestTransfer(let l) = lhs, case .requestTransfer(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.acceptTransfer, .acceptTransfer): return {
-        guard case .acceptTransfer(let l) = lhs, case .acceptTransfer(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.resendChunks, .resendChunks): return {
-        guard case .resendChunks(let l) = lhs, case .resendChunks(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension HardwareModel: @unchecked Sendable {}
-extension Constants: @unchecked Sendable {}
-extension CriticalErrorCode: @unchecked Sendable {}
-extension Position: @unchecked Sendable {}
-extension Position.LocSource: @unchecked Sendable {}
-extension Position.AltSource: @unchecked Sendable {}
-extension User: @unchecked Sendable {}
-extension RouteDiscovery: @unchecked Sendable {}
-extension Routing: @unchecked Sendable {}
-extension Routing.OneOf_Variant: @unchecked Sendable {}
-extension Routing.Error: @unchecked Sendable {}
-extension DataMessage: @unchecked Sendable {}
-extension Waypoint: @unchecked Sendable {}
-extension MqttClientProxyMessage: @unchecked Sendable {}
-extension MqttClientProxyMessage.OneOf_PayloadVariant: @unchecked Sendable {}
-extension MeshPacket: @unchecked Sendable {}
-extension MeshPacket.OneOf_PayloadVariant: @unchecked Sendable {}
-extension MeshPacket.Priority: @unchecked Sendable {}
-extension MeshPacket.Delayed: @unchecked Sendable {}
-extension NodeInfo: @unchecked Sendable {}
-extension MyNodeInfo: @unchecked Sendable {}
-extension LogRecord: @unchecked Sendable {}
-extension LogRecord.Level: @unchecked Sendable {}
-extension QueueStatus: @unchecked Sendable {}
-extension FromRadio: @unchecked Sendable {}
-extension FromRadio.OneOf_PayloadVariant: @unchecked Sendable {}
-extension FileInfo: @unchecked Sendable {}
-extension ToRadio: @unchecked Sendable {}
-extension ToRadio.OneOf_PayloadVariant: @unchecked Sendable {}
-extension Compressed: @unchecked Sendable {}
-extension NeighborInfo: @unchecked Sendable {}
-extension Neighbor: @unchecked Sendable {}
-extension DeviceMetadata: @unchecked Sendable {}
-extension Heartbeat: @unchecked Sendable {}
-extension NodeRemoteHardwarePin: @unchecked Sendable {}
-extension ChunkedPayload: @unchecked Sendable {}
-extension resend_chunks: @unchecked Sendable {}
-extension ChunkedPayloadResponse: @unchecked Sendable {}
-extension ChunkedPayloadResponse.OneOf_PayloadVariant: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -3911,7 +3647,7 @@ extension MeshPacket: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
       if _storage._rxTime != 0 {
         try visitor.visitSingularFixed32Field(value: _storage._rxTime, fieldNumber: 7)
       }
-      if _storage._rxSnr != 0 {
+      if _storage._rxSnr.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._rxSnr, fieldNumber: 8)
       }
       if _storage._hopLimit != 0 {
@@ -4086,7 +3822,7 @@ extension NodeInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
       try { if let v = _storage._position {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
       } }()
-      if _storage._snr != 0 {
+      if _storage._snr.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._snr, fieldNumber: 4)
       }
       if _storage._lastHeard != 0 {
@@ -4859,7 +4595,7 @@ extension Neighbor: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
     if self.nodeID != 0 {
       try visitor.visitSingularUInt32Field(value: self.nodeID, fieldNumber: 1)
     }
-    if self.snr != 0 {
+    if self.snr.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.snr, fieldNumber: 2)
     }
     if self.lastRxTime != 0 {
@@ -4972,8 +4708,8 @@ extension Heartbeat: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementation
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {

--- a/MeshtasticProtobufs/Sources/meshtastic/module_config.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/module_config.pb.swift
@@ -20,7 +20,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public enum RemoteHardwarePinType: SwiftProtobuf.Enum {
+public enum RemoteHardwarePinType: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -58,24 +58,18 @@ public enum RemoteHardwarePinType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension RemoteHardwarePinType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [RemoteHardwarePinType] = [
     .unknown,
     .digitalRead,
     .digitalWrite,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 ///
 /// Module Config
-public struct ModuleConfig {
+public struct ModuleConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -218,7 +212,7 @@ public struct ModuleConfig {
 
   ///
   /// TODO: REPLACE
-  public enum OneOf_PayloadVariant: Equatable {
+  public enum OneOf_PayloadVariant: Equatable, Sendable {
     ///
     /// TODO: REPLACE
     case mqtt(ModuleConfig.MQTTConfig)
@@ -259,73 +253,11 @@ public struct ModuleConfig {
     /// TODO: REPLACE
     case paxcounter(ModuleConfig.PaxcounterConfig)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: ModuleConfig.OneOf_PayloadVariant, rhs: ModuleConfig.OneOf_PayloadVariant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.mqtt, .mqtt): return {
-        guard case .mqtt(let l) = lhs, case .mqtt(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.serial, .serial): return {
-        guard case .serial(let l) = lhs, case .serial(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.externalNotification, .externalNotification): return {
-        guard case .externalNotification(let l) = lhs, case .externalNotification(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.storeForward, .storeForward): return {
-        guard case .storeForward(let l) = lhs, case .storeForward(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.rangeTest, .rangeTest): return {
-        guard case .rangeTest(let l) = lhs, case .rangeTest(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.telemetry, .telemetry): return {
-        guard case .telemetry(let l) = lhs, case .telemetry(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.cannedMessage, .cannedMessage): return {
-        guard case .cannedMessage(let l) = lhs, case .cannedMessage(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.audio, .audio): return {
-        guard case .audio(let l) = lhs, case .audio(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.remoteHardware, .remoteHardware): return {
-        guard case .remoteHardware(let l) = lhs, case .remoteHardware(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.neighborInfo, .neighborInfo): return {
-        guard case .neighborInfo(let l) = lhs, case .neighborInfo(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.ambientLighting, .ambientLighting): return {
-        guard case .ambientLighting(let l) = lhs, case .ambientLighting(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.detectionSensor, .detectionSensor): return {
-        guard case .detectionSensor(let l) = lhs, case .detectionSensor(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.paxcounter, .paxcounter): return {
-        guard case .paxcounter(let l) = lhs, case .paxcounter(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   ///
   /// MQTT Client Config
-  public struct MQTTConfig {
+  public struct MQTTConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -400,7 +332,7 @@ public struct ModuleConfig {
 
   ///
   /// Settings for reporting unencrypted information about our node to a map via MQTT
-  public struct MapReportSettings {
+  public struct MapReportSettings: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -420,7 +352,7 @@ public struct ModuleConfig {
 
   ///
   /// RemoteHardwareModule Config
-  public struct RemoteHardwareConfig {
+  public struct RemoteHardwareConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -444,7 +376,7 @@ public struct ModuleConfig {
 
   ///
   /// NeighborInfoModule Config
-  public struct NeighborInfoConfig {
+  public struct NeighborInfoConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -465,7 +397,7 @@ public struct ModuleConfig {
 
   ///
   /// Detection Sensor Module Config
-  public struct DetectionSensorConfig {
+  public struct DetectionSensorConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -516,7 +448,7 @@ public struct ModuleConfig {
 
   ///
   /// Audio Config for codec2 voice
-  public struct AudioConfig {
+  public struct AudioConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -553,7 +485,7 @@ public struct ModuleConfig {
 
     ///
     /// Baudrate for codec2 voice
-    public enum Audio_Baud: SwiftProtobuf.Enum {
+    public enum Audio_Baud: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case codec2Default // = 0
       case codec23200 // = 1
@@ -600,6 +532,19 @@ public struct ModuleConfig {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [ModuleConfig.AudioConfig.Audio_Baud] = [
+        .codec2Default,
+        .codec23200,
+        .codec22400,
+        .codec21600,
+        .codec21400,
+        .codec21300,
+        .codec21200,
+        .codec2700,
+        .codec2700B,
+      ]
+
     }
 
     public init() {}
@@ -607,7 +552,7 @@ public struct ModuleConfig {
 
   ///
   /// Config for the Paxcounter Module
-  public struct PaxcounterConfig {
+  public struct PaxcounterConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -633,7 +578,7 @@ public struct ModuleConfig {
 
   ///
   /// Serial Config
-  public struct SerialConfig {
+  public struct SerialConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -676,7 +621,7 @@ public struct ModuleConfig {
 
     ///
     /// TODO: REPLACE
-    public enum Serial_Baud: SwiftProtobuf.Enum {
+    public enum Serial_Baud: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case baudDefault // = 0
       case baud110 // = 1
@@ -744,11 +689,31 @@ public struct ModuleConfig {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [ModuleConfig.SerialConfig.Serial_Baud] = [
+        .baudDefault,
+        .baud110,
+        .baud300,
+        .baud600,
+        .baud1200,
+        .baud2400,
+        .baud4800,
+        .baud9600,
+        .baud19200,
+        .baud38400,
+        .baud57600,
+        .baud115200,
+        .baud230400,
+        .baud460800,
+        .baud576000,
+        .baud921600,
+      ]
+
     }
 
     ///
     /// TODO: REPLACE
-    public enum Serial_Mode: SwiftProtobuf.Enum {
+    public enum Serial_Mode: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
       case `default` // = 0
       case simple // = 1
@@ -793,6 +758,17 @@ public struct ModuleConfig {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [ModuleConfig.SerialConfig.Serial_Mode] = [
+        .default,
+        .simple,
+        .proto,
+        .textmsg,
+        .nmea,
+        .caltopo,
+        .ws85,
+      ]
+
     }
 
     public init() {}
@@ -800,7 +776,7 @@ public struct ModuleConfig {
 
   ///
   /// External Notifications Config
-  public struct ExternalNotificationConfig {
+  public struct ExternalNotificationConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -883,7 +859,7 @@ public struct ModuleConfig {
 
   ///
   /// Store and Forward Module Config
-  public struct StoreForwardConfig {
+  public struct StoreForwardConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -919,7 +895,7 @@ public struct ModuleConfig {
 
   ///
   /// Preferences for the RangeTestModule
-  public struct RangeTestConfig {
+  public struct RangeTestConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -944,7 +920,7 @@ public struct ModuleConfig {
 
   ///
   /// Configuration for both device and environment metrics
-  public struct TelemetryConfig {
+  public struct TelemetryConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1001,7 +977,7 @@ public struct ModuleConfig {
 
   ///
   /// TODO: REPLACE
-  public struct CannedMessageConfig {
+  public struct CannedMessageConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1056,7 +1032,7 @@ public struct ModuleConfig {
 
     ///
     /// TODO: REPLACE
-    public enum InputEventChar: SwiftProtobuf.Enum {
+    public enum InputEventChar: SwiftProtobuf.Enum, Swift.CaseIterable {
       public typealias RawValue = Int
 
       ///
@@ -1124,6 +1100,18 @@ public struct ModuleConfig {
         }
       }
 
+      // The compiler won't synthesize support with the UNRECOGNIZED case.
+      public static let allCases: [ModuleConfig.CannedMessageConfig.InputEventChar] = [
+        .none,
+        .up,
+        .down,
+        .left,
+        .right,
+        .select,
+        .back,
+        .cancel,
+      ]
+
     }
 
     public init() {}
@@ -1132,7 +1120,7 @@ public struct ModuleConfig {
   ///
   ///Ambient Lighting Module - Settings for control of onboard LEDs to allow users to adjust the brightness levels and respective color levels.
   ///Initially created for the RAK14001 RGB LED module.
-  public struct AmbientLightingConfig {
+  public struct AmbientLightingConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1165,77 +1153,9 @@ public struct ModuleConfig {
   public init() {}
 }
 
-#if swift(>=4.2)
-
-extension ModuleConfig.AudioConfig.Audio_Baud: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [ModuleConfig.AudioConfig.Audio_Baud] = [
-    .codec2Default,
-    .codec23200,
-    .codec22400,
-    .codec21600,
-    .codec21400,
-    .codec21300,
-    .codec21200,
-    .codec2700,
-    .codec2700B,
-  ]
-}
-
-extension ModuleConfig.SerialConfig.Serial_Baud: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [ModuleConfig.SerialConfig.Serial_Baud] = [
-    .baudDefault,
-    .baud110,
-    .baud300,
-    .baud600,
-    .baud1200,
-    .baud2400,
-    .baud4800,
-    .baud9600,
-    .baud19200,
-    .baud38400,
-    .baud57600,
-    .baud115200,
-    .baud230400,
-    .baud460800,
-    .baud576000,
-    .baud921600,
-  ]
-}
-
-extension ModuleConfig.SerialConfig.Serial_Mode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [ModuleConfig.SerialConfig.Serial_Mode] = [
-    .default,
-    .simple,
-    .proto,
-    .textmsg,
-    .nmea,
-    .caltopo,
-    .ws85,
-  ]
-}
-
-extension ModuleConfig.CannedMessageConfig.InputEventChar: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [ModuleConfig.CannedMessageConfig.InputEventChar] = [
-    .none,
-    .up,
-    .down,
-    .left,
-    .right,
-    .select,
-    .back,
-    .cancel,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
 ///
 /// A GPIO pin definition for remote hardware module
-public struct RemoteHardwarePin {
+public struct RemoteHardwarePin: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1256,31 +1176,6 @@ public struct RemoteHardwarePin {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension RemoteHardwarePinType: @unchecked Sendable {}
-extension ModuleConfig: @unchecked Sendable {}
-extension ModuleConfig.OneOf_PayloadVariant: @unchecked Sendable {}
-extension ModuleConfig.MQTTConfig: @unchecked Sendable {}
-extension ModuleConfig.MapReportSettings: @unchecked Sendable {}
-extension ModuleConfig.RemoteHardwareConfig: @unchecked Sendable {}
-extension ModuleConfig.NeighborInfoConfig: @unchecked Sendable {}
-extension ModuleConfig.DetectionSensorConfig: @unchecked Sendable {}
-extension ModuleConfig.AudioConfig: @unchecked Sendable {}
-extension ModuleConfig.AudioConfig.Audio_Baud: @unchecked Sendable {}
-extension ModuleConfig.PaxcounterConfig: @unchecked Sendable {}
-extension ModuleConfig.SerialConfig: @unchecked Sendable {}
-extension ModuleConfig.SerialConfig.Serial_Baud: @unchecked Sendable {}
-extension ModuleConfig.SerialConfig.Serial_Mode: @unchecked Sendable {}
-extension ModuleConfig.ExternalNotificationConfig: @unchecked Sendable {}
-extension ModuleConfig.StoreForwardConfig: @unchecked Sendable {}
-extension ModuleConfig.RangeTestConfig: @unchecked Sendable {}
-extension ModuleConfig.TelemetryConfig: @unchecked Sendable {}
-extension ModuleConfig.CannedMessageConfig: @unchecked Sendable {}
-extension ModuleConfig.CannedMessageConfig.InputEventChar: @unchecked Sendable {}
-extension ModuleConfig.AmbientLightingConfig: @unchecked Sendable {}
-extension RemoteHardwarePin: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/mqtt.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/mqtt.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 ///
 /// This message wraps a MeshPacket with extra metadata about the sender and how it arrived.
-public struct ServiceEnvelope {
+public struct ServiceEnvelope: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -57,7 +57,7 @@ public struct ServiceEnvelope {
 
 ///
 /// Information about a node intended to be reported unencrypted to a map using MQTT.
-public struct MapReport {
+public struct MapReport: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -120,11 +120,6 @@ public struct MapReport {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension ServiceEnvelope: @unchecked Sendable {}
-extension MapReport: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/paxcount.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/paxcount.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 ///
 /// TODO: REPLACE
-public struct Paxcount {
+public struct Paxcount: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -43,10 +43,6 @@ public struct Paxcount {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension Paxcount: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/portnums.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/portnums.pb.swift
@@ -33,7 +33,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// Note: This was formerly a Type enum named 'typ' with the same id #
 /// We have change to this 'portnum' based scheme for specifying app handlers for particular payloads.
 /// This change is backwards compatible by treating the legacy OPAQUE/CLEAR_TEXT values identically.
-public enum PortNum: SwiftProtobuf.Enum {
+public enum PortNum: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -277,11 +277,6 @@ public enum PortNum: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension PortNum: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [PortNum] = [
     .unknownApp,
@@ -313,13 +308,8 @@ extension PortNum: CaseIterable {
     .atakForwarder,
     .max,
   ]
+
 }
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension PortNum: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/powermon.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/powermon.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 /// Note: There are no 'PowerMon' messages normally in use (PowerMons are sent only as structured logs - slogs).
 ///But we wrap our State enum in this message to effectively nest a namespace (without our linter yelling at us)
-public struct PowerMon {
+public struct PowerMon: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -31,7 +31,7 @@ public struct PowerMon {
 
   /// Any significant power changing event in meshtastic should be tagged with a powermon state transition.
   ///If you are making new meshtastic features feel free to add new entries at the end of this definition.
-  public enum State: SwiftProtobuf.Enum {
+  public enum State: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case none // = 0
     case cpuDeepSleep // = 1
@@ -104,37 +104,31 @@ public struct PowerMon {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [PowerMon.State] = [
+      .none,
+      .cpuDeepSleep,
+      .cpuLightSleep,
+      .vext1On,
+      .loraRxon,
+      .loraTxon,
+      .loraRxactive,
+      .btOn,
+      .ledOn,
+      .screenOn,
+      .screenDrawing,
+      .wifiOn,
+      .gpsActive,
+    ]
+
   }
 
   public init() {}
 }
 
-#if swift(>=4.2)
-
-extension PowerMon.State: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [PowerMon.State] = [
-    .none,
-    .cpuDeepSleep,
-    .cpuLightSleep,
-    .vext1On,
-    .loraRxon,
-    .loraTxon,
-    .loraRxactive,
-    .btOn,
-    .ledOn,
-    .screenOn,
-    .screenDrawing,
-    .wifiOn,
-    .gpsActive,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
 ///
 /// PowerStress testing support via the C++ PowerStress module
-public struct PowerStressMessage {
+public struct PowerStressMessage: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -151,7 +145,7 @@ public struct PowerStressMessage {
   /// What operation would we like the UUT to perform.
   ///note: senders should probably set want_response in their request packets, so that they can know when the state
   ///machine has started processing their request
-  public enum Opcode: SwiftProtobuf.Enum {
+  public enum Opcode: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -272,47 +266,34 @@ public struct PowerStressMessage {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [PowerStressMessage.Opcode] = [
+      .unset,
+      .printInfo,
+      .forceQuiet,
+      .endQuiet,
+      .screenOn,
+      .screenOff,
+      .cpuIdle,
+      .cpuDeepsleep,
+      .cpuFullon,
+      .ledOn,
+      .ledOff,
+      .loraOff,
+      .loraTx,
+      .loraRx,
+      .btOff,
+      .btOn,
+      .wifiOff,
+      .wifiOn,
+      .gpsOff,
+      .gpsOn,
+    ]
+
   }
 
   public init() {}
 }
-
-#if swift(>=4.2)
-
-extension PowerStressMessage.Opcode: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [PowerStressMessage.Opcode] = [
-    .unset,
-    .printInfo,
-    .forceQuiet,
-    .endQuiet,
-    .screenOn,
-    .screenOff,
-    .cpuIdle,
-    .cpuDeepsleep,
-    .cpuFullon,
-    .ledOn,
-    .ledOff,
-    .loraOff,
-    .loraTx,
-    .loraRx,
-    .btOff,
-    .btOn,
-    .wifiOff,
-    .wifiOn,
-    .gpsOff,
-    .gpsOn,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension PowerMon: @unchecked Sendable {}
-extension PowerMon.State: @unchecked Sendable {}
-extension PowerStressMessage: @unchecked Sendable {}
-extension PowerStressMessage.Opcode: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -323,8 +304,8 @@ extension PowerMon: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let _ = try decoder.nextFieldNumber() {
-    }
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
@@ -379,7 +360,7 @@ extension PowerStressMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     if self.cmd != .unset {
       try visitor.visitSingularEnumField(value: self.cmd, fieldNumber: 1)
     }
-    if self.numSeconds != 0 {
+    if self.numSeconds.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.numSeconds, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/MeshtasticProtobufs/Sources/meshtastic/remote_hardware.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/remote_hardware.pb.swift
@@ -30,7 +30,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// because no security yet (beyond the channel mechanism).
 /// It should be off by default and then protected based on some TBD mechanism
 /// (a special channel once multichannel support is included?)
-public struct HardwareMessage {
+public struct HardwareMessage: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -52,7 +52,7 @@ public struct HardwareMessage {
 
   ///
   /// TODO: REPLACE
-  public enum TypeEnum: SwiftProtobuf.Enum {
+  public enum TypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -110,31 +110,20 @@ public struct HardwareMessage {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [HardwareMessage.TypeEnum] = [
+      .unset,
+      .writeGpios,
+      .watchGpios,
+      .gpiosChanged,
+      .readGpios,
+      .readGpiosReply,
+    ]
+
   }
 
   public init() {}
 }
-
-#if swift(>=4.2)
-
-extension HardwareMessage.TypeEnum: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [HardwareMessage.TypeEnum] = [
-    .unset,
-    .writeGpios,
-    .watchGpios,
-    .gpiosChanged,
-    .readGpios,
-    .readGpiosReply,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension HardwareMessage: @unchecked Sendable {}
-extension HardwareMessage.TypeEnum: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/rtttl.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/rtttl.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 ///
 /// Canned message module configuration.
-public struct RTTTLConfig {
+public struct RTTTLConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -35,10 +35,6 @@ public struct RTTTLConfig {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension RTTTLConfig: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/storeforward.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/storeforward.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 ///
 /// TODO: REPLACE
-public struct StoreAndForward {
+public struct StoreAndForward: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -79,7 +79,7 @@ public struct StoreAndForward {
 
   ///
   /// TODO: REPLACE
-  public enum OneOf_Variant: Equatable {
+  public enum OneOf_Variant: Equatable, @unchecked Sendable {
     ///
     /// TODO: REPLACE
     case stats(StoreAndForward.Statistics)
@@ -93,38 +93,12 @@ public struct StoreAndForward {
     /// Text from history message.
     case text(Data)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: StoreAndForward.OneOf_Variant, rhs: StoreAndForward.OneOf_Variant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.stats, .stats): return {
-        guard case .stats(let l) = lhs, case .stats(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.history, .history): return {
-        guard case .history(let l) = lhs, case .history(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.heartbeat, .heartbeat): return {
-        guard case .heartbeat(let l) = lhs, case .heartbeat(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.text, .text): return {
-        guard case .text(let l) = lhs, case .text(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   ///
   /// 001 - 063 = From Router
   /// 064 - 127 = From Client
-  public enum RequestResponse: SwiftProtobuf.Enum {
+  public enum RequestResponse: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
 
     ///
@@ -242,11 +216,31 @@ public struct StoreAndForward {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [StoreAndForward.RequestResponse] = [
+      .unset,
+      .routerError,
+      .routerHeartbeat,
+      .routerPing,
+      .routerPong,
+      .routerBusy,
+      .routerHistory,
+      .routerStats,
+      .routerTextDirect,
+      .routerTextBroadcast,
+      .clientError,
+      .clientHistory,
+      .clientStats,
+      .clientPing,
+      .clientPong,
+      .clientAbort,
+    ]
+
   }
 
   ///
   /// TODO: REPLACE
-  public struct Statistics {
+  public struct Statistics: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -294,7 +288,7 @@ public struct StoreAndForward {
 
   ///
   /// TODO: REPLACE
-  public struct History {
+  public struct History: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -319,7 +313,7 @@ public struct StoreAndForward {
 
   ///
   /// TODO: REPLACE
-  public struct Heartbeat {
+  public struct Heartbeat: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -339,41 +333,6 @@ public struct StoreAndForward {
 
   public init() {}
 }
-
-#if swift(>=4.2)
-
-extension StoreAndForward.RequestResponse: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [StoreAndForward.RequestResponse] = [
-    .unset,
-    .routerError,
-    .routerHeartbeat,
-    .routerPing,
-    .routerPong,
-    .routerBusy,
-    .routerHistory,
-    .routerStats,
-    .routerTextDirect,
-    .routerTextBroadcast,
-    .clientError,
-    .clientHistory,
-    .clientStats,
-    .clientPing,
-    .clientPong,
-    .clientAbort,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension StoreAndForward: @unchecked Sendable {}
-extension StoreAndForward.OneOf_Variant: @unchecked Sendable {}
-extension StoreAndForward.RequestResponse: @unchecked Sendable {}
-extension StoreAndForward.Statistics: @unchecked Sendable {}
-extension StoreAndForward.History: @unchecked Sendable {}
-extension StoreAndForward.Heartbeat: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/MeshtasticProtobufs/Sources/meshtastic/telemetry.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/telemetry.pb.swift
@@ -22,7 +22,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 ///
 /// Supported I2C Sensors for telemetry in Meshtastic
-public enum TelemetrySensorType: SwiftProtobuf.Enum {
+public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
   public typealias RawValue = Int
 
   ///
@@ -198,11 +198,6 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum {
     }
   }
 
-}
-
-#if swift(>=4.2)
-
-extension TelemetrySensorType: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
   public static let allCases: [TelemetrySensorType] = [
     .sensorUnset,
@@ -232,13 +227,12 @@ extension TelemetrySensorType: CaseIterable {
     .dfrobotLark,
     .nau7802,
   ]
-}
 
-#endif  // swift(>=4.2)
+}
 
 ///
 /// Key native device metrics such as battery level
-public struct DeviceMetrics {
+public struct DeviceMetrics: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -270,7 +264,7 @@ public struct DeviceMetrics {
 
 ///
 /// Weather station or other environmental metrics
-public struct EnvironmentMetrics {
+public struct EnvironmentMetrics: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -405,7 +399,7 @@ public struct EnvironmentMetrics {
 
 ///
 /// Power Metrics (voltage / current / etc)
-public struct PowerMetrics {
+public struct PowerMetrics: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -441,7 +435,7 @@ public struct PowerMetrics {
 
 ///
 /// Air quality metrics
-public struct AirQualityMetrics {
+public struct AirQualityMetrics: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -501,7 +495,7 @@ public struct AirQualityMetrics {
 
 ///
 /// Types of Measurements the telemetry module is equipped to handle
-public struct Telemetry {
+public struct Telemetry: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -554,7 +548,7 @@ public struct Telemetry {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum OneOf_Variant: Equatable {
+  public enum OneOf_Variant: Equatable, Sendable {
     ///
     /// Key native device metrics such as battery level
     case deviceMetrics(DeviceMetrics)
@@ -568,32 +562,6 @@ public struct Telemetry {
     /// Power Metrics
     case powerMetrics(PowerMetrics)
 
-  #if !swift(>=4.1)
-    public static func ==(lhs: Telemetry.OneOf_Variant, rhs: Telemetry.OneOf_Variant) -> Bool {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch (lhs, rhs) {
-      case (.deviceMetrics, .deviceMetrics): return {
-        guard case .deviceMetrics(let l) = lhs, case .deviceMetrics(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.environmentMetrics, .environmentMetrics): return {
-        guard case .environmentMetrics(let l) = lhs, case .environmentMetrics(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.airQualityMetrics, .airQualityMetrics): return {
-        guard case .airQualityMetrics(let l) = lhs, case .airQualityMetrics(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      case (.powerMetrics, .powerMetrics): return {
-        guard case .powerMetrics(let l) = lhs, case .powerMetrics(let r) = rhs else { preconditionFailure() }
-        return l == r
-      }()
-      default: return false
-      }
-    }
-  #endif
   }
 
   public init() {}
@@ -601,7 +569,7 @@ public struct Telemetry {
 
 ///
 /// NAU7802 Telemetry configuration, for saving to flash
-public struct Nau7802Config {
+public struct Nau7802Config: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -618,17 +586,6 @@ public struct Nau7802Config {
 
   public init() {}
 }
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension TelemetrySensorType: @unchecked Sendable {}
-extension DeviceMetrics: @unchecked Sendable {}
-extension EnvironmentMetrics: @unchecked Sendable {}
-extension PowerMetrics: @unchecked Sendable {}
-extension AirQualityMetrics: @unchecked Sendable {}
-extension Telemetry: @unchecked Sendable {}
-extension Telemetry.OneOf_Variant: @unchecked Sendable {}
-extension Nau7802Config: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -695,13 +652,13 @@ extension DeviceMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     if self.batteryLevel != 0 {
       try visitor.visitSingularUInt32Field(value: self.batteryLevel, fieldNumber: 1)
     }
-    if self.voltage != 0 {
+    if self.voltage.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.voltage, fieldNumber: 2)
     }
-    if self.channelUtilization != 0 {
+    if self.channelUtilization.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.channelUtilization, fieldNumber: 3)
     }
-    if self.airUtilTx != 0 {
+    if self.airUtilTx.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.airUtilTx, fieldNumber: 4)
     }
     if self.uptimeSeconds != 0 {
@@ -835,55 +792,55 @@ extension EnvironmentMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      if _storage._temperature != 0 {
+      if _storage._temperature.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._temperature, fieldNumber: 1)
       }
-      if _storage._relativeHumidity != 0 {
+      if _storage._relativeHumidity.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._relativeHumidity, fieldNumber: 2)
       }
-      if _storage._barometricPressure != 0 {
+      if _storage._barometricPressure.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._barometricPressure, fieldNumber: 3)
       }
-      if _storage._gasResistance != 0 {
+      if _storage._gasResistance.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._gasResistance, fieldNumber: 4)
       }
-      if _storage._voltage != 0 {
+      if _storage._voltage.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._voltage, fieldNumber: 5)
       }
-      if _storage._current != 0 {
+      if _storage._current.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._current, fieldNumber: 6)
       }
       if _storage._iaq != 0 {
         try visitor.visitSingularUInt32Field(value: _storage._iaq, fieldNumber: 7)
       }
-      if _storage._distance != 0 {
+      if _storage._distance.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._distance, fieldNumber: 8)
       }
-      if _storage._lux != 0 {
+      if _storage._lux.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._lux, fieldNumber: 9)
       }
-      if _storage._whiteLux != 0 {
+      if _storage._whiteLux.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._whiteLux, fieldNumber: 10)
       }
-      if _storage._irLux != 0 {
+      if _storage._irLux.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._irLux, fieldNumber: 11)
       }
-      if _storage._uvLux != 0 {
+      if _storage._uvLux.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._uvLux, fieldNumber: 12)
       }
       if _storage._windDirection != 0 {
         try visitor.visitSingularUInt32Field(value: _storage._windDirection, fieldNumber: 13)
       }
-      if _storage._windSpeed != 0 {
+      if _storage._windSpeed.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._windSpeed, fieldNumber: 14)
       }
-      if _storage._weight != 0 {
+      if _storage._weight.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._weight, fieldNumber: 15)
       }
-      if _storage._windGust != 0 {
+      if _storage._windGust.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._windGust, fieldNumber: 16)
       }
-      if _storage._windLull != 0 {
+      if _storage._windLull.bitPattern != 0 {
         try visitor.visitSingularFloatField(value: _storage._windLull, fieldNumber: 17)
       }
     }
@@ -950,22 +907,22 @@ extension PowerMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.ch1Voltage != 0 {
+    if self.ch1Voltage.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.ch1Voltage, fieldNumber: 1)
     }
-    if self.ch1Current != 0 {
+    if self.ch1Current.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.ch1Current, fieldNumber: 2)
     }
-    if self.ch2Voltage != 0 {
+    if self.ch2Voltage.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.ch2Voltage, fieldNumber: 3)
     }
-    if self.ch2Current != 0 {
+    if self.ch2Current.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.ch2Current, fieldNumber: 4)
     }
-    if self.ch3Voltage != 0 {
+    if self.ch3Voltage.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.ch3Voltage, fieldNumber: 5)
     }
-    if self.ch3Current != 0 {
+    if self.ch3Current.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.ch3Current, fieldNumber: 6)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -1217,7 +1174,7 @@ extension Nau7802Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     if self.zeroOffset != 0 {
       try visitor.visitSingularInt32Field(value: self.zeroOffset, fieldNumber: 1)
     }
-    if self.calibrationFactor != 0 {
+    if self.calibrationFactor.bitPattern != 0 {
       try visitor.visitSingularFloatField(value: self.calibrationFactor, fieldNumber: 2)
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/MeshtasticProtobufs/Sources/meshtastic/xmodem.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/xmodem.pb.swift
@@ -20,7 +20,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public struct XModem {
+public struct XModem: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -35,7 +35,7 @@ public struct XModem {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum Control: SwiftProtobuf.Enum {
+  public enum Control: SwiftProtobuf.Enum, Swift.CaseIterable {
     public typealias RawValue = Int
     case nul // = 0
     case soh // = 1
@@ -79,33 +79,22 @@ public struct XModem {
       }
     }
 
+    // The compiler won't synthesize support with the UNRECOGNIZED case.
+    public static let allCases: [XModem.Control] = [
+      .nul,
+      .soh,
+      .stx,
+      .eot,
+      .ack,
+      .nak,
+      .can,
+      .ctrlz,
+    ]
+
   }
 
   public init() {}
 }
-
-#if swift(>=4.2)
-
-extension XModem.Control: CaseIterable {
-  // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [XModem.Control] = [
-    .nul,
-    .soh,
-    .stx,
-    .eot,
-    .ack,
-    .nak,
-    .can,
-    .ctrlz,
-  ]
-}
-
-#endif  // swift(>=4.2)
-
-#if swift(>=5.5) && canImport(_Concurrency)
-extension XModem: @unchecked Sendable {}
-extension XModem.Control: @unchecked Sendable {}
-#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 


### PR DESCRIPTION
## What changed?

Upgrades the protobuf generation to add sendable conformance, and drops Swift 4 support

## Why did it change?

`swift-protobuf` updated, and now we get Sendable stuff

## How is this tested?

This change should be purely additive. I built and ran the app on a simulator just to make sure things still compiled.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

