### PR TITLE
App badge and unnecessary notification fixes

### DIFF
--- a/Meshtastic/Helpers/LocalNotificationManager.swift
+++ b/Meshtastic/Helpers/LocalNotificationManager.swift
@@ -91,6 +91,17 @@ class LocalNotificationManager {
         }
     }
 
+	func cancelNotificationForMessageId(_ messageId: Int64) {
+		let center = UNUserNotificationCenter.current()
+		center.getPendingNotificationRequests { notifications in
+			for notification in notifications {
+				if let userInfo = notification.content.userInfo["messageId"] as? Int64, userInfo == messageId {
+					Logger.services.debug("Cancelling notification with id: \(notification.identifier)")
+					center.removePendingNotificationRequests(withIdentifiers: [notification.identifier])
+				}
+			}
+		}
+	}
 }
 
 struct Notification {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1073,7 +1073,7 @@ func textMessageAppPacket(
 								if channel.index == newMessage.channel {
 									context.refresh(channel, mergeChanges: true)
 								}
-								if channel.index == newMessage.channel && !channel.mute && UserDefaults.channelMessageNotifications && newMessage.isEmoji == false && newMessage.read == false {
+								if channel.index == newMessage.channel && !channel.mute && UserDefaults.channelMessageNotifications && newMessage.isEmoji == false {
 									// Create an iOS Notification for the received channel message
 									let manager = LocalNotificationManager()
 									manager.notifications = [

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -80,12 +80,15 @@ struct ChannelMessageList: View {
 							  onInteractionComplete: handleInteractionComplete
 						  )
 						  .onAppear {
-							  if !message.read {
+							  // Only mark as read if the app is in the foreground
+							  if !message.read && UIApplication.shared.applicationState == .active {
 								  message.read = true
+								  LocalNotificationManager().cancelNotificationForMessageId(message.messageId)
 								  // Race condition, sometimes the app doesn't update unread count if we run this too early
 								  // So, run it in the main queue after everything saves and stabilizes
 								  DispatchQueue.main.async {
 									  markMessagesAsRead()
+									  scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 								  }
 							  }
 						  }

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -68,8 +68,16 @@ struct UserMessageList: View {
 								onInteractionComplete: handleInteractionComplete
 							)
 							.onAppear {
-								if !message.read {
-									markMessagesAsRead() // Use the function to mark all unread
+								// Only mark as read if the app is in the foreground
+								if !message.read && UIApplication.shared.applicationState == .active {
+									message.read = true
+									LocalNotificationManager().cancelNotificationForMessageId(message.messageId)
+									// Race condition, sometimes the app doesn't update unread count if we run this too early
+									// So, run it in the main queue after everything saves and stabilizes
+									DispatchQueue.main.async {
+										markMessagesAsRead()
+										scrollView.scrollTo("bottomAnchor", anchor: .bottom)
+									}
 								}
 							}
 							.id(redrawTapbacksTrigger)


### PR DESCRIPTION

## What changed?
- Fix for app badge not going to zero if a message arrives while you have that chat open
- Fix for push notifications popping up when a message is received while that chat is open
- Automatically scroll to bottom when a new message is received

## Why did it change?
Having the "1" on the app badge not going away unless I kill the app was annoying. Also, having a notification go to my Notification Center when I already saw the chat item was annoying.

## How is this tested?
Repro steps:
- Have a chat open (DM or Channel)
- Receive a message in that chat
- Previously, see notification at top of screen even though the chat line is visible and marked read. Now, no notification
- Then, leave the app
- Previously, the unread badge stays "1" despite the chat line having been seen. Now, unread badge is not present for that message

Tested on both iOS and Mac.

## Checklist

- [ ✅ ] My code adheres to the project's coding and style guidelines.
- [ ✅ ] I have conducted a self-review of my code.
- [ ✅ ] I have commented my code, particularly in complex areas.
- [ ✅ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ✅ ] I have tested the change to ensure that it works as intended.

