### PR TITLE
Display battery usage on bluetooth radio screen

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		6DA39D8E2A92DC52007E311C /* MeshtasticAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA39D8D2A92DC52007E311C /* MeshtasticAppDelegate.swift */; };
 		6DEDA55A2A957B8E00321D2E /* DetectionSensorLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEDA5592A957B8E00321D2E /* DetectionSensorLog.swift */; };
 		6DEDA55C2A9592F900321D2E /* MessageEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEDA55B2A9592F900321D2E /* MessageEntityExtension.swift */; };
+		A0B2EC462C62EEEC00140B07 /* BatteryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B2EC452C62EEEC00140B07 /* BatteryHelper.swift */; };
 		B399E8A42B6F486400E4488E /* RetryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B399E8A32B6F486400E4488E /* RetryButton.swift */; };
 		B3E905B12B71F7F300654D07 /* TextMessageField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E905B02B71F7F300654D07 /* TextMessageField.swift */; };
 		C9697FA527933B8C00250207 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = C9697FA427933B8C00250207 /* SQLite */; };
@@ -258,6 +259,7 @@
 		6DA39D8D2A92DC52007E311C /* MeshtasticAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshtasticAppDelegate.swift; sourceTree = "<group>"; };
 		6DEDA5592A957B8E00321D2E /* DetectionSensorLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectionSensorLog.swift; sourceTree = "<group>"; };
 		6DEDA55B2A9592F900321D2E /* MessageEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEntityExtension.swift; sourceTree = "<group>"; };
+		A0B2EC452C62EEEC00140B07 /* BatteryHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatteryHelper.swift; sourceTree = "<group>"; };
 		B399E8A32B6F486400E4488E /* RetryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryButton.swift; sourceTree = "<group>"; };
 		B3E905B02B71F7F300654D07 /* TextMessageField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMessageField.swift; sourceTree = "<group>"; };
 		D93068D22B8129510066FBC8 /* MessageContextMenuItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageContextMenuItems.swift; sourceTree = "<group>"; };
@@ -912,6 +914,7 @@
 				DD964FBC296E6B01007C176F /* EmojiOnlyTextField.swift */,
 				DD3619142B1EF9F900C41C8C /* LocationsHandler.swift */,
 				6D825E612C34786C008DBEE4 /* CommonRegex.swift */,
+				A0B2EC452C62EEEC00140B07 /* BatteryHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1365,6 +1368,7 @@
 				DDC4C9FF2A8D982900CE201C /* DetectionSensorConfig.swift in Sources */,
 				D9C983A22B79D1A600BDBE6A /* RequestPositionButton.swift in Sources */,
 				DDDB26442AAC0206003AFCB7 /* NodeDetail.swift in Sources */,
+				A0B2EC462C62EEEC00140B07 /* BatteryHelper.swift in Sources */,
 				DD77093F2AA1B146007A8BF0 /* UIColor.swift in Sources */,
 				DDF6B2482A9AEBF500BA6931 /* StoreForwardConfig.swift in Sources */,
 				DD8169F9271F1A6100F4AB02 /* MeshLogger.swift in Sources */,

--- a/Meshtastic/Helpers/BatteryHelper.swift
+++ b/Meshtastic/Helpers/BatteryHelper.swift
@@ -8,7 +8,7 @@
 import Foundation
 import MeshtasticProtobufs
 
-class BatteryHelper {
+enum BatteryHelper {
 	static func getBatteryFromTelemetries(_ telemetries: NSOrderedSet?) -> Double? {
 		let deviceMetrics = telemetries?.filtered(using: NSPredicate(format: "metricsType == 0"))
 		guard let mostRecent = deviceMetrics?.lastObject as? TelemetryEntity else {

--- a/Meshtastic/Helpers/BatteryHelper.swift
+++ b/Meshtastic/Helpers/BatteryHelper.swift
@@ -1,0 +1,21 @@
+//
+//  BatteryHelper.swift
+//  Meshtastic
+//
+//  Created by Gabe Kangas on 8/6/24.
+//
+
+import Foundation
+import MeshtasticProtobufs
+
+class BatteryHelper {
+	static func getBatteryFromTelemetries(_ telemetries: NSOrderedSet?) -> Double? {
+		let deviceMetrics = telemetries?.filtered(using: NSPredicate(format: "metricsType == 0"))
+		guard let mostRecent = deviceMetrics?.lastObject as? TelemetryEntity else {
+			return nil
+		}
+
+		let batteryLevel = Double(mostRecent.batteryLevel)
+		return batteryLevel
+	}
+}

--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -63,7 +63,13 @@ struct Connect: View {
 										}
 										Text("ble.name").font(.callout)+Text(": \(bleManager.connectedPeripheral?.peripheral.name ?? "unknown".localized)")
 											.font(.callout).foregroundColor(Color.gray)
+
 										if node != nil {
+											if let batteryLevel = BatteryHelper.getBatteryFromTelemetries(node?.telemetries) {
+												Text("battery.level".localized).font(.callout)+Text(": \(Int(batteryLevel))%")
+													.font(.callout).foregroundColor(Color.gray)
+											}
+
 											Text("firmware.version").font(.callout)+Text(": \(node?.metadata?.firmwareVersion ?? "unknown".localized)")
 												.font(.callout).foregroundColor(Color.gray)
 										}


### PR DESCRIPTION
## What changed?

This change adds the battery level to the bluetooth radio status screen. The discussion came up in #837. Closes #847

## Why did it change?

I felt the battery status should be surfaced more conveniently, since it is a common value to be looking at. 

## Screenshots/Videos (when applicable)

<img src="https://github.com/user-attachments/assets/4562b382-a1f0-4273-8d51-c75eca23be2a" width="40%">


## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

