### PR TITLE
Add missing ExchangeUserInfoButton project files from #1550

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -13710,6 +13710,9 @@
         }
       }
     },
+    "Exchange User Info" : {
+
+    },
     "Exclamation" : {
       "localizations" : {
         "de" : {
@@ -14189,6 +14192,9 @@
           }
         }
       }
+    },
+    "Failed to exchange user info." : {
+
     },
     "Failed to get a valid position to exchange" : {
       "localizations" : {
@@ -35555,6 +35561,9 @@
         }
       }
     },
+    "Tap to enter emoji" : {
+
+    },
     "Tapback" : {
       "localizations" : {
         "de" : {
@@ -40235,6 +40244,12 @@
         }
       }
     },
+    "User Info Exchange Failed" : {
+
+    },
+    "User Info Sent" : {
+
+    },
     "User Privacy" : {
 
     },
@@ -42325,6 +42340,9 @@
           }
         }
       }
+    },
+    "Your user info has been sent with a request for a response with their user info." : {
+
     }
   },
   "version" : "1.1"

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		3D3417C82E29D38A006A988B /* GeoJSONOverlayConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3417C72E29D38A006A988B /* GeoJSONOverlayConfig.swift */; };
 		3D3417D22E2DC260006A988B /* MapDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3417D12E2DC260006A988B /* MapDataManager.swift */; };
 		3D3417D42E2DC293006A988B /* MapDataFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3417D32E2DC293006A988B /* MapDataFiles.swift */; };
+		489D84252F0EEFB300B17D47 /* ExchangeUserInfoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489D84242F0EEFB200B17D47 /* ExchangeUserInfoButton.swift */; };
 		6D825E622C34786C008DBEE4 /* CommonRegex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D825E612C34786C008DBEE4 /* CommonRegex.swift */; };
 		6DA39D8E2A92DC52007E311C /* MeshtasticAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA39D8D2A92DC52007E311C /* MeshtasticAppDelegate.swift */; };
 		6DEDA55A2A957B8E00321D2E /* DetectionSensorLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEDA5592A957B8E00321D2E /* DetectionSensorLog.swift */; };
@@ -398,6 +399,7 @@
 		3D3417C72E29D38A006A988B /* GeoJSONOverlayConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoJSONOverlayConfig.swift; sourceTree = "<group>"; };
 		3D3417D12E2DC260006A988B /* MapDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapDataManager.swift; sourceTree = "<group>"; };
 		3D3417D32E2DC293006A988B /* MapDataFiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapDataFiles.swift; sourceTree = "<group>"; };
+		489D84242F0EEFB200B17D47 /* ExchangeUserInfoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUserInfoButton.swift; sourceTree = "<group>"; };
 		6D825E612C34786C008DBEE4 /* CommonRegex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonRegex.swift; sourceTree = "<group>"; };
 		6DA39D8D2A92DC52007E311C /* MeshtasticAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshtasticAppDelegate.swift; sourceTree = "<group>"; };
 		6DEDA5592A957B8E00321D2E /* DetectionSensorLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectionSensorLog.swift; sourceTree = "<group>"; };
@@ -849,6 +851,7 @@
 				DDDFE73E2D0D48FF0044463C /* IgnoreNodeButton.swift */,
 				251926842C3BA97800249DF5 /* FavoriteNodeButton.swift */,
 				251926892C3BB1B200249DF5 /* ExchangePositionsButton.swift */,
+				489D84242F0EEFB200B17D47 /* ExchangeUserInfoButton.swift */,
 				DDF82CBC2D5BC69200DC25EC /* NavigateToButton.swift */,
 				251926862C3BAE2200249DF5 /* NodeAlertsButton.swift */,
 				2519268B2C3BB52000249DF5 /* TraceRouteButton.swift */,
@@ -1722,6 +1725,7 @@
 				2346A7192E2FB9A300CB9239 /* SerialConnection.swift in Sources */,
 				DDDB444A29F8AA3A00EE2349 /* CLLocationCoordinate2D.swift in Sources */,
 				25C49D902C471AEA0024FBD1 /* Constants.swift in Sources */,
+				489D84252F0EEFB300B17D47 /* ExchangeUserInfoButton.swift in Sources */,
 				ABB99DEB2E2EA1C500CFBD05 /* AppIconPicker.swift in Sources */,
 				DD41582628582E9B009B0E59 /* DeviceConfig.swift in Sources */,
 				DDF45C372BC46A5A005ED5F2 /* TimeZone.swift in Sources */,


### PR DESCRIPTION
## What changed?
Added missing Xcode project references and localizations for ExchangeUserInfoButton that were omitted from PR #1550.

## Why did it change?
PR #1550 added the `ExchangeUserInfoButton.swift` source file but didn't include the corresponding Xcode project.pbxproj entries and Localizable.xcstrings updates, which would break the build.

## How is this tested?
  - Project builds successfully with inclusion of these files
  - ExchangeUserInfoButton compiles and links properly
  - All localization strings are available

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

