### PR TITLE
Sort Descriptors for Message Extensions

### DIFF
--- a/Meshtastic/Extensions/CoreData/ChannelEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/ChannelEntityExtension.swift
@@ -13,6 +13,7 @@ extension ChannelEntity {
 	var allPrivateMessages: [MessageEntity] {
 		let context = PersistenceController.shared.container.viewContext
 		let fetchRequest = MessageEntity.fetchRequest()
+		fetchRequest.sortDescriptors = [NSSortDescriptor(key: "messageTimestamp", ascending: true)]
 		fetchRequest.predicate = NSPredicate(format: "channel == %ld AND  toUser == nil AND isEmoji == false", self.index)
 
 		return (try? context.fetch(fetchRequest)) ?? [MessageEntity]()

--- a/Meshtastic/Extensions/CoreData/MessageEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/MessageEntityExtension.swift
@@ -14,7 +14,7 @@ import SwiftUI
 
 extension MessageEntity {
 	var timestamp: Date {
-		let time = messageTimestamp 
+		let time = messageTimestamp
 		return Date(timeIntervalSince1970: TimeInterval(time))
 	}
 
@@ -25,6 +25,7 @@ extension MessageEntity {
 	var tapbacks: [MessageEntity] {
 		let context = PersistenceController.shared.container.viewContext
 		let fetchRequest = MessageEntity.fetchRequest()
+		fetchRequest.sortDescriptors = [NSSortDescriptor(key: "messageTimestamp", ascending: true)]
 		fetchRequest.predicate = NSPredicate(format: "replyID == %lld AND isEmoji == true", self.messageId)
 
 		return (try? context.fetch(fetchRequest)) ?? [MessageEntity]()

--- a/Meshtastic/Extensions/CoreData/MyInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/MyInfoEntityExtension.swift
@@ -12,6 +12,7 @@ extension MyInfoEntity {
 	var messageList: [MessageEntity] {
 		let context = PersistenceController.shared.container.viewContext
 		let fetchRequest = MessageEntity.fetchRequest()
+		fetchRequest.sortDescriptors = [NSSortDescriptor(key: "messageTimestamp", ascending: true)]
 		fetchRequest.predicate = NSPredicate(format: "toUser == nil")
 
 		return (try? context.fetch(fetchRequest)) ?? [MessageEntity]()

--- a/Meshtastic/Extensions/CoreData/UserEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/UserEntityExtension.swift
@@ -14,6 +14,7 @@ extension UserEntity {
 	var messageList: [MessageEntity] {
 		let context = PersistenceController.shared.container.viewContext
 		let fetchRequest = MessageEntity.fetchRequest()
+		fetchRequest.sortDescriptors = [NSSortDescriptor(key: "messageTimestamp", ascending: true)]
 		fetchRequest.predicate = NSPredicate(format: "((toUser == %@) OR (fromUser == %@)) AND toUser != nil AND fromUser != nil AND isEmoji == false AND admin = false AND portNum != 10", self, self)
 
 		return (try? context.fetch(fetchRequest)) ?? [MessageEntity]()
@@ -22,6 +23,7 @@ extension UserEntity {
 	var sensorMessageList: [MessageEntity] {
 		let context = PersistenceController.shared.container.viewContext
 		let fetchRequest = MessageEntity.fetchRequest()
+		fetchRequest.sortDescriptors = [NSSortDescriptor(key: "messageTimestamp", ascending: true)]
 		fetchRequest.predicate = NSPredicate(format: "(fromUser == %@) AND portNum = 10", self)
 
 		return (try? context.fetch(fetchRequest)) ?? [MessageEntity]()


### PR DESCRIPTION
I can't replicate it, but there is not an explicit sort by message timestamp and there have been a couple of reports of out of order messages since the change from fetched properties (which also lacked a default sort from what I can tell)

This seems to be the same order I get by default without the sort descriptors so it does not seem very risky.