### PR TITLE
Timestamps above messages in between distinct conversations

### DIFF
--- a/Meshtastic/Extensions/CoreData/MessageEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/MessageEntityExtension.swift
@@ -31,4 +31,11 @@ extension MessageEntity {
 
 		return (try? context.fetch(fetchRequest)) ?? [MessageEntity]()
 	}
+
+	func displayTimestamp(aboveMessage: MessageEntity?) -> Bool {
+		if let aboveMessage = aboveMessage {
+			return aboveMessage.timestamp.addingTimeInterval(900) < timestamp // 15 seconds
+		}
+		return false // First message will have no timestamp
+	}
 }

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -33,8 +33,15 @@ struct ChannelMessageList: View {
 				ZStack(alignment: .bottomTrailing) {
 					ScrollView {
 						LazyVStack {
-							ForEach(channel.allPrivateMessages) { (message: MessageEntity) in
+							ForEach(Array(channel.allPrivateMessages.enumerated()), id: \.element.id) { index, message in
+								// Get the previous message, if it exists
+								let previousMessage = index > 0 ? channel.allPrivateMessages[index - 1] : nil
 								let currentUser: Bool = (Int64(preferredPeripheralNum) == message.fromUser?.num ? true : false)
+								if message.displayTimestamp(aboveMessage: previousMessage) {
+									Text(message.timestamp.formatted(date: .abbreviated, time: .shortened))
+										.font(.caption)
+										.foregroundColor(.gray)
+								}
 								if message.replyID > 0 {
 									let messageReply = channel.allPrivateMessages.first(where: { $0.messageId == message.replyID })
 									HStack {
@@ -44,7 +51,6 @@ struct ChannelMessageList: View {
 													messageToHighlight = messageNum
 												}
 												scrollView.scrollTo(messageNum, anchor: .center)
-												
 												// Reset highlight after delay
 												Task {
 													try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -33,7 +33,14 @@ struct UserMessageList: View {
 				ZStack(alignment: .bottomTrailing) {
 					ScrollView {
 						LazyVStack {
-							ForEach( user.messageList ) { (message: MessageEntity) in
+							ForEach( Array(user.messageList.enumerated()) , id: \.element.id) { index, message in
+								// Get the previous message, if it exists
+								let previousMessage = index > 0 ? user.messageList[index - 1] : nil
+								if message.displayTimestamp(aboveMessage: previousMessage) {
+									Text(message.timestamp.formatted(date: .abbreviated, time: .shortened))
+										.font(.caption)
+										.foregroundColor(.gray)
+								} 
 								if user.num != bleManager.connectedPeripheral?.num ?? -1 {
 									let currentUser: Bool = (Int64(UserDefaults.preferredPeripheralNum) == message.fromUser?.num ?? -1 ? true : false)
 


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Timestamps are now provided above messages that are more than 15 min apart from the one before it. This is used to indicate the exact time a conversation took place at a glance. This emulates the iMessage behavior.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Users were confused when conversations took place.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
tested sending messages. (I set the interval to 10sec between messages but in reality it would be 15min)
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
![IMG_3760](https://github.com/user-attachments/assets/09e4ed3e-d17e-4497-a11a-285a35283846)
![IMG_3761](https://github.com/user-attachments/assets/625d5a3f-31eb-4698-abce-0e839f5630f1)

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

