### PR TITLE
Fix `wantRangeTestPackets` to correctly follow `rangeTestConfig.enabled`

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
@@ -34,12 +34,10 @@ extension AccessoryManager {
 				// Set initial unread message badge states
 				appState.unreadChannelMessages = fetchedNodeInfo[0].myInfo?.unreadMessages(context: context) ?? 0
 				appState.unreadDirectMessages = fetchedNodeInfo[0].user?.unreadMessages(context: context, skipLastMessageCheck: true) ?? 0 // skipLastMessageCheck=true because we don't update lastMessage on our own connected node
-			}
-			if fetchedNodeInfo.count == 1 && fetchedNodeInfo[0].rangeTestConfig?.enabled == true {
-				wantRangeTestPackets = true
-			}
-			if fetchedNodeInfo.count == 1 && fetchedNodeInfo[0].storeForwardConfig?.enabled == true {
-				wantStoreAndForwardPackets = true
+
+				// Set wantRangeTestPackets and wantStoreAndForwardPackets
+				wantRangeTestPackets = fetchedNodeInfo[0].rangeTestConfig?.enabled ?? false
+				wantStoreAndForwardPackets = fetchedNodeInfo[0].storeForwardConfig?.enabled ?? false
 			}
 		} catch {
 			Logger.data.error("Failed to find a node info for the connected node \(error.localizedDescription, privacy: .public)")

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -141,7 +141,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	let transports: [any Transport]
 
 	// Config
-	public var wantRangeTestPackets = true
+	public var wantRangeTestPackets = false
 	var wantStoreAndForwardPackets = false
 	var shouldAutomaticallyConnectToPreferredPeripheral = true
 	

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -110,6 +110,8 @@ struct RangeTestConfig: View {
 		}
 		.onChange(of: enabled) { _, newEnabled in
 			if newEnabled != node?.rangeTestConfig?.enabled { hasChanges = true }
+
+			// Note: even if this is the connected node, we don't have to update AccessoryManager.wantRangeTestPackets here, because the node will reboot after we save config changes, and we'll pick up the new value after we reconnect.
 		}
 		.onChange(of: save) { _, newSave in
 			if newSave != node?.rangeTestConfig?.save { hasChanges = true }

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -167,6 +167,8 @@ struct StoreForwardConfig: View {
 		}
 		.onChange(of: enabled) { oldEnabled, newEnabled in
 			if oldEnabled != newEnabled && newEnabled != node!.storeForwardConfig!.enabled { hasChanges = true }
+
+			// Note: even if this is the connected node, we don't have to update AccessoryManager.wantStoreAndForwardPackets here, because the node will reboot after we save config changes, and we'll pick up the new value after we reconnect.
 		}
 		.onChange(of: isServer) { oldIsServer, newIsServer in
 			if oldIsServer != newIsServer && newIsServer != node!.storeForwardConfig!.isRouter { hasChanges = true }


### PR DESCRIPTION
Fixes https://github.com/meshtastic/Meshtastic-Apple/issues/1440

Thanks to @martinbogo who correctly pointed out in https://github.com/meshtastic/Meshtastic-Apple/issues/1440#issuecomment-3413430413 there was previously nothing that would set `wantRangeTestPackets` to `false`.

Thanks also to @emilyboda and @Kealper for identifying this issue.

Tested locally with two nodes (one sender, one not-sender), toggling the module on and off a bunch of times for the non-sender. 👍 

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [X] I have commented my code, particularly in complex areas.
- [X] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.