### PR TITLE
Additional Connection timing updates

### DIFF
--- a/Meshtastic/Views/Bluetooth/Connect.swift
+++ b/Meshtastic/Views/Bluetooth/Connect.swift
@@ -282,7 +282,7 @@ struct Connect: View {
 						.controlSize(.large)
 						.padding()
 					}
-					if bleManager.isConnecting {
+					if bleManager.allowDisconnect {
 						Button(role: .destructive, action: {
 							bleManager.cancelPeripheralConnection()
 


### PR DESCRIPTION
Automatically disconnnect after 6 6 second want config failures so that the insufficient encryption error has a chance to fire if the pin dialog is left open.