### PR TITLE
Fix `lastHeard` date in future (coming from position packets with incorrect future `timestamp`)

### DIFF
--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -465,13 +465,17 @@ func upsertPositionPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 					mutablePositions.add(position)
 					fetchedNode[0].id = Int64(packet.from)
 					fetchedNode[0].num = Int64(packet.from)
-					if positionMessage.time > 0 {
+
+					// Update the node's lastHeard.
+					// Some misconfigured nodes will broadcast position packets that claim GPS timestamps in the future. When updating lastHeard, don't use any future timestamps: fallback to using rxTime or Date() instead.
+					if positionMessage.time > 0 && (Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.time))) <= Date()) {
 						fetchedNode[0].lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.time)))
 					} else if packet.rxTime > 0 {
 						fetchedNode[0].lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(packet.rxTime)))
 					} else {
 						fetchedNode[0].lastHeard = Date()
 					}
+
 					fetchedNode[0].snr = packet.rxSnr
 					fetchedNode[0].rssi = packet.rxRssi
 					fetchedNode[0].viaMqtt = packet.viaMqtt


### PR DESCRIPTION
Fixes https://github.com/meshtastic/Meshtastic-Apple/issues/1418 by adding ` && (Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.time))) <= Date())` to `upsertPositionPacket`.

I was experiencing this on just a handful of nodes. No MQTT involved for me -- just over the radio. These only happened while the app was still connected to the radio, since during initial connect, the lastHeard gets set from the node info dump. It's only during connection that `upsertPositionPacket` updates `lastHeard`.

When I investigated, I saw that these nodes were sending position updates that had a `timestamp` (which is supposed to represent the GPS solution time) in the future. I don't know why: maybe an older firmware, maybe some weird timezone issue, maybe a messed up GPS module.

But in any case, I think it makes sense to just not use future `timestamps` to update a node's `lastHeard` value. Instead, fallback to using `rxTime` or `Date()` instead.

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [X] I have commented my code, particularly in complex areas.
- [X] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.