### PR TITLE
Refactor router state to more closely match tab bar behavior

### DIFF
--- a/Meshtastic/Router/NavigationState.swift
+++ b/Meshtastic/Router/NavigationState.swift
@@ -55,17 +55,7 @@ enum SettingsNavigationState: String {
 	case firmwareUpdates
 }
 
-enum NavigationState: Hashable {
-	case messages(MessagesNavigationState? = nil)
-	case bluetooth
-	case nodes(selectedNodeNum: Int64? = nil)
-	case map(MapNavigationState? = nil)
-	case settings(SettingsNavigationState? = nil)
-}
-
-// MARK: Tab Bar
-
-extension NavigationState {
+struct NavigationState: Hashable {
 	enum Tab: String, Hashable {
 		case messages
 		case bluetooth
@@ -74,34 +64,9 @@ extension NavigationState {
 		case settings
 	}
 
-	var tab: Tab {
-		get {
-			switch self {
-			case .messages:
-				.messages
-			case .bluetooth:
-				.bluetooth
-			case .nodes:
-				.nodes
-			case .map:
-				.map
-			case .settings:
-				.settings
-			}
-		}
-		set {
-			self = switch newValue {
-			case .messages:
-				.messages()
-			case .bluetooth:
-				.bluetooth
-			case .nodes:
-				.nodes()
-			case .map:
-				.map()
-			case .settings:
-				.settings()
-			}
-		}
-	}
+	var selectedTab: Tab = .bluetooth
+	var messages: MessagesNavigationState?
+	var nodeListSelectedNodeNum: Int64?
+	var map: MapNavigationState?
+	var settings: SettingsNavigationState?
 }

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -13,14 +13,7 @@ struct ContentView: View {
 	var router: Router
 
 	var body: some View {
-		TabView(selection: Binding(
-			get: {
-				appState.router.navigationState.tab
-			},
-			set: { newValue in
-				appState.router.navigationState.tab = newValue
-			}
-		)) {
+		TabView(selection: $appState.router.navigationState.selectedTab) {
 			Messages(
 				router: appState.router,
 				unreadChannelMessages: $appState.unreadChannelMessages,

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -26,21 +26,6 @@ struct Messages: View {
 	@Binding
 	var unreadDirectMessages: Int
 
-	// Aliases the navigation state for the NavigationSplitView sidebar selection
-	private var messagesSelection: Binding<MessagesNavigationState?> {
-		Binding(
-			get: {
-				guard case .messages(let state) = router.navigationState else {
-					return nil
-				}
-				return state
-			},
-			set: { newValue in
-				router.navigationState = .messages(newValue)
-			}
-		)
-	}
-
 	@State var node: NodeInfoEntity?
 	@State private var userSelection: UserEntity? // Nothing selected by default.
 	@State private var channelSelection: ChannelEntity? // Nothing selected by default.
@@ -49,7 +34,7 @@ struct Messages: View {
 
 	var body: some View {
 		NavigationSplitView(columnVisibility: $columnVisibility) {
-			List(selection: messagesSelection) {
+			List(selection: $router.navigationState.messages) {
 				NavigationLink(value: MessagesNavigationState.channels()) {
 					Label {
 						Text("channels")
@@ -88,11 +73,12 @@ struct Messages: View {
 			.navigationBarTitleDisplayMode(.large)
 			.navigationBarItems(leading: MeshtasticLogo())
 		} content: {
-			if case .messages(.channels) = router.navigationState {
+			switch router.navigationState.messages {
+			case .channels(let channelId, let messageId):
 				ChannelList(node: $node, channelSelection: $channelSelection)
-			} else if case .messages(.directMessages) = router.navigationState {
+			case .directMessages(let userNum, let messageId):
 				UserList(node: $node, userSelection: $userSelection)
-			} else if case .messages(nil) = router.navigationState {
+			case nil:
 				Text("Select a conversation type")
 			}
 		} detail: {
@@ -100,9 +86,9 @@ struct Messages: View {
 				ChannelMessageList(myInfo: myInfo, channel: channelSelection)
 			} else if let userSelection {
 				UserMessageList(user: userSelection)
-			} else if case .messages(.channels) = router.navigationState {
+			} else if case .channels = router.navigationState.messages {
 				Text("Select a channel")
-			} else if case .messages(.directMessages) = router.navigationState {
+			} else if case .directMessages = router.navigationState.messages {
 				Text("Select a conversation")
 			}
 		}.onChange(of: router.navigationState) { _ in
@@ -116,11 +102,7 @@ struct Messages: View {
 			node = getNodeInfo(id: nodeId, context: context)
 		}
 
-		guard case .messages(let state) = router.navigationState else {
-			return
-		}
-
-		guard let state else {
+		guard let state = router.navigationState.messages else {
 			channelSelection = nil
 			userSelection = nil
 			return

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -123,7 +123,7 @@ struct MeshMap: View {
 				MapSettingsForm(traffic: $showTraffic, pointsOfInterest: $showPointsOfInterest, mapLayer: $selectedMapLayer, meshMap: $isMeshMap)
 			}
 			.onChange(of: router.navigationState) {
-				guard case .map(let selectedNodeNum) = router.navigationState else { return }
+				guard case .map = router.navigationState.selectedTab else { return }
 				// TODO: handle deep link for waypoints
 			}
 			.onChange(of: selectedMapLayer) { newMapLayer in

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -335,11 +335,8 @@ struct NodeList: View {
 			}
 		}
 		.onChange(of: router.navigationState) { _ in
-			// Handle deep link routing
-			if case .nodes(let selected) = router.navigationState {
-				self.selectedNode = selected.flatMap {
-					getNodeInfo(id: $0, context: context)
-				}
+			if let selected = router.navigationState.nodeListSelectedNodeNum {
+				self.selectedNode = getNodeInfo(id: selected, context: context)
 			} else {
 				self.selectedNode = nil
 			}

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -299,13 +299,10 @@ struct Settings: View {
 		NavigationStack(
 			path: Binding<[SettingsNavigationState]>(
 				get: {
-					guard case .settings(let route) = router.navigationState, let setting = route else {
-						return []
-					}
-					return [setting]
+					[router.navigationState.settings].compactMap { $0 }
 				},
 				set: { newPath in
-					router.navigationState = .settings(newPath.first)
+					router.navigationState.settings = newPath.first
 				}
 			)
 		) {


### PR DESCRIPTION
## What changed?

This change modifies `NavigationState` to separately track the tab's selection behavior from the selected tab. 

## Why did it change?

This should prevent the issue where switching back & forth between messages / other tabs on a phone will leave the app showing the "Select a conversation" screen. This also simplified the `Binding`s across the root screens for each tab.

## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have tested the change to ensure that it works as intended.

