### PR TITLE
Fix/delete channel messages crash

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		052A45EE2F688BC200DD22E4 /* UpdateCoreDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052A45ED2F688BC200DD22E4 /* UpdateCoreDataTests.swift */; };
 		102B5EAB2E172F41003D191E /* DatadogCore in Frameworks */ = {isa = PBXBuildFile; productRef = 102B5EAA2E172F41003D191E /* DatadogCore */; };
 		102B5EAD2E172F41003D191E /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 102B5EAC2E172F41003D191E /* DatadogCrashReporting */; };
 		102B5EAF2E172F41003D191E /* DatadogLogs in Frameworks */ = {isa = PBXBuildFile; productRef = 102B5EAE2E172F41003D191E /* DatadogLogs */; };
@@ -346,6 +347,7 @@
 
 /* Begin PBXFileReference section */
 		01028778B8BFD81F7A039593 /* TAKConnection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKConnection.swift; sourceTree = "<group>"; };
+		052A45ED2F688BC200DD22E4 /* UpdateCoreDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCoreDataTests.swift; sourceTree = "<group>"; };
 		0618E6D0DF90B74EE32E6C06 /* TAKServerConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKServerConfig.swift; sourceTree = "<group>"; };
 		09936BEBD6D82479B2360FDC /* TAKCertificateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKCertificateManager.swift; sourceTree = "<group>"; };
 		108FFECA2DD3F43C00BFAA81 /* ShareContactQRDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareContactQRDialog.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 		25F5D5C82C4375A8008036E3 /* MeshtasticTests */ = {
 			isa = PBXGroup;
 			children = (
+				052A45ED2F688BC200DD22E4 /* UpdateCoreDataTests.swift */,
 				25F5D5D02C4375DF008036E3 /* RouterTests.swift */,
 			);
 			path = MeshtasticTests;
@@ -1658,6 +1661,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				25F5D5D12C4375DF008036E3 /* RouterTests.swift in Sources */,
+				052A45EE2F688BC200DD22E4 /* UpdateCoreDataTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -155,14 +155,34 @@ extension MeshPackets {
 	}
 	
 	nonisolated public func deleteChannelMessages(channel: ChannelEntity, context: NSManagedObjectContext) {
+		// Ensure we're working with the correct context
+		guard let channelInContext = context.object(with: channel.objectID) as? ChannelEntity else {
+			Logger.data.error("💥 [deleteChannelMessages] Unable to get channel in context")
+			return
+		}
+		
+		// Use a fetch request instead of accessing the relationship directly
+		// Note: MessageEntity.channel is an Int32, not a relationship to ChannelEntity
+		let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "MessageEntity")
+		fetchRequest.predicate = NSPredicate(format: "channel == %d", channelInContext.index)
+		
+		let batchDeleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+		batchDeleteRequest.resultType = .resultTypeObjectIDs
+		
 		do {
-			let objects = channel.allPrivateMessages
-			for object in objects {
-				context.delete(object)
+			let result = try context.execute(batchDeleteRequest) as? NSBatchDeleteResult
+			
+			// Merge the changes into the context
+			if let objectIDArray = result?.result as? [NSManagedObjectID] {
+				let changes = [NSDeletedObjectsKey: objectIDArray]
+				NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [context])
+				Logger.data.info("💾 [deleteChannelMessages] Deleted \(objectIDArray.count) messages from channel")
 			}
+			
 			try context.save()
-		} catch let error as NSError {
-			Logger.data.error("\(error.localizedDescription, privacy: .public)")
+		} catch {
+			context.rollback()
+			Logger.data.error("💥 [deleteChannelMessages] Error deleting channel messages: \(error.localizedDescription, privacy: .public)")
 		}
 	}
 	

--- a/MeshtasticTests/UpdateCoreDataTests.swift
+++ b/MeshtasticTests/UpdateCoreDataTests.swift
@@ -1,0 +1,208 @@
+//
+//  UpdateCoreDataTests.swift
+//  Meshtastic
+//
+//  Tests for deleteChannelMessages functions
+
+import XCTest
+import CoreData
+@testable import Meshtastic
+
+final class DeleteChannelMessagesTests: XCTestCase {
+    private func createTestPersistenceController() -> NSPersistentContainer {
+        let container = NSPersistentContainer(name: "MeshtasticDataModel")
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        container.persistentStoreDescriptions = [description]
+        
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Failed to load test store: \(error)")
+            }
+        }
+        
+        return container
+    }
+    
+    private func createTestChannel(
+        in context: NSManagedObjectContext,
+        messageCount: Int = 0
+    ) -> ChannelEntity {
+        let channel = ChannelEntity(context: context)
+        channel.index = 1
+        channel.name = "Test Channel"
+        
+        for i in 0..<messageCount {
+            let message = MessageEntity(context: context)
+            message.messageId = Int64(i)
+            message.messageTimestamp = Int32(Date().timeIntervalSince1970)
+            message.channel = channel.index
+        }
+        
+        try? context.save()
+        return channel
+    }
+    
+    func testSyncDeleteChannelMessages() throws {
+        let container = createTestPersistenceController()
+        let context = container.newBackgroundContext()
+        
+        var channel: ChannelEntity!
+        var channelObjectID: NSManagedObjectID!
+        
+        container.viewContext.performAndWait {
+            channel = createTestChannel(in: container.viewContext, messageCount: 5)
+            channelObjectID = channel.objectID
+            try? container.viewContext.save()
+        }
+        
+        context.performAndWait {
+            guard let channelInContext = context.object(with: channelObjectID) as? ChannelEntity else {
+                XCTFail("Could not get channel in context")
+                return
+            }
+            
+            MeshPackets.shared.deleteChannelMessages(channel: channelInContext, context: context)
+            
+            let fetchAfter = NSFetchRequest<MessageEntity>(entityName: "MessageEntity")
+            fetchAfter.predicate = NSPredicate(format: "channel == %d", channelInContext.index)
+            let messagesAfter = try? context.fetch(fetchAfter)
+            XCTAssertEqual(messagesAfter?.count, 0, "Should have 0 messages after deletion")
+        }
+    }
+    
+    func testSyncDeleteChannelMessagesInvalidChannel() throws {
+        let container = createTestPersistenceController()
+        let context = container.newBackgroundContext()
+        
+        let channel = createTestChannel(in: container.viewContext, messageCount: 3)
+        
+        context.performAndWait {
+            MeshPackets.shared.deleteChannelMessages(channel: channel, context: context)
+        }
+    }
+    
+    func testSyncDeleteChannelMessagesBatchDelete() throws {
+        let container = createTestPersistenceController()
+        let context = container.newBackgroundContext()
+        
+        var channelObjectID: NSManagedObjectID!
+        
+        container.viewContext.performAndWait {
+            let channel = createTestChannel(in: container.viewContext, messageCount: 100)
+            channelObjectID = channel.objectID
+            try? container.viewContext.save()
+        }
+        
+        context.performAndWait {
+            guard let channelInContext = context.object(with: channelObjectID) as? ChannelEntity else {
+                XCTFail("Could not get channel in context")
+                return
+            }
+            
+            MeshPackets.shared.deleteChannelMessages(channel: channelInContext, context: context)
+            
+            let fetchAfter = NSFetchRequest<MessageEntity>(entityName: "MessageEntity")
+            fetchAfter.predicate = NSPredicate(format: "channel == %d", channelInContext.index)
+            let messagesAfter = try? context.fetch(fetchAfter)
+            XCTAssertEqual(messagesAfter?.count, 0, "All 100 messages should be deleted")
+        }
+    }
+    
+    func testSyncDeleteChannelMessagesMergesChanges() throws {
+        let container = createTestPersistenceController()
+        let backgroundContext = container.newBackgroundContext()
+        
+        var channelObjectID: NSManagedObjectID!
+        
+        container.viewContext.performAndWait {
+            let channel = createTestChannel(in: container.viewContext, messageCount: 10)
+            channelObjectID = channel.objectID
+            try? container.viewContext.save()
+        }
+        
+        backgroundContext.performAndWait {
+            guard let channelInContext = backgroundContext.object(with: channelObjectID) as? ChannelEntity else {
+                XCTFail("Could not get channel in context")
+                return
+            }
+            
+            MeshPackets.shared.deleteChannelMessages(channel: channelInContext, context: backgroundContext)
+        }
+        
+        container.viewContext.performAndWait {
+            container.viewContext.refreshAllObjects()
+            
+            guard let channel = try? container.viewContext.existingObject(with: channelObjectID) as? ChannelEntity else {
+                XCTFail("Could not get channel in view context")
+                return
+            }
+            
+            let fetchAfter = NSFetchRequest<MessageEntity>(entityName: "MessageEntity")
+            fetchAfter.predicate = NSPredicate(format: "channel == %d", channel.index)
+            let messagesAfter = try? container.viewContext.fetch(fetchAfter)
+            XCTAssertEqual(messagesAfter?.count, 0, "Changes should be merged to view context")
+        }
+    }
+    
+    func testSyncDeleteChannelMessagesOnlyAffectsSpecifiedChannel() throws {
+        let container = createTestPersistenceController()
+        let context = container.newBackgroundContext()
+        
+        var channel1ObjectID: NSManagedObjectID!
+        var channel2ObjectID: NSManagedObjectID!
+        
+        container.viewContext.performAndWait {
+            let channel1 = createTestChannel(in: container.viewContext, messageCount: 5)
+            let channel2 = createTestChannel(in: container.viewContext, messageCount: 3)
+            channel1.index = 1
+            channel2.index = 2
+            
+            channel1ObjectID = channel1.objectID
+            channel2ObjectID = channel2.objectID
+            try? container.viewContext.save()
+        }
+        
+        context.performAndWait {
+            guard let channel1InContext = context.object(with: channel1ObjectID) as? ChannelEntity,
+                  let channel2InContext = context.object(with: channel2ObjectID) as? ChannelEntity else {
+                XCTFail("Could not get channels in context")
+                return
+            }
+            
+            MeshPackets.shared.deleteChannelMessages(channel: channel1InContext, context: context)
+            
+            let fetch1 = NSFetchRequest<MessageEntity>(entityName: "MessageEntity")
+            fetch1.predicate = NSPredicate(format: "channel == %d", channel1InContext.index)
+            let messages1 = try? context.fetch(fetch1)
+            XCTAssertEqual(messages1?.count, 0, "Channel 1 should have 0 messages")
+            
+            let fetch2 = NSFetchRequest<MessageEntity>(entityName: "MessageEntity")
+            fetch2.predicate = NSPredicate(format: "channel == %d", channel2InContext.index)
+            let messages2 = try? context.fetch(fetch2)
+            XCTAssertEqual(messages2?.count, 3, "Channel 2 should still have 3 messages")
+        }
+    }
+    
+    func testSyncDeleteChannelMessagesHandlesSaveErrors() throws {
+        let container = createTestPersistenceController()
+        let context = container.newBackgroundContext()
+        
+        var channelObjectID: NSManagedObjectID!
+        
+        container.viewContext.performAndWait {
+            let channel = createTestChannel(in: container.viewContext, messageCount: 2)
+            channelObjectID = channel.objectID
+            try? container.viewContext.save()
+        }
+        
+        context.performAndWait {
+            guard let channelInContext = context.object(with: channelObjectID) as? ChannelEntity else {
+                XCTFail("Could not get channel in context")
+                return
+            }
+            
+            MeshPackets.shared.deleteChannelMessages(channel: channelInContext, context: context)
+        }
+    }
+}


### PR DESCRIPTION
## What changed?
We now verify we get the channel in the correct context before attempting to operate on the data, as well as handling other exceptions gracefully should they arise.

## Why did it change?
We were attempting to operate on data outside of the appropriate context, which then throws an uncaught error which crashes the app. Fixes #1626. Fixes #1599.

## How is this tested?
[Written tests](https://github.com/meshtastic/Meshtastic-Apple/pull/1627/changes#diff-f1ecff18b0b8c9d60d51aae70fca2b775d74b21401dc0cb4a2537eb6898c2309)

## Screenshots/Videos (when applicable)
n/a

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

