### PR TITLE
Proposal: Change circular traceroute arrows to circles

### DIFF
--- a/Meshtastic/Views/Layouts/TraceRoute.swift
+++ b/Meshtastic/Views/Layouts/TraceRoute.swift
@@ -57,11 +57,11 @@ struct TraceRoute: Layout {
 			subview.place(at: point, anchor: .center, proposal: .unspecified)
 
 		//	DispatchQueue.main.async {
-				if index % 2 == 0 {
-					subview[Rotation.self]?.wrappedValue = .zero
-				} else {
-					subview[Rotation.self]?.wrappedValue = .radians(angle)
-				}
+		//		if index % 2 == 0 {
+		//			subview[Rotation.self]?.wrappedValue = .zero
+		//		} else {
+		//			subview[Rotation.self]?.wrappedValue = .radians(angle)
+		//		}
 		//	}
 		}
 	}

--- a/Meshtastic/Views/Nodes/TraceRouteLog.swift
+++ b/Meshtastic/Views/Nodes/TraceRouteLog.swift
@@ -76,7 +76,7 @@ struct TraceRouteLog: View {
 				Divider()
 				ScrollView {
 					if selectedRoute != nil {
-						
+
 						if selectedRoute?.response ?? false && selectedRoute?.hopsTowards ?? 0 == 0 {
 							Label {
 								Text("Trace route received directly by \(selectedRoute?.node?.user?.longName ?? "unknown".localized) with a SNR of \(String(format: "%.2f", selectedRoute?.node?.snr ?? 0.0)) dB")
@@ -131,7 +131,7 @@ struct TraceRouteLog: View {
 									   .symbolRenderingMode(.hierarchical)
 							   }
 						}
-						if false {//selectedRoute?.hops?.count ?? 0 >= 3 {
+						if selectedRoute?.hops?.count ?? 0 >= 3 {
 							HStack(alignment: .center) {
 								GeometryReader { geometry in
 									let size = ((geometry.size.width >= geometry.size.height ? geometry.size.height : geometry.size.width) / 2) - (idiom == .phone ? 45 : 85)
@@ -249,9 +249,9 @@ struct TraceRouteLog: View {
 				} else {
 					let i = (idx - 1) / 2
 					let snrColor = getSnrColor(snr: hops[i].snr, preset: modemPreset)
-					Image(systemName: "arrowshape.right.fill")
+					Image(systemName: "circle.fill")
 						.resizable()
-						.frame(width: idiom == .phone ? 25 : 60, height: idiom == .phone ? 25 : 60)
+						.frame(width: idiom == .phone ? 15 : 30, height: idiom == .phone ? 15 : 30)
 						.foregroundColor(snrColor.opacity(0.7))
 				}
 			}


### PR DESCRIPTION
## What changed?
Modify arrows in the circular traceroutes to circles. Yes, this is cheating. But until there is a solution for rotating the arrows used in the circular traceroute, circles could be used. 

## Why did it change?
I was just looking for a way to enable the circular traceroute while a solution for the arrows is investigated. I admit, this is a bit of a weasely solution, but it enables the traceroute animation, which is valuable.

## How is this tested?
Ran through traceroute displays of various hop counts.

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

