### PR TITLE
Add Exchange User Info

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -2118,4 +2118,34 @@ extension AccessoryManager {
 
 			try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 		}
+
+	public func exchangeUserInfo(fromUser: UserEntity, toUser: UserEntity) async throws -> Int64 {
+
+		let userProto = fromUser.toProto()
+		guard let userPayload: Data = try? userProto.serializedData() else {
+			throw AccessoryError.ioFailed("exchangeUserInfo: Unable to serialize User protobuf")
+		}
+
+		var dataMessage = DataMessage()
+		dataMessage.payload = userPayload
+		dataMessage.portnum = PortNum.nodeinfoApp
+		dataMessage.wantResponse = true
+
+		var meshPacket: MeshPacket = MeshPacket()
+		meshPacket.to = UInt32(toUser.num)
+		meshPacket.from = UInt32(fromUser.num)
+		meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+		meshPacket.priority = MeshPacket.Priority.reliable
+		meshPacket.wantAck = true
+		meshPacket.channel = UInt32(toUser.userNode?.channel ?? 0)
+		meshPacket.decoded = dataMessage
+
+		var toRadio: ToRadio = ToRadio()
+		toRadio.packet = meshPacket
+
+		let logString = String.localizedStringWithFormat("Sent User Info Exchange request from %@ to %@".localized, fromUser.longName ?? "Unknown".localized, toUser.longName ?? "Unknown".localized)
+		try await send(toRadio, debugDescription: logString)
+
+		return Int64(meshPacket.id)
+	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/Actions/ExchangeUserInfoButton.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Actions/ExchangeUserInfoButton.swift
@@ -1,0 +1,61 @@
+import CoreData
+import SwiftUI
+import OSLog
+
+struct ExchangeUserInfoButton: View {
+	var node: NodeInfoEntity
+	var connectedNode: NodeInfoEntity
+
+	@EnvironmentObject var accessoryManager: AccessoryManager
+
+	@State private var isPresentingUserInfoSentAlert: Bool = false
+	@State private var isPresentingUserInfoFailedAlert: Bool = false
+
+	var body: some View {
+		Button {
+			Task {
+				if let fromUser = connectedNode.user, let toUser = node.user {
+					do {
+						_ = try await accessoryManager.exchangeUserInfo(fromUser: fromUser, toUser: toUser)
+						Task { @MainActor in
+							isPresentingUserInfoSentAlert = true
+							DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+								isPresentingUserInfoSentAlert = false
+							}
+						}
+					} catch {
+						Logger.mesh.warning("Failed to exchange user info")
+						Task { @MainActor in
+							isPresentingUserInfoFailedAlert = true
+							DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+								isPresentingUserInfoFailedAlert = false
+							}
+						}
+					}
+				}
+			}
+
+		} label: {
+			Label {
+				Text("Exchange User Info")
+			} icon: {
+				Image(systemName: "person.2.badge.gearshape")
+					.symbolRenderingMode(.hierarchical)
+			}
+		}.alert(
+			"User Info Sent",
+			isPresented: $isPresentingUserInfoSentAlert
+		) {
+			Button("OK") {	}.keyboardShortcut(.defaultAction)
+		} message: {
+			Text("Your user info has been sent with a request for a response with their user info.")
+		}.alert(
+			"User Info Exchange Failed",
+			isPresented: $isPresentingUserInfoFailedAlert
+		) {
+			Button("OK") {	}.keyboardShortcut(.defaultAction)
+		} message: {
+			Text("Failed to exchange user info.")
+		}
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -464,6 +464,10 @@ struct NodeDetail: View {
 									node: node,
 									connectedNode: connectedNode
 								)
+								ExchangeUserInfoButton(
+									node: node,
+									connectedNode: connectedNode
+								)
 								TraceRouteButton(
 									node: node
 								)

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -253,6 +253,19 @@ fileprivate struct FilteredNodeList: View {
 				} label: {
 					Label("Exchange Positions", systemImage: "arrow.triangle.2.circlepath")
 				}
+				Button {
+					Task {
+						if let fromUser = connectedNode.user, let toUser = node.user {
+							do {
+								_ = try await accessoryManager.exchangeUserInfo(fromUser: fromUser, toUser: toUser)
+							} catch {
+								Logger.mesh.warning("Failed to exchange user info")
+							}
+						}
+					}
+				} label: {
+					Label("Exchange User Info", systemImage: "person.2.badge.gearshape")
+				}
 				TraceRouteButton(
 					node: node
 				)


### PR DESCRIPTION
## What changed?
Added "Exchange User Info," the ability to initiate an exchange of your user info to another node and request theirs in return.

The action can be taken from the Node List context menu, by long-pressing or right-clicking a node and selecting "Exchange User Info," or from the Node Detail view, by clicking the "Exchange User Info" button.

## Why did it change?
This functionality exists in the Android app and is useful for forcing info updates on nodes that have been forgotten or deleted.

## How is this tested?
This has been tested on an iPhone 15 Pro Max and an M3 MacBook Air.

## Screenshots/Videos (when applicable)
![ContextMenu](https://github.com/user-attachments/assets/b4f4cfdc-0ad2-456c-a39e-1a1a54721d00)
![DetailView](https://github.com/user-attachments/assets/a6ae5312-9cd1-433a-8353-303bc72b79e0)

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

