### PR TITLE
QR code improvements

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -16446,6 +16446,9 @@
         }
       }
     },
+    "LoRa Config Changes:" : {
+
+    },
     "LoRa config received: %@" : {
       "localizations" : {
         "de" : {

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		BCB613832C672A2600485544 /* MessageChannelIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB613822C672A2600485544 /* MessageChannelIntent.swift */; };
 		BCB613852C68703800485544 /* NodePositionIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB613842C68703800485544 /* NodePositionIntent.swift */; };
 		BCB613872C69A0FB00485544 /* AppIntentErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB613862C69A0FB00485544 /* AppIntentErrors.swift */; };
+		BCD7448D2E0F2FAA00F265A2 /* ContactURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD7448C2E0F2FA300F265A2 /* ContactURLHandler.swift */; };
 		BCD93CBA2D9E11A2006C9214 /* DisconnectNodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD93CB92D9E11A2006C9214 /* DisconnectNodeIntent.swift */; };
 		BCDDFA9A2DBB180D0065189C /* ScrollToBottomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCDDFA992DBB180D0065189C /* ScrollToBottomButton.swift */; };
 		BCE2D3C32C7ADF42008E6199 /* ShutDownNodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE2D3C22C7ADF42008E6199 /* ShutDownNodeIntent.swift */; };
@@ -337,6 +338,7 @@
 		BCB613822C672A2600485544 /* MessageChannelIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageChannelIntent.swift; sourceTree = "<group>"; };
 		BCB613842C68703800485544 /* NodePositionIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodePositionIntent.swift; sourceTree = "<group>"; };
 		BCB613862C69A0FB00485544 /* AppIntentErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentErrors.swift; sourceTree = "<group>"; };
+		BCD7448C2E0F2FA300F265A2 /* ContactURLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactURLHandler.swift; sourceTree = "<group>"; };
 		BCD93CB92D9E11A2006C9214 /* DisconnectNodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectNodeIntent.swift; sourceTree = "<group>"; };
 		BCDDFA992DBB180D0065189C /* ScrollToBottomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollToBottomButton.swift; sourceTree = "<group>"; };
 		BCE2D3C22C7ADF42008E6199 /* ShutDownNodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShutDownNodeIntent.swift; sourceTree = "<group>"; };
@@ -1079,6 +1081,7 @@
 		DDC2E1A526CEB32B0042C5E4 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				BCD7448C2E0F2FA300F265A2 /* ContactURLHandler.swift */,
 				DDD43FE12A78C86B0083A3E9 /* Mqtt */,
 				DDAF8C5226EB1DF10058C060 /* BLEManager.swift */,
 				DD1BEF492E0292220090CE24 /* KeychainHelper.swift */,
@@ -1490,6 +1493,7 @@
 				DDB6ABE628B1406100384BA1 /* LoraConfigEnums.swift in Sources */,
 				DDB8F4142A9EE5F000230ECE /* ChannelList.swift in Sources */,
 				DDD43FE32A78C8900083A3E9 /* MqttClientProxyManager.swift in Sources */,
+				BCD7448D2E0F2FAA00F265A2 /* ContactURLHandler.swift in Sources */,
 				DD007BB02AA5981000F5FA12 /* NodeInfoEntityExtension.swift in Sources */,
 				DDDB26422AABF655003AFCB7 /* NodeListItem.swift in Sources */,
 				DDDB444629F8A96500EE2349 /* Character.swift in Sources */,

--- a/Meshtastic/Helpers/BLEManager.swift
+++ b/Meshtastic/Helpers/BLEManager.swift
@@ -1755,7 +1755,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 		return 0
 	}
 
-	public func saveChannelSet(base64UrlString: String, addChannels: Bool = false) -> Bool {
+	public func saveChannelSet(base64UrlString: String, addChannels: Bool = false, okToMQTT: Bool = false) -> Bool {
 		if isConnected {
 
 			var i: Int32 = 0
@@ -1837,6 +1837,7 @@ class BLEManager: NSObject, CBPeripheralDelegate, MqttClientProxyManagerDelegate
 					// Save the LoRa Config and the device will reboot
 					var adminPacket = AdminMessage()
 					adminPacket.setConfig.lora = channelSet.loraConfig
+					adminPacket.setConfig.lora.configOkToMqtt = okToMQTT // Preserve users okToMQTT choice
 					var meshPacket: MeshPacket = MeshPacket()
 					meshPacket.to = UInt32(connectedPeripheral.num)
 					meshPacket.from	= UInt32(connectedPeripheral.num)

--- a/Meshtastic/Helpers/ContactURLHandler.swift
+++ b/Meshtastic/Helpers/ContactURLHandler.swift
@@ -1,0 +1,86 @@
+//
+//  URLHandler.swift
+//  Meshtastic
+//
+//  Created by Benjamin Faershtein on 6/27/25.
+//
+import SwiftUI
+import CoreData
+import OSLog
+import TipKit
+import MeshtasticProtobufs
+
+struct ContactURLHandler {
+	
+	static var minimumContactVersion = "2.6.9"
+
+	
+	static func handleContactUrl(url: URL, bleManager: BLEManager) {
+		let supportedVersion = UserDefaults.firmwareVersion == "0.0.0" ||
+			minimumContactVersion.compare(UserDefaults.firmwareVersion, options: .numeric) == .orderedAscending ||
+			minimumContactVersion.compare(UserDefaults.firmwareVersion, options: .numeric) == .orderedSame
+		
+		if !supportedVersion {
+			let alertController = UIAlertController(
+				title: "Firmware Upgrade Required",
+				message: "In order to import contacts via a QR code you need firmware version 2.6.9 or greater.",
+				preferredStyle: .alert
+			)
+			alertController.addAction(UIAlertAction(
+				title: "Close",
+				style: .cancel,
+				handler: nil
+			))
+			if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+			   let rootViewController = windowScene.windows.first?.rootViewController {
+				rootViewController.present(alertController, animated: true)
+			}
+			Logger.services.debug("User Alerted that a firmware upgrade is required to import contacts.")
+		} else {
+			let components = url.absoluteString.components(separatedBy: "#")
+			if let contactData = components.last {
+				let decodedString = contactData.base64urlToBase64()
+				if let decodedData = Data(base64Encoded: decodedString) {
+					do {
+						let contact = try MeshtasticProtobufs.SharedContact(serializedBytes: decodedData)
+						let alertController = UIAlertController(
+							title: "Add Contact",
+							message: "Would you like to add \(contact.user.longName) as a contact?",
+							preferredStyle: .alert
+						)
+						alertController.addAction(UIAlertAction(
+							title: "Yes",
+							style: .default,
+							handler: { _ in
+								let success = bleManager.addContactFromURL(base64UrlString: contactData)
+								Logger.services.debug("Contact added from URL: \(success ? "success" : "failed")")
+							}
+						))
+						alertController.addAction(UIAlertAction(
+							title: "No",
+							style: .cancel,
+							handler: nil
+						))
+						if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+						   let rootViewController = windowScene.windows.first?.rootViewController {
+							rootViewController.present(alertController, animated: true)
+						}
+						Logger.services.debug("Contact data extracted from URL: \(contactData, privacy: .public)")
+					} catch {
+						Logger.services.error("Failed to parse contact data: \(error.localizedDescription, privacy: .public)")
+						if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+						   let rootViewController = windowScene.windows.first?.rootViewController {
+							let errorAlert = UIAlertController(
+								title: "Error",
+								message: "Could not process contact information. Invalid format.",
+								preferredStyle: .alert
+							)
+							errorAlert.addAction(UIAlertAction(title: "OK", style: .default))
+							rootViewController.present(errorAlert, animated: true)
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/Meshtastic/Views/Settings/SaveChannelQRCode.swift
+++ b/Meshtastic/Views/Settings/SaveChannelQRCode.swift
@@ -5,16 +5,24 @@
 //  Copyright(c) Garth Vander Houwen 7/13/22.
 //
 import SwiftUI
+import CoreData
+import OSLog
+import MeshtasticProtobufs
 
 struct SaveChannelQRCode: View {
-
 	@Environment(\.dismiss) private var dismiss
+	@Environment(\.managedObjectContext) var context
 
-	var channelSetLink: String
+	let channelSetLink: String
 	var addChannels: Bool = false
 	var bleManager: BLEManager
-	@State var showError: Bool = false
-	@State var connectedToDevice = false
+
+	@State private var showError: Bool = false
+	@State private var errorMessage: String = ""
+	@State private var connectedToDevice: Bool = false
+	@State private var loraChanges: [String] = []
+	@State private var okToMQTT: Bool = false
+	
 
 	var body: some View {
 		VStack {
@@ -26,20 +34,50 @@ struct SaveChannelQRCode: View {
 				.font(.title3)
 				.padding()
 
+			if !loraChanges.isEmpty {
+				VStack(alignment: .leading) {
+					Text("LoRa Config Changes:")
+						.font(.headline)
+						.padding(.bottom, 5)
+					ForEach(loraChanges, id: \.self) { change in
+						Text("• \(change)")
+							.font(.callout)
+							.foregroundColor(.orange)
+					}
+				}
+				.padding()
+			}
+
 			if showError {
-				Text("Channels being added from the QR code did not save. When adding channels the names must be unique.")
+				Text(errorMessage.isEmpty ? "Channels being added from the QR code did not save. When adding channels the names must be unique." : errorMessage)
 					.fixedSize(horizontal: false, vertical: true)
 					.foregroundColor(.red)
 					.font(.callout)
 					.padding()
 			}
+
 			HStack {
 				if !showError {
 					Button {
-						let success = bleManager.saveChannelSet(base64UrlString: channelSetLink, addChannels: addChannels)
+						// Extract channel data if it's a full URL
+						let channelData: String
+						if channelSetLink.hasPrefix("http") || channelSetLink.hasPrefix("meshtastic://") {
+							guard let extractedData = extractChannelDataFromURL(channelSetLink) else {
+								Logger.data.error("Failed to extract channel data from URL during save: \(channelSetLink)")
+								errorMessage = "Invalid channel URL format"
+								showError = true
+								return
+							}
+							channelData = extractedData
+						} else {
+							channelData = channelSetLink
+						}
+						
+						let success = bleManager.saveChannelSet(base64UrlString: channelData, addChannels: addChannels, okToMQTT: okToMQTT)
 						if success {
 							dismiss()
 						} else {
+							errorMessage = "Failed to save channel configuration"
 							showError = true
 						}
 					} label: {
@@ -50,24 +88,23 @@ struct SaveChannelQRCode: View {
 					.controlSize(.large)
 					.padding()
 					.disabled(!connectedToDevice)
-#if targetEnvironment(macCatalyst)
-	Button {
-		dismiss()
-	} label: {
-		Label("Cancel", systemImage: "xmark")
 
-	}
-	.buttonStyle(.bordered)
-	.buttonBorderShape(.capsule)
-	.controlSize(.large)
-	.padding()
-#endif
+					#if targetEnvironment(macCatalyst)
+					Button {
+						dismiss()
+					} label: {
+						Label("Cancel", systemImage: "xmark")
+					}
+					.buttonStyle(.bordered)
+					.buttonBorderShape(.capsule)
+					.controlSize(.large)
+					.padding()
+					#endif
 				} else {
 					Button {
 						dismiss()
 					} label: {
 						Label("Cancel", systemImage: "xmark")
-
 					}
 					.buttonStyle(.bordered)
 					.buttonBorderShape(.capsule)
@@ -77,7 +114,226 @@ struct SaveChannelQRCode: View {
 			}
 		}
 		.onAppear {
+			Logger.data.info("Ch set link \(channelSetLink)")
 			connectedToDevice = bleManager.connectToPreferredPeripheral()
+			fetchLoRaConfigChanges()
 		}
+	}
+	
+	private func extractChannelDataFromURL(_ urlString: String) -> String? {
+		Logger.data.info("Extracting channel data from URL: \(urlString)")
+		
+		
+		if let url = URL(string: urlString) {
+			// Get the fragment (part after #)
+			if let fragment = url.fragment, !fragment.isEmpty {
+				Logger.data.info("Extracted fragment from URL: \(fragment)")
+				return fragment
+			}
+		}
+		
+		// Fallback: manually extract everything after the last #
+		if let hashIndex = urlString.lastIndex(of: "#") {
+			let startIndex = urlString.index(after: hashIndex)
+			let channelData = String(urlString[startIndex...])
+			if !channelData.isEmpty {
+				Logger.data.info("Extracted channel data manually: \(channelData)")
+				return channelData
+			}
+		}
+		
+		Logger.data.error("Failed to extract channel data from URL: \(urlString)")
+		return nil
+	}
+	
+	private func fetchLoRaConfigChanges() {
+		var currentLoRaConfig: Config.LoRaConfig?
+
+		// First, extract the actual channel data from the URL if it's a full URL
+		let channelData: String
+		if channelSetLink.hasPrefix("http") || channelSetLink.hasPrefix("meshtastic://") {
+			guard let extractedData = extractChannelDataFromURL(channelSetLink) else {
+				Logger.data.error("Failed to extract channel data from URL: \(channelSetLink)")
+				errorMessage = "Invalid channel URL format"
+				showError = true
+				return
+			}
+			channelData = extractedData
+		} else {
+			// Assume it's already the base64 data
+			channelData = channelSetLink
+		}
+		
+		Logger.data.info("Processing channel data: \(channelData)")
+
+		// Fetch current LoRa config from Core Data
+		let fetchRequest = NodeInfoEntity.fetchRequest()
+		fetchRequest.predicate = NSPredicate(format: "num == %lld", Int64(bleManager.connectedPeripheral?.num ?? 0))
+
+		do {
+			let nodes = try context.fetch(fetchRequest)
+			if let node = nodes.first {
+				currentLoRaConfig = node.loRaConfig?.toProto()
+			}
+		} catch {
+			Logger.data.error("Failed to fetch NodeInfoEntity: \(error.localizedDescription, privacy: .public)")
+		}
+
+		// Decode base64url string
+		let decodedString = channelData.base64urlToBase64()
+		guard let decodedData = Data(base64Encoded: decodedString) else {
+			Logger.data.error("Invalid base64 for ChannelSet data: \(channelData, privacy: .public)")
+			errorMessage = "Invalid channel data format"
+			showError = true
+			return
+		}
+
+		do {
+			let channelSet = try ChannelSet(serializedBytes: decodedData)
+			let newLoRaConfig = channelSet.loraConfig
+			var changes: [String] = []
+
+			// Preserve user's current okToMQTT setting
+			okToMQTT = currentLoRaConfig?.configOkToMqtt ?? false
+
+			if let current = currentLoRaConfig {
+				// Compare each field and track changes
+				if current.hopLimit != newLoRaConfig.hopLimit {
+					changes.append("Hop Limit: \(current.hopLimit) -> \(newLoRaConfig.hopLimit)")
+				}
+				if current.region != newLoRaConfig.region {
+					let currentRegionDesc = RegionCodes(rawValue: Int(current.region.rawValue))?.description ?? "Unknown"
+					let newRegionDesc = RegionCodes(rawValue: Int(newLoRaConfig.region.rawValue))?.description ?? "Unknown"
+					changes.append("Region: \(currentRegionDesc) -> \(newRegionDesc)")
+				}
+				if current.modemPreset != newLoRaConfig.modemPreset {
+					let currentPresetDesc = ModemPresets(rawValue: Int(current.modemPreset.rawValue))?.description ?? "Unknown"
+					let newPresetDesc = ModemPresets(rawValue: Int(newLoRaConfig.modemPreset.rawValue))?.description ?? "Unknown"
+					changes.append("Modem Preset: \(currentPresetDesc) -> \(newPresetDesc)")
+				}
+				if current.usePreset != newLoRaConfig.usePreset {
+					changes.append("Use Preset: \(current.usePreset) -> \(newLoRaConfig.usePreset)")
+				}
+				if current.txEnabled != newLoRaConfig.txEnabled {
+					changes.append("Transmit Enabled: \(current.txEnabled) -> \(newLoRaConfig.txEnabled)")
+				}
+				if current.txPower != newLoRaConfig.txPower {
+					changes.append("Transmit Power: \(current.txPower)dBm -> \(newLoRaConfig.txPower)dBm")
+				}
+				if current.channelNum != newLoRaConfig.channelNum {
+					changes.append("Channel Number: \(current.channelNum) -> \(newLoRaConfig.channelNum)")
+				}
+				if current.bandwidth != newLoRaConfig.bandwidth {
+					changes.append("Bandwidth: \(current.bandwidth) -> \(newLoRaConfig.bandwidth)")
+				}
+				if current.codingRate != newLoRaConfig.codingRate {
+					changes.append("Coding Rate: \(current.codingRate) -> \(newLoRaConfig.codingRate)")
+				}
+				if current.spreadFactor != newLoRaConfig.spreadFactor {
+					changes.append("Spread Factor: \(current.spreadFactor) -> \(newLoRaConfig.spreadFactor)")
+				}
+				if current.sx126XRxBoostedGain != newLoRaConfig.sx126XRxBoostedGain {
+					changes.append("RX Boosted Gain: \(current.sx126XRxBoostedGain) -> \(newLoRaConfig.sx126XRxBoostedGain)")
+				}
+				if current.overrideFrequency != newLoRaConfig.overrideFrequency {
+					changes.append("Override Frequency: \(current.overrideFrequency) -> \(newLoRaConfig.overrideFrequency)")
+				}
+				if current.ignoreMqtt != newLoRaConfig.ignoreMqtt {
+					changes.append("Ignore MQTT: \(current.ignoreMqtt) -> \(newLoRaConfig.ignoreMqtt)")
+				}
+			} else {
+				// Compare against default values when no current config exists
+				let defaultConfig = getDefaultLoRaConfig()
+				
+				if newLoRaConfig.hopLimit != defaultConfig.hopLimit {
+					changes.append("Hop Limit: \(defaultConfig.hopLimit) -> \(newLoRaConfig.hopLimit)")
+				}
+				if newLoRaConfig.region != defaultConfig.region {
+					let newRegionDesc = RegionCodes(rawValue: Int(newLoRaConfig.region.rawValue))?.description ?? "Unknown"
+					changes.append("Region: Unset -> \(newRegionDesc)")
+				}
+				if newLoRaConfig.modemPreset != defaultConfig.modemPreset {
+					let newPresetDesc = ModemPresets(rawValue: Int(newLoRaConfig.modemPreset.rawValue))?.description ?? "Unknown"
+					changes.append("Modem Preset: Long Fast -> \(newPresetDesc)")
+				}
+				if newLoRaConfig.usePreset != defaultConfig.usePreset {
+					changes.append("Use Preset: \(defaultConfig.usePreset) -> \(newLoRaConfig.usePreset)")
+				}
+				if newLoRaConfig.txEnabled != defaultConfig.txEnabled {
+					changes.append("Transmit Enabled: \(defaultConfig.txEnabled) -> \(newLoRaConfig.txEnabled)")
+				}
+				if newLoRaConfig.txPower != defaultConfig.txPower {
+					changes.append("Transmit Power: \(defaultConfig.txPower)dBm -> \(newLoRaConfig.txPower)dBm")
+				}
+				if newLoRaConfig.channelNum != defaultConfig.channelNum {
+					changes.append("Channel Number: \(defaultConfig.channelNum) -> \(newLoRaConfig.channelNum)")
+				}
+				if newLoRaConfig.bandwidth != defaultConfig.bandwidth {
+					changes.append("Bandwidth: \(defaultConfig.bandwidth) -> \(newLoRaConfig.bandwidth)")
+				}
+				if newLoRaConfig.codingRate != defaultConfig.codingRate {
+					changes.append("Coding Rate: \(defaultConfig.codingRate) -> \(newLoRaConfig.codingRate)")
+				}
+				if newLoRaConfig.spreadFactor != defaultConfig.spreadFactor {
+					changes.append("Spread Factor: \(defaultConfig.spreadFactor) -> \(newLoRaConfig.spreadFactor)")
+				}
+				if newLoRaConfig.sx126XRxBoostedGain != defaultConfig.sx126XRxBoostedGain {
+					changes.append("RX Boosted Gain: \(defaultConfig.sx126XRxBoostedGain) -> \(newLoRaConfig.sx126XRxBoostedGain)")
+				}
+				if newLoRaConfig.overrideFrequency != defaultConfig.overrideFrequency {
+					changes.append("Override Frequency: \(defaultConfig.overrideFrequency) -> \(newLoRaConfig.overrideFrequency)")
+				}
+				if newLoRaConfig.ignoreMqtt != defaultConfig.ignoreMqtt {
+					changes.append("Ignore MQTT: \(defaultConfig.ignoreMqtt) -> \(newLoRaConfig.ignoreMqtt)")
+				}
+			}
+
+			loraChanges = changes
+
+		} catch {
+			Logger.data.error("Failed to decode ChannelSet: \(error.localizedDescription, privacy: .public)")
+			errorMessage = "Failed to decode channel configuration"
+			showError = true
+		}
+	}
+	
+	private func getDefaultLoRaConfig() -> Config.LoRaConfig {
+		var config = Config.LoRaConfig()
+		config.hopLimit = 3
+		config.region = .unset
+		config.modemPreset = .longFast
+		config.usePreset = true
+		config.txEnabled = true
+		config.txPower = 0
+		config.channelNum = 0
+		config.bandwidth = 0
+		config.codingRate = 0
+		config.spreadFactor = 0
+		config.sx126XRxBoostedGain = false
+		config.overrideFrequency = 0.0
+		config.ignoreMqtt = false
+		config.configOkToMqtt = false
+		return config
+	}
+}
+
+extension LoRaConfigEntity {
+	func toProto() -> Config.LoRaConfig {
+		var config = Config.LoRaConfig()
+		config.hopLimit = UInt32(self.hopLimit)
+		config.region = Config.LoRaConfig.RegionCode(rawValue: Int(self.regionCode)) ?? .unset
+		config.modemPreset = Config.LoRaConfig.ModemPreset(rawValue: Int(self.modemPreset)) ?? .longFast
+		config.usePreset = self.usePreset
+		config.txEnabled = self.txEnabled
+		config.txPower = Int32(self.txPower)
+		config.channelNum = UInt32(self.channelNum)
+		config.bandwidth = UInt32(self.bandwidth)
+		config.codingRate = UInt32(self.codingRate)
+		config.spreadFactor = UInt32(self.spreadFactor)
+		config.sx126XRxBoostedGain = self.sx126xRxBoostedGain
+		config.overrideFrequency = self.overrideFrequency
+		config.ignoreMqtt = self.ignoreMqtt
+		config.configOkToMqtt = self.okToMqtt
+		return config
 	}
 }


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Inform the user of what lora changes are being made in comparison to their current config. Respect the users okToMQTT choice no matter what the url says. Fix an issue where a nil was being passed as the channel settings causing it to not work. Allow channel links and contact links to be pressed from inside Meshtastic messages.
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Malicius qr codes can be made to change lora settings which could be illegal and this was not presented to the user well. Now everything that is being changed in lora settings as the result of a qr code is presented to users. Also okToMQTT choices are not changed by qr codes as this should be mannually chosen by the user to cosent to data uplink. 
## How is this tested?
<!-- Describe your approach to testing the feature. -->
I tested this by sending lots of qr codes.
## Screenshots/Videos (when applicable)

https://github.com/user-attachments/assets/709ac917-88e3-41d5-9691-bb7580aa0f9b

![image](https://github.com/user-attachments/assets/ce3ae5bc-13ba-4145-bce5-087efca57652)


## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

