### PR TITLE
Traceroute SNR cleanup

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -835,8 +835,8 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					let traceRoute = getTraceRoute(id: Int64(decodedInfo.packet.decoded.requestID), context: context)
 					traceRoute?.response = true
 					if routingMessage.route.count == 0 {
-						let snr = routingMessage.snrBack.count > 0 ? routingMessage.snrBack[0] / 4 : 0
-						traceRoute?.snr = Float(snr)
+						let snr = routingMessage.snrBack.count > 0 ? Float(routingMessage.snrBack[0]) / 4 : 0.0
+						traceRoute?.snr = snr
 						let logString = String.localizedStringWithFormat("mesh.log.traceroute.received.direct %@".localized, String(snr))
 						MeshLogger.log("🪧 \(logString)")
 					} else {
@@ -848,7 +848,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 						connectedHop.time = Date()
 						connectedHop.num = connectedPeripheral.num
 						connectedHop.name = connectedNode.user?.longName ?? "???"
-						connectedHop.snr = Float(routingMessage.snrBack.last ?? 0 / 4)
+						connectedHop.snr = Float(routingMessage.snrBack.last ?? 0) / 4
 						if let mostRecent = traceRoute?.node?.positions?.lastObject as? PositionEntity, mostRecent.time! >= Calendar.current.date(byAdding: .hour, value: -24, to: Date())! {
 							connectedHop.altitude = mostRecent.altitude
 							connectedHop.latitudeI = mostRecent.latitudeI
@@ -866,7 +866,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 							let traceRouteHop = TraceRouteHopEntity(context: context)
 							traceRouteHop.time = Date()
 							if routingMessage.snrTowards.count >= index + 1 {
-								traceRouteHop.snr = Float(routingMessage.snrTowards[index] / 4)
+								traceRouteHop.snr = Float(routingMessage.snrTowards[index]) / 4
 							}
 							if let hn = hopNode, hn.hasPositions {
 								if let mostRecent = hn.positions?.lastObject as? PositionEntity, mostRecent.time! >= Calendar.current.date(byAdding: .hour, value: -24, to: Date())! {
@@ -888,7 +888,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 						let destinationHop = TraceRouteHopEntity(context: context)
 						destinationHop.name = traceRoute?.node?.user?.longName ?? "unknown".localized
 						destinationHop.time = Date()
-						destinationHop.snr = Float(routingMessage.snrTowards.last ?? 0 / 4)
+						destinationHop.snr = Float(routingMessage.snrTowards.last ?? 0) / 4
 						destinationHop.num = traceRoute?.node?.num ?? 0
 						if let mostRecent = traceRoute?.node?.positions?.lastObject as? PositionEntity, mostRecent.time! >= Calendar.current.date(byAdding: .hour, value: -24, to: Date())! {
 							destinationHop.altitude = mostRecent.altitude
@@ -910,7 +910,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 							traceRouteHop.time = Date()
 							traceRouteHop.back = true
 							if routingMessage.snrBack.count >= index + 1 {
-								traceRouteHop.snr = Float(routingMessage.snrBack[index] / 4)
+								traceRouteHop.snr = Float(routingMessage.snrBack[index]) / 4
 							}
 							if let hn = hopNode, hn.hasPositions {
 								if let mostRecent = hn.positions?.lastObject as? PositionEntity, mostRecent.time! >= Calendar.current.date(byAdding: .hour, value: -24, to: Date())! {

--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -867,6 +867,9 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 							traceRouteHop.time = Date()
 							if routingMessage.snrTowards.count >= index + 1 {
 								traceRouteHop.snr = Float(routingMessage.snrTowards[index]) / 4
+							} else {
+								// If no snr in route, try last snr from node
+								traceRouteHop.snr = hopNode?.snr ?? 0
 							}
 							if let hn = hopNode, hn.hasPositions {
 								if let mostRecent = hn.positions?.lastObject as? PositionEntity, mostRecent.time! >= Calendar.current.date(byAdding: .hour, value: -24, to: Date())! {
@@ -883,7 +886,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 								}
 							}
 							hopNodes.append(traceRouteHop)
-							routeString += "\(hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))) \(hopNode?.viaMqtt ?? false ? "MQTT" : "") (\(traceRouteHop.snr > 0 ? hopNode?.snr ?? 0.0 : 0.0)dB) --> "
+							routeString += "\(hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))) \(hopNode?.viaMqtt ?? false ? "MQTT" : "") (\(traceRouteHop.snr)dB) --> "
 						}
 						let destinationHop = TraceRouteHopEntity(context: context)
 						destinationHop.name = traceRoute?.node?.user?.longName ?? "unknown".localized
@@ -898,8 +901,8 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 						}
 						hopNodes.append(destinationHop)
 						/// Add the destination node to the end of the route towards string and the beginning of teh route back string
-						routeString += "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) \(traceRoute?.node?.snr ?? 0 > 0 ? traceRoute?.node?.snr ?? 0 : 0.0)dB)"
-						var routeBackString = "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) \(traceRoute?.node?.snr ?? 0 > 0 ? traceRoute?.node?.snr ?? 0 : 0.0)dB) --> "
+						routeString += "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) (\(traceRoute?.node?.snr ?? traceRoute?.node?.snr ?? 0.0)dB)"
+						var routeBackString = "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) (\(traceRoute?.node?.snr ?? traceRoute?.node?.snr ?? 0.0)dB) --> "
 						traceRoute?.hopsBack = Int32(routingMessage.routeBack.count)
 						for (index, node) in routingMessage.routeBack.enumerated() {
 							var hopNode = getNodeInfo(id: Int64(node), context: context)
@@ -911,6 +914,9 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 							traceRouteHop.back = true
 							if routingMessage.snrBack.count >= index + 1 {
 								traceRouteHop.snr = Float(routingMessage.snrBack[index]) / 4
+							} else {
+								// If no snr in route, try last snr from node
+								traceRouteHop.snr = hopNode?.snr ?? 0
 							}
 							if let hn = hopNode, hn.hasPositions {
 								if let mostRecent = hn.positions?.lastObject as? PositionEntity, mostRecent.time! >= Calendar.current.date(byAdding: .hour, value: -24, to: Date())! {
@@ -927,9 +933,9 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 								}
 							}
 							hopNodes.append(traceRouteHop)
-							routeBackString += "\(hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))) \(hopNode?.viaMqtt ?? false ? "MQTT" : "") (\(traceRouteHop.snr > 0 ? hopNode?.snr ?? 0.0 : 0.0)dB) --> "
+							routeBackString += "\(hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))) \(hopNode?.viaMqtt ?? false ? "MQTT" : "") (\(traceRouteHop.snr)dB) --> "
 						}
-						routeBackString += "\(connectedNode.user?.longName ?? String(connectedNode.num.toHex())) \(connectedNode.snr > 0 ? connectedNode.snr : 0.0)dB)"
+						routeBackString += "\(connectedNode.user?.longName ?? String(connectedNode.num.toHex()))"
 						traceRoute?.routeText = routeString
 						traceRoute?.routeBackText = routeBackString
 						traceRoute?.hops = NSOrderedSet(array: hopNodes)

--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -890,7 +890,11 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 								}
 							}
 							hopNodes.append(traceRouteHop)
-							routeString += "\(hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))) \(hopNode?.viaMqtt ?? false ? "MQTT" : "") (\(traceRouteHop.snr != -32 ? String(traceRouteHop.snr) : "unknown ".localized)dB) --> "
+
+							let hopName = hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))
+							let mqttLabel = hopNode?.viaMqtt ?? false ? "MQTT " : ""
+							let snrLabel = (traceRouteHop.snr != -32) ? String(traceRouteHop.snr) : "unknown ".localized
+							routeString += "\(hopName) \(mqttLabel)(\(snrLabel)dB) --> "
 						}
 						let destinationHop = TraceRouteHopEntity(context: context)
 						destinationHop.name = traceRoute?.node?.user?.longName ?? "unknown".localized
@@ -905,7 +909,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 							traceRoute?.hasPositions = true
 						}
 						hopNodes.append(destinationHop)
-						/// Add the destination node to the end of the route towards string and the beginning of teh route back string
+						/// Add the destination node to the end of the route towards string and the beginning of the route back string
 						routeString += "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) (\(destinationHop.snr != -32 ? String(destinationHop.snr) : "unknown ".localized)dB)"
 						traceRoute?.routeText = routeString
 
@@ -942,7 +946,11 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 									}
 								}
 								hopNodes.append(traceRouteHop)
-								routeBackString += "\(hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))) \(hopNode?.viaMqtt ?? false ? "MQTT" : "") (\(traceRouteHop.snr != -32 ? String(traceRouteHop.snr) : "unknown ".localized)dB) --> "
+
+								let hopName = hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))
+								let mqttLabel = hopNode?.viaMqtt ?? false ? "MQTT " : ""
+								let snrLabel = (traceRouteHop.snr != -32) ? String(traceRouteHop.snr) : "unknown ".localized
+								routeBackString += "\(hopName) \(mqttLabel)(\(snrLabel)dB) --> "
 							}
 							// If nil, set to unknown, INT8_MIN (-128) then divide by 4
 							let snrBackLast = Float(routingMessage.snrBack.last ?? -128) / 4

--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -907,44 +907,48 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 						hopNodes.append(destinationHop)
 						/// Add the destination node to the end of the route towards string and the beginning of teh route back string
 						routeString += "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) (\(destinationHop.snr != -32 ? String(destinationHop.snr) : "unknown ".localized)dB)"
-						var routeBackString = "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) --> "
-						traceRoute?.hopsBack = Int32(routingMessage.routeBack.count)
-						for (index, node) in routingMessage.routeBack.enumerated() {
-							var hopNode = getNodeInfo(id: Int64(node), context: context)
-							if hopNode == nil && hopNode?.num ?? 0 > 0 && node != 4294967295 {
-								hopNode = createNodeInfo(num: Int64(node), context: context)
-							}
-							let traceRouteHop = TraceRouteHopEntity(context: context)
-							traceRouteHop.time = Date()
-							traceRouteHop.back = true
-							if routingMessage.snrBack.count >= index + 1 {
-								traceRouteHop.snr = Float(routingMessage.snrBack[index]) / 4
-							} else {
-								// If no snr in route, set to unknown
-								traceRouteHop.snr = -32
-							}
-							if let hn = hopNode, hn.hasPositions {
-								if let mostRecent = hn.positions?.lastObject as? PositionEntity, mostRecent.time! >= Calendar.current.date(byAdding: .hour, value: -24, to: Date())! {
-									traceRouteHop.altitude = mostRecent.altitude
-									traceRouteHop.latitudeI = mostRecent.latitudeI
-									traceRouteHop.longitudeI = mostRecent.longitudeI
-									traceRoute?.hasPositions = true
-								}
-							}
-							traceRouteHop.num = hopNode?.num ?? 0
-							if hopNode != nil {
-								if decodedInfo.packet.rxTime > 0 {
-									hopNode?.lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(decodedInfo.packet.rxTime)))
-								}
-							}
-							hopNodes.append(traceRouteHop)
-							routeBackString += "\(hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))) \(hopNode?.viaMqtt ?? false ? "MQTT" : "") (\(traceRouteHop.snr != -32 ? String(traceRouteHop.snr) : "unknown ".localized)dB) --> "
-						}
-						// If nil, set to unknown, INT8_MIN (-128) then divide by 4
-						let snrBackLast = Float(routingMessage.snrBack.last ?? -128) / 4
-						routeBackString += "\(connectedNode.user?.longName ?? String(connectedNode.num.toHex())) (\(snrBackLast != -32 ? String(snrBackLast) : "unknown ".localized)dB)"
 						traceRoute?.routeText = routeString
-						traceRoute?.routeBackText = routeBackString
+
+						traceRoute?.hopsBack = Int32(routingMessage.routeBack.count)
+						// Only if hopStart is set and there is an SNR entry
+						if decodedInfo.packet.hopStart > 0 && routingMessage.snrBack.count > 0 {
+							var routeBackString = "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) --> "
+							for (index, node) in routingMessage.routeBack.enumerated() {
+								var hopNode = getNodeInfo(id: Int64(node), context: context)
+								if hopNode == nil && hopNode?.num ?? 0 > 0 && node != 4294967295 {
+									hopNode = createNodeInfo(num: Int64(node), context: context)
+								}
+								let traceRouteHop = TraceRouteHopEntity(context: context)
+								traceRouteHop.time = Date()
+								traceRouteHop.back = true
+								if routingMessage.snrBack.count >= index + 1 {
+									traceRouteHop.snr = Float(routingMessage.snrBack[index]) / 4
+								} else {
+									// If no snr in route, set to unknown
+									traceRouteHop.snr = -32
+								}
+								if let hn = hopNode, hn.hasPositions {
+									if let mostRecent = hn.positions?.lastObject as? PositionEntity, mostRecent.time! >= Calendar.current.date(byAdding: .hour, value: -24, to: Date())! {
+										traceRouteHop.altitude = mostRecent.altitude
+										traceRouteHop.latitudeI = mostRecent.latitudeI
+										traceRouteHop.longitudeI = mostRecent.longitudeI
+										traceRoute?.hasPositions = true
+									}
+								}
+								traceRouteHop.num = hopNode?.num ?? 0
+								if hopNode != nil {
+									if decodedInfo.packet.rxTime > 0 {
+										hopNode?.lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(decodedInfo.packet.rxTime)))
+									}
+								}
+								hopNodes.append(traceRouteHop)
+								routeBackString += "\(hopNode?.user?.longName ?? (node == 4294967295 ? "Repeater" : String(hopNode?.num.toHex() ?? "unknown".localized))) \(hopNode?.viaMqtt ?? false ? "MQTT" : "") (\(traceRouteHop.snr != -32 ? String(traceRouteHop.snr) : "unknown ".localized)dB) --> "
+							}
+							// If nil, set to unknown, INT8_MIN (-128) then divide by 4
+							let snrBackLast = Float(routingMessage.snrBack.last ?? -128) / 4
+							routeBackString += "\(connectedNode.user?.longName ?? String(connectedNode.num.toHex())) (\(snrBackLast != -32 ? String(snrBackLast) : "unknown ".localized)dB)"
+							traceRoute?.routeBackText = routeBackString
+						}
 						traceRoute?.hops = NSOrderedSet(array: hopNodes)
 						traceRoute?.time = Date()
 						do {

--- a/Meshtastic/Views/Nodes/TraceRouteLog.swift
+++ b/Meshtastic/Views/Nodes/TraceRouteLog.swift
@@ -72,14 +72,13 @@ struct TraceRouteLog: View {
 					}
 					.listStyle(.plain)
 				}
-				.frame(minHeight: CGFloat(node.traceRoutes?.count ?? 0 * 40), maxHeight: 250)
+				.frame(minHeight: CGFloat((node.traceRoutes?.count ?? 0) * 40), maxHeight: 250)
 				Divider()
 				ScrollView {
 					if selectedRoute != nil {
-						
 						if selectedRoute?.response ?? false && selectedRoute?.hopsTowards ?? 0 == 0 {
 							Label {
-								Text("Trace route received directly by \(selectedRoute?.node?.user?.longName ?? "unknown".localized) with a SNR of \(String(format: "%.2f", selectedRoute?.node?.snr ?? 0.0)) dB")
+								Text("Trace route received directly by \(selectedRoute?.node?.user?.longName ?? "unknown".localized) with a SNR of \(String(format: "%.2f", selectedRoute?.snr ?? 0.0)) dB")
 							} icon: {
 								Image(systemName: "signpost.right.and.left")
 									.symbolRenderingMode(.hierarchical)
@@ -131,7 +130,7 @@ struct TraceRouteLog: View {
 									   .symbolRenderingMode(.hierarchical)
 							   }
 						}
-						if false {//selectedRoute?.hops?.count ?? 0 >= 3 {
+						if false {// selectedRoute?.hops?.count ?? 0 >= 3 {
 							HStack(alignment: .center) {
 								GeometryReader { geometry in
 									let size = ((geometry.size.width >= geometry.size.height ? geometry.size.height : geometry.size.width) / 2) - (idiom == .phone ? 45 : 85)


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
This change updates traceroute handling of SNR values.

1. For direct traceroute results, use the SNR from the routing message, rather than pulling it from the node entry. Pulling from the node entry causes every direct traceroute entry to show the current SNR for the node, rather than the SNR at the time of the traceroute
2. cleans up a couple spots where the SNR is divided by 4. The change casts them to Floats first then divides so that the decimals aren't truncated.
3. Clean up some incorrect snr checks against 0. SNR can be negative. An unknown SNR is represented as -32. When the SNR value is encoded as an int in the routing message, the value is -128.
4. Fix up some formatting issues with the routeString and routeBackString

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
These changes clean up some areas which were returning incorrect SNR values as well as some incorrect formatting of the route strings

## How is this tested?
<!-- Describe your approach to testing the feature. -->
This change was tested with multiple traceroute runs and results

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

