### PR TITLE
Fix View issue when node traceroute list gets long

### DIFF
--- a/Meshtastic/Views/Nodes/TraceRouteLog.swift
+++ b/Meshtastic/Views/Nodes/TraceRouteLog.swift
@@ -72,7 +72,6 @@ struct TraceRouteLog: View {
 					}
 					.listStyle(.plain)
 				}
-				.frame(minHeight: CGFloat((node.traceRoutes?.count ?? 0) * 40), maxHeight: 250)
 				Divider()
 				ScrollView {
 					if selectedRoute != nil {


### PR DESCRIPTION

## What changed?
<!-- Provide a clear description for the change -->
This change removes the explicit sizing in the traceroute log view, allowing the view to manage the size.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
When the traceroute list gets long enough it can push the selected node off the bottom of the screen.
With the explicit min/max heights removed, the view will split the screen between the list and the selected node view.
Looks like this changed behavior with this commit https://github.com/meshtastic/Meshtastic-Apple/commit/f7630262039e697bbe0449bf3ebe9e2a4b092a69. An operator precedence issue was addressed, which exposed this issue. Prior to this change the frame minHeight was not being multiplied as intended, and remained too small to have an impact. 

## How is this tested?
<!-- Describe your approach to testing the feature. -->
Ran tests with varying sized traceroute lists and varying screen sizes.

## Screenshots/Videos (when applicable)

Here's an example of the current behavior with a long list. The selected route view is inaccessible.
![4887FA2F-DB82-4CF1-9BFA-63386A3740CB_1_102_o](https://github.com/user-attachments/assets/a108d1e2-a1dd-44f1-8fc9-cb1a1dc74c0a)


Here's an example of the same list with this change. Here the list and the selected route view are split across the screen.
![8B5528C8-D6B3-4908-BD53-4BB6C129C860_1_102_o](https://github.com/user-attachments/assets/e873b7ed-b212-4b06-a94a-6e44ae123402)


<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

