### PR TITLE
Don't alert (with sound: .default) when updating Live Activity

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -881,8 +881,8 @@ func telemetryPacket(packet: MeshPacket, connectedNode: Int64, context: NSManage
 					let meshActivity = Activity<MeshActivityAttributes>.activities.first(where: { $0.attributes.nodeNum == connectedNode })
 					if meshActivity != nil {
 						Task {
-							await meshActivity?.update(updatedContent, alertConfiguration: alertConfiguration)
-							// await meshActivity?.update(updatedContent)
+							// await meshActivity?.update(updatedContent, alertConfiguration: alertConfiguration)
+							await meshActivity?.update(updatedContent)
 							Logger.services.debug("Updated live activity.")
 						}
 					}


### PR DESCRIPTION
I don't need my phone to vibrate every 15 minutes for this. (I suspect it was used to be that way, because the other version was commented out.)