### PR TITLE
Added better config and db logic on connection with timeout

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -52,6 +52,9 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 	let FROMNUM_UUID = CBUUID(string: "0xED9DA18C-A800-4F66-A670-AA7547E34453")
 	let LEGACY_LOGRADIO_UUID = CBUUID(string: "0x6C6FD238-78FA-436B-AACF-15C5BE1EF2E2")
 	let LOGRADIO_UUID = CBUUID(string: "0x5a3d6e49-06e6-4423-9944-e9de8cdf9547")
+	
+	let NONCE_ONLY_CONFIG = 69420
+	let NONCE_ONLY_DB = 69421
 
 	// MARK: init
 	private override init() {
@@ -511,9 +514,9 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 			Logger.mesh.info("🛎️ \(logString, privacy: .public)")
 			// BLE Characteristics discovered, issue wantConfig
 			var toRadio: ToRadio = ToRadio()
-			configNonce = UInt32(69421)
+			configNonce = UInt32(NONCE_ONLY_DB)
 			if !isSubscribed {
-				configNonce = UInt32(69420) // Get config first
+				configNonce = UInt32(NONCE_ONLY_CONFIG) // Get config first
 			}
 			toRadio.wantConfigID = configNonce
 			guard let binaryData: Data = try? toRadio.serializedData() else {
@@ -985,7 +988,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 				Logger.mesh.warning("🕸️ MESH PACKET received for Key Verification App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
 			}
 
-			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == 69420 {
+			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == NONCE_ONLY_CONFIG {
 				invalidVersion = false
 				lastConnectionError = ""
 				isSubscribed = true
@@ -1043,7 +1046,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 				}
 				return
 			}
-			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == 69421 {
+			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == NONCE_ONLY_DB {
 				Logger.mesh.info("🤜 [BLE] Want Config DB Complete. ID:\(decodedInfo.configCompleteID, privacy: .public)")
 			}
 

--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -1029,9 +1029,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					sendWantConfig()
 
 				}
-				if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == 69421 {
-					Logger.mesh.info("🤜 [BLE] Want Config DB Complete. ID:\(decodedInfo.configCompleteID, privacy: .public)")
-				}
+				
 
 				// MARK: Share Location Position Update Timer
 				// Use context to pass the radio name with the timer
@@ -1044,6 +1042,9 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					}
 				}
 				return
+			}
+			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == 69421 {
+				Logger.mesh.info("🤜 [BLE] Want Config DB Complete. ID:\(decodedInfo.configCompleteID, privacy: .public)")
 			}
 
 		case FROMNUM_UUID:

--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -511,7 +511,10 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 			Logger.mesh.info("🛎️ \(logString, privacy: .public)")
 			// BLE Characteristics discovered, issue wantConfig
 			var toRadio: ToRadio = ToRadio()
-			configNonce += 1
+			configNonce = UInt32(69421)
+			if !isSubscribed {
+				configNonce = UInt32(69420) // Get config first
+			}
 			toRadio.wantConfigID = configNonce
 			guard let binaryData: Data = try? toRadio.serializedData() else {
 				return
@@ -982,7 +985,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 				Logger.mesh.warning("🕸️ MESH PACKET received for Key Verification App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
 			}
 
-			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == configNonce {
+			if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == 69420 {
 				invalidVersion = false
 				lastConnectionError = ""
 				isSubscribed = true
@@ -1022,6 +1025,12 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					} catch {
 						Logger.data.error("Failed to find a node info for the connected node \(error.localizedDescription, privacy: .public)")
 					}
+					Logger.mesh.info("🤜 [BLE] Want Config Complete. ID:\(decodedInfo.configCompleteID, privacy: .public)")
+					sendWantConfig()
+
+				}
+				if decodedInfo.configCompleteID != 0 && decodedInfo.configCompleteID == 69421 {
+					Logger.mesh.info("🤜 [BLE] Want Config DB Complete. ID:\(decodedInfo.configCompleteID, privacy: .public)")
 				}
 
 				// MARK: Share Location Position Update Timer


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Added logic to first fetch config -> subscribe -> fetch db in the background. Also each config send has a 5 second timeout, so if the node doesn't respond back within that time another wantConfig will be sent and if this happens more than 2 times the node will be disconnected.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
This provides for a more semaless and faster connecction experience. With people not left waiting forever if a wantConfig send fails. Also connections are faster as the whole DB is not needed to be fetched to subscribe.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested connecting to tons of nodes
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
<img width="1015" alt="Screenshot 2025-06-14 at 1 27 08 PM" src="https://github.com/user-attachments/assets/32f00d11-5ca5-4807-9e9c-b05f66ed8e7a" />

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

