### PR TITLE
only hide unmonitored nodes when no messages

### DIFF
--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -337,8 +337,8 @@ struct FilteredUserList<Content: View>: View {
 			}
 		}
 		// Always apply unmessagable and connected node filters
-		// Only hide unmessagable nodes if they have 0 messages
-		let isUnmessagablePredicate = NSPredicate(format: "unmessagable == NO AND (SUBQUERY(messageList, $msg, $msg.messageId != nil).@count == 0)")
+		// Show unmessagable nodes only if they have messages, otherwise hide them
+		let isUnmessagablePredicate = NSPredicate(format: "unmessagable == NO OR ((SUBQUERY(receivedMessages, $msg, $msg.messageId != nil).@count > 0) OR (SUBQUERY(sentMessages, $msg, $msg.messageId != nil).@count > 0))")
 		predicates.append(isUnmessagablePredicate)
 		let isIgnoredPredicate = NSPredicate(format: "userNode.ignored == NO")
 		predicates.append(isIgnoredPredicate)

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -337,7 +337,8 @@ struct FilteredUserList<Content: View>: View {
 			}
 		}
 		// Always apply unmessagable and connected node filters
-		let isUnmessagablePredicate = NSPredicate(format: "unmessagable == NO")
+		// Only hide unmessagable nodes if they have 0 messages
+		let isUnmessagablePredicate = NSPredicate(format: "unmessagable == NO AND (SUBQUERY(messageList, $msg, $msg.messageId != nil).@count == 0)")
 		predicates.append(isUnmessagablePredicate)
 		let isIgnoredPredicate = NSPredicate(format: "userNode.ignored == NO")
 		predicates.append(isIgnoredPredicate)


### PR DESCRIPTION
## What changed?
This change will show unmonitored nodes in the direct messages list when there are messages to view.

## Why did it change?
Unmonitored nodes may in some cases send messages, causing the app to increment the unread message count without any way to view the messages.

## How is this tested?
N/A

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

