### PR TITLE
Fixed the persistence of channel mute settings

### DIFF
--- a/Meshtastic/Extensions/CoreData/ChannelEntityExtension.swift
+++ b/Meshtastic/Extensions/CoreData/ChannelEntityExtension.swift
@@ -32,6 +32,7 @@ extension ChannelEntity {
 		channel.settings.psk = self.psk ?? Data()
 		channel.role = Channel.Role(rawValue: Int(self.role)) ?? Channel.Role.secondary
 		channel.settings.moduleSettings.positionPrecision = UInt32(self.positionPrecision)
+		channel.settings.moduleSettings.isClientMuted = self.mute
 		return channel
 	}
 }

--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -26,6 +26,12 @@ struct ChannelList: View {
 
 	var restrictedChannels = ["gpio", "mqtt", "serial", "admin"]
 
+	@FetchRequest(
+			sortDescriptors: [NSSortDescriptor(keyPath: \ChannelEntity.index, ascending: true)],
+			predicate: nil,
+			animation: .default
+		) private var channels: FetchedResults<ChannelEntity>
+
 	@ViewBuilder
 	private func makeChannelRow(
 		myInfo: MyInfoEntity,
@@ -87,6 +93,9 @@ struct ChannelList: View {
 								.foregroundColor(.secondary)
 						}
 					}
+					if channel.mute {
+						Image(systemName: "bell.slash")
+					}
 				}
 
 				if channel.allPrivateMessages.count > 0 {
@@ -103,7 +112,7 @@ struct ChannelList: View {
 	var body: some View {
 		VStack {
 			// Display Contacts for the rest of the non admin channels
-			if let node, let myInfo = node.myInfo, let channels = myInfo.channels?.array as? [ChannelEntity] {
+			if let node, let myInfo = node.myInfo {
 				List(selection: $channelSelection) {
 					ForEach(channels) { (channel: ChannelEntity) in
 						if !restrictedChannels.contains(channel.name?.lowercased() ?? "") {
@@ -119,7 +128,7 @@ struct ChannelList: View {
 										}
 									}
 									Button {
-										channel.mute = !channel.mute
+										channel.mute.toggle()
 										do {
 											let adminMessageId =  bleManager.saveChannel(channel: channel.protoBuf, fromUser: node.user!, toUser: node.user!)
 											if adminMessageId > 0 {


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Changed channels to a fetch request, added a visual indicator if a channel is muted. Also, fixed the channel saving logic to save channels even if they are muted.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Before, channel mute settings were remaining unchanged even when in the code the channel was muted, also the mute status of the channel was not actually saving to the device and not persisting.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Sent a message from another n0ode and switched to the node where that channel was muted.
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

https://github.com/user-attachments/assets/e36ce8e4-75d5-4592-860d-84a4fbd0a692


## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

