### PR TITLE
Reduce Dependency on BLEManager by moving context to @Environment in WaypointForm

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -1823,12 +1823,12 @@
 				INFOPLIST_FILE = Meshtastic/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Meshtastic;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.6.10;
+				MARKETING_VERSION = 2.6.11;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
@@ -1856,12 +1856,12 @@
 				INFOPLIST_FILE = Meshtastic/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Meshtastic;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.6.10;
+				MARKETING_VERSION = 2.6.11;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = YES;
@@ -1886,13 +1886,13 @@
 				INFOPLIST_FILE = Widgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Widgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.6.10;
+				MARKETING_VERSION = 2.6.11;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1918,13 +1918,13 @@
 				INFOPLIST_FILE = Widgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Widgets;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.6.10;
+				MARKETING_VERSION = 2.6.11;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -15,7 +15,7 @@ import OSLog
 import ActivityKit
 #endif
 
-// Simple extension to consicely pass values through a has_XXX boolean check
+// Simple extension to concisely pass values through a has_XXX boolean check
 fileprivate extension Bool {
 	func then<T>(_ value: T) -> T? {
 		self ? value : nil

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -454,7 +454,7 @@ func upsertPositionPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 					}
 					/// Don't save nearly the same position over and over. If the next position is less than 10 meters from the new position, delete the previous position and save the new one.
 					if mutablePositions.count > 0 && (position.precisionBits == 32 || position.precisionBits == 0) {
-						if let mostRecent = mutablePositions.lastObject as? PositionEntity, mostRecent.coordinate.distance(from: position.coordinate) < 15.0 {
+						if let mostRecent = mutablePositions.lastObject as? PositionEntity, mostRecent.coordinate.distance(from: position.coordinate) < 9.0 {
 							mutablePositions.remove(mostRecent)
 						}
 					} else if mutablePositions.count > 0 {

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct WaypointForm: View {
 
 	@EnvironmentObject var bleManager: BLEManager
+	@Environment(\.managedObjectContext) var context
 	@Environment(\.dismiss) private var dismiss
 	@State var waypoint: WaypointEntity
 	let distanceFormatter = MKDistanceFormatter()
@@ -210,11 +211,11 @@ struct WaypointForm: View {
 
 						Menu {
 							Button("For me", action: {
-								bleManager.context.delete(waypoint)
+								context.delete(waypoint)
 								do {
-									try bleManager.context.save()
+									try context.save()
 								} catch {
-									bleManager.context.rollback()
+									context.rollback()
 								}
 								dismiss() })
 							Button("For everyone", action: {
@@ -239,11 +240,11 @@ struct WaypointForm: View {
 								newWaypoint.expire = UInt32(1)
 								if bleManager.sendWaypoint(waypoint: newWaypoint) {
 
-									bleManager.context.delete(waypoint)
+									context.delete(waypoint)
 									do {
-										try bleManager.context.save()
+										try context.save()
 									} catch {
-										bleManager.context.rollback()
+										context.rollback()
 									}
 									dismiss()
 								} else {
@@ -384,11 +385,11 @@ struct WaypointForm: View {
 		}
 		.alert("Waypoint Failed to Send", isPresented: $waypointFailedAlert) {
 					Button("OK", role: .cancel) {
-						bleManager.context.delete(waypoint)
+						context.delete(waypoint)
 						do {
-							try bleManager.context.save()
+							try context.save()
 						} catch {
-							bleManager.context.rollback()
+							context.rollback()
 						}
 						dismiss()
 					}
@@ -396,18 +397,18 @@ struct WaypointForm: View {
 		.onDisappear {
 			if waypoint.id == 0 {
 					// New, unsent waypoint created by the user: delete it
-					bleManager.context.delete(waypoint)
+					context.delete(waypoint)
 					do {
-						try bleManager.context.save()
+						try context.save()
 					} catch {
-						bleManager.context.rollback()
+						context.rollback()
 						Logger.mesh.error("Failed to save context on waypoint deletion: \(error)")
 					}
 				}
 		}
 		.onAppear {
 			if waypoint.id > 0 {
-				let waypoint  = getWaypoint(id: Int64(waypoint.id), context: bleManager.context)
+				let waypoint  = getWaypoint(id: Int64(waypoint.id), context: context)
 				name = waypoint.name ?? "Dropped Pin"
 				description = waypoint.longDescription ?? ""
 				icon = String(UnicodeScalar(Int(waypoint.icon)) ?? "📍")


### PR DESCRIPTION
## What changed?
WaypointForm was accessing the coredata context via the BLEManager.
Moved this access into the @Environment

## Why did it change?
Reducing dependency on BLEManager, one step at a time.

## How is this tested?
Just checked that the WaypointForm keeps working, but someone who uses Waypoints more could stand to test this.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

