### PR TITLE
Waypointform drop maps pin

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -6729,6 +6729,9 @@
     "Drag & Drop is the recommended way to update firmware for NRF devices. If your iPhone or iPad is USB-C it will work with your regular USB-C charging cable, for lightning devices you need the Apple Lightning to USB camera adaptor." : {
 
     },
+    "Drop Pin in Maps" : {
+
+    },
     "echo" : {
       "localizations" : {
         "de" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -15390,6 +15390,9 @@
     "Never" : {
 
     },
+    "New Key%@" : {
+
+    },
     "Newer firmware is available" : {
 
     },
@@ -16755,6 +16758,9 @@
 
     },
     "Public Key Mismatch" : {
+
+    },
+    "Public Key%@" : {
 
     },
     "PWD" : {

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -269,10 +269,8 @@ struct WaypointForm: View {
 									.fixedSize(horizontal: false, vertical: true)
 							} icon: {
 								Image(systemName: "doc.plaintext")
-									.symbolRenderingMode(.hierarchical)
-									.frame(width: 35)
 							}
-							.padding(.bottom, 5)
+							.padding(.bottom)
 						}
 						/// Coordinate
 						Label {
@@ -280,11 +278,18 @@ struct WaypointForm: View {
 								.textSelection(.enabled)
 								.foregroundColor(.primary)
 						} icon: {
-							Image(systemName: "mappin.and.ellipse")
-								.symbolRenderingMode(.hierarchical)
-								.frame(width: 35)
+							Image(systemName: "mappin.circle")
 						}
-						.padding(.bottom, 5)
+						.padding(.bottom)
+						// Drop Maps Pin
+						Button(action: {
+							if let url = URL(string: "http://maps.apple.com/?ll=\(waypoint.coordinate.latitude),\(waypoint.coordinate.longitude)&q=\(waypoint.name ?? "Dropped Pin")") {
+							   UIApplication.shared.open(url)
+							}
+						}) {
+							Label("Drop Pin in Maps", systemImage: "mappin.and.ellipse")
+						}
+						.padding(.bottom)
 						/// Created
 						Label {
 							Text("Created: \(waypoint.created?.formatted() ?? "?")")
@@ -292,9 +297,8 @@ struct WaypointForm: View {
 						} icon: {
 							Image(systemName: "clock.badge.checkmark")
 								.symbolRenderingMode(.hierarchical)
-								.frame(width: 35)
 						}
-						.padding(.bottom, 5)
+						.padding(.bottom)
 						/// Updated
 						if waypoint.lastUpdated != nil {
 							Label {
@@ -303,9 +307,8 @@ struct WaypointForm: View {
 							} icon: {
 								Image(systemName: "clock.arrow.circlepath")
 									.symbolRenderingMode(.hierarchical)
-									.frame(width: 35)
 							}
-							.padding(.bottom, 5)
+							.padding(.bottom)
 						}
 						/// Expires
 						if waypoint.expire != nil {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -54,6 +54,12 @@ struct NodeDetail: View {
 									Text("The public key does not match the recorded key. You may delete the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.")
 										.font(.caption)
 										.foregroundStyle(.red)
+									Text("Public Key\(user.publicKey?.base64EncodedString() ?? "Empty Key")")
+										.monospaced()
+										.allowsTightening(/*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
+									Text("New Key\(user.newPublicKey?.base64EncodedString() ?? "Empty Key")")
+										.monospaced()
+										.allowsTightening(/*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)
 								}
 							} icon: {
 								Image(systemName: "key.slash.fill")


### PR DESCRIPTION
## What changed?
Added a link to the waypoint details view to drop the waypoint as a pin in maps

