### PR TITLE
Add Brazil along Australia/New Zealand

### DIFF
--- a/Meshtastic/Enums/LoraConfigEnums.swift
+++ b/Meshtastic/Enums/LoraConfigEnums.swift
@@ -104,7 +104,7 @@ enum RegionCodes: Int, CaseIterable, Identifiable {
 		case .jp:
 			return "Japan".localized
 		case .anz:
-			return "Australia / New Zealand".localized
+			return "Australia / Brazil / New Zealand".localized
 		case .anz433:
 			return "Australia / New Zealand 433MHz".localized
 		case .kr:


### PR DESCRIPTION
According to PR https://github.com/meshtastic/Meshtastic-Android/pull/2476, the Android version will have the ANZ region text renamed from "Australia / New Zealand" to "Australia / Brazil / New Zealand".

This PR also corrects the name in the iOS version of the app.

I can't test it to take a screenshot.

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.