### PR TITLE
remove outdated TCP not available on Apple devices

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -12753,24 +12753,24 @@
         }
       }
     },
-    "Enabling Ethernet will disable the bluetooth connection to the app. TCP node connections are not available on Apple devices." : {
+    "Enabling Ethernet will disable the bluetooth connection to the app." : {
       "localizations" : {
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abilitando l'Ethernet verrà disabilita la connessione bluetooth all'applicazione. La connessione a nodi TCP non è disponibile su dispositivi Apple."
+            "value" : "Abilitando l'Ethernet verrà disabilita la connessione bluetooth all'applicazione."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ethernetを有効にすると、アプリへのBluetooth接続が無効になります。AppleデバイスではTCPノード接続は利用できません。"
+            "value" : "Ethernetを有効にすると、アプリへのBluetooth接続が無効になります。"
           }
         },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Омогућавање Ethernet-а ће онемогућити Bluetooth везу са апликацијом. TCP везе са чвором нису доступне на Apple уређајима.\n"
+            "value" : "Омогућавање Ethernet-а ће онемогућити Bluetooth везу са апликацијом."
           }
         }
       }

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -83,7 +83,7 @@ struct NetworkConfig: View {
 						Section(header: Text("Ethernet Options")) {
 							Toggle(isOn: $ethEnabled) {
 								Label("Enabled", systemImage: "network")
-								Text("Enabling Ethernet will disable the bluetooth connection to the app. TCP node connections are not available on Apple devices.")
+								Text("Enabling Ethernet will disable the bluetooth connection to the app.")
 							}
 							.tint(.accentColor)
 						}


### PR DESCRIPTION
## What changed?
Removed the outdated sentence “TCP node connections are not available on Apple devices.”
Cleaned up translations for that warning in it, ja, and sr.
No functional code changes.

## Why did it change?
TCP transport is supported now. This updates user interface text to reflect current capabilities.
Issue #1341 added TCP transport support so this can be removed now.

## How is this tested?
Removed code and tested for English.
Untested for other languages.

## Screenshots/Videos

<img width="120" height="240" alt="IMG_1971" src="https://github.com/user-attachments/assets/b42726f8-18d7-4ee1-ac07-3f035b7625cc" />

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [X] I have commented my code, particularly in complex areas.
- [X] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.

