### PR TITLE
Made the freq slot input a numpad and moved dismiss to the side

### DIFF
--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -157,13 +157,14 @@ struct LoRaConfig: View {
 							TextField("Frequency Slot", value: $channelNum, formatter: formatter)
 								.toolbar {
 									ToolbarItemGroup(placement: .keyboard) {
+										Spacer()
 										Button("Dismiss") {
 											focusedField = nil
 										}
 										.font(.subheadline)
 									}
 								}
-								.keyboardType(.decimalPad)
+								.keyboardType(.numberPad)
 								.scrollDismissesKeyboard(.immediately)
 								.focused($focusedField, equals: .channelNum)
 								.disabled(overrideFrequency > 0.0)


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Made the freq slot input a numpad and moved dismiss to the side
## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
The input can only be an int and the dismiss button was getting in the way of the save button in ios26
## How is this tested?
<!-- Describe your approach to testing the feature. -->
iphone
## Screenshots/Videos (when applicable)
<img width="590" height="1278" alt="Screenshot 2025-09-17 at 1 51 57 PM" src="https://github.com/user-attachments/assets/8790ecd9-280b-4730-afcb-e46ea8f994ed" />

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

