### PR TITLE
Update frequency slot description in Settings >> LoRa

### DIFF
--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -168,7 +168,7 @@ struct LoRaConfig: View {
 								.focused($focusedField, equals: .channelNum)
 								.disabled(overrideFrequency > 0.0)
 						}
-						Text("This determines the actual frequency you are transmitting on in the band. If set to 0 this value will be calculated automatically based on the primary channel name.")
+						Text("Your node’s operating frequency is calculated based on the region, modem preset, and this field. When 0, the slot is automatically calculated based on the primary channel name.")
 							.foregroundColor(.gray)
 							.font(.callout)
 					}


### PR DESCRIPTION
## What changed?
Edit descriptive text to clarify (1) device frequency is calculated based on slot number and other fields, (2) device has a single operating frequency.

## Why did it change?
Short-time listener, first-time caller.  Please feel free to ignore/reject.

Based on [discussion regarding primary private channels](https://www.reddit.com/r/meshtastic/comments/1howp8k/frequency_slot_changes/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) in r/Meshtastic

I thought it might help if user guidance pulled in a little more from these resources.
 - https://meshtastic.org/docs/configuration/tips/#creating-a-private-primary-with-default-secondary
 - https://meshtastic.org/docs/overview/radio-settings/#frequency-slot-calculator

## How is this tested?
String edit only.

## Screenshots/Videos (when applicable)
![Pasted_Image_12_29_24__1_57 PM](https://github.com/user-attachments/assets/65f64ec7-7261-47c0-a7bc-011af5738e20)

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

