### PR TITLE
Update Localizable.xcstrings

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -14812,7 +14812,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Taste"
+            "value" : "Schlüssel"
           }
         },
         "sr" : {
@@ -14838,7 +14838,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tastengröße"
+            "value" : "Schlüsselgröße"
           }
         },
         "sr" : {


### PR DESCRIPTION
Replaced incorrect german translation in 2 locations Old: key -> Taste (meaning key as in keyboard)
New: key -> Schlüssel (meaning key as in access key)

## What changed?
Resource entries for 2 german localizations.
Location in app: Settings for channel encryption, key and key length/size.

Line 31336 is an unexpected change and should be omitted.

## Why did it change?
The previous translation made no sense in that context.
The english word key was translated to german as a key you find on a keyboard or piano, but in this context an access/encryption key is meant. The correct translation for such a key is "Schlüssel" as in "Zugangsschlüssel" and "Schlüssellänge"

## How is this tested?
Test correct display of the umlaut (there was already one present, so no problem expected) and for cropping/line break through length.

## Screenshots/Videos (when applicable)

n/a

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [n/a] I have commented my code, particularly in complex areas.
- [n/a] I have made corresponding changes to the documentation.
- [-] I have tested the change to ensure that it works as intended.

