### PR TITLE
Update hopsAway filter to not filter out direct nodes when hopsAway > 0

### DIFF
--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -297,11 +297,8 @@ struct FilteredUserList<Content: View>: View {
 			predicates.append(compoundPredicate)
 		}
 		// Hops Away
-		if hopsAway == 0 {
-			let hopsAwayPredicate = NSPredicate(format: "userNode.hopsAway == %i", Int32(hopsAway))
-			predicates.append(hopsAwayPredicate)
-		} else if hopsAway > -1.0 {
-			let hopsAwayPredicate = NSPredicate(format: "userNode.hopsAway > 0 AND userNode.hopsAway <= %i", Int32(hopsAway))
+		if hopsAway > -1.0 {
+			let hopsAwayPredicate = NSPredicate(format: "userNode.hopsAway <= %i", Int32(hopsAway))
 			predicates.append(hopsAwayPredicate)
 		}
 		// Online


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
This change causes 0 hop nodes to be included in the filter results when hopsAway > 0.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Currently the the direct nodes will be filtered out when hopsAway are > 0. While the code implies that this
is purposeful, it's counterintuitive. I'm not sure why users would want to 0 hops to not be included when 
looking at, say, "2 or less hops".

## How is this tested?
<!-- Describe your approach to testing the feature. -->
Built and ran app, Observed that 0-hop nodes are included in the filtered list.

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

