### PR TITLE
Update Localizable.xcstrings

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -2116,6 +2116,12 @@
     },
     "Available modem presets, default is Long Fast." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verfügbare Modemvoreinstellungen, Standard ist Hohe Reichweite - Schnell."
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7012,6 +7018,12 @@
     },
     "Device Role" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerät Rolle"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7607,6 +7619,12 @@
     "device.role.name.clientMute" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Client (stumm)"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8917,6 +8935,12 @@
     },
     "Double Tap as Button" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doppeltes Antippen als Taste"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11874,6 +11898,12 @@
     },
     "Hourly Duty Cycle" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stündliche Sendebeschränkung"
+          }
+        }
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12318,6 +12348,12 @@
     },
     "Ignore MQTT" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MQTT ignorieren"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15296,6 +15332,12 @@
     },
     "Limit all periodic broadcast intervals especially telemetry and position. If you need to increase hops, do it on nodes at the edges, not the ones in the middle. MQTT is not advised when you are duty cycle restricted because the gateway node is then doing all the work." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Begrenzen Sie alle regelmäßigen Sendeintervalle, insbesondere Telemetrie und Position. Wenn Sie die Anzahl der Zwischenstationen (Hops) erhöhen müssen, tun Sie dies bei den Knoten an den Randbereichen, nicht bei denen in der Mitte. MQTT ist nicht empfohlen, wenn eine Sendebeschränkung vorliegt, da der Gateway-Knoten dann die Hauptarbeit übernimmt."
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15927,6 +15969,12 @@
     "long.range.fast" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hohe Reichweite - Schnell"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15944,6 +15992,12 @@
     "long.range.moderate" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hohe Reichweite - Gemäßigt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15961,6 +16015,12 @@
     "long.range.slow" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hohe Reichweite - Langsam"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16131,7 +16191,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Schlechte Signalstärke"
+            "value" : "Schwach"
           }
         },
         "en" : {
@@ -16154,7 +16214,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ordentliche Signalstärke"
+            "value" : "Ausreichend"
           }
         },
         "en" : {
@@ -16177,7 +16237,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gute Signalstärke"
+            "value" : "Stark"
           }
         },
         "en" : {
@@ -21165,6 +21225,12 @@
     },
     "Node Info Broadcast Interval" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Knoten Info Broadcast Intervall"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21760,6 +21826,12 @@
     },
     "Ok to MQTT" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MQTT ist in Ordnung"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22794,6 +22866,12 @@
     },
     "Please connect to a radio to configure settings." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitte verbinden Sie sich mit einem Endgerät, um die Einstellungen zu konfigurieren."
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22811,6 +22889,12 @@
     "Please set a region" : {
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitte legen Sie eine Region fest"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23276,6 +23360,12 @@
     },
     "Presets" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voreinstellungen"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23939,6 +24029,12 @@
     },
     "Rebroadcast Mode" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rebroadcast Modus"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26965,6 +27061,12 @@
     },
     "Send a position on the primary channel when the user button is triple clicked." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senden der Position auf dem Hauptkanal, wenn die Benutzer-Taste dreimal betätigt wird."
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27778,6 +27880,12 @@
     },
     "Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. O hop broadcast messages will not get ACKs." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legt die maximale Anzahl von Zwischenstationen (Hops) fest, Vorgabe ist 3. Eine Erhöhung der Hops vergrößert auch die Netzüberlastung und sollte mit Vorsicht verwendet werden. 0-Hop-Broadcast-Nachrichten erhalten keine ACKs."
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29817,6 +29925,12 @@
     },
     "The last 4 of the device MAC address will be appended to the short name to set the device's BLE Name.  Short name can be up to 4 bytes long." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die letzten 4 Zeichen der MAC-Adresse des Geräts werden an den Kurznamen angehängt, um den BLE-Namen des Geräts festzulegen. Der Kurzname kann bis zu 4 Byte lang sein."
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31127,6 +31241,12 @@
     },
     "Transmit Enabled" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senden Aktiviert"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31143,6 +31263,12 @@
     },
     "Treat double tap on supported accelerometers as a user button press." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doppeltes Antippen bei unterstützten Beschleunigungsmessern wird als Tastendruck behandelt."
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31169,6 +31295,12 @@
     },
     "Triple Click Ad Hoc Ping" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dreifach-Klick für Ping"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31805,6 +31937,12 @@
     },
     "Use Preset" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voreinstellung verwenden"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31836,7 +31974,14 @@
       }
     },
     "Used to create a shared key with a remote device." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird verwendet, um einen gemeinsamen Schlüssel mit einem Remote-Gerät zu erstellen."
+          }
+        }
+      }
     },
     "user" : {
       "localizations" : {
@@ -31904,6 +32049,12 @@
     },
     "User Config" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerkonfiguration"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31920,6 +32071,12 @@
     },
     "User Details" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Benutzerdetails"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32771,6 +32928,12 @@
     },
     "Your region has a %lld%% hourly duty cycle, your radio will stop sending packets when it reaches the hourly limit." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ihre Region hat eine stündliche Sendebeschränkung von %lld%%, Ihr Endgerät hört auf, Pakete zu senden, wenn es die stündliche Grenze erreicht."
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",


### PR DESCRIPTION
Added missing German translations
Changed some German translations to closer reflect the original meaning/length

## What changed?
Changed translations of the following strings:

device.role.name.clientMute
Client Mute
Client (stumm)

lora.signal.strength.bad
Schlechte Signalstärke
Schwach

lora.signal.strength.fair
Ordentliche Signalstärke
Ausreichend

lora.signal.strength.good
Gute Signalstärke
Stark

Your region has a %lld%% hourly duty cycle, your radio will stop sending packets when it reaches the hourly limit.
Ihre Region hat eine stündliche Sendebeschränkung von %lld%%, Ihr Endgerät hört auf, Pakete zu senden, wenn es die stündliche Grenze erreicht.

Hourly Duty Cycle
Stündliche Sendebeschränkung

Limit all periodic broadcast intervals especially telemetry and position. If you need to increase hops, do it on nodes at the edges, not the ones in the middle. MQTT is not advised when you are duty cycle restricted because the gateway node is then doing all the work.
Begrenzen Sie alle regelmäßigen Sendeintervalle, insbesondere Telemetrie und Position. Wenn Sie die Anzahl der Zwischenstationen (Hops) erhöhen müssen, tun Sie dies bei den Knoten an den Randbereichen, nicht bei denen in der Mitte. MQTT ist nicht empfohlen, wenn eine Sendebeschränkung vorliegt, da der Gateway-Knoten dann die Hauptarbeit übernimmt.

Please connect to a radio to configure settings.
Bitte verbinden Sie sich mit einem Endgerät, um die Einstellungen zu konfigurieren.

Please set a Region
Bitte legen Sie eine Region fest

Use Preset
Voreinstellung verwenden

Presets
Voreinstellungen

long.range.fast
Long Range - Fast
Hohe Reichweite - Schnell

long.range.moderate
Long Range - Moderate
Hohe Reichweite - Gemäßigt

long.range.slow
Long Range - Slow
Hohe Reichweite - Langsam

Available modem presets, default is Long Fast.
Verfügbare Modemvoreinstellungen, Standard ist Hohe Reichweite - Schnell.

Ignore MQTT
MQTT ignorieren

Ok to MQTT
MQTT ist in Ordnung

Transmit Enabled
Senden Aktiviert

Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. O hop broadcast messages will not get ACKs.
Legt die maximale Anzahl von Zwischenstationen (Hops) fest, Vorgabe ist 3. Eine Erhöhung der Hops vergrößert auch die Netzüberlastung und sollte mit Vorsicht verwendet werden. 0-Hop-Broadcast-Nachrichten erhalten keine ACKs.

Used to create a shared key with a remote device.
Wird verwendet, um einen gemeinsamen Schlüssel mit einem Remote-Gerät zu erstellen.

User Config
Benutzerkonfiguration

User Details
Benutzerdetails

The last 4 of the device MAC address will be appended to the short name to set the device's BLE Name.  Short name can be up to 4 bytes long.
Die letzten 4 Zeichen der MAC-Adresse des Geräts werden an den Kurznamen angehängt, um den BLE-Namen des Geräts festzulegen. Der Kurzname kann bis zu 4 Byte lang sein.

Device Role
Gerät Rolle

Rebroadcast Mode
Rebroadcast Modus

Node Info Broadcast Interval
Knoten Info Broadcast Intervall

Double Tap as Button
Doppeltes Antippen als Taste

Treat double tap on supported accelerometers as a user button press.
Doppeltes Antippen bei unterstützten Beschleunigungsmessern wird als Tastendruck behandelt.

Triple Click Ad Hoc Ping
Dreifach-Klick für Ping

Send a position on the primary channel when the user button is triple clicked.
Senden der Position auf dem Hauptkanal, wenn die Benutzer-Taste dreimal betätigt wird.

## Why did it change?
Some default strings or English original strings are still shown in the German translation.
Also changed naming of signal strengths based on proposal in the last fork.

## How is this tested?
Strings are roughly the same lengths as the original ones

Side note: The original string is already too long in one case:
"Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. O hop broadcast messages will not get ACKs."
This string is found under Settings->LoRa settings->Advanced and is cut off after "O hop broadcast".

## Screenshots/Videos (when applicable)

N/A

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested the change to ensure that it works as intended.

