### PR TITLE
Update traceroute back route display to handle case where route back is not valid

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -903,10 +903,11 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					/// Add the destination node to the end of the route towards string and the beginning of the route back string
 					routeString += "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) (\(destinationHop.snr != -32 ? String(destinationHop.snr) : "unknown ".localized)dB)"
 					traceRoute?.routeText = routeString
-
-					traceRoute?.hopsBack = Int32(routingMessage.routeBack.count)
+					// Default to -1 only fill in if routeBack is valid below
+					traceRoute?.hopsBack = -1
 					// Only if hopStart is set and there is an SNR entry
 					if decodedInfo.packet.hopStart > 0 && routingMessage.snrBack.count > 0 {
+						traceRoute?.hopsBack = Int32(routingMessage.routeBack.count)
 						var routeBackString = "\(traceRoute?.node?.user?.longName ?? "unknown".localized) \((traceRoute?.node?.num ?? 0).toHex()) --> "
 						for (index, node) in routingMessage.routeBack.enumerated() {
 							var hopNode = getNodeInfo(id: Int64(node), context: context)
@@ -947,19 +948,19 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 						let snrBackLast = Float(routingMessage.snrBack.last ?? -128) / 4
 						routeBackString += "\(connectedNode.user?.longName ?? String(connectedNode.num.toHex())) (\(snrBackLast != -32 ? String(snrBackLast) : "unknown ".localized)dB)"
 						traceRoute?.routeBackText = routeBackString
-						traceRoute?.hops = NSOrderedSet(array: hopNodes)
-						traceRoute?.time = Date()
-						do {
-							try context.save()
-							Logger.data.info("💾 Saved Trace Route")
-						} catch {
-							context.rollback()
-							let nsError = error as NSError
-							Logger.data.error("Error Updating Core Data TraceRouteHop: \(nsError, privacy: .public)")
-						}
-						let logString = String.localizedStringWithFormat("mesh.log.traceroute.received.route %@".localized, routeString)
-						MeshLogger.log("🪧 \(logString)")
 					}
+					traceRoute?.hops = NSOrderedSet(array: hopNodes)
+					traceRoute?.time = Date()
+					do {
+						try context.save()
+						Logger.data.info("💾 Saved Trace Route")
+					} catch {
+						context.rollback()
+						let nsError = error as NSError
+						Logger.data.error("Error Updating Core Data TraceRouteHop: \(nsError, privacy: .public)")
+					}
+					let logString = String.localizedStringWithFormat("mesh.log.traceroute.received.route %@".localized, routeString)
+					MeshLogger.log("🪧 \(logString)")
 				}
 			case .neighborinfoApp:
 				if let neighborInfo = try? NeighborInfo(serializedBytes: decodedInfo.packet.decoded.payload) {

--- a/Meshtastic/Views/Nodes/TraceRouteLog.swift
+++ b/Meshtastic/Views/Nodes/TraceRouteLog.swift
@@ -44,7 +44,7 @@ struct TraceRouteLog: View {
 									.font(.caption)
 							} else if route.response {
 								let hopTowardsString = String(localized: "\(route.hopsTowards) Hops")
-								let hopBackString = String(localized: "\(route.hopsBack) Hops")
+								let hopBackString = route.hopsBack >= 0 ? String(localized: "\(route.hopsBack) Hops") : String(localized: "unknown")
 								Text("\(routeTime) - \(hopTowardsString) Towards  \(hopBackString) Back")
 									.font(.caption)
 							} else if route.sent {


### PR DESCRIPTION


## What changed?
<!-- Provide a clear description for the change -->
Fixed issue where traceroute info wasn't saved if route back wasn't valid.
Update route back handling to display "unknown" when the route back info is not valid.


## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Looks like the traceroute data could get dropped if the route back isn't valid. With that fixed, the route back could display "Direct" when the route back data is invalid which is incorrect.

Looking for feedback. The other option is that we just drop references to back messages. But I thought this was a little more clear that the route back data is invalid.

## How is this tested?
<!-- Describe your approach to testing the feature. -->
Ran various traceroutes and validated the data. I. don't have a setup that will return invalid route back info, so I tested that by artificially dropping the route back processing.

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
Here's an example of what the message will look like if the route back data is invalid. 
![Screenshot 2025-01-08 at 09 16 23 jpeg](https://github.com/user-attachments/assets/7a971480-6db3-413f-92bd-43ddc65b35f0)

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

