### PR TITLE
0 Message Time Logic

### DIFF
--- a/Meshtastic/Extensions/CoreData/ChannelEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/ChannelEntityExtension.swift
@@ -14,7 +14,7 @@ extension ChannelEntity {
 		let context = PersistenceController.shared.container.viewContext
 		let fetchRequest = MessageEntity.fetchRequest()
 		fetchRequest.sortDescriptors = [NSSortDescriptor(key: "messageTimestamp", ascending: true)]
-		fetchRequest.predicate = NSPredicate(format: "channel == %ld AND  toUser == nil AND isEmoji == false", self.index)
+		fetchRequest.predicate = NSPredicate(format: "channel == %ld AND toUser == nil AND isEmoji == false", self.index)
 
 		return (try? context.fetch(fetchRequest)) ?? [MessageEntity]()
 	}

--- a/Meshtastic/Extensions/CoreData/MyInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/MyInfoEntityExtension.swift
@@ -22,6 +22,7 @@ extension MyInfoEntity {
 		let unreadMessages = messageList.filter { ($0 as AnyObject).read == false && ($0 as AnyObject).isEmoji == false }
 		return unreadMessages.count
 	}
+
 	var hasAdmin: Bool {
 		let adminChannel = channels?.filter { ($0 as AnyObject).name?.lowercased() == "admin" }
 		return adminChannel?.count ?? 0 > 0

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -808,8 +808,7 @@ func textMessageAppPacket(
 			let fetchedUsers = try context.fetch(messageUsers)
 			let newMessage = MessageEntity(context: context)
 			newMessage.messageId = Int64(packet.id)
-			/// For message display if the rx time is off by more than 20 seconds set the timestamp to now to assist sorting
-			if Date().timeIntervalSince1970 < Double(packet.rxTime - 10000) || Date().timeIntervalSince1970 > Double(packet.rxTime + 10000) {
+			if packet.rxTime == 0 {
 				newMessage.messageTimestamp = Int32(Date().timeIntervalSince1970)
 			} else {
 				newMessage.messageTimestamp = Int32(packet.rxTime)

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -808,7 +808,12 @@ func textMessageAppPacket(
 			let fetchedUsers = try context.fetch(messageUsers)
 			let newMessage = MessageEntity(context: context)
 			newMessage.messageId = Int64(packet.id)
-			newMessage.messageTimestamp = Int32(bitPattern: packet.rxTime)
+			/// For message display if the rx time is off by more than 20 seconds set the timestamp to now to assist sorting
+			if Date().timeIntervalSince1970 < Double(packet.rxTime - 10000) || Date().timeIntervalSince1970 > Double(packet.rxTime + 10000) {
+				newMessage.messageTimestamp = Int32(Date().timeIntervalSince1970)
+			} else {
+				newMessage.messageTimestamp = Int32(bitPattern: packet.rxTime)
+			}
 			newMessage.receivedACK = false
 			newMessage.snr = packet.rxSnr
 			newMessage.rssi = packet.rxRssi

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -812,7 +812,7 @@ func textMessageAppPacket(
 			if Date().timeIntervalSince1970 < Double(packet.rxTime - 10000) || Date().timeIntervalSince1970 > Double(packet.rxTime + 10000) {
 				newMessage.messageTimestamp = Int32(Date().timeIntervalSince1970)
 			} else {
-				newMessage.messageTimestamp = Int32(bitPattern: packet.rxTime)
+				newMessage.messageTimestamp = Int32(packet.rxTime)
 			}
 			newMessage.receivedACK = false
 			newMessage.snr = packet.rxSnr

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct ContentView: View {
 	@ObservedObject
 	var appState: AppState
-	
+
 	@ObservedObject
 	var router: Router
 

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -37,7 +37,6 @@ struct NodeList: View {
 	@State private var isPresentingDeleteNodeAlert = false
 	@State private var deleteNodeId: Int64 = 0
 
-
 	var boolFilters: [Bool] {[
 		isOnline,
 		isFavorite,

--- a/Meshtastic/Views/Settings/Routes.swift
+++ b/Meshtastic/Views/Settings/Routes.swift
@@ -58,6 +58,7 @@ struct Routes: View {
 						}
 
 						do {
+							
 							guard let fileContent = String(data: try Data(contentsOf: selectedFile), encoding: .utf8) else { return }
 							let routeName = selectedFile.lastPathComponent.dropLast(4)
 							let lines = fileContent.components(separatedBy: "\n")


### PR DESCRIPTION
Use RX time for messages unless it is off by more than 10 seconds in either direction and then use the current time from the phone to prevent bad times in the past or future from affecting message sort.

Everything else will continue to use RX time and NSOrderedSets