### PR TITLE
`UpdateCoreData.updateAnyPacketFrom`: mirror firmware's lastHeard/snr/rssi/hopsAway update logic from `NodeDB::updateFrom`

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -493,6 +493,14 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			handleMyInfo(myNodeInfo)
 
 		case .packet(let packet):
+			// All received packets get passed through updateAnyPacketFrom to update lastHeard, rxSnr, etc. (like firmware's NodeDB::updateFrom).
+			if let connectedNodeNum = self.activeDeviceNum {
+				updateAnyPacketFrom(packet: packet, activeDeviceNum: connectedNodeNum, context: context)
+			} else {
+				Logger.mesh.error("🕸️ Unable to determine connectedNodeNum for updateAnyPacketFrom. Skipping.")
+			}
+
+			// Dispatch based on packet contents.
 			if case let .decoded(data) = packet.payloadVariant {
 				switch data.portnum {
 				case .textMessageApp, .detectionSensorApp, .alertApp:

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -165,6 +165,60 @@ public func clearCoreDataDatabase(context: NSManagedObjectContext, includeRoutes
 	}
 }
 
+func updateAnyPacketFrom (packet: MeshPacket, activeDeviceNum: Int64, context: NSManagedObjectContext) {
+	// Update NodeInfoEntity for any packet received. This mirrors the firmware's NodeDB::updateFrom, which sniffs ALL received packets and updates the radio's nodeDB with packet.from's:
+	// - last_heard (from rxTime)
+	// - snr
+	// - via_mqtt
+	// - hops_away
+
+	// However, unlike the firmware, this function will NOT create a new NodeInfoEntity if we don't have it already. We'll leave that to the existing code paths.
+
+	// We do NOT update fetchedNode[0].channel, because we may hear a node over multiple channels, and only some packet types should update what we consider the node's channel to be. (Example: primary private channel, secondary public channel. A text message on the secondary public channel should NOT change fetchedNode[0].channel.)
+
+	guard packet.from > 0 else { return }
+	guard packet.from != activeDeviceNum else { return } // Ignore if packet is from our own node
+
+	let fetchNodeInfoAppRequest = NodeInfoEntity.fetchRequest()
+	fetchNodeInfoAppRequest.predicate = NSPredicate(format: "num == %lld", Int64(packet.from))
+
+	do {
+		let fetchedNode = try context.fetch(fetchNodeInfoAppRequest)
+		if fetchedNode.count >= 1 {
+			fetchedNode[0].id = Int64(packet.from)
+			fetchedNode[0].num = Int64(packet.from)
+
+			if packet.rxTime > 0 {
+				fetchedNode[0].lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(packet.rxTime)))
+				Logger.data.info("💾 [updateAnyPacketFrom] Updating node \(packet.from.toHex(), privacy: .public) lastHeard from rxTime=\(packet.rxTime)")
+			} else {
+				fetchedNode[0].lastHeard = Date()
+				Logger.data.info("💾 [updateAnyPacketFrom] Updating node \(packet.from.toHex(), privacy: .public) lastHeard to now (rxTime==0)")
+			}
+
+			fetchedNode[0].snr = packet.rxSnr
+			fetchedNode[0].rssi = packet.rxRssi
+			fetchedNode[0].viaMqtt = packet.viaMqtt
+
+			if packet.hopStart != 0 && packet.hopLimit <= packet.hopStart {
+				fetchedNode[0].hopsAway = Int32(packet.hopStart - packet.hopLimit)
+				Logger.data.info("💾 [updateAnyPacketFrom] Updating node \(packet.from.toHex(), privacy: .public) hopsAway=\(fetchedNode[0].hopsAway)")
+			}
+
+			do {
+				try context.save()
+				Logger.data.info("💾 [updateAnyPacketFrom] Updating node \(fetchedNode[0].num.toHex(), privacy: .public) snr=\(fetchedNode[0].snr), rssi=\(fetchedNode[0].rssi) from packet \(packet.id.toHex(), privacy: .public)")
+			} catch {
+				context.rollback()
+				let nsError = error as NSError
+				Logger.data.error("💥 [updateAnyPacketFrom] Error Saving node \(fetchedNode[0].num.toHex(), privacy: .public) from packet \(packet.id.toHex(), privacy: .public)  \(nsError, privacy: .public)")
+			}
+		}
+	} catch {
+		Logger.data.error("💥 [updateAnyPacketFrom] fetch data error")
+	}
+}
+
 func upsertNodeInfoPacket (packet: MeshPacket, favorite: Bool = false, context: NSManagedObjectContext) {
 
 	let logString = String.localizedStringWithFormat("[NodeInfo] received for: %@".localized, packet.from.toHex())
@@ -316,16 +370,6 @@ func upsertNodeInfoPacket (packet: MeshPacket, favorite: Bool = false, context: 
 
 		} else {
 			// Update an existing node
-			fetchedNode[0].id = Int64(packet.from)
-			fetchedNode[0].num = Int64(packet.from)
-			if packet.rxTime > 0 {
-				fetchedNode[0].lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(packet.rxTime)))
-			} else {
-				fetchedNode[0].lastHeard = Date()
-			}
-			fetchedNode[0].snr = packet.rxSnr
-			fetchedNode[0].rssi = packet.rxRssi
-			fetchedNode[0].viaMqtt = packet.viaMqtt
 			if packet.to == Constants.maximumNodeNum || packet.to == UserDefaults.preferredPeripheralNum {
 				fetchedNode[0].channel = Int32(packet.channel)
 			}
@@ -463,22 +507,7 @@ func upsertPositionPacket (packet: MeshPacket, context: NSManagedObjectContext) 
 						mutablePositions.removeAllObjects()
 					}
 					mutablePositions.add(position)
-					fetchedNode[0].id = Int64(packet.from)
-					fetchedNode[0].num = Int64(packet.from)
 
-					// Update the node's lastHeard.
-					// Some misconfigured nodes will broadcast position packets that claim GPS timestamps in the future. When updating lastHeard, don't use any future timestamps: fallback to using rxTime or Date() instead.
-					if positionMessage.time > 0 && (Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.time))) <= Date()) {
-						fetchedNode[0].lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.time)))
-					} else if packet.rxTime > 0 {
-						fetchedNode[0].lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(packet.rxTime)))
-					} else {
-						fetchedNode[0].lastHeard = Date()
-					}
-
-					fetchedNode[0].snr = packet.rxSnr
-					fetchedNode[0].rssi = packet.rxRssi
-					fetchedNode[0].viaMqtt = packet.viaMqtt
 					fetchedNode[0].channel = Int32(packet.channel)
 					fetchedNode[0].positions = mutablePositions.copy() as? NSOrderedSet
 


### PR DESCRIPTION
While thinking about https://github.com/meshtastic/Meshtastic-Apple/pull/1488 I realized that the logic for updating `lastHeard` was different from that used in the firmware.

In the firmware, updates to `last_heard`, `rx_snr`, `rx_time`, `via_mqtt`, `hops_away` are all set in one small function `NodeDB::updateFrom`, which receives all packets:

https://github.com/meshtastic/firmware/blob/28f53d132aa0d3903482ea9b475527068389244a/src/mesh/NodeDB.cpp#L1733-L1762

I think it simplifies things to use essentially the same logic in the client, especially since we update `lastHeard` etc from the radio whenever we connect and re-fetch the node database.

This change: 
- 🐞  fixes a bug that `lastHeard` was being updated whenever we *sent* a DM, due to `addContactFromURL` calling `upsertNodeInfoPacket` with a synthetic packet
- deals with the position packets more consistently (only using `rxTime` to update `lastHeard` like the firmware does, and never `position.timestamp` which can be in the future)
- makes it so messages/ACKs/traceroutes/telemetry (for example) also update `lastHeard` and `rxSnr` etc
- factors out some common code
- and generally synchronizes this logic with the firmware.

I've tested it on iOS and macOS clients. The result seems to be a more active node list, no nodes with times in the future, and immediate updates to SNR/RSSI when viewing nearby nodes!

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [X] I have commented my code, particularly in complex areas.
- [X] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.

