### PR TITLE
Fixed waypoints popup form

### DIFF
--- a/Meshtastic/Extensions/UserDefaults.swift
+++ b/Meshtastic/Extensions/UserDefaults.swift
@@ -98,7 +98,7 @@ extension UserDefaults {
 	@UserDefault(.meshMapDistance, defaultValue: 800000)
 	static var meshMapDistance: Double
 
-	@UserDefault(.enableMapWaypoints, defaultValue: false)
+	@UserDefault(.enableMapWaypoints, defaultValue: true)
 	static var enableMapWaypoints: Bool
 
 	@UserDefault(.enableMapRecentering, defaultValue: false)

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -20,7 +20,7 @@ struct MeshMapContent: MapContent {
 	@Binding var selectedMapLayer: MapLayer
 	// Map Configuration
 	@Binding var selectedPosition: PositionEntity?
-	@AppStorage("enableMapWaypoints") private var showWaypoints = false
+	@AppStorage("enableMapWaypoints") private var showWaypoints = true
 	@Binding var selectedWaypoint: WaypointEntity?
 
 	@FetchRequest(fetchRequest: PositionEntity.allPositionsFetchRequest(), animation: .easeIn)

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -74,9 +74,9 @@ struct MeshMapContent: MapContent {
 						}
 					}
 				}
-				.onTapGesture { _ in
+				.highPriorityGesture(TapGesture().onEnded { _ in
 					selectedPosition = (selectedPosition == position ? nil : position)
-				}
+				})
 			}
 			/// Node History and Route Lines for favorites
 			if let nodePosition = position.nodePosition,
@@ -186,7 +186,7 @@ struct MeshMapContent: MapContent {
 					LazyVStack {
 						ZStack {
 							CircleText(text: String(UnicodeScalar(Int(waypoint.icon)) ?? "📍"), color: Color.orange, circleSize: 40)
-								.onTapGesture(perform: { _ in
+								.highPriorityGesture(TapGesture().onEnded { _ in
 									selectedWaypoint = (selectedWaypoint == waypoint ? nil : waypoint)
 								})
 						}

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/NodeMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/NodeMapContent.swift
@@ -16,7 +16,7 @@ struct NodeMapContent: MapContent {
 	/// Map State User Defaults
 	@AppStorage("meshMapShowNodeHistory") private var showNodeHistory = false
 	@AppStorage("meshMapShowRouteLines") private var showRouteLines = false
-	@AppStorage("enableMapWaypoints") private var showWaypoints = false
+	@AppStorage("enableMapWaypoints") private var showWaypoints = true
 	@AppStorage("enableMapConvexHull") private var showConvexHull = false
 	@AppStorage("enableMapTraffic") private var showTraffic: Bool = false
 	@AppStorage("enableMapPointsOfInterest") private var showPointsOfInterest: Bool = false

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -183,16 +183,6 @@ struct WaypointForm: View {
 					.padding(.bottom)
 
 					Button(role: .cancel) {
-						if waypoint.id == 0 {
-								// New, unsent waypoint created by the user: delete it
-								bleManager.context.delete(waypoint)
-								do {
-									try bleManager.context.save()
-								} catch {
-									bleManager.context.rollback()
-									Logger.mesh.error("Failed to save context on waypoint deletion: \(error)")
-								}
-							}
 						dismiss()
 					} label: {
 						Label("Cancel", systemImage: "x.circle")

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -134,40 +134,44 @@ struct WaypointForm: View {
 				.scrollDismissesKeyboard(.immediately)
 				HStack {
 					Button {
-						/// Send a new or exiting waypoint
-						var newWaypoint = Waypoint()
-						if waypoint.id  ==  0 {
-							newWaypoint.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
-							waypoint.id = Int64(newWaypoint.id)
-						} else {
-							newWaypoint.id = UInt32(waypoint.id)
-						}
-						newWaypoint.latitudeI = waypoint.latitudeI
-						newWaypoint.longitudeI = waypoint.longitudeI
-						newWaypoint.name = name.count > 0 ? name : "Dropped Pin"
-						newWaypoint.description_p = description
-						// Unicode scalar value for the icon emoji string
-						let unicodeScalers = icon.unicodeScalars
-						// First element as an UInt32
-						let unicode = unicodeScalers[unicodeScalers.startIndex].value
-						newWaypoint.icon = unicode
-						if locked {
-							if lockedTo == 0 {
-								newWaypoint.lockedTo = UInt32(bleManager.connectedPeripheral!.num)
+						if bleManager.isConnected {
+							/// Send a new or exiting waypoint
+							var newWaypoint = Waypoint()
+							if waypoint.id  ==  0 {
+								newWaypoint.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+								waypoint.id = Int64(newWaypoint.id)
 							} else {
-								newWaypoint.lockedTo = UInt32(lockedTo)
+								newWaypoint.id = UInt32(waypoint.id)
 							}
-						}
-						if expires {
-							newWaypoint.expire = UInt32(expire.timeIntervalSince1970)
+							newWaypoint.latitudeI = waypoint.latitudeI
+							newWaypoint.longitudeI = waypoint.longitudeI
+							newWaypoint.name = name.count > 0 ? name : "Dropped Pin"
+							newWaypoint.description_p = description
+							// Unicode scalar value for the icon emoji string
+							let unicodeScalers = icon.unicodeScalars
+							// First element as an UInt32
+							let unicode = unicodeScalers[unicodeScalers.startIndex].value
+							newWaypoint.icon = unicode
+							if locked {
+								if lockedTo == 0 {
+									newWaypoint.lockedTo = UInt32(bleManager.connectedPeripheral!.num)
+								} else {
+									newWaypoint.lockedTo = UInt32(lockedTo)
+								}
+							}
+							if expires {
+								newWaypoint.expire = UInt32(expire.timeIntervalSince1970)
+							} else {
+								newWaypoint.expire = 0
+							}
+							if bleManager.sendWaypoint(waypoint: newWaypoint) {
+								dismiss()
+							} else {
+								dismiss()
+								Logger.mesh.warning("Send waypoint failed")
+							}
 						} else {
-							newWaypoint.expire = 0
-						}
-						if bleManager.sendWaypoint(waypoint: newWaypoint) {
-							dismiss()
-						} else {
-							dismiss()
-							Logger.mesh.warning("Send waypoint failed")
+							Logger.mesh.warning("Send waypoint failed, node not connected")
 						}
 					} label: {
 						Label("Send", systemImage: "arrow.up")
@@ -179,6 +183,16 @@ struct WaypointForm: View {
 					.padding(.bottom)
 
 					Button(role: .cancel) {
+						if waypoint.id == 0 {
+								// New, unsent waypoint created by the user: delete it
+								bleManager.context.delete(waypoint)
+								do {
+									try bleManager.context.save()
+								} catch {
+									bleManager.context.rollback()
+									Logger.mesh.error("Failed to save context on waypoint deletion: \(error)")
+								}
+							}
 						dismiss()
 					} label: {
 						Label("Cancel", systemImage: "x.circle")
@@ -363,6 +377,18 @@ struct WaypointForm: View {
 #endif
 				}
 			}
+		}
+		.onDisappear {
+			if waypoint.id == 0 {
+					// New, unsent waypoint created by the user: delete it
+					bleManager.context.delete(waypoint)
+					do {
+						try bleManager.context.save()
+					} catch {
+						bleManager.context.rollback()
+						Logger.mesh.error("Failed to save context on waypoint deletion: \(error)")
+					}
+				}
 		}
 		.onAppear {
 			if waypoint.id > 0 {


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
I set all default occurrences of enableMapWaypoints to be true. I also made it so that any unsent waypoints made during the creation process are deleted if a user cancels or leaves the screen.
## Why did it change?
<!--A brief overview of why the change is being added. Explain the functionality and its intended purpose. -->
There was a discrepancy in the state of enableMapWaypoints (reported in #1081 ), which caused the toggle switch to be on for waypoints but the actual state to be off, so by default, waypoints would not show up on the mesh map. Also, when creating waypoints but never sending them and cancelling or dismissing the view, a permanent waypoint would show up that was never sent to the mesh and cannot be removed.

## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested on two iPhones one with and one without the fix.
## Screenshots/Videos (when applicable)
Before the Fix:

https://github.com/user-attachments/assets/18bd69ea-ffab-488f-92b8-09a8f83afeaa

https://github.com/user-attachments/assets/86f31466-1706-4270-9b23-dd989d0b6d47


After the Fix:

https://github.com/user-attachments/assets/e292bba9-b326-4563-9d01-2eba50d73b29



<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

