### PR TITLE
Icon Composer Icon

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		231B3F272D0885240069A07D /* MetricsColumnDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231B3F262D0885240069A07D /* MetricsColumnDetail.swift */; };
 		232ED4C32E2C5E89009DA392 /* TCPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232ED4C22E2C5E89009DA392 /* TCPTransport.swift */; };
 		232ED4C52E2C5EDD009DA392 /* TCPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232ED4C42E2C5EDD009DA392 /* TCPConnection.swift */; };
+		2339EA982E6C65570032C234 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 2339EA972E6C65570032C234 /* AppIcon.icon */; };
+		2339EA9A2E6C65DC0032C234 /* AppIconDebug.icon in Resources */ = {isa = PBXBuildFile; fileRef = 2339EA992E6C65DC0032C234 /* AppIconDebug.icon */; };
 		233E99B62D849C3D00CC3A77 /* WeatherConditionsCompactWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233E99B52D849C3D00CC3A77 /* WeatherConditionsCompactWidget.swift */; };
 		233E99B82D849C6500CC3A77 /* HumidityCompactWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233E99B72D849C6500CC3A77 /* HumidityCompactWidget.swift */; };
 		233E99BA2D849C7000CC3A77 /* PressureCompactWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233E99B92D849C7000CC3A77 /* PressureCompactWidget.swift */; };
@@ -327,6 +329,8 @@
 		231B3F262D0885240069A07D /* MetricsColumnDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsColumnDetail.swift; sourceTree = "<group>"; };
 		232ED4C22E2C5E89009DA392 /* TCPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCPTransport.swift; sourceTree = "<group>"; };
 		232ED4C42E2C5EDD009DA392 /* TCPConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCPConnection.swift; sourceTree = "<group>"; };
+		2339EA972E6C65570032C234 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
+		2339EA992E6C65DC0032C234 /* AppIconDebug.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIconDebug.icon; sourceTree = "<group>"; };
 		233E99B32D84969500CC3A77 /* MeshtasticDataModelV 50.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 50.xcdatamodel"; sourceTree = "<group>"; };
 		233E99B52D849C3D00CC3A77 /* WeatherConditionsCompactWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherConditionsCompactWidget.swift; sourceTree = "<group>"; };
 		233E99B72D849C6500CC3A77 /* HumidityCompactWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HumidityCompactWidget.swift; sourceTree = "<group>"; };
@@ -1190,6 +1194,8 @@
 		DDC2E18926CE24F70042C5E4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				2339EA992E6C65DC0032C234 /* AppIconDebug.icon */,
+				2339EA972E6C65570032C234 /* AppIcon.icon */,
 				DDB75A192A05EB67006ED576 /* alpha.png */,
 				DDC2E15B26CE248F0042C5E4 /* Assets.xcassets */,
 				DD0E21002B8A6BC500F2D100 /* DeviceHardware.json */,
@@ -1507,6 +1513,8 @@
 				DDC2E15F26CE248F0042C5E4 /* Preview Assets.xcassets in Resources */,
 				25AECD4F2C2F723200862C8E /* Localizable.xcstrings in Resources */,
 				DDDE5A1329AFEAB900490C6C /* Assets.xcassets in Resources */,
+				2339EA9A2E6C65DC0032C234 /* AppIconDebug.icon in Resources */,
+				2339EA982E6C65570032C234 /* AppIcon.icon in Resources */,
 				DDB75A1A2A05EB67006ED576 /* alpha.png in Resources */,
 				DDC2E15C26CE248F0042C5E4 /* Assets.xcassets in Resources */,
 				DD0E21012B8A6F1300F2D100 /* DeviceHardware.json in Resources */,
@@ -2024,6 +2032,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDebug;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				ASSETCATALOG_OTHER_FLAGS = "--enable-icon-stack-fallback-generation=disabled";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Meshtastic/Meshtastic.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
@@ -2057,6 +2066,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				ASSETCATALOG_OTHER_FLAGS = "--enable-icon-stack-fallback-generation=disabled";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Meshtastic/Meshtastic.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Inner Circle.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Inner Circle.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <g transform="matrix(-1,0,0,1,511.941,614.467)">
+        <g id="Normal">
+            <g id="Grid">
+                <g>
+                    <g>
+                        <circle cx="0" cy="-102" r="102" style="fill:none;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Inner Stroke.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Inner Stroke.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(-1,0,0,1,511.941,614.467)">
+        <g id="Normal">
+            <g id="Grid">
+                <g>
+                    <g>
+                        <path d="M0,-207.125C-58.02,-207.125 -105.125,-160.02 -105.125,-102C-105.125,-43.98 -58.02,3.125 0,3.125C58.02,3.125 105.125,-43.98 105.125,-102C105.125,-160.02 58.02,-207.125 0,-207.125ZM0,-200.875C54.571,-200.875 98.875,-156.571 98.875,-102C98.875,-47.429 54.571,-3.125 0,-3.125C-54.571,-3.125 -98.875,-47.429 -98.875,-102C-98.875,-156.571 -54.571,-200.875 0,-200.875Z" style="fill:rgb(39,107,62);"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Middle Circle.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Middle Circle.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <g transform="matrix(-1,0,0,1,511.941,768.467)">
+        <g id="Normal">
+            <g id="Grid">
+                <g>
+                    <g>
+                        <path d="M0,-512C-141.385,-512 -256,-397.385 -256,-256C-256,-114.615 -141.385,0 0,0C141.385,0 256,-114.615 256,-256C256,-397.385 141.385,-512 0,-512Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Middle Stroke 3.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Middle Stroke 3.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(-1,0,0,1,511.941,768.467)">
+        <path d="M0,-515.125C-143.111,-515.125 -259.125,-399.111 -259.125,-256C-259.125,-112.889 -143.111,3.125 0,3.125C143.111,3.125 259.125,-112.889 259.125,-256C259.125,-399.111 143.111,-515.125 0,-515.125ZM0,-508.875C139.659,-508.875 252.875,-395.659 252.875,-256C252.875,-116.341 139.659,-3.125 0,-3.125C-139.659,-3.125 -252.875,-116.341 -252.875,-256C-252.875,-395.659 -139.659,-508.875 0,-508.875Z" style="fill:rgb(39,107,62);"/>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Outer Circle.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Outer Circle.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <g transform="matrix(-1,0,0,1,511.941,922.467)">
+        <g id="Normal">
+            <g id="Grid">
+                <g>
+                    <g>
+                        <path d="M0,-820C-226.437,-820 -410,-636.437 -410,-410C-410,-183.563 -226.437,0 0,0C226.437,0 410,-183.563 410,-410C410,-636.437 226.437,-820 0,-820Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Outer Stroke 2.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid Outer Stroke 2.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(-1,0,0,1,511.941,922.467)">
+        <path d="M0,-823.125C-228.163,-823.125 -413.125,-638.163 -413.125,-410C-413.125,-181.837 -228.163,3.125 0,3.125C228.163,3.125 413.125,-181.837 413.125,-410C413.125,-638.163 228.163,-823.125 0,-823.125ZM0,-816.875C224.711,-816.875 406.875,-634.711 406.875,-410C406.875,-185.289 224.711,-3.125 0,-3.125C-224.711,-3.125 -406.875,-185.289 -406.875,-410C-406.875,-634.711 -224.711,-816.875 0,-816.875Z" style="fill:rgb(39,107,62);"/>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid.svg
@@ -3,12 +3,6 @@
 <svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
     <g id="Normal" transform="matrix(1,0,0,1,-0.0592795,0.467396)">
         <g id="Grid">
-            <g transform="matrix(-0.707107,0.707107,0.707107,0.707107,512,1236.08)">
-                <path d="M-1236.08,-512L212.077,-512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
-            </g>
-            <g transform="matrix(-0.707107,-0.707107,-0.707107,0.707107,512,-212.077)">
-                <path d="M-1236.08,512L212.077,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
-            </g>
             <g>
                 <g transform="matrix(-1,0,0,1,0,128)">
                     <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
@@ -60,20 +54,6 @@
                 </g>
                 <g transform="matrix(-1,0,0,1,0,384)">
                     <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
-                </g>
-                <g transform="matrix(-1,0,0,1,0,256)">
-                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
-                </g>
-            </g>
-            <g>
-                <g transform="matrix(-1,0,0,1,512,922)">
-                    <path d="M0,-820C-226.437,-820 -410,-636.437 -410,-410C-410,-183.563 -226.437,0 0,0C226.437,0 410,-183.563 410,-410C410,-636.437 226.437,-820 0,-820Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
-                </g>
-                <g transform="matrix(-1,0,0,1,512,768)">
-                    <path d="M0,-512C-141.385,-512 -256,-397.385 -256,-256C-256,-114.615 -141.385,0 0,0C141.385,0 256,-114.615 256,-256C256,-397.385 141.385,-512 0,-512Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
-                </g>
-                <g transform="matrix(-1,0,0,1,512,614)">
-                    <circle cx="0" cy="-102" r="102" style="fill:none;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
                 </g>
             </g>
         </g>

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Icon Grid.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <g id="Normal" transform="matrix(1,0,0,1,-0.0592795,0.467396)">
+        <g id="Grid">
+            <g transform="matrix(-0.707107,0.707107,0.707107,0.707107,512,1236.08)">
+                <path d="M-1236.08,-512L212.077,-512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+            </g>
+            <g transform="matrix(-0.707107,-0.707107,-0.707107,0.707107,512,-212.077)">
+                <path d="M-1236.08,512L212.077,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+            </g>
+            <g>
+                <g transform="matrix(-1,0,0,1,0,128)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1024,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1024,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,896,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,768,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,640,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1152,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1280,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1408,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,1,1,0,1024,512)">
+                    <path d="M-512,-512L512,-512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,512)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,1,1,0,1024,512)">
+                    <path d="M-512,-512L512,-512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,512)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,640)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,768)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,896)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,384)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,256)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+            </g>
+            <g>
+                <g transform="matrix(-1,0,0,1,512,922)">
+                    <path d="M0,-820C-226.437,-820 -410,-636.437 -410,-410C-410,-183.563 -226.437,0 0,0C226.437,0 410,-183.563 410,-410C410,-636.437 226.437,-820 0,-820Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,512,768)">
+                    <path d="M0,-512C-141.385,-512 -256,-397.385 -256,-256C-256,-114.615 -141.385,0 0,0C141.385,0 256,-114.615 256,-256C256,-397.385 141.385,-512 0,-512Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,512,614)">
+                    <circle cx="0" cy="-102" r="102" style="fill:none;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIcon.icon/Assets/Meshtastic Logo.svg
+++ b/Meshtastic/Resources/AppIcon.icon/Assets/Meshtastic Logo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 730 385" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-147.227,-320.039)">
+        <g transform="matrix(3.58406,0,0,3.58405,-273.806,-782.504)">
+            <path d="M250.908,330.267L193.126,415.005L180.938,406.694L244.802,313.037C246.174,311.024 248.453,309.819 250.889,309.816C253.326,309.814 255.606,311.015 256.982,313.026L320.994,406.536L308.821,414.869L250.908,330.267Z" style="fill:rgb(103,234,148);"/>
+        </g>
+        <g transform="matrix(3.60446,0,0,3.60446,-124.993,-1391.04)">
+            <path d="M87.642,581.398L154.757,482.977L142.638,474.713L75.523,573.134L87.642,581.398Z" style="fill:rgb(103,234,148);"/>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIcon.icon/icon.json
+++ b/Meshtastic/Resources/AppIcon.icon/icon.json
@@ -1,0 +1,71 @@
+{
+  "fill" : {
+    "automatic-gradient" : "extended-srgb:0.20392,0.78039,0.34902,1.00000"
+  },
+  "groups" : [
+    {
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "value" : {
+                "automatic-gradient" : "extended-gray:0.00000,1.00000"
+              }
+            },
+            {
+              "appearance" : "dark",
+              "value" : {
+                "automatic-gradient" : "display-p3:0.51705,0.94704,0.59696,1.00000"
+              }
+            },
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "automatic-gradient" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "glass" : true,
+          "hidden" : false,
+          "image-name" : "Meshtastic Logo.svg",
+          "name" : "Meshtastic Logo"
+        },
+        {
+          "glass" : true,
+          "hidden" : true,
+          "image-name" : "Icon Grid.svg",
+          "name" : "Icon Grid",
+          "opacity" : 0.5,
+          "position" : {
+            "scale" : 1,
+            "translation-in-points" : [
+              0,
+              25
+            ]
+          }
+        }
+      ],
+      "position" : {
+        "scale" : 1,
+        "translation-in-points" : [
+          -3.6015625,
+          -31.94921875
+        ]
+      },
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.5
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}

--- a/Meshtastic/Resources/AppIcon.icon/icon.json
+++ b/Meshtastic/Resources/AppIcon.icon/icon.json
@@ -31,11 +31,126 @@
           "name" : "Meshtastic Logo"
         },
         {
-          "glass" : true,
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "solid" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "hidden" : true,
+          "image-name" : "Icon Grid Inner Stroke.svg",
+          "name" : "Icon Grid Inner Stroke",
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 0.7
+            }
+          ]
+        },
+        {
+          "hidden" : true,
+          "image-name" : "Icon Grid Inner Circle.svg",
+          "name" : "Icon Grid Inner Circle"
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "solid" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "hidden" : true,
+          "image-name" : "Icon Grid Middle Stroke 3.svg",
+          "name" : "Icon Grid Middle Stroke 3",
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 0.7
+            }
+          ]
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "automatic-gradient" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "hidden" : true,
+          "image-name" : "Icon Grid Middle Circle.svg",
+          "name" : "Icon Grid Middle Circle",
+          "opacity-specializations" : [
+            {
+              "value" : 1
+            },
+            {
+              "appearance" : "tinted",
+              "value" : 0.15
+            }
+          ]
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "solid" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "hidden" : true,
+          "image-name" : "Icon Grid Outer Stroke 2.svg",
+          "name" : "Icon Grid Outer Stroke 2",
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 0.7
+            }
+          ]
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "automatic-gradient" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "hidden" : true,
+          "image-name" : "Icon Grid Outer Circle.svg",
+          "name" : "Icon Grid Outer Circle",
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 0.2
+            }
+          ]
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "solid" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
           "hidden" : true,
           "image-name" : "Icon Grid.svg",
           "name" : "Icon Grid",
-          "opacity" : 0.5,
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 0.7
+            }
+          ],
           "position" : {
             "scale" : 1,
             "translation-in-points" : [

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Inner Circle.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Inner Circle.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <g transform="matrix(-1,0,0,1,511.941,614.467)">
+        <g id="Normal">
+            <g id="Grid">
+                <g>
+                    <g>
+                        <circle cx="0" cy="-102" r="102" style="fill:none;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Inner Stroke.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Inner Stroke.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(-1,0,0,1,511.941,614.467)">
+        <g id="Normal">
+            <g id="Grid">
+                <g>
+                    <g>
+                        <path d="M0,-207.125C-58.02,-207.125 -105.125,-160.02 -105.125,-102C-105.125,-43.98 -58.02,3.125 0,3.125C58.02,3.125 105.125,-43.98 105.125,-102C105.125,-160.02 58.02,-207.125 0,-207.125ZM0,-200.875C54.571,-200.875 98.875,-156.571 98.875,-102C98.875,-47.429 54.571,-3.125 0,-3.125C-54.571,-3.125 -98.875,-47.429 -98.875,-102C-98.875,-156.571 -54.571,-200.875 0,-200.875Z" style="fill:rgb(39,107,62);"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Middle Circle.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Middle Circle.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <g transform="matrix(-1,0,0,1,511.941,768.467)">
+        <g id="Normal">
+            <g id="Grid">
+                <g>
+                    <g>
+                        <path d="M0,-512C-141.385,-512 -256,-397.385 -256,-256C-256,-114.615 -141.385,0 0,0C141.385,0 256,-114.615 256,-256C256,-397.385 141.385,-512 0,-512Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Middle Stroke 3.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Middle Stroke 3.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(-1,0,0,1,511.941,768.467)">
+        <path d="M0,-515.125C-143.111,-515.125 -259.125,-399.111 -259.125,-256C-259.125,-112.889 -143.111,3.125 0,3.125C143.111,3.125 259.125,-112.889 259.125,-256C259.125,-399.111 143.111,-515.125 0,-515.125ZM0,-508.875C139.659,-508.875 252.875,-395.659 252.875,-256C252.875,-116.341 139.659,-3.125 0,-3.125C-139.659,-3.125 -252.875,-116.341 -252.875,-256C-252.875,-395.659 -139.659,-508.875 0,-508.875Z" style="fill:rgb(39,107,62);"/>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Outer Circle.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Outer Circle.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <g transform="matrix(-1,0,0,1,511.941,922.467)">
+        <g id="Normal">
+            <g id="Grid">
+                <g>
+                    <g>
+                        <path d="M0,-820C-226.437,-820 -410,-636.437 -410,-410C-410,-183.563 -226.437,0 0,0C226.437,0 410,-183.563 410,-410C410,-636.437 226.437,-820 0,-820Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Outer Stroke 2.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid Outer Stroke 2.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(-1,0,0,1,511.941,922.467)">
+        <path d="M0,-823.125C-228.163,-823.125 -413.125,-638.163 -413.125,-410C-413.125,-181.837 -228.163,3.125 0,3.125C228.163,3.125 413.125,-181.837 413.125,-410C413.125,-638.163 228.163,-823.125 0,-823.125ZM0,-816.875C224.711,-816.875 406.875,-634.711 406.875,-410C406.875,-185.289 224.711,-3.125 0,-3.125C-224.711,-3.125 -406.875,-185.289 -406.875,-410C-406.875,-634.711 -224.711,-816.875 0,-816.875Z" style="fill:rgb(39,107,62);"/>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid.svg
@@ -3,12 +3,6 @@
 <svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
     <g id="Normal" transform="matrix(1,0,0,1,-0.0592795,0.467396)">
         <g id="Grid">
-            <g transform="matrix(-0.707107,0.707107,0.707107,0.707107,512,1236.08)">
-                <path d="M-1236.08,-512L212.077,-512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
-            </g>
-            <g transform="matrix(-0.707107,-0.707107,-0.707107,0.707107,512,-212.077)">
-                <path d="M-1236.08,512L212.077,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
-            </g>
             <g>
                 <g transform="matrix(-1,0,0,1,0,128)">
                     <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
@@ -60,20 +54,6 @@
                 </g>
                 <g transform="matrix(-1,0,0,1,0,384)">
                     <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
-                </g>
-                <g transform="matrix(-1,0,0,1,0,256)">
-                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
-                </g>
-            </g>
-            <g>
-                <g transform="matrix(-1,0,0,1,512,922)">
-                    <path d="M0,-820C-226.437,-820 -410,-636.437 -410,-410C-410,-183.563 -226.437,0 0,0C226.437,0 410,-183.563 410,-410C410,-636.437 226.437,-820 0,-820Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
-                </g>
-                <g transform="matrix(-1,0,0,1,512,768)">
-                    <path d="M0,-512C-141.385,-512 -256,-397.385 -256,-256C-256,-114.615 -141.385,0 0,0C141.385,0 256,-114.615 256,-256C256,-397.385 141.385,-512 0,-512Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
-                </g>
-                <g transform="matrix(-1,0,0,1,512,614)">
-                    <circle cx="0" cy="-102" r="102" style="fill:none;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
                 </g>
             </g>
         </g>

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Icon Grid.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-miterlimit:10;">
+    <g id="Normal" transform="matrix(1,0,0,1,-0.0592795,0.467396)">
+        <g id="Grid">
+            <g transform="matrix(-0.707107,0.707107,0.707107,0.707107,512,1236.08)">
+                <path d="M-1236.08,-512L212.077,-512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+            </g>
+            <g transform="matrix(-0.707107,-0.707107,-0.707107,0.707107,512,-212.077)">
+                <path d="M-1236.08,512L212.077,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+            </g>
+            <g>
+                <g transform="matrix(-1,0,0,1,0,128)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1024,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1024,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,896,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,768,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,640,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1152,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1280,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,-1,-1,0,1408,512)">
+                    <path d="M-512,512L512,512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,1,1,0,1024,512)">
+                    <path d="M-512,-512L512,-512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,512)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(0,1,1,0,1024,512)">
+                    <path d="M-512,-512L512,-512" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,512)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,640)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,768)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,896)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,384)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,0,256)">
+                    <path d="M-1024,0L0,0" style="fill:none;fill-rule:nonzero;stroke:rgb(51,142,82);stroke-width:6.25px;"/>
+                </g>
+            </g>
+            <g>
+                <g transform="matrix(-1,0,0,1,512,922)">
+                    <path d="M0,-820C-226.437,-820 -410,-636.437 -410,-410C-410,-183.563 -226.437,0 0,0C226.437,0 410,-183.563 410,-410C410,-636.437 226.437,-820 0,-820Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,512,768)">
+                    <path d="M0,-512C-141.385,-512 -256,-397.385 -256,-256C-256,-114.615 -141.385,0 0,0C141.385,0 256,-114.615 256,-256C256,-397.385 141.385,-512 0,-512Z" style="fill:none;fill-rule:nonzero;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                </g>
+                <g transform="matrix(-1,0,0,1,512,614)">
+                    <circle cx="0" cy="-102" r="102" style="fill:none;stroke:rgb(39,107,62);stroke-width:6.25px;"/>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIconDebug.icon/Assets/Meshtastic Logo.svg
+++ b/Meshtastic/Resources/AppIconDebug.icon/Assets/Meshtastic Logo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 730 385" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1,0,0,1,-147.227,-320.039)">
+        <g transform="matrix(3.58406,0,0,3.58405,-273.806,-782.504)">
+            <path d="M250.908,330.267L193.126,415.005L180.938,406.694L244.802,313.037C246.174,311.024 248.453,309.819 250.889,309.816C253.326,309.814 255.606,311.015 256.982,313.026L320.994,406.536L308.821,414.869L250.908,330.267Z" style="fill:rgb(103,234,148);"/>
+        </g>
+        <g transform="matrix(3.60446,0,0,3.60446,-124.993,-1391.04)">
+            <path d="M87.642,581.398L154.757,482.977L142.638,474.713L75.523,573.134L87.642,581.398Z" style="fill:rgb(103,234,148);"/>
+        </g>
+    </g>
+</svg>

--- a/Meshtastic/Resources/AppIconDebug.icon/icon.json
+++ b/Meshtastic/Resources/AppIconDebug.icon/icon.json
@@ -1,0 +1,91 @@
+{
+  "fill" : {
+    "automatic-gradient" : "extended-srgb:0.20392,0.78039,0.34902,1.00000"
+  },
+  "groups" : [
+    {
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "value" : {
+                "automatic-gradient" : "extended-gray:0.00000,1.00000"
+              }
+            },
+            {
+              "appearance" : "dark",
+              "value" : {
+                "automatic-gradient" : "display-p3:0.51705,0.94704,0.59696,1.00000"
+              }
+            },
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "automatic-gradient" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "glass" : true,
+          "hidden" : false,
+          "image-name" : "Meshtastic Logo.svg",
+          "name" : "Meshtastic Logo"
+        },
+        {
+          "blend-mode-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : "normal"
+            }
+          ],
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : "none"
+            }
+          ],
+          "glass" : true,
+          "hidden" : false,
+          "image-name" : "Icon Grid.svg",
+          "name" : "Icon Grid",
+          "opacity-specializations" : [
+            {
+              "value" : 0.75
+            },
+            {
+              "appearance" : "tinted",
+              "value" : 1
+            }
+          ],
+          "position" : {
+            "scale" : 1,
+            "translation-in-points" : [
+              0,
+              25
+            ]
+          }
+        }
+      ],
+      "position" : {
+        "scale" : 1,
+        "translation-in-points" : [
+          -3.6015625,
+          -31.94921875
+        ]
+      },
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.5
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "circles" : [
+      "watchOS"
+    ],
+    "squares" : "shared"
+  }
+}

--- a/Meshtastic/Resources/AppIconDebug.icon/icon.json
+++ b/Meshtastic/Resources/AppIconDebug.icon/icon.json
@@ -31,26 +31,118 @@
           "name" : "Meshtastic Logo"
         },
         {
-          "blend-mode-specializations" : [
-            {
-              "appearance" : "tinted",
-              "value" : "normal"
-            }
-          ],
           "fill-specializations" : [
             {
               "appearance" : "tinted",
-              "value" : "none"
+              "value" : {
+                "solid" : "extended-gray:1.00000,1.00000"
+              }
             }
           ],
-          "glass" : true,
           "hidden" : false,
+          "image-name" : "Icon Grid Inner Stroke.svg",
+          "name" : "Icon Grid Inner Stroke",
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 1
+            }
+          ]
+        },
+        {
+          "hidden" : false,
+          "image-name" : "Icon Grid Inner Circle.svg",
+          "name" : "Icon Grid Inner Circle"
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "solid" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "image-name" : "Icon Grid Middle Stroke 3.svg",
+          "name" : "Icon Grid Middle Stroke 3",
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 1
+            }
+          ]
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "automatic-gradient" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "hidden" : false,
+          "image-name" : "Icon Grid Middle Circle.svg",
+          "name" : "Icon Grid Middle Circle",
+          "opacity-specializations" : [
+            {
+              "value" : 1
+            },
+            {
+              "appearance" : "tinted",
+              "value" : 0.15
+            }
+          ]
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "solid" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "image-name" : "Icon Grid Outer Stroke 2.svg",
+          "name" : "Icon Grid Outer Stroke 2",
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 1
+            }
+          ]
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "automatic-gradient" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
+          "hidden" : false,
+          "image-name" : "Icon Grid Outer Circle.svg",
+          "name" : "Icon Grid Outer Circle",
+          "opacity-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : 0.2
+            }
+          ]
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "solid" : "extended-gray:1.00000,1.00000"
+              }
+            }
+          ],
           "image-name" : "Icon Grid.svg",
           "name" : "Icon Grid",
           "opacity-specializations" : [
-            {
-              "value" : 0.75
-            },
             {
               "appearance" : "tinted",
               "value" : 1


### PR DESCRIPTION
## What changed?

- Added Icon Composer based icons for OS26.
- Updated `Asset Catalog Other` flags to `--enable-icon-stack-fallback-generation=disabled` to prevent Xcode from rendering the Icon Composer icon for previous versions of iOS.   This can be removed if we want to standardize icons across older OS versions.  With this flag, the original PNG asset catalog icons will be used on versions prior to OS26

## Why did it change?
Gotta change with the times

## How is this tested?
- iOS simulator on both iOS 18 iOS26
- iPhone 16 Pro running iOS26 Beta 8
- MacOS running iOS26 Beta 8. (note you might need to clean build folders/trash derived data to get the icon to update)

## Screenshots/Videos (when applicable)
<img width="167" height="167" alt="AppIconDebug-iOS-Default-83 5x83 5@2x" src="https://github.com/user-attachments/assets/952e8f85-8241-4fd9-8c61-e7dba0316beb" />
<img width="167" height="167" alt="AppIconDebug-iOS-Dark-83 5x83 5@2x" src="https://github.com/user-attachments/assets/490bba08-4e13-4e91-93b5-2fd28ab9dec0" />
<img width="167" height="167" alt="AppIconDebug-iOS-TintedLight-83 5x83 5@2x" src="https://github.com/user-attachments/assets/f24b008a-491f-45c1-bdaa-95b3aa1bc7c4" />
<img width="167" height="167" alt="AppIconDebug-iOS-TintedDark-83 5x83 5@2x" src="https://github.com/user-attachments/assets/c6428d3f-e522-4b17-a869-8b78a974e22f" />


<img width="167" height="167" alt="AppIcon-iOS-Default-83 5x83 5@2x" src="https://github.com/user-attachments/assets/1a59e75d-3637-4100-ab66-5f0aecf86546" />
<img width="167" height="167" alt="AppIcon-iOS-Dark-83 5x83 5@2x" src="https://github.com/user-attachments/assets/dd4d8f97-6817-4571-a874-7dffe2142528" />
<img width="167" height="167" alt="AppIcon-iOS-TintedLight-83 5x83 5@2x" src="https://github.com/user-attachments/assets/be3fe372-1c88-40af-823d-ffcd9bd35c65" />
<img width="167" height="167" alt="AppIcon-iOS-TintedDark-83 5x83 5@2x" src="https://github.com/user-attachments/assets/1d20d71f-bbd2-4b17-b9ca-0a10e4c3f024" />

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

