### PR TITLE
Filter variation selectors from Short Name field

### DIFF
--- a/Meshtastic/Extensions/String.swift
+++ b/Meshtastic/Extensions/String.swift
@@ -90,4 +90,15 @@ extension String {
 		let end = index(start, offsetBy: range.upperBound - range.lowerBound)
 		return String(self[start ..< end])
 	}
+
+	// Filter out variation selectors from the string
+	var withoutVariationSelectors: String {
+		return self.unicodeScalars
+			.filter { scalar in
+				return !scalar.properties.isVariationSelector
+			}
+			.compactMap { UnicodeScalar($0) }
+			.map { String($0) }
+			.joined()
+	}
 }

--- a/Meshtastic/Views/Settings/UserConfig.swift
+++ b/Meshtastic/Views/Settings/UserConfig.swift
@@ -75,11 +75,16 @@ struct UserConfig: View {
 							TextField("Short Name", text: $shortName)
 								.foregroundColor(.gray)
 								.onChange(of: shortName) {
-									var totalBytes = shortName.utf8.count
+									let newValue = shortName.withoutVariationSelectors
+									let totalBytes = newValue.utf8.count
 									// Only mess with the value if it is too big
 									if totalBytes > 4 {
+										// If too long, drop the last thing entered
 										shortName = String(shortName.dropLast())
-										totalBytes = shortName.utf8.count
+									} else if shortName != newValue {
+										// If not too long, make sure the stripped
+										// variant is placed back in text field if necessary
+										shortName = newValue
 									}
 								}
 								.foregroundColor(.gray)


### PR DESCRIPTION
## What changed?

The iOS keyboard appends Unicode 'variation selectors' (extra bytes) to some characters.  This will cause the validation on the shortName field to block using these emojis because they appear as too many bytes. 

This pull request will filter out the variation selectors from the shortName field allowing more emoji to be used in short names.

## Why did it change?

Some, but not all emoji have 2 presentations.  A colored graphical representation (❤️ ) and a black and white representation (♥).  The unicode standard defines additional bytes, called "variation selectors" that allow you to select the variant you want.

In the case of short name, we probably don't care.  When the variation selector is not provided, [the default is the emoji style](https://en.wikipedia.org/wiki/Emoticons_(Unicode_block)#Variant_forms).

This pull request will filter the variation selectors from the short name field, unlocking additional Emoji.  Note that there are still quite a few emoji that are more than 4 bytes (such as the country flags) that are still not allowed. 

## How is this tested?

Generally testing it locally.  I am NOT an expert in Unicode, so I've tried to explain myself above.  I am hopeful that this does not cause bad data to find its way into the Short Name field and cause downstream problems, but my node happily has the Short Name of ☢️ .

## Screenshots/Videos (when applicable)

![image](https://github.com/user-attachments/assets/63e1c9ef-7fae-427f-9bbf-c3d3c46e817f)

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

