### PR TITLE
Reimplemented sendTime() and sendTime on connect

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -129,8 +129,10 @@ extension AccessoryManager {
 			
 			// Step 7: Update UI and status to connected
 			Step { @MainActor _ in
-				Logger.transport.info("🔗👟 [Connect] Step 7: Update UI and status")
-
+				Logger.transport.info("🔗👟 [Connect] Step 7: Update Time, UI and status")
+				// Send time to device
+				try? await self.sendTime()
+				
 				// We have an active connection
 				self.updateDevice(deviceId: device.id, key: \.connectionState, value: .connected)
 				self.updateState(.subscribed)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -185,7 +185,7 @@ extension AccessoryManager {
 		} else {
 			throw AccessoryError.ioFailed("sendTime: Unable to serialize admin packet")
 		}
-		let messageDescription = "🕛 Sent Set Time Admin Message to the connectecd node."
+		let messageDescription = "🕛 Sent Set Time Admin Message to the connected node."
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 	}
 	

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -162,7 +162,33 @@ extension AccessoryManager {
 		}
 		await self.heartbeatResponseTimer?.reset(delay: .seconds(5.0))
 	}
-
+	
+	public func sendTime() async throws {
+		guard let deviceNum = self.activeDeviceNum.map({ UInt32($0) }) else {
+			Logger.mesh.error("🚫 Unable to send time, connected node is disconnected or invalid")
+			return
+		}
+		var adminPacket = AdminMessage()
+		adminPacket.setTimeOnly = UInt32(Date().timeIntervalSince1970)
+		var meshPacket: MeshPacket = MeshPacket()
+		meshPacket.to = deviceNum
+		meshPacket.from = deviceNum
+		meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+		meshPacket.priority =  MeshPacket.Priority.reliable
+		meshPacket.wantAck = true
+		meshPacket.channel = 0
+		var dataMessage = DataMessage()
+		if let serializedData: Data = try? adminPacket.serializedData() {
+			dataMessage.payload = serializedData
+			dataMessage.portnum = PortNum.adminApp
+			meshPacket.decoded = dataMessage
+		} else {
+			throw AccessoryError.ioFailed("sendTime: Unable to serialize admin packet")
+		}
+		let messageDescription = "🕛 Sent Set Time Admin Message to the connectecd node."
+		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+	}
+	
 	public func sendShutdown(fromUser: UserEntity, toUser: UserEntity) async throws {
 		var adminPacket = AdminMessage()
 		adminPacket.shutdownSeconds = 5


### PR DESCRIPTION
## What changed?
sendTime was overlooked during the implementation of transports.
Added it back and added it to the connection process to sync the device time

## Why did it change?
Bug fix

## How is this tested?
Heltec Mesh Pocket was reset, had 0:00 time and then time was set after connection

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

