### PR TITLE
Clickable node circles that redirect to node info

### DIFF
--- a/Meshtastic/Views/Helpers/CircleText.swift
+++ b/Meshtastic/Views/Helpers/CircleText.swift
@@ -13,14 +13,15 @@ struct CircleText: View {
 	var node: NodeInfoEntity? = nil
 	
 	var body: some View {
-		NavigationStack{
 			if let node = node {
-				NavigationLink(destination: NodeDetail(node: node)) {
-					circleContent
-				}
+					NavigationStack{
+						NavigationLink(destination: NodeDetail(node: node)) {
+							circleContent
+						}
+					}
 			} else {
 				circleContent
-			}
+			
 		}
 			
 	}

--- a/Meshtastic/Views/Helpers/CircleText.swift
+++ b/Meshtastic/Views/Helpers/CircleText.swift
@@ -4,29 +4,43 @@ A view draws a circle in the background of the shortName text
 */
 
 import SwiftUI
+import CoreData
 
 struct CircleText: View {
-    var text: String
-    var color: Color
+	var text: String
+	var color: Color
 	var circleSize: CGFloat = 45
+	var node: NodeInfoEntity? = nil
+	
+	var body: some View {
+		NavigationStack{
+			if let node = node {
+				NavigationLink(destination: NodeDetail(node: node)) {
+					circleContent
+				}
+			} else {
+				circleContent
+			}
+		}
+			
+	}
 
-    var body: some View {
-
-        ZStack {
-            Circle()
-                .fill(color)
-                .frame(width: circleSize, height: circleSize)
-			Text(text.addingVariationSelectors)
+	var circleContent: some View {
+		ZStack {
+			Circle()
+				.fill(color)
+				.frame(width: circleSize, height: circleSize)
+			Text(text)
 				.frame(width: circleSize * 0.9, height: circleSize * 0.9, alignment: .center)
 				.foregroundColor(color.isLight() ? .black : .white)
 				.minimumScaleFactor(0.001)
 				.font(.system(size: 1300))
-        }
-    }
+		}
+	}
 }
 
 struct CircleText_Previews: PreviewProvider {
-    static var previews: some View {
+	static var previews: some View {
 		VStack {
 			HStack {
 				CircleText(text: "N1", color: Color.yellow, circleSize: 80)
@@ -75,5 +89,5 @@ struct CircleText_Previews: PreviewProvider {
 					.previewLayout(.fixed(width: 300, height: 100))
 			}
 		}
-    }
+	}
 }

--- a/Meshtastic/Views/Helpers/CircleText.swift
+++ b/Meshtastic/Views/Helpers/CircleText.swift
@@ -19,11 +19,10 @@ struct CircleText: View {
 							circleContent
 						}
 					}
+
 			} else {
 				circleContent
-			
 		}
-			
 	}
 
 	var circleContent: some View {

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -160,8 +160,8 @@ struct ChannelMessageList: View {
 		.toolbar {
 			ToolbarItem(placement: .principal) {
 				HStack {
-					CircleText(text: String(channel.index), color: .accentColor, circleSize: 44).fixedSize()
-					Text(String(channel.name ?? "unknown".localized).camelCaseToWords()).font(.headline)
+						CircleText(text: String(channel.index), color: .accentColor, circleSize: 44).fixedSize()
+						Text(String(channel.name ?? "unknown".localized).camelCaseToWords()).font(.headline)
 				}
 			}
 			ToolbarItem(placement: .navigationBarTrailing) {

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -48,7 +48,7 @@ struct ChannelMessageList: View {
 							HStack(alignment: .bottom) {
 								if currentUser { Spacer(minLength: 50) }
 								if !currentUser {
-									CircleText(text: message.fromUser?.shortName ?? "?", color: Color(UIColor(hex: UInt32(message.fromUser?.num ?? 0))), circleSize: 44)
+									CircleText(text: message.fromUser?.shortName ?? "?", color: Color(UIColor(hex: UInt32(message.fromUser?.num ?? 0))), circleSize: 44, node: getNodeInfo(id: Int64(message.fromUser?.num ?? 0), context: context))
 										.padding(.all, 5)
 										.offset(y: -7)
 								}

--- a/Meshtastic/Views/Nodes/Helpers/Map/PositionPopover.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/PositionPopover.swift
@@ -23,10 +23,10 @@ struct PositionPopover: View {
 	var body: some View {
 		// Node Color from node.num
 		let nodeColor = UIColor(hex: UInt32(position.nodePosition?.num ?? 0))
+		NavigationStack{
 		VStack {
 			HStack {
 				ZStack {
-
 					if position.nodePosition?.isOnline ?? false {
 						Circle()
 							.fill(Color(nodeColor.lighter()).opacity(0.4).shadow(.drop(color: Color(nodeColor).isLight() ? .black : .white, radius: 5)))
@@ -34,16 +34,15 @@ struct PositionPopover: View {
 							.scaleEffect(scale)
 							.animation(
 								Animation.easeInOut(duration: 0.6)
-								   .repeatForever().delay(delay), value: scale
+									.repeatForever().delay(delay), value: scale
 							)
 							.onAppear {
 								self.scale = 1
 							}
 							.frame(width: 90, height: 90)
 					}
-					CircleText(text: position.nodePosition?.user?.shortName ?? "?", color: Color(nodeColor), circleSize: 65)
+					CircleText(text: position.nodePosition?.user?.shortName ?? "?", color: Color(nodeColor), circleSize: 65, node: getNodeInfo(id: Int64(position.nodePosition?.user?.num ?? 0), context: context))
 				}
-
 				Text(position.nodePosition?.user?.longName ?? "Unknown")
 					.font(.largeTitle)
 			}
@@ -106,7 +105,7 @@ struct PositionPopover: View {
 								.foregroundColor(.primary)
 								.font(idiom == .phone ? .callout : .body)
 						}
-
+						
 					} icon: {
 						Image(systemName: "mountain.2.fill")
 							.symbolRenderingMode(.hierarchical)
@@ -147,9 +146,9 @@ struct PositionPopover: View {
 						Text("Heading: \(heading.formatted(.measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0)))))")
 					} icon: {
 						Image(systemName: "location.north")
-							 .symbolRenderingMode(.hierarchical)
-							 .frame(width: 35)
-							 .rotationEffect(degrees)
+							.symbolRenderingMode(.hierarchical)
+							.frame(width: 35)
+							.rotationEffect(degrees)
 					}
 					.padding(.bottom, 5)
 					/// Distance
@@ -181,15 +180,15 @@ struct PositionPopover: View {
 					}
 					.padding(.bottom, 5)
 					if position.nodePosition?.viaMqtt ?? false {
-
+						
 						Label {
 							Text("MQTT")
 								.font(idiom == .phone ? .callout : .body)
 						} icon: {
 							Image(systemName: "network")
-								 .symbolRenderingMode(.hierarchical)
-								 .frame(width: 35)
-								 .rotationEffect(degrees)
+								.symbolRenderingMode(.hierarchical)
+								.frame(width: 35)
+								.rotationEffect(degrees)
 						}
 						.padding(.bottom, 5)
 					}
@@ -244,6 +243,7 @@ struct PositionPopover: View {
 #endif
 			}
 		}
+	}
 		.presentationDetents([.fraction(0.65), .large])
 		.presentationContentInteraction(.scrolls)
 		.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -520,6 +520,7 @@ struct NodeDetail: View {
 				}
 			}
 			.listStyle(.insetGrouped)
+			.navigationBarTitle(String(node.user?.longName?.addingVariationSelectors ?? "unknown".localized), displayMode: .inline)
 		}
 	}
 }

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -264,7 +264,6 @@ struct NodeList: View {
 						columnVisibility: columnVisibility
 					)
 					.edgesIgnoringSafeArea([.leading, .trailing])
-					.navigationBarTitle(String(node.user?.longName?.addingVariationSelectors ?? "unknown".localized), displayMode: .inline)
 					.navigationBarItems(
 						trailing: ZStack {
 							if UIDevice.current.userInterfaceIdiom != .phone {


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Added clickable node circles to the channel message list and the position popover.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
The ability to quickly get in-depth data about a node without having to search for the node in node info tab is very useful.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
I tested it on my iPhone.
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->


https://github.com/user-attachments/assets/d692dcd5-d4f9-4377-a18a-48c96df9eeef


https://github.com/user-attachments/assets/6fac45dc-ed52-4ce0-8ae5-49af9faba276





## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

