### PR TITLE
App option to purge node entities not heard in certain amount of time

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1379,6 +1379,12 @@
         }
       }
     },
+    "0" : {
+
+    },
+    "1" : {
+
+    },
     "1 byte" : {
       "localizations" : {
         "it" : {
@@ -1652,6 +1658,9 @@
           }
         }
       }
+    },
+    "180" : {
+
     },
     "256 bit" : {
       "localizations" : {
@@ -2455,6 +2464,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "之後"
+          }
+        }
+      }
+    },
+    "After %lld Days" : {
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "After %lld Day"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "After %lld Days"
+                }
+              }
+            }
           }
         }
       }
@@ -6379,6 +6410,9 @@
           }
         }
       }
+    },
+    "Clear Stale Nodes" : {
+
     },
     "Client" : {
       "localizations" : {

--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -36,6 +36,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 	var timeoutTimer: Timer?
 	var timeoutTimerCount = 0
 	var positionTimer: Timer?
+	var maintenenceTimer: Timer?
 	let mqttManager = MqttClientProxyManager.shared
 	var wantRangeTestPackets = false
 	var wantStoreAndForwardPackets = false
@@ -52,6 +53,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 	let FROMNUM_UUID = CBUUID(string: "0xED9DA18C-A800-4F66-A670-AA7547E34453")
 	let LEGACY_LOGRADIO_UUID = CBUUID(string: "0x6C6FD238-78FA-436B-AACF-15C5BE1EF2E2")
 	let LOGRADIO_UUID = CBUUID(string: "0x5a3d6e49-06e6-4423-9944-e9de8cdf9547")
+	@AppStorage("purgeStaleNodeDays") var purgeStaleNodeDays: Double = 0
 
 	// MARK: init
 	private override init() {
@@ -68,13 +70,17 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 	}
 
 	private init(appState: AppState, context: NSManagedObjectContext) {
-	   self.appState = appState
-	   self.context = context
-	   self.lastConnectionError = ""
-	   self.connectedVersion = "0.0.0"
-	   super.init()
-	   centralManager = CBCentralManager(delegate: self, queue: nil)
-	   mqttManager.delegate = self
+		self.appState = appState
+		self.context = context
+		self.lastConnectionError = ""
+		self.connectedVersion = "0.0.0"
+		super.init()
+		centralManager = CBCentralManager(delegate: self, queue: nil)
+		mqttManager.delegate = self
+		// Run clearStaleNodes every 10 minutes
+		maintenenceTimer = Timer.scheduledTimer(withTimeInterval: 600, repeats: true, block: { _ in
+			clearStaleNodes(nodeExpireDays: Int(self.purgeStaleNodeDays), context: self.context)
+		})
 	}
 
 	// MARK: Scanning for BLE Devices

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -292,9 +292,13 @@ func nodeInfoPacket (nodeInfo: NodeInfo, channel: UInt32, context: NSManagedObje
 				newTelemetries.append(telemetry)
 				newNode.telemetries? = NSOrderedSet(array: newTelemetries)
 			}
-
-			newNode.firstHeard = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.lastHeard)))
-			newNode.lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.lastHeard)))
+			if nodeInfo.lastHeard > 0 {
+				newNode.firstHeard = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.lastHeard)))
+				newNode.lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.lastHeard)))
+			} else {
+				newNode.firstHeard = Date()
+				newNode.lastHeard = Date()
+			}
 			newNode.snr = nodeInfo.snr
 			if nodeInfo.hasUser {
 

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -11,6 +11,8 @@ struct AppSettings: View {
 	@State var totalDownloadedTileSize = ""
 	@State private var isPresentingCoreDataResetConfirm = false
 	@State private var isPresentingDeleteMapTilesConfirm = false
+	@State private var purgeStaleNodes: Bool = false
+	@AppStorage("purgeStaleNodeDays") private var  purgeStaleNodeDays: Double = 0
 	@AppStorage("environmentEnableWeatherKit") private var  environmentEnableWeatherKit: Bool = true
 	@AppStorage("enableAdministration") private var  enableAdministration: Bool = false
 	var body: some View {
@@ -40,6 +42,36 @@ struct AppSettings: View {
 					}
 				}
 				Section(header: Text("App Data")) {
+					Toggle(isOn: $purgeStaleNodes ) {
+						Label {
+							Text("Clear Stale Nodes")
+						} icon: {
+							Image(systemName: "list.bullet.circle")
+						}
+					}
+					.onFirstAppear {
+						purgeStaleNodes = purgeStaleNodeDays > 0
+						Logger.services.info("ℹ️ Purge Stale Nodes toggle initialized to \(purgeStaleNodes)")
+					}
+					.onChange(of: purgeStaleNodes) { _, newValue in
+						purgeStaleNodeDays = purgeStaleNodeDays > 0 ? purgeStaleNodeDays : 7
+						purgeStaleNodeDays = newValue ? purgeStaleNodeDays : 0
+						Logger.services.info("ℹ️ Purge Stale Nodes changed to \(purgeStaleNodeDays)")
+					}
+					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+					.listRowSeparator(purgeStaleNodes ? .hidden : .visible)
+					if purgeStaleNodes {
+						VStack(alignment: .leading) {
+							Text(String(localized: "After \(Int(purgeStaleNodeDays)) Days"))
+							Slider(value: $purgeStaleNodeDays, in: 1...180, step: 1) {
+							} minimumValueLabel: {
+								Text("1")
+							} maximumValueLabel: {
+								Text("180")
+							}
+						}
+					}
 					Button {
 						isPresentingCoreDataResetConfirm = true
 					} label: {


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Add an option to the App Setting to purge nodes entities after they haven't been heard for a certain
number of days.
This purges entries from the app's node list, but not from the connected node.
This will not clear out nodes that have been favorited or ignored
Create a periodic task to check for stale node entries and delete them.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
I'm in an area where there quite a few nodes coming and going. Node lists in the app can get into the 200-300 range pretty quickly. As a result, we end up with quite a few stale node entities in the app DB.
A number of folks in the area regularly clear their node DB to clear out the stale nodes. This would help manage that.


## How is this tested?
<!-- Describe your approach to testing the feature. -->
Have been running with various stale times and favorite, ignored settings. Ensured only the expected nodes were deleted.


## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

