### PR TITLE
DataDog action logging

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		23D316932E5618D2002FA4FB /* AsyncGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D316922E5618D2002FA4FB /* AsyncGate.swift */; };
 		23D9D9392E50DA97005D1C18 /* ResettableTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D9D9382E50DA97005D1C18 /* ResettableTimer.swift */; };
 		23E23F922E392C2B00919073 /* LogRecord+StringRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E23F912E392C2B00919073 /* LogRecord+StringRepresentation.swift */; };
+		23F061B32E7B056600A1E2EA /* Logger+DataDog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F061B22E7B056600A1E2EA /* Logger+DataDog.swift */; };
 		23F488122E32980B002C776F /* AccessoryManager+Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F488112E32980B002C776F /* AccessoryManager+Position.swift */; };
 		23FF00B62E323C75001DF095 /* AccessoryManager+Connect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF00B52E323C75001DF095 /* AccessoryManager+Connect.swift */; };
 		251926852C3BA97800249DF5 /* FavoriteNodeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251926842C3BA97800249DF5 /* FavoriteNodeButton.swift */; };
@@ -366,6 +367,7 @@
 		23D316922E5618D2002FA4FB /* AsyncGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncGate.swift; sourceTree = "<group>"; };
 		23D9D9382E50DA97005D1C18 /* ResettableTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResettableTimer.swift; sourceTree = "<group>"; };
 		23E23F912E392C2B00919073 /* LogRecord+StringRepresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LogRecord+StringRepresentation.swift"; sourceTree = "<group>"; };
+		23F061B22E7B056600A1E2EA /* Logger+DataDog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+DataDog.swift"; sourceTree = "<group>"; };
 		23F488112E32980B002C776F /* AccessoryManager+Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessoryManager+Position.swift"; sourceTree = "<group>"; };
 		23FF00B52E323C75001DF095 /* AccessoryManager+Connect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccessoryManager+Connect.swift"; sourceTree = "<group>"; };
 		251926842C3BA97800249DF5 /* FavoriteNodeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteNodeButton.swift; sourceTree = "<group>"; };
@@ -1344,6 +1346,7 @@
 				DDD5BB172C2F9C36007E03CA /* OSLogEntryLog.swift */,
 				DDF45C362BC46A5A005ED5F2 /* TimeZone.swift */,
 				DDD5BB0C2C285F00007E03CA /* Logger.swift */,
+				23F061B22E7B056600A1E2EA /* Logger+DataDog.swift */,
 				DD6F65732C6CB80A0053C113 /* View.swift */,
 			);
 			path = Extensions;
@@ -1655,6 +1658,7 @@
 				DD4A911E2708C65400501B7E /* AppSettings.swift in Sources */,
 				DD1BD0F32C63C65E008C0C70 /* SecurityConfig.swift in Sources */,
 				DD1BEF4C2E030D310090CE24 /* KeyBackupStatus.swift in Sources */,
+				23F061B32E7B056600A1E2EA /* Logger+DataDog.swift in Sources */,
 				DD2160AF28C5552500C17253 /* MQTTConfig.swift in Sources */,
 				DD6F65722C6AB8EC0053C113 /* SecureInput.swift in Sources */,
 				DD13AA492AB73BF400BA0C98 /* PositionPopover.swift in Sources */,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -147,6 +147,16 @@ extension AccessoryManager {
 				if transport.requiresPeriodicHeartbeat {
 					await self.setupPeriodicHeartbeat()
 				}
+				
+				if let device = self.activeConnection?.device {
+					let connectionAttributes: [String: any Encodable] = [
+						"firmware_version": device.firmwareVersion,
+						"transport_type": device.transportType.rawValue,  // e.g., "websocket", "http/2", "quic"
+						"hardware_model": device.hardwareModel,
+						"nodes": self.expectedNodeDBSize
+					]
+					Logger.datadog.action(name: "connect", attributes: connectionAttributes )
+				}
 			}
 		}
 		

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -112,6 +112,7 @@ extension AccessoryManager {
 				if let user = nodeInfo.user {
 					updateDevice(deviceId: activeDevice.id, key: \.shortName, value: user.shortName ?? "?")
 					updateDevice(deviceId: activeDevice.id, key: \.longName, value: user.longName ?? "Unknown".localized)
+					updateDevice(deviceId: activeDevice.id, key: \.hardwareModel, value: user.hwModel)
 				}
 			}
 		}

--- a/Meshtastic/Accessory/Protocols/Device.swift
+++ b/Meshtastic/Accessory/Protocols/Device.swift
@@ -17,6 +17,7 @@ struct Device: Identifiable, Hashable {
 	var shortName: String?
 	var longName: String?
 	var firmwareVersion: String?
+	var hardwareModel: String?
 	var rssi: Int?
 	var lastUpdate: Date?
 

--- a/Meshtastic/Extensions/Logger+DataDog.swift
+++ b/Meshtastic/Extensions/Logger+DataDog.swift
@@ -1,0 +1,69 @@
+//
+//  Logger+DataDog.swift
+//  Meshtastic
+//
+//  Created by Jake Bordens on 9/17/25.
+//
+
+import Foundation
+import os.log
+import DatadogRUM
+import DatadogLogs
+
+struct DatadogLogger {
+	private let osLogger: os.Logger
+	private let ddLogger: any DatadogLogs.LoggerProtocol
+	
+	// Initialize with a subsystem and category, similar to Logger
+	fileprivate init(subsystem: String, category: String) {
+		self.osLogger = Logger(subsystem: subsystem, category: category)
+		self.ddLogger = DatadogLogs.Logger.create(
+			with: Logger.Configuration(
+				name: "gvh.Meshtastic",
+				networkInfoEnabled: true,
+				remoteLogThreshold: .debug,
+				consoleLogFormat: .short
+			)
+		)
+	}
+	
+	// ✨ os.Logger functions like debug, info, etc., are not normal functions.
+	// They rely on compiler magic to parse the interpolated string, identify the
+	// privacy modifiers (.public, .private), and handle the data securely without
+	// ever creating a potentially sensitive string in your app's memory.
+	// To do this, the compiler must see the string literal at the point of the call.
+	// Since this is going to Datadog, care should be taken to only use these functions
+	// with public debug data.
+	func debug(_ message: String) {
+		osLogger.debug("\(message, privacy: .public)")
+		ddLogger.debug(message)
+	}
+
+	func info(_ message: String) {
+		osLogger.info("\(message, privacy: .public)")
+		ddLogger.info(message)
+	}
+
+	func warning(_ message: String) {
+		osLogger.warning("\(message, privacy: .public)")
+		ddLogger.warn(message)
+	}
+
+	func error(_ message: String) {
+		osLogger.error("\(message, privacy: .public)")
+		ddLogger.error(message)
+	}
+	
+	// MARK: - Methods for RUM actions
+	func action(name: String, attributes: [String: any Encodable]? = nil) {
+		RUMMonitor.shared().addAction(
+			type: .custom,
+			name: name,
+			attributes: attributes ?? [:]
+		)
+	}
+}
+
+extension os.Logger {
+	static let datadog = DatadogLogger(subsystem: "datadog", category: "🐶 DataDog")
+}

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -75,11 +75,6 @@ struct MeshtasticAppleApp: App {
 				trackBackgroundEvents: true
 			)
 		)
-		let attributes: [String: Encodable] = [
-			"firmware_version": UserDefaults.firmwareVersion,
-			"hardware_model": UserDefaults.hardwareModel
-		]
-		RUMMonitor.shared().addAttributes(attributes)
 #if DEBUG
 		SessionReplay.enable(
 		  with: SessionReplay.Configuration(


### PR DESCRIPTION
## What changed?
Added action logging on connect events. This will allow us to collect metrics on node hardware models, transport usage, and initial node DB size.

Also added a "datadog" logger (`Logger.datadog`) , which will emit log messages into both the local OSLogger as well as DataDog's live tail.  Note, however, that this should be only used for public log messages.  Secret or senstive information should not be sent to the DataDog logger.

## Why did it change?
Better logging

## How is this tested?
Locally on iOS26

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

