### PR TITLE
Call `clearStaleNodes` at start of `sendWantConfig`

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -14315,6 +14315,7 @@
       }
     },
     "Favorited and ignored nodes are always retained. Nodes without PKC keys are cleared from the app database on the schedule set by the user, nodes with PKC keys are cleared only if the interval is set to 7 days or longer. This feature only purges nodes from the app that are not stored in the device node database." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -14335,6 +14336,9 @@
           }
         }
       }
+    },
+    "Favorited and ignored nodes are always retained. Other nodes are cleared from the app database on the schedule set by the user. (Nodes with PKC keys are always retained for at least 7 days.) This feature only purges nodes from the app that are not stored in the device node database." : {
+
     },
     "Favorites" : {
       "localizations" : {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -196,6 +196,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			Logger.transport.error("Unable to send wantConfig (config): No device connected")
 			return
 		}
+
+		_ = clearStaleNodes(nodeExpireDays: Int(UserDefaults.purgeStaleNodeDays), context: self.context)
 		
 		try await withTaskCancellationHandler {
 			var toRadio: ToRadio = ToRadio()

--- a/Meshtastic/Extensions/UserDefaults.swift
+++ b/Meshtastic/Extensions/UserDefaults.swift
@@ -80,6 +80,7 @@ extension UserDefaults {
 		case showDeviceOnboarding
 		case usageDataAndCrashReporting
 		case autoconnectOnDiscovery
+		case purgeStaleNodeDays
 		case manualConnections
 		case testIntEnum
 	}
@@ -177,6 +178,9 @@ extension UserDefaults {
 
 	@UserDefault(.autoconnectOnDiscovery, defaultValue: true)
 	static var autoconnectOnDiscovery: Bool
+
+	@UserDefault(.purgeStaleNodeDays, defaultValue: 0)
+	static var purgeStaleNodeDays: Double
 
 	@UserDefault(.testIntEnum, defaultValue: .one)
 	static var testIntEnum: TestIntEnum

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -120,7 +120,7 @@ struct AppSettings: View {
 								Text("180")
 							}
 						}
-						Text("Favorited and ignored nodes are always retained. Nodes without PKC keys are cleared from the app database on the schedule set by the user, nodes with PKC keys are cleared only if the interval is set to 7 days or longer. This feature only purges nodes from the app that are not stored in the device node database.")
+						Text("Favorited and ignored nodes are always retained. Other nodes are cleared from the app database on the schedule set by the user. (Nodes with PKC keys are always retained for at least 7 days.) This feature only purges nodes from the app that are not stored in the device node database.")
 							.foregroundStyle(.secondary)
 							.font(idiom == .phone ? .caption : .callout)
 					}


### PR DESCRIPTION
## What changed?

Fixes https://github.com/meshtastic/Meshtastic-Apple/issues/1491

- calls `clearStaleNodes` at the top of `sendWantConfig`
- updates wording regarding the behavior that retains nodes with known public keys to match the code

## Why did it change?

Previously, `clearStaleNodes` was called by a timer every hour. However, this timer was inadvertently removed, so `clearStaleNodes` never gets called. (See https://github.com/meshtastic/Meshtastic-Apple/issues/1491 for detail.)

Instead of re-adding the timer, I decided to just call it from the start of `sendWantConfig`. That way, we don't have to add another expensive call to `sendWantConfig` after clearing nodes!

## How is this tested?

Tested on iOS 26.2

## Screenshots/Videos (when applicable)

n/a

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [X] I have commented my code, particularly in complex areas.
- [X] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.

