### PR TITLE
Fix TraceRoute notification navigation to correct node (#1115)

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -940,7 +940,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 								subtitle: "TR received back from \(destinationHop.name ?? "unknown")",
 								content: "Hops from: \(tr.hopsTowards), Hops back: \(tr.hopsBack)\n\(tr.routeText ?? "Unknown".localized)\n\(tr.routeBackText ?? "Unknown".localized)",
 								target: "nodes",
-								path: "meshtastic:///nodes?nodenum=\(connectedNode.user?.num ?? 0)"
+								path: "meshtastic:///nodes?nodenum=\(tr.node?.num ?? 0)"
 							)
 						]
 						manager.schedule()

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -28,6 +28,8 @@ struct NodeList: View {
 	@State private var isFavorite = false
 	@State private var isIgnored = false
 	@State private var isEnvironment = false
+	// Force refresh ID to make SwiftUI rebuild the view hierarchy
+	@State private var forceRefreshID = UUID()
 	@State private var distanceFilter = false
 	@State private var maxDistance: Double = 800000
 	@State private var hopsAway: Double = -1.0
@@ -142,6 +144,7 @@ struct NodeList: View {
 	}
 
 	var body: some View {
+		// Use forceRefreshID to completely rebuild the view when notifications update the selected node
 		NavigationSplitView(columnVisibility: $columnVisibility) {
 			List(nodes, id: \.self, selection: $selectedNode) { node in
 				NodeListItem(
@@ -326,15 +329,40 @@ struct NodeList: View {
 		}
 		.onChange(of: router.navigationState) {
 			if let selected = router.navigationState.nodeListSelectedNodeNum {
-				self.selectedNode = getNodeInfo(id: selected, context: context)
+				// Force a complete view rebuild by generating a new UUID
+				Logger.services.info("Forcing view rebuild with new ID: \(self.forceRefreshID)")
+				// First clear selection
+				self.forceRefreshID = UUID()
+				self.selectedNode = nil
+				// Then after a short delay, set the new selection. Makes it obvious to use page is refreshing too.
+				DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+					// Generate another UUID to ensure view gets rebuilt
+					self.forceRefreshID = UUID()
+					self.selectedNode = getNodeInfo(id: selected, context: context)
+					Logger.services.info("Complete view refresh with node: \(selected, privacy: .public)")
+				}
 			} else {
 				self.selectedNode = nil
 			}
 		}
 		.onAppear {
+			// Set up notification observer for forced refreshes from notifications
+			NotificationCenter.default.addObserver(forName: NSNotification.Name("ForceNavigationRefresh"), object: nil, queue: .main) { notification in
+				if let nodeNum = notification.userInfo?["nodeNum"] as? Int64 {
+					// Force complete refresh of view
+					self.forceRefreshID = UUID()
+					self.selectedNode = getNodeInfo(id: nodeNum, context: self.context)
+					Logger.services.info("NodeList directly updated from notification for node: \(nodeNum, privacy: .public)")
+				}
+			}
+			
 			Task {
 				await searchNodeList()
 			}
+		}
+		.onDisappear {
+			// Remove observer when view disappears
+			NotificationCenter.default.removeObserver(self, name: NSNotification.Name("ForceNavigationRefresh"), object: nil)
 		}
 	}
 


### PR DESCRIPTION
When clicking on a completed TraceRoute notification, the app now navigates to the correct destination node instead of the connected node. This fixes issue #1115 where the app was navigating to the wrong node detail screen.

## What changed?
Fir for issue #1115 

## Why did it change?
Point at the traceroute destination rather than source node and force GUI updates such that this mechanism works more than once (observed during testing without).

## How is this tested?
On a tethered phone

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [X ] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [X] I have commented my code, particularly in complex areas.
- [X] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.

