### PR TITLE
If no unread messages go straight to bottom

### DIFF
--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -180,24 +180,24 @@ struct ChannelMessageList: View {
 					}
 					.scrollDismissesKeyboard(.interactively)
 					.onFirstAppear {
-						// Find first unread message
-						if let firstUnreadMessageId = channel.allPrivateMessages.first(where: { !$0.read })?.messageId {
+						if channel.unreadMessages == 0 {
 							withAnimation {
-								scrollView.scrollTo(firstUnreadMessageId, anchor: .top)
-								showScrollToBottomButton = true
+								scrollView.scrollTo("bottomAnchor", anchor: .bottom)
+								hasReachedBottom = true
 							}
 						} else {
-							// If no unread messages, scroll to bottom
-							withAnimation {
-								scrollView.scrollTo(channel.allPrivateMessages.last?.messageId ?? 0, anchor: .bottom)
-								hasReachedBottom = true
+							if let firstUnreadMessageId = channel.allPrivateMessages.first(where: { !$0.read })?.messageId {
+								withAnimation {
+									scrollView.scrollTo(firstUnreadMessageId, anchor: .top)
+									showScrollToBottomButton = true
+								}
 							}
 						}
 						gotFirstUnreadMessage = true
 					}
 					.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
 						withAnimation {
-							scrollView.scrollTo(channel.allPrivateMessages.last?.messageId ?? 0, anchor: .bottom)
+							scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 							hasReachedBottom = true
 							showScrollToBottomButton = false
 						}
@@ -205,7 +205,7 @@ struct ChannelMessageList: View {
 					.onChange(of: channel.allPrivateMessages) {
 						if hasReachedBottom {
 							withAnimation {
-								scrollView.scrollTo(channel.allPrivateMessages.last?.messageId ?? 0, anchor: .bottom)
+								scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 							}
 						} else {
 							showScrollToBottomButton = true

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -167,24 +167,24 @@ struct UserMessageList: View {
 					}
 					.scrollDismissesKeyboard(.interactively)
 					.onFirstAppear {
-						// Find first unread message
-						if let firstUnreadMessageId = user.messageList.first(where: { !$0.read })?.messageId {
+						if user.unreadMessages == 0 {
 							withAnimation {
-								scrollView.scrollTo(firstUnreadMessageId, anchor: .top)
-								showScrollToBottomButton = true
+								scrollView.scrollTo("bottomAnchor", anchor: .bottom)
+								hasReachedBottom = true
 							}
 						} else {
-							// If no unread messages, scroll to bottom
-							withAnimation {
-								scrollView.scrollTo(user.messageList.last?.messageId ?? 0, anchor: .bottom)
-								hasReachedBottom = true
+							if let firstUnreadMessageId = user.messageList.first(where: { !$0.read })?.messageId {
+								withAnimation {
+									scrollView.scrollTo(firstUnreadMessageId, anchor: .top)
+									showScrollToBottomButton = true
+								}
 							}
 						}
 						gotFirstUnreadMessage = true
 					}
 					.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
 						withAnimation {
-							scrollView.scrollTo(user.messageList.last?.messageId ?? 0, anchor: .bottom)
+							scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 							hasReachedBottom = true
 							showScrollToBottomButton = false
 						}
@@ -192,7 +192,7 @@ struct UserMessageList: View {
 					.onChange(of: user.messageList) {
 						if hasReachedBottom {
 							withAnimation {
-								scrollView.scrollTo(user.messageList.last?.messageId ?? 0, anchor: .bottom)
+								scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 							}
 						} else {
 							showScrollToBottomButton = true


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Made it so if unread count is 0 go to bottom.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Issue reported by Jason.
## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
Before:



https://github.com/user-attachments/assets/ff87eb62-9004-4bf7-858a-a6d58d920472


After Fix:

https://github.com/user-attachments/assets/1d1e1f03-b10c-4a4d-bc1f-3cc26bbeacae


https://github.com/user-attachments/assets/7939be4d-e16f-471c-a849-9cdaad49831c


## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

