### PR TITLE
Allow Unmessegable Nodes to be DMed, but instead present a disclamer

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -31205,6 +31205,9 @@
         }
       }
     },
+    "This node is unmessegable and your message will likley not be read" : {
+
+    },
     "This will disable fixed position and remove the currently set position." : {
       "localizations" : {
         "it" : {

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -47,7 +47,7 @@ struct UserList: View {
 						  NSSortDescriptor(key: "userNode.lastHeard", ascending: false),
 						  NSSortDescriptor(key: "longName", ascending: true)],
 		predicate: NSPredicate(
-		  format: "userNode.ignored == NO AND unmessagable = NO"
+		  format: "userNode.ignored == NO"
 		), animation: .spring
 	)
 	var users: FetchedResults<UserEntity>

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -27,6 +27,16 @@ struct UserMessageList: View {
 
 	var body: some View {
 		VStack {
+			if (user.unmessagable) {
+				HStack {
+					Image(systemName: "iphone.gen3.slash")
+						.foregroundColor(Color.red)
+						.font(.title)
+					Text("This node is unmessegable and your message will likley not be read")
+						.padding(.leading, 8)
+				}
+				.padding()
+			}
 			ScrollViewReader { scrollView in
 				ZStack(alignment: .bottomTrailing) {
 					ScrollView {

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -94,7 +94,6 @@ struct NodeList: View {
 			FavoriteNodeButton(bleManager: bleManager, context: context, node: node)
 			/// Don't show message, trace route, position exchange or delete context menu items for the connected node
 			if connectedNode.num != node.num {
-				if !(node.user?.unmessagable ?? true) {
 					Button(action: {
 						if let url = URL(string: "meshtastic:///messages?userNum=\(node.num)") {
 						   UIApplication.shared.open(url)
@@ -102,7 +101,6 @@ struct NodeList: View {
 					}) {
 						Label("Message", systemImage: "message")
 					}
-				}
 				TraceRouteButton(
 					bleManager: bleManager,
 					node: node


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Allows unmessegable nodes to be dmed but instead provides a big disclamer locked at the top that the nodes messages will not be read.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Unmessegable is confusing for newer users since its set by defualt on a lot of nodes. Also lots of power users like sending dms to their actually unmessegable routers to test propogation. Even though you can send trace routes dms are less expensive than TRs so we should encourage this type of behavior. Simply hiding unmmesegable nodes is confusing for people and actually discourages its use for power users.

## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tesed on my iPhone
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

https://github.com/user-attachments/assets/ad78b767-ac6d-414f-8193-f4a2221b0510

![IMG_3946](https://github.com/user-attachments/assets/7be8c02d-ae3a-48ea-ace6-e9628d4bada3)


## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

