### PR TITLE
Add support for navigating to currently connected node info

### DIFF
--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -308,7 +308,8 @@ struct Connect: View {
 			)
 			.navigationDestination(isPresented: $navigateToMetricsLog) {
 				if let node {
-					DeviceMetricsLog(node: node)
+					NodeDetail(bleManager: _bleManager, connectedNode: node, node: node)
+						.navigationBarTitleDisplayMode(.inline)
 				}
 			}
 			.onAppear {

--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -27,6 +27,7 @@ struct Connect: View {
 	@State var invalidFirmwareVersion = false
 	@State var liveActivityStarted = false
 	@State var selectedPeripherialId = ""
+	@State var navigateToMetricsLog = false
 
 	init () {
 		let notificationCenter = UNUserNotificationCenter.current()
@@ -84,10 +85,20 @@ struct Connect: View {
 											}
 										}
 									}
+									if bleManager.isSubscribed {
+										VStack(alignment: .trailing) {
+											Image(systemName: "chevron.right")
+										}
+									}
 								}
 								.font(.caption)
 								.foregroundColor(Color.gray)
 								.padding([.top, .bottom])
+								.onTapGesture {
+									if bleManager.isSubscribed {
+										navigateToMetricsLog = true
+									}
+								}
 								.swipeActions {
 									Button(role: .destructive) {
 										if let connectedPeripheral = bleManager.connectedPeripheral,
@@ -295,6 +306,14 @@ struct Connect: View {
 					)
 				}
 			)
+			.navigationDestination(isPresented: $navigateToMetricsLog) {
+				if let node {
+					DeviceMetricsLog(node: node)
+				}
+			}
+			.onAppear {
+				navigateToMetricsLog = false
+			}
 		}
 		.sheet(isPresented: $invalidFirmwareVersion, onDismiss: didDismissSheet) {
 			InvalidVersion(minimumVersion: self.bleManager.minimumVersion, version: self.bleManager.connectedVersion)


### PR DESCRIPTION
No pressure to accept this PR if it doesn't make sense or I'm overlooking something obvious. 

Closes #836

This PR adds support for navigating to the currently connected node info screen directly from the bluetooth radio screen 
by tapping on the connected radio.

It adds a small right pointing chevron after the radio is connected to show that tapping on it will navigate somewhere.

## What changed?

Updated `Connect.swift` to support navigating to the device node info screen.

## Why did it change?

To add a level of convenience to getting to your currently connected device's details.

## How is this tested?

It was tested with my local node on iOS hardware.

## Screenshots/Videos (when applicable)

https://github.com/user-attachments/assets/4e67c99a-7e4c-4dbc-a31a-c529d76a36a4

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

