### PR TITLE
Clarify public key sub-text in settings

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -15802,18 +15802,18 @@
         }
       }
     },
-    "Generated from your public key and sent out to other nodes on the mesh to allow them to compute a shared secret key." : {
+    "Generated from your private key and sent to other nodes on the mesh so they can compute a shared secret key." : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "パブリックキーから生成され、メッシュ上の他のノードに送信されて、共有秘密キーの計算を可能にします。"
+            "value" : "秘密キーから生成され、メッシュ上の他のノードに送信されて、共有秘密キーの計算を可能にします。"
           }
         },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Генерисано из твог јавног кључа и послато другим чворовима на мрежи како би им омогућило да израчунају заједнички тајни кључ.\n"
+            "value" : "Генерисано из твог приватног кључа и послато другим чворовима на мрежи како би им омогућило да израчунају заједнички тајни кључ.\n"
           }
         }
       }

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -68,7 +68,7 @@ struct SecurityConfig: View {
 								RoundedRectangle(cornerRadius: 10.0)
 									.stroke(isValidKeyPair ? Color.clear : Color.red, lineWidth: 2.0)
 							)
-						Text("Generated from your public key and sent out to other nodes on the mesh to allow them to compute a shared secret key.")
+						Text("Generated from your private key and sent to other nodes on the mesh so they can compute a shared secret key.")
 							.foregroundStyle(.secondary)
 							.font(idiom == .phone ? .caption : .callout)
 						Divider()


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->

The public key sub-text in the security config view. Updated english text as well as `ja` and `sr` translations.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->

Updated to clarify that the public key is generated from the private key, not from the public key itself.

## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->
<img height="800" alt="Screenshot 2025-09-17 at 3 58 32 PM" src="https://github.com/user-attachments/assets/a7b141b5-3051-4604-91ba-09c516dd8d6d" />



## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [X] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.

