### PR TITLE
Adjust factory reset language

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -703,7 +703,7 @@
     "All" : {
 
     },
-    "All device and app data will be deleted. You will also need to forget your devices under Settings > Bluetooth." : {
+    "All device data will be deleted. You will also need to forget your devices under Settings > Bluetooth. Does not clear app data." : {
 
     },
     "Allow Position Requests" : {
@@ -7174,7 +7174,7 @@
     "Factory Reset" : {
 
     },
-    "Factory reset your device and app? " : {
+    "Factory reset your device? " : {
 
     },
     "Failed to get a valid position to exchange" : {


### PR DESCRIPTION
The factory reset button only resets the device, but doesn't clear out app state (such as node database). Updating language to match since this is intentional: https://discord.com/channels/867578229534359593/874835141145542716/1272982591204622472

## What changed?
Update to localized strings

## Why did it change?
Messaging doesn't match what actually happens

## How is this tested?
Not tested

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

N/A, not a code change. I just updated the strings. Please let me know if I need to set up a build environment and test this.

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested the change to ensure that it works as intended.

