### PR TITLE
Fixes channel message mark as read lagging the channel message list view

### DIFF
--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -112,16 +112,8 @@ struct ChannelMessageList: View {
 							.frame(maxWidth: .infinity)
 							.id(message.messageId)
 							.onAppear {
-								if !message.read {
-									message.read = true
-									do {
-										try context.save()
-										Logger.data.info("📖 [App] Read message \(message.messageId) ")
-										appState.unreadChannelMessages = myInfo.unreadMessages
-										context.refresh(myInfo, mergeChanges: true)
-									} catch {
-										Logger.data.error("Failed to read message \(message.messageId): \(error.localizedDescription)")
-									}
+								Task {
+									await markMessageAsRead(message)
 								}
 							}
 						}
@@ -178,4 +170,21 @@ struct ChannelMessageList: View {
 			}
 		}
 	}
+	
+	@MainActor
+		func markMessageAsRead(_ message: MessageEntity) async {
+			guard !message.read else { return }
+			
+			message.read = true
+			
+			do {
+				try await Task.sleep(nanoseconds: 300_000_000) // 300ms debounce
+				try context.save()
+				Logger.data.info("📖 [App] Read message \(message.messageId)")
+				appState.unreadChannelMessages = myInfo.unreadMessages
+				context.refresh(myInfo, mergeChanges: true)
+			} catch {
+				Logger.data.error("Failed to read message \(message.messageId): \(error.localizedDescription)")
+			}
+		}
 }


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Added an async function with debounce to handle the read message.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
With a large amount of messages in a channel, scrolling would be very laggy.

## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested on one iPhone with my fix and another iPhone without it. I sent around 33 messages to test what would happen.
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
Before Fix:

https://github.com/user-attachments/assets/73fd8316-3d4b-42c2-8ed9-d269b81d3bf6

After Fix:

https://github.com/user-attachments/assets/47fb9512-3c4f-44f0-a380-3c001bbdc3d4


## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have tested the change to ensure that it works as intended.

