### PR TITLE
Reset wantConfigRetries on disconnect

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -255,6 +255,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 
 	// Disconnect Peripheral Event
 	func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+		resetWantConfigRetries()
 		self.connectedPeripheral = nil
 		self.isConnecting = false
 		self.isConnected = false


### PR DESCRIPTION
Small change to reset the wantConfig countdown when the node is disconnected
