### PR TITLE
First get config to subscribe then fetch nodes

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -511,7 +511,10 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 			Logger.mesh.info("🛎️ \(logString, privacy: .public)")
 			// BLE Characteristics discovered, issue wantConfig
 			var toRadio: ToRadio = ToRadio()
-			configNonce += 1
+			configNonce = UInt32(69421)
+			if !isSubscribed {
+				configNonce = UInt32(69420) // Get config first
+			}
 			toRadio.wantConfigID = configNonce
 			guard let binaryData: Data = try? toRadio.serializedData() else {
 				return
@@ -982,7 +985,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 				Logger.mesh.warning("🕸️ MESH PACKET received for Key Verification App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
 			}
 
-			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == configNonce {
+			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == 69420 {
 				invalidVersion = false
 				lastConnectionError = ""
 				isSubscribed = true
@@ -1022,6 +1025,12 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					} catch {
 						Logger.data.error("Failed to find a node info for the connected node \(error.localizedDescription, privacy: .public)")
 					}
+					Logger.mesh.info("🤜 [BLE] Want Config Complete. ID:\(decodedInfo.configCompleteID, privacy: .public)")
+					sendWantConfig()
+
+				}
+				if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == 69421 {
+					Logger.mesh.info("🤜 [BLE] Want Config DB Complete. ID:\(decodedInfo.configCompleteID, privacy: .public)")
 				}
 
 				// MARK: Share Location Position Update Timer


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
First fetch config to subscribe and then send 69421 to get DB.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Very slow wait to subscribe if you have a lot of nodes in DB.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested with a node with lots of nodes in db.
## Screenshots/Videos (when applicable)

https://github.com/user-attachments/assets/3131b255-dbc3-4d66-b687-1ab49aff8fa3


<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

