### PR TITLE
Only send battery nofifications from the local node

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -757,7 +757,7 @@ func telemetryPacket(packet: MeshPacket, connectedNode: Int64, context: NSManage
 				// Connected Device Metrics
 				// ------------------------
 				// Low Battery notification
-				if connectedNode != Int64(packet.from) {
+				if connectedNode == Int64(packet.from) {
 					if UserDefaults.lowBatteryNotifications && telemetry.batteryLevel > 0 && telemetry.batteryLevel < 4 {
 						let manager = LocalNotificationManager()
 						manager.notifications = [


### PR DESCRIPTION
## What changed?
Refactor caused low battery notifications to be sent for every node but the connected one

