### PR TITLE
Fix issue where wrong pub key copied for connected node

### DIFF
--- a/.github/workflows/macos-dSYM.yml
+++ b/.github/workflows/macos-dSYM.yml
@@ -32,23 +32,23 @@ jobs:
           # Create build directory
           mkdir -p ./build/dSYMs
           
-          # Build iOS App Archive with dSYMs
+          # Build for iOS Simulator to generate dSYMs without code signing
           xcodebuild \
             -workspace Meshtastic.xcworkspace \
             -scheme Meshtastic \
-            -allowProvisioningUpdates \
             -configuration Release \
-            -destination 'generic/platform=iOS' \
-            -archivePath ./build/Meshtastic.xcarchive \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath ./build/DerivedData \
             DATADOG_CLIENT_TOKEN="${DATADOG_CLIENT_TOKEN}" \
             DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
-            DWARF_DSYM_FOLDER_PATH=./build/dSYMs \
-            archive
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
             
-      - name: Extract dSYMs from Archive
+      - name: Extract dSYMs from Build
         run: |
-          # Find and copy all dSYM files from the archive
-          find ./build/Meshtastic.xcarchive -name "*.dSYM" -exec cp -R {} ./build/dSYMs/ \;
+          # Find and copy all dSYM files from the build
+          find ./build/DerivedData -name "*.dSYM" -exec cp -R {} ./build/dSYMs/ \;
           
           # List what we found
           echo "Found dSYM files:"
@@ -79,5 +79,5 @@ jobs:
           name: dsym-files
           path: |
             ./build/dSYMs
-            ./build/Meshtastic.xcarchive
+            ./build/DerivedData
           retention-days: 30

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -43,7 +43,7 @@ struct MeshtasticAppleApp: App {
 				env: environment,
 				site: .us5
 			),
-			trackingConsent: UserDefaults.usageDataAndCrashReporting ? .granted : .notGranted,
+			trackingConsent: UserDefaults.usageDataAndCrashReporting ? .granted : .notGranted
 		)
 		DatadogCrashReporting.CrashReporting.enable()
 		Logs.enable()

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -115,30 +115,32 @@ struct NodeDetail: View {
 							.textSelection(.enabled)
 					}
 					.accessibilityElement(children: .combine)
-					if node.user?.keyMatch ?? false {
-						if let publicKey = node.user?.publicKey {
-							HStack {
-								Label {
-									Text("Public Key")
-								} icon: {
-									Image(systemName: "lock.fill")
-										.foregroundColor(.green)
-								}
-								Spacer()
-								Button(action: {
-									context.perform {
-										UIPasteboard.general.string = publicKey.base64EncodedString()
+					let connectedNode = getNodeInfo(id: BLEManager.shared.connectedPeripheral?.num ?? 0, context: context)
+							if let user = node.user, user.keyMatch {
+								let publicKey = node.num == connectedNode?.num
+									? node.securityConfig?.publicKey?.base64EncodedString() ?? ""
+									: user.publicKey?.base64EncodedString() ?? ""
+								HStack {
+									Label {
+										Text("Public Key")
+									} icon: {
+										Image(systemName: "lock.fill")
+											.foregroundColor(.green)
 									}
-								}) {
-									HStack {
-										Image(systemName: "key.horizontal.fill")
-										Text("Copy")
+									Spacer()
+									Button(action: {
+										context.perform {
+											UIPasteboard.general.string = publicKey
+										}
+									}) {
+										HStack {
+											Image(systemName: "key.horizontal.fill")
+											Text("Copy")
+										}
 									}
 								}
+								.accessibilityElement(children: .combine)
 							}
-							.accessibilityElement(children: .combine)
-						}
-					}
 					if let metadata = node.metadata {
 						HStack {
 							Label {


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Fetch the security config pub key for connected nodes instead of through the node db
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Sometimes, when you change the public key of your node, it only changes in the security config. Therefore, we now always fetch the key from the security config for connected nodes.
## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

