### PR TITLE
fix: show ADC Multiplier Override for all hardware platforms

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -2869,7 +2869,11 @@
         }
       }
     },
+    "ADC Multiplier Override" : {
+
+    },
     "ADC Override" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -9435,6 +9439,9 @@
           }
         }
       }
+    },
+    "Common values: RAK4631/T114 = 4.916, Heltec V3 = 5.1205. Use 0 for firmware default." : {
+
     },
     "Communicate off-the-grid with your friends and community without cell service." : {
       "localizations" : {
@@ -29837,6 +29844,9 @@
         }
       }
     },
+    "Override the default ADC multiplier for battery voltage measurement. Set to 0 to use the firmware default." : {
+
+    },
     "Packet Count" : {
       "localizations" : {
         "ru" : {
@@ -41604,7 +41614,6 @@
       }
     },
     "TAK" : {
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -51,27 +51,29 @@ struct PowerConfig: View {
 			} header: {
 				Text("Power")
 			}
-			if currentDevice?.architecture == .esp32 || currentDevice?.architecture == .esp32S3 {
-				Section {
-					Toggle(isOn: $adcOverride) {
-						Text("ADC Override")
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-
-					if adcOverride {
-						HStack {
-							Text("Multiplier")
-							Spacer()
-							FloatField(title: "Multiplier", number: $adcMultiplier) {
-								(2.0 ... 6.0).contains($0)
-							}
-							.focused($isFocused)
-							Spacer()
-						}
-					}
-				} header: {
-					Text("Battery")
+			Section {
+				Toggle(isOn: $adcOverride) {
+					Label("ADC Multiplier Override", systemImage: "bolt.batteryblock")
+					Text("Override the default ADC multiplier for battery voltage measurement. Set to 0 to use the firmware default.")
 				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+
+				if adcOverride {
+					HStack {
+						Text("Multiplier")
+						Spacer()
+						FloatField(title: "Multiplier", number: $adcMultiplier) {
+							$0 == 0 || (0.0 ... 7.0).contains($0)
+						}
+						.focused($isFocused)
+						Spacer()
+					}
+					Text("Common values: RAK4631/T114 = 4.916, Heltec V3 = 5.1205. Use 0 for firmware default.")
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
+			} header: {
+				Text("Battery")
 			}
 		}
 		.disabled(!accessoryManager.isConnected || node?.powerConfig == nil)


### PR DESCRIPTION
Remove ESP32-only restriction on ADC Multiplier Override field in Power Config. The firmware supports this setting on all platforms (nRF52, RP2040, ESP32) since meshtastic/meshtastic#1135.

Changes:
- Remove architecture check that hid the field for non-ESP32 devices
- Widen validation range from 2-6 to 0-7 to support all device types
- Add descriptive help text with common device multiplier values
- Add caption with common values (T114=4.916, Heltec V3=5.1205)

Tested on Heltec T114 (nRF52840) - value saves and persists correctly.

Fixes #698

## What changed?
Removed the ESP32-only architecture check that prevented the ADC Multiplier Override field from appearing on nRF52 and RP2040 devices. Widened the validation range from 2–6 to 0–7. Added descriptive help text and common device multiplier values as a caption.

## Why did it change?
Firmware changes (meshtastic/meshtastic#1135) made adc_multiplier_override work on all platforms, but the iOS app still gated the field to ESP32 devices only. This blocks users of popular nRF52 devices like the Heltec T114 (which needs a multiplier of ~4.916) from calibrating battery reporting without resorting to the Python CLI.

## How is this tested?
Built from source and tested on a Heltec Mesh Node T114 (nRF52840):

ADC Multiplier Override field is now visible for nRF52 devices
Entered 4.916 — value saved, device rebooted, value persisted on reconnect
Changed back to 4.9489 — saved correctly
Battery level reporting updated correctly after calibration
Setting value to 0 resets to firmware default

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [ ] My code adheres to the project's coding and style guidelines.
- [ ] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

