### PR TITLE
Fixed connection issues 

### DIFF
--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -525,11 +525,20 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 		 invalidVersion = true
 		 return
 	 } else {
+		 
+		 // Send Heartbeat before wantConfig
+		var heartbeatToRadio: ToRadio = ToRadio()
+		heartbeatToRadio.payloadVariant = .heartbeat(Heartbeat())
+		guard let heartbeatBinaryData: Data = try? heartbeatToRadio.serializedData() else {
+			Logger.mesh.error("Failed to serialize Heartbeat ToRadio message")
+			return
+		}
+		connectedPeripheral!.peripheral.writeValue(heartbeatBinaryData, for: TORADIO_characteristic, type: .withResponse)
 
 		 let nodeName = connectedPeripheral?.peripheral.name ?? "Unknown".localized
 		 let logString = String.localizedStringWithFormat("Issuing Want Config to %@".localized, nodeName)
 		 Logger.mesh.info("🛎️ \(logString, privacy: .public)")
-
+		 
 		 // BLE Characteristics discovered, issue wantConfig
 		 var toRadio: ToRadio = ToRadio()
 		 configNonce = UInt32(NONCE_ONLY_DB)
@@ -567,6 +576,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 	 } else {
 		 Logger.mesh.error("🚨 Want Config failed after \(self.maxWantConfigRetries) attempts, forcing disconnect")
 		 lastConnectionError = "Bluetooth connection timeout, keep your node closer or reboot your radio if the problem continues.".localized
+		 disconnectPeripheral(reconnect: false)
 	 }
  }
 


### PR DESCRIPTION

## What changed?
<!-- Provide a clear description for the change -->
First send heartbeat and then wantConfig, also disconnect node after failures to prevent a user being trapped with a forver connecting node.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
This prevents the node from ignoring wantConfig as sometimes they come back to back.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested by connecting to node
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

