### PR TITLE
Add node name below traceroute node circles

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -869,6 +869,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 									traceRoute?.hasPositions = true
 								}
 							}
+							traceRouteHop.name = hopNode?.user?.longName ?? "Unknown"
 							traceRouteHop.num = hopNode?.num ?? 0
 							if hopNode != nil {
 								if decodedInfo.packet.rxTime > 0 {
@@ -898,6 +899,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 									traceRoute?.hasPositions = true
 								}
 							}
+							traceRouteHop.name = hopNode?.user?.longName ?? "Unknown"
 							traceRouteHop.num = hopNode?.num ?? 0
 							if hopNode != nil {
 								if decodedInfo.packet.rxTime > 0 {

--- a/Meshtastic/Views/Nodes/TraceRouteLog.swift
+++ b/Meshtastic/Views/Nodes/TraceRouteLog.swift
@@ -225,6 +225,10 @@ struct TraceRouteLog: View {
 					VStack {
 						let nodeColor = UIColor(hex: UInt32(truncatingIfNeeded: hops[i].num))
 						CircleText(text: String(hops[i].num.toHex().suffix(4)), color: Color(nodeColor), circleSize: idiom == .phone ? 70 : 125)
+							Text(String(hops[i].name ?? "Unknown"))
+								.font(idiom == .phone ? .caption2 : .headline)
+								.allowsTightening(true)
+								.fontWeight(.semibold)
 							Text("\(String(format: "%.2f", hops[i].snr)) dB")
 								.font(idiom == .phone ? .caption2 : .headline)
 								.foregroundColor(snrColor)


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Proposing adding the long node name below the node circles in the tracroute view. This change adds
some missing traceRouteHop name assignments and then adds the name string below the node
circle and above the snr string.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Currently neither the node's short nor long name are part of circular traceroute view. This leverages the 
fact that the name is already available to the view and adds it in the same way other node circle names
are represented elsewhere in the app.

## How is this tested?
Ran various traceroute iterations and saw that the name was being shown under the circles in the circular
traceroute display.

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.