### PR TITLE
Overriding frequency is now exportable

### DIFF
--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -280,6 +280,7 @@ struct ShareChannels: View {
 		loRaConfig.channelNum = UInt32(node?.loRaConfig?.channelNum ?? 0)
 		loRaConfig.sx126XRxBoostedGain = node?.loRaConfig?.sx126xRxBoostedGain ?? false
 		loRaConfig.ignoreMqtt = node?.loRaConfig?.ignoreMqtt ?? false
+		loRaConfig.overrideFrequency = node?.loRaConfig?.overrideFrequency ?? 0.0
 		channelSet.loraConfig = loRaConfig
 		if node?.myInfo?.channels != nil && node?.myInfo?.channels?.count ?? 0 > 0 {
 			for ch in node?.myInfo?.channels?.array as? [ChannelEntity] ?? [] where ch.role > 0 {


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Overriding frequency is now exportable in the qr code
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
Changes to frequency override were not being saved to the channel qr code in lora config
## How is this tested?
<!-- Describe your approach to testing the feature. -->
Tested sharing channel between ios and andorid
## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
<img width="1080" height="404" alt="image" src="https://github.com/user-attachments/assets/a63de13d-9bda-43da-bda9-0b9caa822f6c" />

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

