### PR TITLE
Fixed transparent tab view

### DIFF
--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -11,6 +11,12 @@ struct ContentView: View {
 	@ObservedObject
 	var router: Router
 
+	init(appState: AppState, router: Router) {
+		self.appState = appState
+		self.router = router
+		UITabBar.appearance().scrollEdgeAppearance = UITabBarAppearance(idiom: .unspecified)
+	}
+
 	var body: some View {
 		TabView(selection: $appState.router.navigationState.selectedTab) {
 			Messages(


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
I fixed the swift ui glitch where the tab bar goes transparent.
Used this as the reference https://developer.apple.com/forums/thread/690563
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Very annoying for users and a visual bug.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested by using Jason's method to make it transparent
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

