### PR TITLE
message-list-performance: revert scrolling changes

### DIFF
--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -24,8 +24,7 @@ struct ChannelMessageList: View {
 	@AppStorage("preferredPeripheralNum") private var preferredPeripheralNum = -1
 	@State private var messageToHighlight: Int64 = 0
 	@FetchRequest private var allPrivateMessages: FetchedResults<MessageEntity>
-	@State private var scrollToBottomWorkItem: DispatchWorkItem?
-
+	
 	init(myInfo: MyInfoEntity, channel: ChannelEntity) {
 		self.myInfo = myInfo
 		self.channel = channel
@@ -52,28 +51,13 @@ struct ChannelMessageList: View {
 			for unreadMessage in allPrivateMessages.filter({ !$0.read }) {
 				unreadMessage.read = true
 			}
-
-			if context.hasChanges {
-				try context.save()
-				Logger.data.info("📖 [App] All unread messages marked as read.")
-			}
-
+			try context.save()
+			Logger.data.info("📖 [App] All unread messages marked as read.")
 			appState.unreadChannelMessages = myInfo.unreadMessages
 			context.refresh(myInfo, mergeChanges: true)
 		} catch {
 			Logger.data.error("Failed to read messages: \(error.localizedDescription, privacy: .public)")
 		}
-	}
-
-	func debouncedScrollToBottom(scrollView: ScrollViewProxy, lastMessageId: Int64?, delay: TimeInterval = 0.1) {
-		scrollToBottomWorkItem?.cancel()
-
-		let scrollTarget: AnyHashable = lastMessageId != nil ? lastMessageId : "bottomAnchor"
-		let work = DispatchWorkItem {
-			scrollView.scrollTo(scrollTarget, anchor: .bottom)
-		}
-		scrollToBottomWorkItem = work
-		DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
 	}
 
 	private func routerIsShowingThisChannel() -> Bool {
@@ -92,8 +76,6 @@ struct ChannelMessageList: View {
 			for m in messages { dict[m.messageId] = prev; prev = m }
 			return dict
 		}()
-
-		let lastMessageId: Int64? = messages.last?.messageId
 
 		ScrollViewReader { scrollView in
 			ScrollView {
@@ -126,6 +108,7 @@ struct ChannelMessageList: View {
 								  }
 							  }
 						  }
+
 					}
 					Color.clear
 						.frame(height: 1)
@@ -136,21 +119,12 @@ struct ChannelMessageList: View {
 			.defaultScrollAnchorTopAlignment()
 			.defaultScrollAnchorBottomSizeChanges()
 			.scrollDismissesKeyboard(.immediately)
-			.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
-				// Keyboard is about to appear: keyboard show animation hasn't quite started yet.
-				// Schedule an immediate scroll to the bottom message by its messageId, in order to force LazyVStack to render that cell if it isn't rendered already
-				debouncedScrollToBottom(scrollView: scrollView, lastMessageId: lastMessageId, delay: 0.0)
-			}
-			.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
-				// Keyboard is fully visible.
-				// Scroll after the keyboard is fully showing, with a short delay to allow things to settle (TextMessageField height update, for example)
-				debouncedScrollToBottom(scrollView: scrollView, lastMessageId: lastMessageId, delay: 0.1)
-			}
 			.onChange(of: messageFieldFocused) {
 				if messageFieldFocused {
-					// macOS doesn't have keyboard show animation, but we still want to scroll to the bottom.
-					debouncedScrollToBottom(scrollView: scrollView, lastMessageId: lastMessageId, delay: 0.0)
-				 }
+					DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+						scrollView.scrollTo("bottomAnchor", anchor: .bottom)
+					}
+				}
 			}
 			TextMessageField(
 				destination: .channel(channel),


### PR DESCRIPTION
This PR reverts the scrolling changes

- https://github.com/meshtastic/Meshtastic-Apple/commit/ee1a7c44157eb6970ec2111fc1ac4d67a44a8238
- https://github.com/meshtastic/Meshtastic-Apple/commit/e0f0b4a0f749d2e83946f2c1297e5c97c9fdf46e

so that `message-list-performance` solely deals with the performance and bug fixes in and around `messageList`
as requested by @garthvh  https://discord.com/channels/867578229534359593/874835141145542716/1428499016215433288 Thanks!