### PR TITLE
fix typo in hop limit option description

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -39073,7 +39073,7 @@
         }
       }
     },
-    "Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. O hop broadcast messages will not get ACKs." : {
+    "Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. 0 hop broadcast messages will not get ACKs." : {
       "localizations" : {
         "it" : {
           "stringUnit" : {

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -142,7 +142,7 @@ struct LoRaConfig: View {
 								.tag($0)
 						}
 					}
-					Text("Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. O hop broadcast messages will not get ACKs.")
+					Text("Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. 0 hop broadcast messages will not get ACKs.")
 						.foregroundColor(.gray)
 						.font(.callout)
 				}


### PR DESCRIPTION
O hop -> 0 hop

## What changed?
<!-- Provide a clear description for the change -->
Corrected a typo (0 mistyped as O) in the description of the "Number of hops" option

## Why did it change?
<!--A brief overview of why the change being added. Explain the functionality and its intended purpose. -->
In the context of the text, 0 is correct

## How is this tested?
<!-- Describe your approach to testing the feature. -->
cosmetic, testing not required

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [ ] I have tested the change to ensure that it works as intended.

