### PR TITLE
MeshMap: add setting to hide location precision circles

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -19884,6 +19884,9 @@
     "Show Alerts" : {
 
     },
+    "Show Location Precision" : {
+
+    },
     "Show Node History" : {
 
     },

--- a/Meshtastic/Extensions/UserDefaults.swift
+++ b/Meshtastic/Extensions/UserDefaults.swift
@@ -50,6 +50,7 @@ extension UserDefaults {
 		case meshMapRecentering
 		case meshMapShowNodeHistory
 		case meshMapShowRouteLines
+		case meshMapShowLocationPrecision
 		case enableMapConvexHull
 		case enableMapRecentering
 		case enableMapNodeHistoryPins
@@ -96,6 +97,9 @@ extension UserDefaults {
 
 	@UserDefault(.meshMapDistance, defaultValue: 800000)
 	static var meshMapDistance: Double
+	
+	@UserDefault(.meshMapShowLocationPrecision, defaultValue: true)
+	static var meshMapShowLocationPrecision: Bool
 
 	@UserDefault(.enableMapWaypoints, defaultValue: false)
 	static var enableMapWaypoints: Bool

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -14,6 +14,7 @@ struct MeshMapContent: MapContent {
 	/// Parameters
 	@Binding var showUserLocation: Bool
 	@AppStorage("meshMapShowNodeHistory") private var showNodeHistory = false
+	@AppStorage("meshMapShowLocationPrecision") private var showLocationPrecision = true
 	@AppStorage("meshMapShowRouteLines") private var showRouteLines = false
 	@AppStorage("enableMapConvexHull") private var showConvexHull = false
 	@Binding var showTraffic: Bool
@@ -134,7 +135,7 @@ struct MeshMapContent: MapContent {
 			if 10...19 ~= position.precisionBits {
 				let pp = PositionPrecision(rawValue: Int(position.precisionBits))
 				let radius: CLLocationDistance = pp?.precisionMeters ?? 0
-				if radius > 0.0 {
+				if radius > 0.0 && showLocationPrecision {
 					MapCircle(center: position.coordinate, radius: radius)
 						.foregroundStyle(Color(nodeColor).opacity(0.25))
 						.stroke(.white, lineWidth: 2)

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
@@ -18,6 +18,7 @@ struct MapSettingsForm: View {
 	@AppStorage("meshMapShowRouteLines") private var routeLines = false
 	@AppStorage("enableMapConvexHull") private var convexHull = false
 	@AppStorage("enableMapWaypoints") private var waypoints = true
+	@AppStorage("meshMapShowLocationPrecision") private var showLocationPrecision = true
 	@Binding var traffic: Bool
 	@Binding var pointsOfInterest: Bool
 	@Binding var mapLayer: MapLayer
@@ -55,6 +56,13 @@ struct MapSettingsForm: View {
 						}
 						.onChange(of: meshMapDistance) { newMeshMapDistance in
 							UserDefaults.meshMapDistance = newMeshMapDistance
+						}
+						Toggle(isOn: $showLocationPrecision) {
+							Label("Show Location Precision", systemImage: "circle.dotted.and.circle")
+						}
+						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+						.onTapGesture {
+							UserDefaults.meshMapShowLocationPrecision = !showLocationPrecision
 						}
 						Toggle(isOn: $waypoints) {
 							Label("Show Waypoints ", systemImage: "signpost.right.and.left")

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -120,7 +120,12 @@ struct MeshMap: View {
 					.padding()
 			}
 			.sheet(isPresented: $editingSettings) {
-				MapSettingsForm(traffic: $showTraffic, pointsOfInterest: $showPointsOfInterest, mapLayer: $selectedMapLayer, meshMap: $isMeshMap)
+				MapSettingsForm(
+					traffic: $showTraffic,
+					pointsOfInterest: $showPointsOfInterest,
+					mapLayer: $selectedMapLayer,
+					meshMap: $isMeshMap
+				)
 			}
 			.onChange(of: router.navigationState) {
 				guard case .map = router.navigationState.selectedTab else { return }

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -120,12 +120,7 @@ struct MeshMap: View {
 					.padding()
 			}
 			.sheet(isPresented: $editingSettings) {
-				MapSettingsForm(
-					traffic: $showTraffic,
-					pointsOfInterest: $showPointsOfInterest,
-					mapLayer: $selectedMapLayer,
-					meshMap: $isMeshMap
-				)
+				MapSettingsForm(traffic: $showTraffic, pointsOfInterest: $showPointsOfInterest, mapLayer: $selectedMapLayer, meshMap: $isMeshMap)
 			}
 			.onChange(of: router.navigationState) {
 				guard case .map = router.navigationState.selectedTab else { return }


### PR DESCRIPTION
Resolves: https://github.com/meshtastic/Meshtastic-Apple/issues/920

## What changed?
Added menu option to hide location precision circles for nodes

## Why did it change?
Allows for cleaner UIs when map areas have users with very low location precision

## How is this tested?
Manually on iPhone

## Screenshots/Videos (when applicable)
https://github.com/user-attachments/assets/9ea4086b-7e19-435e-8840-48984ad6ac81

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

