### PR TITLE
Changed capitalization from 'environment' to 'Environment' for section heading

### DIFF
--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -70,7 +70,7 @@ struct AppSettings: View {
 					}
 #endif
 				}
-				Section(header: Text("environment")) {
+				Section(header: Text("Environment")) {
 					VStack(alignment: .leading) {
 						Toggle(isOn: $environmentEnableWeatherKit) {
 							Label("Weather Conditions", systemImage: "cloud.sun")


### PR DESCRIPTION
## What changed?
Updated the capitalization of the Environment section from 'environment' to 'Environment'

## Why did it change?
The capitalization of this string was changed to maintain consistency with other section headings. 

## How is this tested?
I built and ran this in the iOS simulator.

## Screenshots/Videos (when applicable)
<img width="406" height="112" alt="Screenshot 2026-02-12 at 3 04 05 PM" src="https://github.com/user-attachments/assets/04ae56ce-3fe2-40c8-8fc0-0dc29fc25f66" />

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

