### PR TITLE
Node List / Details Context Menu Items and Actions Logic

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -7183,6 +7183,9 @@
     "Failed to get a valid position to exchange" : {
 
     },
+    "Failed to get a valid position to exchange." : {
+
+    },
     "Favorite" : {
 
     },
@@ -22499,9 +22502,6 @@
 
     },
     "Your MQTT Server must support TLS." : {
-
-    },
-    "Your position has been sent with a request for a response with their position." : {
 
     },
     "Your position has been sent with a request for a response with their position. You will receive a notification when a position is returned." : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -7180,6 +7180,9 @@
     "Factory reset your device and app? " : {
 
     },
+    "Failed to get a valid position to exchange" : {
+
+    },
     "Favorite" : {
 
     },
@@ -16427,6 +16430,12 @@
         }
       }
     },
+    "Position Exchange Failed" : {
+
+    },
+    "Position Exchange Requested" : {
+
+    },
     "Position Flags" : {
 
     },
@@ -20929,6 +20938,9 @@
     "This conversation will be deleted." : {
 
     },
+    "This could take a while, response will appear in the trace route log for the node it was sent to." : {
+
+    },
     "This could take a while. The response will appear in the trace route log for the node it was sent to." : {
 
     },
@@ -22490,6 +22502,9 @@
 
     },
     "Your position has been sent with a request for a response with their position." : {
+
+    },
+    "Your position has been sent with a request for a response with their position. You will receive a notification when a position is returned." : {
 
     },
     "Your region has a %lld%% duty cycle. MQTT is not advised when you are duty cycle restricted, the extra traffic will quickly overwhelm your LoRa mesh." : {

--- a/Meshtastic/Views/Nodes/Helpers/Actions/ExchangePositionsButton.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Actions/ExchangePositionsButton.swift
@@ -41,7 +41,7 @@ struct ExchangePositionsButton: View {
 		) {
 			Button("OK") {	}.keyboardShortcut(.defaultAction)
 		} message: {
-			Text("Your position has been sent with a request for a response with their position.")
+			Text("Your position has been sent with a request for a response with their position. You will receive a notification when a position is returned.")
 		}.alert(
 			"Position Exchange Failed",
 			isPresented: $isPresentingPositionFailedAlert

--- a/Meshtastic/Views/Nodes/Helpers/Actions/ExchangePositionsButton.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Actions/ExchangePositionsButton.swift
@@ -6,16 +6,28 @@ struct ExchangePositionsButton: View {
 
 	var node: NodeInfoEntity
 
-	@State
-	private var isPresentingPositionSentAlert: Bool = false
+	@State private var isPresentingPositionSentAlert: Bool = false
+	@State private var isPresentingPositionFailedAlert: Bool = false
 
     var body: some View {
 		Button {
-			isPresentingPositionSentAlert = bleManager.sendPosition(
+			let positionSent = bleManager.sendPosition(
 				channel: node.channel,
 				destNum: node.num,
 				wantResponse: true
 			)
+			if positionSent {
+				isPresentingPositionSentAlert = true
+				DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+					isPresentingPositionSentAlert = false
+				}
+			} else {
+				isPresentingPositionFailedAlert = true
+				DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+					isPresentingPositionFailedAlert = false
+				}
+			}
+
 		} label: {
 			Label {
 				Text("Exchange Positions")
@@ -30,6 +42,13 @@ struct ExchangePositionsButton: View {
 			Button("OK") {	}.keyboardShortcut(.defaultAction)
 		} message: {
 			Text("Your position has been sent with a request for a response with their position.")
+		}.alert(
+			"Position Exchange Failed",
+			isPresented: $isPresentingPositionFailedAlert
+		) {
+			Button("OK") {	}.keyboardShortcut(.defaultAction)
+		} message: {
+			Text("Failed to get a valid position to exchange.")
 		}
     }
 }

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -281,12 +281,6 @@ struct NodeDetail: View {
 				}
 
 				Section("Actions") {
-					FavoriteNodeButton(
-						bleManager: bleManager,
-						context: context,
-						node: node
-					)
-
 					if let user = node.user {
 						NodeAlertsButton(
 							context: context,
@@ -295,19 +289,21 @@ struct NodeDetail: View {
 						)
 					}
 
-					if let connectedPeripheral = bleManager.connectedPeripheral,
-					   node.num != connectedPeripheral.num {
-						ExchangePositionsButton(
+					if let connectedNode {
+						FavoriteNodeButton(
 							bleManager: bleManager,
+							context: context,
 							node: node
 						)
-
-						TraceRouteButton(
-							bleManager: bleManager,
-							node: node
-						)
-
-						if let connectedNode {
+						if connectedNode.num != node.num {
+							ExchangePositionsButton(
+								bleManager: bleManager,
+								node: node
+							)
+							TraceRouteButton(
+								bleManager: bleManager,
+								node: node
+							)
 							if node.isStoreForwardRouter {
 								ClientHistoryButton(
 									bleManager: bleManager,
@@ -315,7 +311,6 @@ struct NodeDetail: View {
 									node: node
 								)
 							}
-
 							DeleteNodeButton(
 								bleManager: bleManager,
 								context: context,


### PR DESCRIPTION
While a little ugly right now this is the right logic / flow for the node list context menu items and node details actions

* [x] Mute is available even if you are not connected
* [x] You need to be connected to take any other actions
* [x] the connected node can not trace route, position or delete itself
* [x] Trace route and position pop up a alert that you dismiss (or auto dismisses in 2 seconds)
* [x] Exchange position notifies the user that a valid position was not available to send
* [x] Delete node uses a confirmation dialog