### PR TITLE
BLE Reconnect Improvements/Fixes

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Discovery.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Discovery.swift
@@ -63,7 +63,7 @@ extension AccessoryManager {
 						if self.shouldAutomaticallyConnectToPreferredPeripheral,
 						   UserDefaults.autoconnectOnDiscovery, UserDefaults.preferredPeripheralId == newDevice.id.uuidString {
 							Logger.transport.debug("🔎 [Discovery] Found preferred peripheral \(newDevice.name)")
-							self.connectToPreferredDevice()
+							self.connectToPreferredDevice(device: newDevice)
 						}
 						
 						// Update the list of discovered devices on the main thread for presentation

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -180,10 +180,12 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		return transports.first(where: {$0.type == type })
 	}
 	
-	func connectToPreferredDevice() {
+	func connectToPreferredDevice(device: Device) {
 		if !self.isConnected && !self.isConnecting,
-		   let preferredDevice = self.devices.first(where: { $0.id.uuidString == UserDefaults.preferredPeripheralId }) {
-			Task { try await self.connect(to: preferredDevice) }
+		   let preferredDevice = device ?? self.devices.first(where: { $0.id.uuidString == UserDefaults.preferredPeripheralId }) {
+			Task {
+				try await self.connect(to: preferredDevice)
+			}
 		}
 	}
 


### PR DESCRIPTION
## What changed?

Two improvements to auto-reconnect on BLE discovery.

1.  A recent change stopped attempts to update a @Published device list when in the background to solve a SwiftUI crash.  This device list was also used in the connection process, and since the device didn't exist, a reconnect was not issued upon discovery.  Added an optional parameter to `connectToPreferredDevice` to bypass the list check and reconnect to the given preferred device.

2. Step one of the connection process is as follows (pseudocode):

- if provided a connection, use the provided connection
- if not provided a connection, `try await transport.connect(to: device)`
- setup the event stream with `try await connection.connect()`

The two `try` steps can fail.  The normal way the Connection reports a disconnect to the Accessory manager is by ending the event stream.  However, these try steps happen BEFORE the event stream is stood up.  This means a failure is never reported to the `BLETransport` object.  While this isn't terrible in itself, the BLETransport never removes the device from its internal discovery list.  This means subsequent discovery events do not trigger a "new device discovered" workflow, and hence a `connectToPreferredDevice`.  This means the app sits in a disconnected state.

Updated `BLETransport.connect()` to remove a failed connection device from its list and `BLEConnection.connect()` to notify BLETransport to do the same upon a failure.  This leaves the discovery list in a state where the next discovery can trigger a reconnect.


## Why did it change?

Better reconnect behavior


## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

