### PR TITLE
Fixes #1007

### DIFF
--- a/Meshtastic/Helpers/LocalNotificationManager.swift
+++ b/Meshtastic/Helpers/LocalNotificationManager.swift
@@ -4,36 +4,36 @@ import OSLog
 
 class LocalNotificationManager {
 
-    var notifications = [Notification]()
+	var notifications = [Notification]()
 	let thumbsUpAction = UNNotificationAction(identifier: "messageNotification.thumbsUpAction", title: "👍 \(Tapbacks.thumbsUp.description)", options: [])
 	let thumbsDownAction = UNNotificationAction(identifier: "messageNotification.thumbsDownAction", title: "👎  \(Tapbacks.thumbsDown.description)", options: [])
 	let replyInputAction =  UNTextInputNotificationAction(identifier: "messageNotification.replyInputAction", title: "reply".localized, options: [])
 
-    // Step 1 Request Permissions for notifications
-    private func requestAuthorization() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+	// Step 1 Request Permissions for notifications
+	private func requestAuthorization() {
+		UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
 
-            if granted == true && error == nil {
+			if granted == true && error == nil {
 				self.scheduleNotifications()
-            }
-        }
-    }
+			}
+		}
+	}
 
 	func schedule() {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            switch settings.authorizationStatus {
-            case .notDetermined:
+		UNUserNotificationCenter.current().getNotificationSettings { settings in
+			switch settings.authorizationStatus {
+			case .notDetermined:
 				self.requestAuthorization()
-            case .authorized, .provisional:
-                self.scheduleNotifications()
-            default:
-                break // Do nothing
-            }
-        }
-    }
+			case .authorized, .provisional:
+				self.scheduleNotifications()
+			default:
+				break // Do nothing
+			}
+		}
+	}
 
-    // This function iterates over the Notification objects in the notifications array and schedules them for delivery in the future
-    private func scheduleNotifications() {
+	// This function iterates over the Notification objects in the notifications array and schedules them for delivery in the future
+	private func scheduleNotifications() {
 		let messageNotificationCategory = UNNotificationCategory(
 				 identifier: "messageNotificationCategory",
 				 actions: [thumbsUpAction, thumbsDownAction, replyInputAction],
@@ -43,13 +43,15 @@ class LocalNotificationManager {
 
 				UNUserNotificationCenter.current().setNotificationCategories([messageNotificationCategory])
 
-        for notification in notifications {
-            let content = UNMutableNotificationContent()
-            content.subtitle = notification.subtitle
-            content.title = notification.title
-            content.body = notification.content
-            content.sound = .default
-            content.interruptionLevel = .timeSensitive
+		for notification in notifications {
+			let content = UNMutableNotificationContent()
+			if let subtitle = notification.subtitle {
+				content.subtitle = subtitle
+			}
+			content.title = notification.title
+			content.body = notification.content
+			content.sound = .default
+			content.interruptionLevel = .timeSensitive
 
 			if notification.target != nil {
 				content.userInfo["target"] = notification.target
@@ -68,34 +70,33 @@ class LocalNotificationManager {
 				content.userInfo["userNum"] = notification.userNum
 			}
 
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
-            let request = UNNotificationRequest(identifier: notification.id, content: content, trigger: trigger)
+			let request = UNNotificationRequest(identifier: notification.id, content: content, trigger: nil)
 
-            UNUserNotificationCenter.current().add(request) { error in
+			UNUserNotificationCenter.current().add(request) { error in
 				if let error {
 					Logger.services.error("Error Scheduling Notification: \(error.localizedDescription)")
 				}
-            }
-        }
-    }
+			}
+		}
+	}
 
-    // Check and debug what local notifications have been scheduled
-    func listScheduledNotifications() {
-        UNUserNotificationCenter.current().getPendingNotificationRequests { notifications in
+	// Check and debug what local notifications have been scheduled
+	func listScheduledNotifications() {
+		UNUserNotificationCenter.current().getPendingNotificationRequests { notifications in
 
-            for notification in notifications {
+			for notification in notifications {
 				Logger.services.debug("\(notification, privacy: .public)")
-            }
-        }
-    }
+			}
+		}
+	}
 
 }
 
 struct Notification {
-    var id: String
-    var title: String
-    var subtitle: String
-    var content: String
+	var id: String
+	var title: String
+	var subtitle: String?
+	var content: String
 	var target: String?
 	var path: String?
 	var messageId: Int64?


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Now provides notifications when unknown nodes send a channel message. Also, schedule all local notifications immediately instead of on a 1-second delay.

## Why did it change?
<!--A brief overview of why the change is being added. Explain the functionality and its intended purpose. -->
Often time-sensitive notifications from nodes could be missed because their node had not yet exchanged node info. This is a bad pattern to just ignore all unknown nodes. Also delaying notifications by 1 second could lead to pile-ups for notifications all spaced out by 1 second. And message notifications came in at a delay.

## How is this tested?
<!-- Describe your approach to testing the feature. -->
I tested it on my iPhone and can confirm that the unknown node's notifications work and notifications are being delivered immediately with no issues. Also confirmed that notification actions work.

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
![IMG_2541](https://github.com/user-attachments/assets/2edad589-afff-48ef-b168-2e638b892d94)

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

