### PR TITLE
Fixes for the Italian translation

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -28340,7 +28340,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Config. Radio"
+            "value" : "Configurazione Radio"
           }
         },
         "ja" : {
@@ -36978,6 +36978,7 @@
       }
     },
     "The public key does not match the recorded key. You may delete the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action." : {
+      "extractionState" : "stale",
       "localizations" : {
         "it" : {
           "stringUnit" : {


### PR DESCRIPTION
## What changed?
I reworked the Italian strings for the app. Specifically:
- I added the translations that were missing
- I corrected several major mistranslations; I believe a sizable percentage of the earlier translation was done blindly through a MT
- I improved consistency across similar strings, so that they all use similar terms for similar labels
- I simplified segments wherever possible, since Italian tends to be more verbose than English
- I shortened the length of a few strings when the original translation was too long compared to the English text, as it often broke the layout

Note however that some mistakes may remain, as the strings have no comments and it's not always easy to infer how they are used in practice (e.g. verbs vs. nouns). I will gladly make further amendments in the future as needed.

Further, several strings still show up in English, presumably because they are not included in the Localized Strings file. Among those that I noticed were:
- "Random PIN" in the BLE configuration page
- "Contacts (%@)" at the top of the direct messages page (this one _is_ in the Localized Strings file, but for some reason it's not used)
- The whole onboarding text when the app is first opened (except for a few of, not all, the headers)

Also, for some reason one of the segments was listed as "Stale", and marked in yellow, within Xcode's interface. It's my first time using Xcode to localize strings and I only focused on the Localized Strings file, so I'm genuinely confused as to why that may be the case. I still checked the translation but didn't do anything else.

On that note, if I may, a humble suggestion: using a crowdsourced translation platform (e.g. Crowdin) would make it easier for non-developers to localize the app (and keep the localizations up to date).

## Why did it change?
The earlier translation was sub-optimal.

## How is this tested?
I translated the strings and ran the app.

## Screenshots/Videos (when applicable)
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-15 at 22 18 39" src="https://github.com/user-attachments/assets/ab295a7d-1855-471d-837a-42ae16eeacf7" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-15 at 22 18 48" src="https://github.com/user-attachments/assets/64b97d45-3f05-4d6a-91ce-3dcc6bfc9fc4" />


## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] (N/A) I have commented my code, particularly in complex areas.
- [x] (N/A) I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

(Also please note that this is my very first PR on GitHub. Please be patient if I made any mistakes at any point during the whole procedure!)