### PR TITLE
fix: Mesh Map missing some nodes

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -62,7 +62,7 @@ struct MeshMapContent: MapContent {
 					// Imprecise location: fuzz slightly so overlapping nodes are visible and clickable at highest zoom levels.
 					position.fuzzedCoordinate
 				}
-				if 12...15 ~= position.precisionBits || position.isPreciseLocation {
+				if position.precisionBits >= 12 || position.isPreciseLocation {
 					
 					let nodeColor = UIColor(hex: UInt32(position.nodePosition?.num ?? 0))
 					let positionName = position.nodePosition?.user?.longName ?? "?"


### PR DESCRIPTION
## What changed?
Loosens the filter for Mesh Map to show assumed exact locations so more appear on the map.

## Why did it change?
Nodes with unset or zero-precision (likely manually set) do not appear on the map, though the user expects to see them. 

The Android Meshtastic app doesn't seem to be doing _any_ filtering based on precision, leading to a discrepancy between nodes that can be seen in the Android vs iOS, furthering user confusion. Some filtering based on accuracy is probably warranted, so I kept it at what was potentially the original intent of this `if` statement and allowed all values greater than or equal to 12 bits.

Note the definition of `isPreciseLocation` in PositionEntityExtension.swift:
```swift
var isPreciseLocation: Bool {
  precisionBits == 32 || precisionBits == 0
}
```

## How is this tested?
I have not tested this yet as I haven't figured out how to run on-device so I can test connected to a node.

## Screenshots/Videos (when applicable)
n/a

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

Fixes https://github.com/meshtastic/Meshtastic-Apple/issues/1581