### PR TITLE
Add missing timestamps to TraceRoute data structures

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -858,6 +858,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 								hopNode = createNodeInfo(num: Int64(node), context: context)
 							}
 							let traceRouteHop = TraceRouteHopEntity(context: context)
+							traceRouteHop.time = Date()
 							if routingMessage.snrTowards.count >= index + 1 {
 								traceRouteHop.snr = Float(routingMessage.snrTowards[index] / 4)
 							}
@@ -910,6 +911,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 						traceRoute?.routeText = routeString
 						traceRoute?.routeBackText = routeBackString
 						traceRoute?.hops = NSOrderedSet(array: hopNodes)
+						traceRoute?.time = Date()
 						do {
 							try context.save()
 							Logger.data.info("💾 Saved Trace Route")


### PR DESCRIPTION
## What changed?
This change sets timestamps in the TraceRoute data structure. Missing timestamps in
the TraceRouteEntity was causing CoreData exceptions, resulting in multi-hop traceroutes
not showing up in the App. 

## Why did it change?
The App was throwing an exception because the time field is required and was not always getting
set.

## How is this tested?
I ran this on my phone against a number of nodes in the area which can result in a variety of routes
and direct responses.

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

