### PR TITLE
Text effect keyboard toolbar for bold, italic, underline and strikethrough formatting

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -692,9 +692,6 @@
     "Airtime %@%%" : {
 
     },
-    "Alert" : {
-
-    },
     "Alert GPIO buzzer when receiving a bell" : {
 
     },

--- a/Meshtastic/Views/Messages/TextMessageField/AlertButton.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/AlertButton.swift
@@ -5,11 +5,8 @@ struct AlertButton: View {
 
 	var body: some View {
 		Button(action: action) {
-			Text("Alert")
-			Image(systemName: "bell.fill")
-				.symbolRenderingMode(.hierarchical)
-				.imageScale(.large)
-				.foregroundColor(.accentColor)
+			Image(systemName: "bell.and.waves.left.and.right")
+				.foregroundColor(.primary)
 		}
 	}
 }

--- a/Meshtastic/Views/Messages/TextMessageField/RequestPositionButton.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/RequestPositionButton.swift
@@ -6,11 +6,8 @@ struct RequestPositionButton: View {
 	var body: some View {
 		Button(action: action) {
 			Image(systemName: "mappin.and.ellipse")
-				.symbolRenderingMode(.hierarchical)
-				.imageScale(.large)
-				.foregroundColor(.accentColor)
+				.foregroundColor(.primary)
 		}
-		.padding(.trailing)
 	}
 }
 

--- a/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
@@ -13,9 +13,10 @@ struct TextMessageField: View {
 	@State private var typingMessage: String = ""
 	@State private var totalBytes = 0
 	@State private var sendPositionWithMessage = false
+	@State private var textEffects = false
 
 	var body: some View {
-		#if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst)
 		HStack {
 			if destination.showAlertButton {
 				Spacer()
@@ -25,7 +26,7 @@ struct TextMessageField: View {
 			RequestPositionButton(action: requestPosition)
 			TextMessageSize(maxbytes: Self.maxbytes, totalBytes: totalBytes).padding(.trailing)
 		}
-		#endif
+#endif
 
 		HStack(alignment: .top) {
 			ZStack {
@@ -40,19 +41,70 @@ struct TextMessageField: View {
 					.keyboardType(.default)
 					.toolbar {
 						ToolbarItemGroup(placement: .keyboard) {
-							Button("dismiss.keyboard") {
-								isFocused = false
-							}
-							.font(.subheadline)
-
-							if destination.showAlertButton {
+							if !textEffects {
+								VStack {
+									HStack {
+										TextMessageSize(maxbytes: Self.maxbytes, totalBytes: totalBytes)
+										Spacer()
+										if destination.showAlertButton {
+											AlertButton { typingMessage += "🔔 Alert Bell Character! \u{7}" }
+											Spacer()
+										}
+										RequestPositionButton(action: requestPosition)
+										Spacer()
+										Button {
+											textEffects = true
+										}
+										label: {
+											Image(systemName: "bold.italic.underline")
+												.foregroundColor(.primary)
+										}
+										Spacer()
+										Spacer()
+										Button {
+											isFocused = false
+										}
+										label: {
+											Image(systemName: "keyboard.chevron.compact.down")
+												.foregroundColor(.primary)
+										}
+									}
+								}
+							} else {
 								Spacer()
-								AlertButton { typingMessage += "🔔 Alert Bell Character! \u{7}" }
+								Button {
+									textEffects = false
+								}
+								label: {
+									Image(systemName: "bold")
+										.foregroundColor(.primary)
+								}
+								Spacer()
+								Button {
+									textEffects = false
+								}
+								label: {
+									Image(systemName: "italic")
+										.foregroundColor(.primary)
+								}
+								Spacer()
+								Button {
+									textEffects = false
+								}
+								label: {
+									Image(systemName: "underline")
+										.foregroundColor(.primary)
+								}
+								Spacer()
+								Button {
+									textEffects = false
+								}
+								label: {
+									Image(systemName: "strikethrough")
+										.foregroundColor(.primary)
+								}
+								Spacer()
 							}
-
-							Spacer()
-							RequestPositionButton(action: requestPosition)
-							TextMessageSize(maxbytes: Self.maxbytes, totalBytes: totalBytes)
 						}
 					}
 					.padding(.horizontal, 8)
@@ -61,18 +113,16 @@ struct TextMessageField: View {
 					.frame(minHeight: 50)
 					.keyboardShortcut(.defaultAction)
 					.onSubmit {
-					#if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst)
 						sendMessage()
-					#endif
+#endif
 					}
-
 				Text(typingMessage)
 					.opacity(0)
 					.padding(.all, 0)
 			}
 			.overlay(RoundedRectangle(cornerRadius: 20).stroke(.tertiary, lineWidth: 1))
 			.padding(.bottom, 15)
-
 			Button(action: sendMessage) {
 				Image(systemName: "arrow.up.circle.fill")
 					.font(.largeTitle)
@@ -122,21 +172,21 @@ private extension MessageDestination {
 		case .channel: return "has shared their position with you"
 		}
 	}
-
+	
 	var positionDestNum: Int64 {
 		switch self {
 		case let .user(user): return user.num
 		case .channel: return Int64(Constants.maximumNodeNum)
 		}
 	}
-
+	
 	var showAlertButton: Bool {
 		switch self {
 		case .user: return true
 		case .channel: return true
 		}
 	}
-
+	
 	var wantPositionResponse: Bool {
 		switch self {
 		case .user: return true

--- a/Meshtastic/Views/Messages/TextMessageField/TextMessageSize.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/TextMessageSize.swift
@@ -6,9 +6,9 @@ struct TextMessageSize: View {
 
 	var body: some View {
 		ProgressView("\("bytes".localized): \(totalBytes) / \(maxbytes)", value: Double(totalBytes), total: Double(maxbytes))
-			.frame(width: 130)
-			.padding(5)
-			.font(.subheadline)
+			.frame(width: 120)
+			.font(.caption)
+			.fixedSize()
 			.accentColor(.accentColor)
 	}
 }


### PR DESCRIPTION
## What changed?
A button and toolbar is going to be added to devices running iOS 18 to allow them to add formatting to their text messages.  The text message control on iOS already uses markdown to build the url and phone number links in messages so these already display properly.

## Why did it change?
iOS 18 is adding Text Effects which adds a keyboard toolbar item to allow for adding GitHub flavored markdown in messages for bold, italic, strikethrough and underline.

## How is this tested?
This is a iOS 18 only feature

## Screenshots/Videos (when applicable)



## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested the change to ensure that it works as intended.

