### PR TITLE
Make unencrypted channels less confusing for users

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1699,6 +1699,9 @@
     "A green lock means the channel is securely encrypted with either a 128 or 256 bit AES key." : {
 
     },
+    "A lock with a slash means the channel is not securely encrypted, it uses either no key at all or a 1 byte known key. Traffic on this channel is easily intercepted. This is not an error, it is simply a reminder that messages sent here should be considered to be able to be received by all." : {
+
+    },
     "A Meshtastic QR code contains the LoRa config and channel values needed for radios to communicate. You can share a complete channel configuration using the Replace Channels option, if you choose Add Channels your shared channels will be added to the channels on the receiving radio." : {
       "localizations" : {
         "de" : {
@@ -1756,9 +1759,6 @@
           }
         }
       }
-    },
-    "A red lock with a slash means the channel is not securely encrypted, it uses either no key at all or a 1 byte known key. Traffic on this channel is easily intercepted." : {
-
     },
     "A Trace Route was sent, no response has been received." : {
       "localizations" : {
@@ -28238,6 +28238,7 @@
       }
     },
     "Shows information for the Lora radio connected via bluetooth. You can swipe left to disconnect the radio and long press start the live activity." : {
+      "extractionState" : "stale",
       "localizations" : {
         "it" : {
           "stringUnit" : {
@@ -28252,6 +28253,9 @@
           }
         }
       }
+    },
+    "Shows information for the Lora radio connected via bluetooth. You can swipe left to disconnect the radio and long press to start the live activity." : {
+
     },
     "Shut Down" : {
       "localizations" : {

--- a/Meshtastic/Views/Helpers/Help/ChannelsHelp.swift
+++ b/Meshtastic/Views/Helpers/Help/ChannelsHelp.swift
@@ -37,9 +37,8 @@ struct ChannelsHelp: View {
 				HStack {
 					Image(systemName: "lock.slash.fill")
 						.padding(.bottom)
-						.foregroundColor(Color.red)
 						.font(.largeTitle)
-					Text("A red lock with a slash means the channel is not securely encrypted, it uses either no key at all or a 1 byte known key. Traffic on this channel is easily intercepted.")
+					Text("A lock with a slash means the channel is not securely encrypted, it uses either no key at all or a 1 byte known key. Traffic on this channel is easily intercepted. This is not an error, it is simply a reminder that messages sent here should be considered to be able to be received by all.")
 						.fixedSize(horizontal: false, vertical: true)
 						.padding(.bottom)
 				}

--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -60,7 +60,6 @@ struct ChannelList: View {
 				HStack {
 					if channel.psk?.hexDescription.count ??  0 <  3 {
 						Image(systemName: "lock.slash.fill")
-							.foregroundColor(.red)
 					} else {
 						Image(systemName: "lock.fill")
 							.foregroundColor(.green)

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -126,7 +126,6 @@ struct Channels: View {
 										HStack {
 											if channel.psk?.hexDescription.count ??  0 <  3 {
 												Image(systemName: "lock.slash.fill")
-													.foregroundColor(.red)
 											} else {
 												Image(systemName: "lock.fill")
 													.foregroundColor(.green)

--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -84,7 +84,6 @@ struct ShareChannels: View {
 									Text(((channel.name!.isEmpty ? "Primary" : channel.name) ?? "Primary").camelCaseToWords())
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
-											.foregroundColor(.red)
 									} else {
 										Image(systemName: "lock.fill")
 											.foregroundColor(.green)
@@ -97,7 +96,6 @@ struct ShareChannels: View {
 									Text(((channel.name!.isEmpty ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
-											.foregroundColor(.red)
 									} else {
 										Image(systemName: "lock.fill")
 											.foregroundColor(.green)
@@ -110,7 +108,6 @@ struct ShareChannels: View {
 									Text(((channel.name!.isEmpty ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
-											.foregroundColor(.red)
 									} else {
 										Image(systemName: "lock.fill")
 											.foregroundColor(.green)
@@ -123,7 +120,6 @@ struct ShareChannels: View {
 									Text(((channel.name!.isEmpty ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
-											.foregroundColor(.red)
 									} else {
 										Image(systemName: "lock.fill")
 											.foregroundColor(.green)
@@ -136,7 +132,6 @@ struct ShareChannels: View {
 									Text(((channel.name!.isEmpty ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
-											.foregroundColor(.red)
 									} else {
 										Image(systemName: "lock.fill")
 											.foregroundColor(.green)
@@ -149,7 +144,6 @@ struct ShareChannels: View {
 									Text(((channel.name!.isEmpty ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
-											.foregroundColor(.red)
 									} else {
 										Image(systemName: "lock.fill")
 											.foregroundColor(.green)
@@ -162,7 +156,6 @@ struct ShareChannels: View {
 									Text(((channel.name!.isEmpty ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
-											.foregroundColor(.red)
 									} else {
 										Image(systemName: "lock.fill")
 											.foregroundColor(.green)
@@ -175,7 +168,6 @@ struct ShareChannels: View {
 									Text(((channel.name!.isEmpty ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
-											.foregroundColor(.red)
 									} else {
 										Image(systemName: "lock.fill")
 											.foregroundColor(.green)


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Removed the red color from the slashed locks and made the help text more informative.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Lots of users were confused and thought it was an error
## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

