### PR TITLE
Fixed waypoint updating logic and waypoint notification

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1104,7 +1104,7 @@ func waypointPacket(packet: MeshPacket, context: NSManagedObjectContext) {
 				if existingWaypoint.locked == 0 || existingWaypoint.locked == packet.from {
 					let currentTime = Int64(Date().timeIntervalSince1970)
 					if waypointMessage.expire > 0 && waypointMessage.expire <= currentTime {
-						BLEManager.shared.context.delete(existingWaypoint)
+						context.delete(existingWaypoint)
 						do {
 							try context.save()
 							Logger.data.info("💾 Deleted a waypoint")
@@ -1113,26 +1113,27 @@ func waypointPacket(packet: MeshPacket, context: NSManagedObjectContext) {
 							let nsError = error as NSError
 							Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
 						}
-					}
-					existingWaypoint.name = waypointMessage.name
-					existingWaypoint.longDescription = waypointMessage.description_p
-					existingWaypoint.latitudeI = waypointMessage.latitudeI
-					existingWaypoint.longitudeI = waypointMessage.longitudeI
-					existingWaypoint.icon = Int64(waypointMessage.icon)
-					existingWaypoint.locked = Int64(waypointMessage.lockedTo)
-					if waypointMessage.expire >= 1 {
-						existingWaypoint.expire = Date(timeIntervalSince1970: TimeInterval(Int64(waypointMessage.expire)))
 					} else {
-						existingWaypoint.expire = nil
-					}
-					existingWaypoint.lastUpdated = Date()
-					do {
-						try context.save()
-						Logger.data.info("💾 Updated Node Waypoint App Packet For: \(existingWaypoint.id, privacy: .public)")
-					} catch {
-						context.rollback()
-						let nsError = error as NSError
-						Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
+						existingWaypoint.name = waypointMessage.name
+						existingWaypoint.longDescription = waypointMessage.description_p
+						existingWaypoint.latitudeI = waypointMessage.latitudeI
+						existingWaypoint.longitudeI = waypointMessage.longitudeI
+						existingWaypoint.icon = Int64(waypointMessage.icon)
+						existingWaypoint.locked = Int64(waypointMessage.lockedTo)
+						if waypointMessage.expire >= 1 {
+							existingWaypoint.expire = Date(timeIntervalSince1970: TimeInterval(Int64(waypointMessage.expire)))
+						} else {
+							existingWaypoint.expire = nil
+						}
+						existingWaypoint.lastUpdated = Date()
+						do {
+							try context.save()
+							Logger.data.info("💾 Updated Node Waypoint App Packet For: \(existingWaypoint.id, privacy: .public)")
+						} catch {
+							context.rollback()
+							let nsError = error as NSError
+							Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
+						}
 					}
 				}
 			}

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1035,22 +1035,33 @@ func textMessageAppPacket(
 	}
 }
 
-func waypointPacket (packet: MeshPacket, context: NSManagedObjectContext) {
-
+func waypointPacket(packet: MeshPacket, context: NSManagedObjectContext) {
 	let logString = String.localizedStringWithFormat("mesh.log.waypoint.received %@".localized, String(packet.from))
 	Logger.mesh.info("📍 \(logString, privacy: .public)")
 
-	let fetchWaypointRequest = WaypointEntity.fetchRequest()
-	fetchWaypointRequest.predicate = NSPredicate(format: "id == %lld", Int64(packet.id))
-
 	do {
-
 		if let waypointMessage = try? Waypoint(serializedBytes: packet.decoded.payload) {
-			let fetchedWaypoint = try context.fetch(fetchWaypointRequest)
-			if fetchedWaypoint.isEmpty {
-				let waypoint = WaypointEntity(context: context)
+			// Fetch waypoint by waypointMessage.id, not packet.id
+			let fetchWaypointRequest = WaypointEntity.fetchRequest()
+			fetchWaypointRequest.predicate = NSPredicate(format: "id == %lld", Int64(waypointMessage.id))
 
-				waypoint.id = Int64(packet.id)
+			let fetchedWaypoint = try context.fetch(fetchWaypointRequest)
+			// Fetch the node info to get the short name
+			var nodeShortName: String = "?"
+			let fetchNodeRequest = NodeInfoEntity.fetchRequest()
+			fetchNodeRequest.predicate = NSPredicate(format: "num == %lld", Int64(packet.from))
+			do {
+				let fetchedNode = try context.fetch(fetchNodeRequest)
+				if let node = fetchedNode.first, let user = node.user {
+				nodeShortName = user.shortName ?? node.user?.userId ?? String(packet.from.toHex())
+				}
+			} catch {
+				Logger.data.error("Failed to fetch NodeInfoEntity for node \(packet.from.toHex(), privacy: .public): \(error)")
+			}
+			if fetchedWaypoint.isEmpty {
+				// Create a new waypoint
+				let waypoint = WaypointEntity(context: context)
+				waypoint.id = Int64(waypointMessage.id) // Use waypointMessage.id
 				waypoint.name = waypointMessage.name
 				waypoint.longDescription = waypointMessage.description_p
 				waypoint.latitudeI = waypointMessage.latitudeI
@@ -1073,7 +1084,7 @@ func waypointPacket (packet: MeshPacket, context: NSManagedObjectContext) {
 					manager.notifications = [
 						Notification(
 							id: ("notification.id.\(waypoint.id)"),
-							title: "New Waypoint Received",
+							title: "New Waypoint From \(nodeShortName)",
 							subtitle: "\(icon) \(waypoint.name ?? "Dropped Pin")",
 							content: "\(waypoint.longDescription ?? "\(latitude), \(longitude)")",
 							target: "map",
@@ -1088,26 +1099,41 @@ func waypointPacket (packet: MeshPacket, context: NSManagedObjectContext) {
 					Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
 				}
 			} else {
-				fetchedWaypoint[0].id = Int64(packet.id)
-				fetchedWaypoint[0].name = waypointMessage.name
-				fetchedWaypoint[0].longDescription = waypointMessage.description_p
-				fetchedWaypoint[0].latitudeI = waypointMessage.latitudeI
-				fetchedWaypoint[0].longitudeI = waypointMessage.longitudeI
-				fetchedWaypoint[0].icon = Int64(waypointMessage.icon)
-				fetchedWaypoint[0].locked = Int64(waypointMessage.lockedTo)
-				if waypointMessage.expire >= 1 {
-					fetchedWaypoint[0].expire = Date(timeIntervalSince1970: TimeInterval(Int64(waypointMessage.expire)))
-				} else {
-					fetchedWaypoint[0].expire = nil
-				}
-				fetchedWaypoint[0].lastUpdated = Date()
-				do {
-					try context.save()
-					Logger.data.info("💾 Updated Node Waypoint App Packet For: \(fetchedWaypoint[0].id, privacy: .public)")
-				} catch {
-					context.rollback()
-					let nsError = error as NSError
-					Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
+				// Update existing waypoint
+				let existingWaypoint = fetchedWaypoint[0]
+				if existingWaypoint.locked == 0 || existingWaypoint.locked == packet.from {
+					let currentTime = Int64(Date().timeIntervalSince1970)
+					if waypointMessage.expire > 0 && waypointMessage.expire <= currentTime {
+						BLEManager.shared.context.delete(existingWaypoint)
+						do {
+							try context.save()
+							Logger.data.info("💾 Deleted a waypoint")
+						} catch {
+							context.rollback()
+							let nsError = error as NSError
+							Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
+						}
+					}
+					existingWaypoint.name = waypointMessage.name
+					existingWaypoint.longDescription = waypointMessage.description_p
+					existingWaypoint.latitudeI = waypointMessage.latitudeI
+					existingWaypoint.longitudeI = waypointMessage.longitudeI
+					existingWaypoint.icon = Int64(waypointMessage.icon)
+					existingWaypoint.locked = Int64(waypointMessage.lockedTo)
+					if waypointMessage.expire >= 1 {
+						existingWaypoint.expire = Date(timeIntervalSince1970: TimeInterval(Int64(waypointMessage.expire)))
+					} else {
+						existingWaypoint.expire = nil
+					}
+					existingWaypoint.lastUpdated = Date()
+					do {
+						try context.save()
+						Logger.data.info("💾 Updated Node Waypoint App Packet For: \(existingWaypoint.id, privacy: .public)")
+					} catch {
+						context.rollback()
+						let nsError = error as NSError
+						Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Stops making duplicates of waypoints instead of updating a waypoint. Also updates the notification of a new waypoint to show who sent it.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
An update/deletion of a waypoint created a duplicate of that same waypoint as the packet.id was used for the waypoint id instead of the actual waypoint id.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested on my iPhone, sending, receiving, and modifying waypoints.
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
![IMG_3750](https://github.com/user-attachments/assets/02cf6193-6670-4e76-992c-dcdb81039a0a)
Realtime updating and deletion of a waypoint:

https://github.com/user-attachments/assets/6738abee-ef08-426e-816c-726abff55404


## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

