### PR TITLE
Security settings improvements

### DIFF
--- a/Meshtastic/Views/Helpers/SecureInput.swift
+++ b/Meshtastic/Views/Helpers/SecureInput.swift
@@ -12,19 +12,28 @@ struct SecureInput: View {
 	private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
 	@Binding private var text: String
 	@Binding private var isValid: Bool
-	@State var isSecure: Bool = true
 	private var title: String
 
-	init(_ title: String, text: Binding<String>, isValid: Binding<Bool>) {
+	// Local state to store the value of iSSecure, or optionally a binding
+	private var isSecureBinding: Binding<Bool>?
+	@State private var isSecureLocal: Bool = true
+
+	private var isSecure: Binding<Bool> {
+		// Use the binding if we have one, otherwise fallback to the local state variable
+		isSecureBinding ?? $isSecureLocal
+	}
+
+	init(_ title: String, text: Binding<String>, isValid: Binding<Bool>, isSecure: Binding<Bool>? = nil) {
 		self.title = title
 		self._text = text
 		self._isValid = isValid
+		self.isSecureBinding = isSecure
 	}
 
 	var body: some View {
 		ZStack(alignment: .trailing) {
 			Group {
-				if isSecure {
+				if isSecure.wrappedValue {
 					SecureField(title, text: $text)
 						.font(idiom == .phone ? .caption : .callout)
 						.allowsTightening(true)
@@ -51,9 +60,9 @@ struct SecureInput: View {
 
 			if !text.isEmpty {
 				Button(action: {
-					isSecure.toggle()
+					isSecure.wrappedValue.toggle()
 				}) {
-					Image(systemName: self.isSecure ? "eye.slash" : "eye")
+					Image(systemName: self.isSecure.wrappedValue ? "eye.slash" : "eye")
 						.accentColor(.secondary)
 				}.buttonStyle(BorderlessButtonStyle())
 			}


### PR DESCRIPTION
## What changed?
1. Updated `SecureInput` to optionally take a binding for `isSecure` allowing the parent view to see/change the whether the field is masked or viewable free text.
2. Use this new binding to unmask the field when a new key is generated.
3. Added `generatePublicKey` function to take a private Curve25519 key and generate the public key.
4. Use this new function to generate the public key when the private key changes, and highlight the public key in red when the key pair is not valid.

## Why did it change?
General usability improvements

## How is this tested?
More testing needed

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

