### PR TITLE
Add list of canned messages

### DIFF
--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -205,7 +205,7 @@ struct CannedMessagesConfig: View {
 								_ = try await accessoryManager.saveCannedMessageModuleConfig(config: cmc, fromUser: node!.user!, toUser: node!.user!)
 								await MainActor.run { hasChanges = false }
 							} catch {
-								Logger.mesh.error("Save config failed")
+								Logger.mesh.error("Unable to save canned message module config: \(error)")
 							}
 						}
 					}


### PR DESCRIPTION
## What changed?
<!-- Provide a clear description for the change -->
Instead of manually typing canned messages out now made a easy-to-use list.

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
It is not intuitive to use pipes to separate messages and dealing with a large list of canned messages is tedious
## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Screenshots/Videos (when applicable)

https://github.com/user-attachments/assets/f0f5b0c5-dfdd-4ff2-9c46-2641ec276818


<!-- Attach screenshots or videos demonstrating the new feature in action. -->
![IMG_5178](https://github.com/user-attachments/assets/3f26eb7e-4a5c-4c8f-8bfb-b03eba8e9d37)

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

