### PR TITLE
Don't cover messages when keyboard is presented

### DIFF
--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -127,9 +127,13 @@ struct ChannelMessageList: View {
 						}
 					}
 				}
-				.padding([.top])
-				.scrollDismissesKeyboard(.immediately)
+				.scrollDismissesKeyboard(.interactively)
 				.onFirstAppear {
+					withAnimation {
+						scrollView.scrollTo(channel.allPrivateMessages.last?.messageId ?? 0, anchor: .bottom)
+					}
+				}
+				.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
 					withAnimation {
 						scrollView.scrollTo(channel.allPrivateMessages.last?.messageId ?? 0, anchor: .bottom)
 					}

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -115,9 +115,13 @@ struct UserMessageList: View {
 						}
 					}
 				}
-				.padding([.top])
-				.scrollDismissesKeyboard(.immediately)
+				.scrollDismissesKeyboard(.interactively)
 				.onFirstAppear {
+					withAnimation {
+						scrollView.scrollTo(user.messageList.last?.messageId ?? 0, anchor: .bottom)
+					}
+				}
+				.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
 					withAnimation {
 						scrollView.scrollTo(user.messageList.last?.messageId ?? 0, anchor: .bottom)
 					}


### PR DESCRIPTION
## What changed?

Prevents the keybaord from covering message content. 

- Scroll to content when keybaord appears
- Use interactive dismiss so users can scroll (slowly) while the keyboard is displayed without dismissing it
- Remove needless padding at the top of the view preventing nav bar transparency effect

## Why did it change?

Keyboard behavior was janky and difficult to use. 

## How is this tested?
Tested on a physical device

## Screenshots/Videos (when applicable)

### Before

https://github.com/user-attachments/assets/e4d1ceef-62f9-4640-bd96-0f4b25f27136


### After


https://github.com/user-attachments/assets/225a9e1d-1d4a-4a5d-ad02-ab2878efa983


## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested the change to ensure that it works as intended.

