### PR TITLE
Only mark messages as read if they are unread

### DIFF
--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -159,7 +159,9 @@ struct ChannelMessageList: View {
 						.frame(maxWidth: .infinity)
 						.id(message.messageId)
 						.onAppear {
-							markMessagesAsRead()
+							if !message.read {
+								markMessagesAsRead()
+							}
 						}
 					}
 					Color.clear

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -130,7 +130,6 @@ struct ChannelMessageList: View {
 								
 								TapbackResponses(message: message) {
 									appState.unreadChannelMessages = myInfo.unreadMessages
-									context.refresh(myInfo, mergeChanges: true)
 								}
 								
 								HStack {


### PR DESCRIPTION
Only run the reading logic if the message is unread. This saves performance as we do not run context refreshes on all messages