### PR TITLE
send tr received notification

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -960,6 +960,22 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					}
 					traceRoute?.hops = NSOrderedSet(array: hopNodes)
 					traceRoute?.time = Date()
+
+					if let tr = traceRoute {
+						let manager = LocalNotificationManager()
+						manager.notifications = [
+							Notification(
+								id: (UUID().uuidString),
+								title: "Traceroute Complete",
+								subtitle: "TR received back from \(destinationHop.name ?? "unknown")",
+								content: "Hops from: \(tr.hopsTowards), Hops back: \(tr.hopsBack)\n\(tr.routeText ?? "unknown".localized)\n\(tr.routeBackText ?? "unknown".localized)",
+								target: "nodes",
+								path: "meshtastic:///nodes?nodenum=\(connectedNode.user?.num ?? 0)"
+							)
+						]
+						manager.schedule()
+					}
+
 					do {
 						try context.save()
 						Logger.data.info("💾 Saved Trace Route")


### PR DESCRIPTION
## What changed?
Adds a notification for completed traceroutes. The notification includes the routeText and the routeBackText seen in the TR log, as well as as hop from and hop back value

## Why did it change?
Right now, it's hard to know when a TR has been completed

## How is this tested?
Run a TR on a node, wait for it to complete, see the notification

## Screenshots/Videos (when applicable)
![IMG_4720](https://github.com/user-attachments/assets/34284915-29c7-442c-b248-f450c349c1c5)


## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

