### PR TITLE
Update Muzi R1 Neo to actively supported

### DIFF
--- a/Meshtastic/Resources/DeviceHardware.json
+++ b/Meshtastic/Resources/DeviceHardware.json
@@ -1051,7 +1051,7 @@
 	"hwModelSlug": "MUZI_R1_NEO",
 	"platformioTarget": "r1-neo",
 	"architecture": "nrf52840",
-	"activelySupported": false,
+	"activelySupported": true,
 	"supportLevel": 1,
 	"displayName": "muzi R1 Neo",
 	"tags": [
@@ -1183,3 +1183,4 @@
 	]
   }
 ]
+


### PR DESCRIPTION
This appears to be the value that sets the supported badge. Update the R1 Neo to actively supported.