### PR TITLE
Added better UX for disconnect MQTT

### DIFF
--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -64,17 +64,41 @@ struct MQTTConfig: View {
 					}
 					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 
-					if enabled && proxyToClientEnabled && node?.mqttConfig?.proxyToClientEnabled ?? false == true {
-						Toggle(isOn: $mqttConnected) {
-							Label(mqttConnected ? "mqtt.disconnect".localized : "mqtt.connect".localized, systemImage: "server.rack")
+					if enabled && proxyToClientEnabled && node?.mqttConfig?.proxyToClientEnabled ?? false {
+						VStack(alignment: .leading, spacing: 8) {
+							Button(action: {
+								mqttConnected.toggle()
+							}) {
+								HStack {
+									Image(systemName: "server.rack")
+										.foregroundColor(mqttConnected ? .red : .green)
+									Text(mqttConnected ? "mqtt.disconnect".localized : "mqtt.connect".localized)
+										.fontWeight(.medium)
+									Spacer()
+									// Connection status indicator
+									Circle()
+										.frame(width: 10, height: 10)
+										.foregroundColor(mqttConnected ? .green : .gray)
+								}
+								.padding(.vertical, 8)
+								.padding(.horizontal, 12)
+								.background(
+									RoundedRectangle(cornerRadius: 8)
+										.fill(mqttConnected ? Color.red.opacity(0.1) : Color.green.opacity(0.1))
+								)
+							}
+							.buttonStyle(PlainButtonStyle()) // Removes default button styling
+							// Error message display
 							if bleManager.mqttError.count > 0 {
 								Text(bleManager.mqttError)
-									.fixedSize(horizontal: false, vertical: true)
+									.font(.caption)
 									.foregroundColor(.red)
+									.lineLimit(2)
+									.fixedSize(horizontal: false, vertical: true)
+									.transition(.opacity) // Smooth appearance
 							}
-
 						}
-						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+						.animation(.easeInOut(duration: 0.2), value: mqttConnected) // Smooth state transitions
 					}
 
 					Toggle(isOn: $encryptionEnabled) {


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Added a better UX for disconnect MQTT by using a button and indicating to the user if they are already connected/not connected
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
This toggle was confusing to users.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested on my  iPhone
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

https://github.com/user-attachments/assets/b1dd25a6-0697-4cf3-bb3b-bac6c792d647


## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

