### PR TITLE
Add shorter distance options to distance filtering

### DIFF
--- a/Meshtastic/Enums/AppSettingsEnums.swift
+++ b/Meshtastic/Enums/AppSettingsEnums.swift
@@ -51,6 +51,10 @@ enum MeshMapTypes: Int, CaseIterable, Identifiable {
 }
 
 enum MeshMapDistances: Double, CaseIterable, Identifiable {
+	case twoMiles = 3218.69
+	case fiveMiles = 8046.72
+	case tenMiles = 16093.4
+	case twentyFiveMiles = 40233.6
 	case fiftyMiles = 80467.2
 	case oneHundredMiles = 160934
 	case twoHundredMiles = 321869


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Add some shorter distance options to the filtering. This adds options for 2, 5, 10 and 25 miles.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
For areas with a dense collection of nodes, such as urban areas, filtering distances of shorter then 50 miles is very helpful. 

## How is this tested?
<!-- Describe your approach to testing the feature. -->
Selecting various distances 2, 5, 10, 25, and further to verify that the correct nodes are displayed. Tested with Node List and Mesh Map

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

