### PR TITLE
fix: Stale nodes

### DIFF
--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -122,6 +122,15 @@ struct NodeList: View {
 				ContentUnavailableView("Select a Node", systemImage: "flipphone")
 			}
 		}
+		.onAppear {
+			if accessoryManager.isConnected {
+				Logger.services.info("🛣 [NodeList] Refreshing nodes from device")
+				Task {
+					_ = await MeshPackets.shared.clearStaleNodes(nodeExpireDays: Int(UserDefaults.purgeStaleNodeDays))
+					try? await accessoryManager.sendWantDatabase()
+				}
+			}
+		}
 		.onChange(of: router.navigationState.nodeListSelectedNodeNum) { _, newNum in
 			if let num = newNum {
 				self.selectedNode = getNodeInfo(id: num, context: context)


### PR DESCRIPTION
## What changed?

Nodes get refreshed on each Nodes menu access.

## Why did it change?

There were stale nodes in the Nodes list.

## How is this tested?

Xcode with https://github.com/mickeyl/ImpossiBLE.

## Screenshots/Videos (when applicable)

<img width="948" height="794" alt="image" src="https://github.com/user-attachments/assets/942f42af-6b6f-4917-827d-edb297b04a99" />

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

