### PR TITLE
Improvements to emoji handling for node names

### DIFF
--- a/Meshtastic/Extensions/String.swift
+++ b/Meshtastic/Extensions/String.swift
@@ -101,4 +101,30 @@ extension String {
 			.map { String($0) }
 			.joined()
 	}
+
+	// Adds variation selectors to prefer the graphical form of emoji.
+	// Looks ahead to make sure that the variation selector is not already applied.
+	var addingVariationSelectors: String {
+		var result = ""
+		var scalars = self.unicodeScalars
+		var index = scalars.startIndex
+		while index < scalars.endIndex {
+			let currentScalar = scalars[index]
+			result += String(currentScalar)
+			if currentScalar.properties.isEmoji && !currentScalar.properties.isEmojiPresentation {
+				// Check if the next scalar is U+FE0F
+				let nextIndex = scalars.index(after: index)
+				if nextIndex < scalars.endIndex && scalars[nextIndex].value == 0xFE0F {
+					// Already has variation selector; skip the next scalar
+					index = nextIndex
+				} else {
+					// Append variation selector
+					result += String(UnicodeScalar(0xFE0F)!)
+				}
+			}
+			// Move to the next scalar
+			index = scalars.index(after: index)
+		}
+		return result
+	}
 }

--- a/Meshtastic/Views/Helpers/CircleText.swift
+++ b/Meshtastic/Views/Helpers/CircleText.swift
@@ -16,7 +16,7 @@ struct CircleText: View {
             Circle()
                 .fill(color)
                 .frame(width: circleSize, height: circleSize)
-			Text(text)
+			Text(text.addingVariationSelectors)
 				.frame(width: circleSize * 0.9, height: circleSize * 0.9, alignment: .center)
 				.foregroundColor(color.isLight() ? .black : .white)
 				.minimumScaleFactor(0.001)

--- a/Meshtastic/Views/Helpers/ConnectedDevice.swift
+++ b/Meshtastic/Views/Helpers/ConnectedDevice.swift
@@ -28,7 +28,7 @@ struct ConnectedDevice: View {
                             .imageScale(.large)
                             .foregroundColor(.green)
                             .symbolRenderingMode(.hierarchical)
-                        Text(name).font(name.isEmoji() ? .title : .callout).foregroundColor(.gray)
+						Text(name.addingVariationSelectors).font(name.isEmoji() ? .title : .callout).foregroundColor(.gray)
                     } else {
                         Image(systemName: "antenna.radiowaves.left.and.right.slash")
                             .imageScale(.medium)

--- a/Meshtastic/Views/Settings/UserConfig.swift
+++ b/Meshtastic/Views/Settings/UserConfig.swift
@@ -50,12 +50,14 @@ struct UserConfig: View {
 
 							TextField("Long Name", text: $longName)
 								.onChange(of: longName) {
-									var totalBytes = longName.utf8.count
+									var newValue = longName.withoutVariationSelectors
+									var totalBytes = newValue.utf8.count
 									// Only mess with the value if it is too big
 									while totalBytes > (isLicensed ? 6 : 36) {
-										longName = String(longName.dropLast())
-										totalBytes = longName.utf8.count
+										newValue = String(newValue.dropLast())
+										totalBytes = newValue.utf8.count
 									}
+									longName = newValue
 								}
 						}
 						.keyboardType(.default)


### PR DESCRIPTION
## What changed?
See #1116 for a discussion on variation selectors and how they work.

This pull request:
- Removes variation selectors from the longName field (previously only shortName) to save a few bytes.
- adds a `addingVariationSelectors` function to the String extension to add back a preference for the graphical/color variant of any emoji in the string.
- uses this new extension in the `CircleText` and `ConnectedDevice` views so that they prefer the graphical/color representations of any Emoji.

## Why did it change?
The graphical/color emojis are mostly preferred on iOS by default.  But on Mac Catalyst, its seems the B&W glyphs are preferred. This will hopefully make the behavior consistent across devices.

## How is this tested?
Tested on Mac OS and iOS with various emoji combinations, but probably more extensive testing is necessary.
Also there may be other places in the app that need `addingVariationSelectors` applied to a node long or short name.

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

