### PR TITLE
Fix typo in firmware update view

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -5034,7 +5034,7 @@
     "Current: %lld" : {
 
     },
-    "Currently the reccomended way to update ESP32 devices is using the web flasher on a desktop computer from a chrome based browser. It does not work on mobile devices or over BLE." : {
+    "Currently the recommended way to update ESP32 devices is using the web flasher on a desktop computer from a chrome based browser. It does not work on mobile devices or over BLE." : {
 
     },
     "Date" : {

--- a/Meshtastic/Views/Settings/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware.swift
@@ -148,7 +148,7 @@ struct Firmware: View {
 					VStack(alignment: .leading) {
 						Text("ESP32 Device Firmware Update")
 							.font(.title3)
-						Text("Currently the reccomended way to update ESP32 devices is using the web flasher on a desktop computer from a chrome based browser. It does not work on mobile devices or over BLE.")
+						Text("Currently the recommended way to update ESP32 devices is using the web flasher on a desktop computer from a chrome based browser. It does not work on mobile devices or over BLE.")
 							.font(.caption)
 						Link("Web Flasher", destination: URL(string: "https://flash.meshtastic.org")!)
 							.font(.callout)


### PR DESCRIPTION
## What changed?
The ESP32 Device Firmware Update text on the Firmware Updates view was updated to correct a typo.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->

## How is this tested?
I verified the fix in Simulator.

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

