### PR TITLE
Add TracerouteIntent for iOS Shortcuts integration

### DIFF
--- a/Meshtastic/AppIntents/TracerouteIntent.swift
+++ b/Meshtastic/AppIntents/TracerouteIntent.swift
@@ -1,0 +1,27 @@
+import Foundation
+import AppIntents
+
+struct TracerouteIntent: AppIntent {
+	static var title: LocalizedStringResource = "Send a Traceroute"
+
+	static var description: IntentDescription = "Send a traceroute request to a certain Meshtastic node"
+
+	@Parameter(title: "Node Number")
+	var nodeNumber: Int
+
+	static var parameterSummary: some ParameterSummary {
+		Summary("Send traceroute to \(\.$nodeNumber)")
+	}
+
+	func perform() async throws -> some IntentResult {
+		if !BLEManager.shared.isConnected {
+			throw AppIntentErrors.AppIntentError.notConnected
+		}
+
+		if !BLEManager.shared.sendTraceRouteRequest(destNum: Int64(nodeNumber), wantResponse: true) {
+			throw AppIntentErrors.AppIntentError.message("Failed to send traceroute request")
+		}
+
+		return .result()
+	}
+}


### PR DESCRIPTION
This commit adds a new AppIntent called TracerouteIntent, allowing users to send a traceroute request to a specific Meshtastic node directly via iOS Shortcuts or Siri.

The intent calls BLEManager.shared.sendTraceRouteRequest(destNum:wantResponse:) and provides basic validation to ensure the device is connected.

No other files or logic were modified. This follows the same structural pattern as MessageNodeIntent.swift.

## What changed?
adds a new AppIntent called TracerouteIntent, allowing users to send a traceroute request to a specific Meshtastic node directly via iOS Shortcuts or Siri.

## Why did it change?
adds a new AppIntent called TracerouteIntent, allowing users to send a traceroute request to a specific Meshtastic node directly via iOS Shortcuts or Siri.


## How is this tested?
on iOS

## Screenshots/Videos (when applicable)

non

## Checklist

- [x ] My code adheres to the project's coding and style guidelines.
- [ x] I have conducted a self-review of my code.
- [x ] I have commented my code, particularly in complex areas.
- [x ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x ] I have tested the change to ensure that it works as intended.

