### PR TITLE
Do not display hops away on node that you are connected to

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -207,7 +207,7 @@ struct NodeListItem: View {
 								}
 							}
 						}
-						if node.hopsAway > 0 {
+						if node.hopsAway > 0  && !connected{
 							HStack {
 								Image(systemName: "hare")
 									.font(.callout)


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Stops the "hops away" from displaying on a node that you are connected to via BLE.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Confusing for people because the node is via BLE but app shows some random amount of hops
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested on my iPhone
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
Images of the error (before my fix)
![image](https://github.com/user-attachments/assets/349e22c7-61e5-4823-a644-91d743c9aa4c)

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

