### PR TITLE
fix signal quality display when rssi missing

### DIFF
--- a/Meshtastic/Views/Helpers/LoRaSignalStrengthIndicator.swift
+++ b/Meshtastic/Views/Helpers/LoRaSignalStrengthIndicator.swift
@@ -72,6 +72,20 @@ private func getColor(signalStrength: LoRaSignalStrength) -> Color {
 }
 
 func getLoRaSignalStrength(snr: Float, rssi: Int32, preset: ModemPresets) -> LoRaSignalStrength {
+	// rssi is 0 when not available
+	if rssi == 0 {
+		if snr > (preset.snrLimit()) {
+			return .good
+		}
+		if snr < (preset.snrLimit() - 7.5) {
+			return .none
+		}
+		if snr <= (preset.snrLimit() - 5.5) {
+			return .bad
+		}
+		return .fair
+	}
+
 	if rssi > -115 && snr > (preset.snrLimit()) {
 		return .good
 	} else if rssi < -126 && snr < (preset.snrLimit() - 7.5) {


### PR DESCRIPTION
## What changed?
Fixed incorrect signal quality caculations when RSSI was not present. (this is common because NodeInfo does not store RSSI)

Hide RSSI when value is 0 (unknown).

https://github.com/meshtastic/Meshtastic-Apple/issues/930

## Why did it change?
UI was showing misleading signal quality metrics.

## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Screenshots/Videos (when applicable)

<img width="413" alt="image" src="https://github.com/user-attachments/assets/4bd4152e-3abd-48aa-983e-afd22e30b92d">

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested the change to ensure that it works as intended.

