### PR TITLE
SecureInput fix: multiple buttons in form triggered by one tap

### DIFF
--- a/Meshtastic/Views/Helpers/SecureInput.swift
+++ b/Meshtastic/Views/Helpers/SecureInput.swift
@@ -55,7 +55,7 @@ struct SecureInput: View {
 				}) {
 					Image(systemName: self.isSecure ? "eye.slash" : "eye")
 						.accentColor(.secondary)
-				}
+				}.buttonStyle(BorderlessButtonStyle())
 			}
 		}
 	}


### PR DESCRIPTION
## What changed?
One button does not trigger all the fields anymore.
see https://stackoverflow.com/questions/72163289/swiftui-picker-and-buttons-inside-same-form-section-are-triggered-by-the-same-us

## Why did it change?
It was a bug

## How is this tested?
Briefly

## Screenshots/Videos (when applicable)


## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

