### PR TITLE
Remove redundant gotFirstUnreadMessage 

### DIFF
--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -23,7 +23,6 @@ struct ChannelMessageList: View {
 	// Scroll state
 	@State private var showScrollToBottomButton = false
 	@State private var hasReachedBottom = false
-	@State private var gotFirstUnreadMessage: Bool = false
 
 		@State private var messageToHighlight: Int64 = 0
 
@@ -145,7 +144,6 @@ struct ChannelMessageList: View {
 								.frame(maxWidth: .infinity)
 								.id(message.messageId)
 								.onAppear {
-									if gotFirstUnreadMessage {
 										if !message.read {
 											message.read = true
 											do {
@@ -165,7 +163,6 @@ struct ChannelMessageList: View {
 											hasReachedBottom = true
 											showScrollToBottomButton = false
 										}
-									}
 								}
 							}
 							// Invisible spacer to detect reaching bottom
@@ -193,7 +190,6 @@ struct ChannelMessageList: View {
 								}
 							}
 						}
-						gotFirstUnreadMessage = true
 					}
 					.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
 						withAnimation {

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -22,7 +22,6 @@ struct UserMessageList: View {
 	// Scroll state
 	@State private var showScrollToBottomButton = false
 	@State private var hasReachedBottom = false
-	@State private var gotFirstUnreadMessage: Bool = false
 	@State private var messageToHighlight: Int64 = 0
 
 	var body: some View {
@@ -132,7 +131,6 @@ struct UserMessageList: View {
 									.frame(maxWidth: .infinity)
 									.id(message.messageId)
 									.onAppear {
-										if gotFirstUnreadMessage {
 											if !message.read {
 												message.read = true
 												do {
@@ -151,7 +149,6 @@ struct UserMessageList: View {
 												hasReachedBottom = true
 												showScrollToBottomButton = false
 											}
-										}
 									}
 								}
 							}
@@ -180,7 +177,6 @@ struct UserMessageList: View {
 								}
 							}
 						}
-						gotFirstUnreadMessage = true
 					}
 					.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
 						withAnimation {


### PR DESCRIPTION

## What changed?
<!-- Provide a clear description for the change -->
Remove redundant gotFirstUnreadMessage variable, which prevents everything from being set as read until it is true
## Why did it change?
<!--A brief overview of why the change is being added. Explain the functionality and its intended purpose. -->
This could improve performance, as everything will be marked as read on load instead of only when scrolled to the first unread item.
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested on my iPhone
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

