### PR TITLE
Update factory reset and restart intents

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -13634,6 +13634,9 @@
         }
       }
     },
+    "Hard Reset" : {
+
+    },
     "Hardware" : {
       "localizations" : {
         "it" : {
@@ -14972,6 +14975,9 @@
           }
         }
       }
+    },
+    "In addition to Config, Keys and BLE bonds will be wiped" : {
+
     },
     "Include" : {
       "localizations" : {
@@ -23027,6 +23033,9 @@
         }
       }
     },
+    "Provide Confirmation" : {
+
+    },
     "Public Key" : {
       "localizations" : {
         "de" : {
@@ -26425,6 +26434,7 @@
       }
     },
     "Send a Direct Message" : {
+      "extractionState" : "stale",
       "localizations" : {
         "it" : {
           "stringUnit" : {
@@ -26513,6 +26523,7 @@
       }
     },
     "Send a message to a certain meshtastic node" : {
+      "extractionState" : "stale",
       "localizations" : {
         "it" : {
           "stringUnit" : {
@@ -28178,6 +28189,9 @@
           }
         }
       }
+    },
+    "Show a confirmation dialog before performing the factory reset" : {
+
     },
     "Show alerts" : {
       "localizations" : {

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -59,7 +59,6 @@
 		B399E8A42B6F486400E4488E /* RetryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B399E8A32B6F486400E4488E /* RetryButton.swift */; };
 		B3E905B12B71F7F300654D07 /* TextMessageField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E905B02B71F7F300654D07 /* TextMessageField.swift */; };
 		BC10380F2DD4334400B00BFA /* AddContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC10380E2DD4333C00B00BFA /* AddContactIntent.swift */; };
-		BC47C2EF2CE0017D008245CA /* MessageNodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC47C2EE2CE0017D008245CA /* MessageNodeIntent.swift */; };
 		BC6B45FF2CB2F98900723CEB /* SaveChannelSettingsIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6B45FE2CB2F98900723CEB /* SaveChannelSettingsIntent.swift */; };
 		BCB613812C67290800485544 /* SendWaypointIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB613802C67290800485544 /* SendWaypointIntent.swift */; };
 		BCB613832C672A2600485544 /* MessageChannelIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB613822C672A2600485544 /* MessageChannelIntent.swift */; };
@@ -325,7 +324,6 @@
 		B399E8A32B6F486400E4488E /* RetryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryButton.swift; sourceTree = "<group>"; };
 		B3E905B02B71F7F300654D07 /* TextMessageField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMessageField.swift; sourceTree = "<group>"; };
 		BC10380E2DD4333C00B00BFA /* AddContactIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddContactIntent.swift; sourceTree = "<group>"; };
-		BC47C2EE2CE0017D008245CA /* MessageNodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageNodeIntent.swift; sourceTree = "<group>"; };
 		BC5EBA3B2D002A2000C442FF /* MessageNodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageNodeIntent.swift; sourceTree = "<group>"; };
 		BC6B45FE2CB2F98900723CEB /* SaveChannelSettingsIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveChannelSettingsIntent.swift; sourceTree = "<group>"; };
 		BCB613802C67290800485544 /* SendWaypointIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendWaypointIntent.swift; sourceTree = "<group>"; };
@@ -694,7 +692,6 @@
 				BCE2D3C82C7C377F008E6199 /* FactoryResetNodeIntent.swift */,
 				BCE2D3C62C7B0D0A008E6199 /* ShortcutsProvider.swift */,
 				BC6B45FE2CB2F98900723CEB /* SaveChannelSettingsIntent.swift */,
-				BC47C2EE2CE0017D008245CA /* MessageNodeIntent.swift */,
 				BCD93CB92D9E11A2006C9214 /* DisconnectNodeIntent.swift */,
 			);
 			path = AppIntents;
@@ -1378,7 +1375,6 @@
 				DDFFA7472B3A7F3C004730DB /* Bundle.swift in Sources */,
 				DD457188293C7E63000C49FB /* BLESignalStrengthIndicator.swift in Sources */,
 				DDA9515C2BC6631200CEA535 /* TelemetryEnums.swift in Sources */,
-				BC47C2EF2CE0017D008245CA /* MessageNodeIntent.swift in Sources */,
 				DDFEB3BB29900C1200EE7472 /* CurrentConditionsCompact.swift in Sources */,
 				DD836AE726F6B38600ABCC23 /* Connect.swift in Sources */,
 				D93069082B81DF040066FBC8 /* SaveConfigButton.swift in Sources */,

--- a/Meshtastic/AppIntents/FactoryResetNodeIntent.swift
+++ b/Meshtastic/AppIntents/FactoryResetNodeIntent.swift
@@ -11,11 +11,19 @@ import AppIntents
 struct FactoryResetNodeIntent: AppIntent {
 	static var title: LocalizedStringResource = "Factory Reset"
 	static var description: IntentDescription = "Perform a factory reset on the node you are connected to"
+	
+	@Parameter(title: "Hard Reset", description: "In addition to Config, Keys and BLE bonds will be wiped", default: false)
+	var hardReset: Bool
+	
+	@Parameter(title: "Provide Confirmation", description: "Show a confirmation dialog before performing the factory reset", default: true)
+	var provideConfirmation: Bool
 
 	func perform() async throws -> some IntentResult {
 		// Request user confirmation before performing the factory reset
-		try await requestConfirmation(result: .result(dialog: "Are you sure you want to factory reset the node?"), confirmationActionName: ConfirmationActionName
-			.custom(acceptLabel: "Factory Reset", acceptAlternatives: [], denyLabel: "Cancel", denyAlternatives: [], destructive: true))
+		if provideConfirmation {
+			try await requestConfirmation(result: .result(dialog: "Are you sure you want to factory reset the node?"), confirmationActionName: ConfirmationActionName
+				.custom(acceptLabel: "Factory Reset", acceptAlternatives: [], denyLabel: "Cancel", denyAlternatives: [], destructive: true))
+		}
 
 		// Ensure the node is connected
 		if !BLEManager.shared.isConnected {
@@ -29,7 +37,7 @@ struct FactoryResetNodeIntent: AppIntent {
 		   let toUser = connectedNode.user {
 
 			// Attempt to send a factory reset command, throw an error if it fails
-			if !BLEManager.shared.sendFactoryReset(fromUser: fromUser, toUser: toUser) {
+			if !BLEManager.shared.sendFactoryReset(fromUser: fromUser, toUser: toUser, resetDevice: hardReset) {
 				throw AppIntentErrors.AppIntentError.message("Failed to perform factory reset")
 			}
 		} else {

--- a/Meshtastic/AppIntents/RestartNodeIntent.swift
+++ b/Meshtastic/AppIntents/RestartNodeIntent.swift
@@ -15,7 +15,6 @@ struct RestartNodeIntent: AppIntent {
 
 	func perform() async throws -> some IntentResult {
 
-		try await requestConfirmation(result: .result(dialog: "Reboot node?"))
 
 		if !BLEManager.shared.isConnected {
 			throw AppIntentErrors.AppIntentError.notConnected


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Added the option for a hard reset in factory reset intent and an option not to have a confirmation dialogue. Removed confirmation dialogue from restart intent as it is not that destructive.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Added more functionality for people to create "kill switches" for nodes. Also easier to do reboots now.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Factory reset is not tested as I did not find a sacrificial node.
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
![image](https://github.com/user-attachments/assets/f9d383f5-ab11-4ce3-ad3b-5e54d51270b3)

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

