### PR TITLE
Add animation to demo swipe to disconnect

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -8692,6 +8692,12 @@
         }
       }
     },
+    "Disconnect Node" : {
+
+    },
+    "Disconnect the currently connected node" : {
+
+    },
     "Dismiss" : {
       "localizations" : {
         "de" : {
@@ -23168,6 +23174,7 @@
       }
     },
     "Power Metrics Log}" : {
+      "extractionState" : "stale",
       "localizations" : {
         "sr" : {
           "stringUnit" : {

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		BCB613832C672A2600485544 /* MessageChannelIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB613822C672A2600485544 /* MessageChannelIntent.swift */; };
 		BCB613852C68703800485544 /* NodePositionIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB613842C68703800485544 /* NodePositionIntent.swift */; };
 		BCB613872C69A0FB00485544 /* AppIntentErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB613862C69A0FB00485544 /* AppIntentErrors.swift */; };
+		BCD93CBA2D9E11A2006C9214 /* DisconnectNodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD93CB92D9E11A2006C9214 /* DisconnectNodeIntent.swift */; };
 		BCE2D3C32C7ADF42008E6199 /* ShutDownNodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE2D3C22C7ADF42008E6199 /* ShutDownNodeIntent.swift */; };
 		BCE2D3C52C7AE369008E6199 /* RestartNodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE2D3C42C7AE369008E6199 /* RestartNodeIntent.swift */; };
 		BCE2D3C72C7B0D0A008E6199 /* ShortcutsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE2D3C62C7B0D0A008E6199 /* ShortcutsProvider.swift */; };
@@ -326,6 +327,7 @@
 		BCB613822C672A2600485544 /* MessageChannelIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageChannelIntent.swift; sourceTree = "<group>"; };
 		BCB613842C68703800485544 /* NodePositionIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodePositionIntent.swift; sourceTree = "<group>"; };
 		BCB613862C69A0FB00485544 /* AppIntentErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentErrors.swift; sourceTree = "<group>"; };
+		BCD93CB92D9E11A2006C9214 /* DisconnectNodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectNodeIntent.swift; sourceTree = "<group>"; };
 		BCE2D3C22C7ADF42008E6199 /* ShutDownNodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShutDownNodeIntent.swift; sourceTree = "<group>"; };
 		BCE2D3C42C7AE369008E6199 /* RestartNodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestartNodeIntent.swift; sourceTree = "<group>"; };
 		BCE2D3C62C7B0D0A008E6199 /* ShortcutsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsProvider.swift; sourceTree = "<group>"; };
@@ -686,6 +688,7 @@
 				BCE2D3C62C7B0D0A008E6199 /* ShortcutsProvider.swift */,
 				BC6B45FE2CB2F98900723CEB /* SaveChannelSettingsIntent.swift */,
 				BC47C2EE2CE0017D008245CA /* MessageNodeIntent.swift */,
+				BCD93CB92D9E11A2006C9214 /* DisconnectNodeIntent.swift */,
 			);
 			path = AppIntents;
 			sourceTree = "<group>";
@@ -1421,6 +1424,7 @@
 				DDC94FCE29CF55310082EA6E /* RtttlConfig.swift in Sources */,
 				DD964FBD296E6B01007C176F /* EmojiOnlyTextField.swift in Sources */,
 				DD8169FF272476C700F4AB02 /* LogDocument.swift in Sources */,
+				BCD93CBA2D9E11A2006C9214 /* DisconnectNodeIntent.swift in Sources */,
 				DDC94FC129CE063B0082EA6E /* BatteryLevel.swift in Sources */,
 				231B3F252D087C3C0069A07D /* EnvironmentDefaultColumns.swift in Sources */,
 				25F5D5BE2C3F6D87008036E3 /* NavigationState.swift in Sources */,

--- a/Meshtastic/AppIntents/DisconnectNodeIntent.swift
+++ b/Meshtastic/AppIntents/DisconnectNodeIntent.swift
@@ -1,0 +1,31 @@
+//
+//  DisconnectNodeIntent.swift
+//  Meshtastic
+//
+//  Created by Benjamin Faershtein on 4/2/25.
+//
+
+import Foundation
+import AppIntents
+
+struct DisconnectNodeIntent: AppIntent {
+	static var title: LocalizedStringResource = "Disconnect Node"
+
+	static var description: IntentDescription = "Disconnect the currently connected node"
+
+
+	func perform() async throws -> some IntentResult {
+		if !BLEManager.shared.isConnected {
+			throw AppIntentErrors.AppIntentError.notConnected
+		}
+
+		if let connectedPeripheral = BLEManager.shared.connectedPeripheral,
+				   connectedPeripheral.peripheral.state == .connected {
+					BLEManager.shared.disconnectPeripheral(reconnect: false)
+		} else {
+			throw AppIntentErrors.AppIntentError.message("Error disconnecting node")
+		}
+
+	return .result()
+	}
+}

--- a/Meshtastic/AppIntents/ShortcutsProvider.swift
+++ b/Meshtastic/AppIntents/ShortcutsProvider.swift
@@ -32,5 +32,13 @@ struct ShortcutsProvider: AppShortcutsProvider {
 							  "Send a \(.applicationName) group message"],
 					shortTitle: "Group Message",
 					systemImageName: "message")
+		
+		AppShortcut(intent: DisconnectNodeIntent(),
+					phrases: ["Disconnect \(.applicationName) node",
+							  "Disconnect my \(.applicationName) node",
+							   "Disconnect from \(.applicationName)",
+							   "Disconnect \(.applicationName)"],
+					shortTitle: "Disconnect",
+					systemImageName: "antenna.radiowaves.left.and.right.slash")
 	}
 }

--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -149,7 +149,15 @@ struct Connect: View {
 										Text("Short Name: \(node?.user?.shortName ?? "?")")
 										Text("Long Name: \(node?.user?.longName?.addingVariationSelectors ?? "unknown".localized)")
 										Text("BLE RSSI: \(connectedPeripheral.rssi)")
-
+										
+										Button(role: .destructive) {
+											if let connectedPeripheral = bleManager.connectedPeripheral,
+											   connectedPeripheral.peripheral.state == .connected {
+												bleManager.disconnectPeripheral(reconnect: false)
+											}
+										} label: {
+											Label("Disconnect", systemImage: "antenna.radiowaves.left.and.right.slash")
+										}
 										Button {
 											if !bleManager.sendShutdown(fromUser: node!.user!, toUser: node!.user!, adminIndex: node!.myInfo!.adminIndex) {
 												Logger.mesh.error("Shutdown Failed")


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Add animation to demo swipe to disconnect on first connection.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Users do not understand that it is possible to swipe left on a node, this brings it to their attention more prominently.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested on my iPhone.
## Screenshots/Videos (when applicable)

https://github.com/user-attachments/assets/0b11dee2-6273-4e22-8a51-02ee8a2435fc


<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

