### PR TITLE
Add UDP Broadcast setting to Network config

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -9301,6 +9301,9 @@
         }
       }
     },
+    "Enable broadcasting packets via UDP over the local network." : {
+
+    },
     "Enable Notifications" : {
       "localizations" : {
         "sr" : {
@@ -31501,6 +31504,9 @@
           }
         }
       }
+    },
+    "UDP Broadcast" : {
+
     },
     "Ukraine 433mhz" : {
       "extractionState" : "manual",

--- a/Meshtastic/Meshtastic.xcdatamodeld/MeshtasticDataModelV 50.xcdatamodel/contents
+++ b/Meshtastic/Meshtastic.xcdatamodeld/MeshtasticDataModelV 50.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24D70" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24D81" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AmbientLightingConfigEntity" representedClassName="AmbientLightingConfigEntity" syncable="YES" codeGenerationType="class">
         <attribute name="blue" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="current" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
@@ -208,6 +208,7 @@
     </entity>
     <entity name="NetworkConfigEntity" representedClassName="NetworkConfigEntity" syncable="YES" codeGenerationType="class">
         <attribute name="dns" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="enabledProtocols" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="ethEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="gateway" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="ip" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -658,12 +658,14 @@ func upsertNetworkConfigPacket(config: Config.NetworkConfig, nodeNum: Int64, ses
 				newNetworkConfig.wifiSsid = config.wifiSsid
 				newNetworkConfig.wifiPsk = config.wifiPsk
 				newNetworkConfig.ethEnabled = config.ethEnabled
+				newNetworkConfig.enabledProtocols = Int32(config.enabledProtocols)
 				fetchedNode[0].networkConfig = newNetworkConfig
 			} else {
 				fetchedNode[0].networkConfig?.ethEnabled = config.ethEnabled
 				fetchedNode[0].networkConfig?.wifiEnabled = config.wifiEnabled
 				fetchedNode[0].networkConfig?.wifiSsid = config.wifiSsid
 				fetchedNode[0].networkConfig?.wifiPsk = config.wifiPsk
+				fetchedNode[0].networkConfig?.enabledProtocols = Int32(config.enabledProtocols)
 			}
 			if sessionPasskey != nil {
 				fetchedNode[0].sessionPasskey = sessionPasskey


### PR DESCRIPTION
## What changed?
- Added UDP broadcast to network configuration 
- Setting will appear when node supports Wifi or Ethernet
- Database field added in v50 of the CoreData database (Part of 2.5.21) 
- 
## Why did it change?
UDP broadcast was recently added to firmware

## How is this tested?
- using a node running 2.6 - setting is persisted via the firmware

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have tested the change to ensure that it works as intended.

