### PR TITLE
feat: Allow dismissal of Messages tip

### DIFF
--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -63,8 +63,7 @@ struct Messages: View {
 					$0[.leading]
 				}
 				Spacer()
-				TipView(MessagesTip(), arrowEdge: .top)
-					.tipViewStyle(PersistentTip())
+				TipView(MessagesTip())
 					.listRowSeparator(.hidden)
 				Spacer()
 					.listRowSeparator(.hidden)


### PR DESCRIPTION
## What changed?
This changes the style of the MessagesTip on Messages view to:
- Allow it to be dismissible
- Removes the arrow

## Why did it change?
- After understanding what Messages are for, the user does not need to be reminded and the tip clutters the UI.
- The arrow was a little vague as to what it was pointing to. The tip refers to the whole of the concept of the Messages view so it doesn't need to point at anything.

## How is this tested?
Tested on simulator for iOS and iPad OS.

## Screenshots/Videos (when applicable)
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/b69f5d71-e315-4df9-bec7-fad6ee1fd0aa" />
<img width="2752" height="2064" alt="image" src="https://github.com/user-attachments/assets/a9ba6383-2896-42fc-95b9-d9ba2be5fd5f" />

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

