### PR TITLE
Add compact view

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -39970,6 +39970,9 @@
     "Show Power" : {
 
     },
+    "Show Role" : {
+
+    },
     "Show Telemetry Icons" : {
 
     },

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -9526,8 +9526,6 @@
         }
       }
     },
-    "Compact Layout" : {
-    },
     "Compass" : {
       "localizations" : {
         "ru" : {
@@ -41609,7 +41607,6 @@
       }
     },
     "TAK" : {
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -15569,6 +15569,7 @@
 
     },
     "environment" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -27912,6 +27913,9 @@
         }
       }
     },
+    "Node Layout" : {
+
+    },
     "Node List Density" : {
 
     },
@@ -33833,6 +33837,9 @@
           }
         }
       }
+    },
+    "Relative Last Heard Time" : {
+
     },
     "Relayed by %d %@" : {
       "localizations" : {
@@ -39834,6 +39841,12 @@
         }
       }
     },
+    "Show Last Heard Time" : {
+
+    },
+    "Show Location" : {
+
+    },
     "Show nodes" : {
       "localizations" : {
         "de" : {
@@ -39953,6 +39966,12 @@
           }
         }
       }
+    },
+    "Show Power" : {
+
+    },
+    "Show Telemetry Icons" : {
+
     },
     "Show Waypoints" : {
       "extractionState" : "stale",

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -22448,9 +22448,6 @@
         }
       }
     },
-    "Layout" : {
-
-    },
     "LED Heartbeat" : {
       "localizations" : {
         "it" : {
@@ -27916,6 +27913,9 @@
           }
         }
       }
+    },
+    "Node List Density" : {
+
     },
     "Node Map" : {
       "localizations" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -9526,6 +9526,8 @@
         }
       }
     },
+    "Compact Layout" : {
+    },
     "Compass" : {
       "localizations" : {
         "ru" : {
@@ -22445,6 +22447,9 @@
           }
         }
       }
+    },
+    "Layout" : {
+
     },
     "LED Heartbeat" : {
       "localizations" : {

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		9604373EEB96801AA89DF48C /* EXICodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0A8ABAEF1E587683970927 /* EXICodec.swift */; };
 		A5339E2F74E83F8FC41EEE33 /* TAKServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0618E6D0DF90B74EE32E6C06 /* TAKServerConfig.swift */; };
 		AB61EBF12E3326DC00B35962 /* NodeListItemCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */; };
+		AB6E72762E3FC85A00639328 /* LayoutEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E72752E3FC85A00639328 /* LayoutEnums.swift */; };
 		ABA8E6402E2F2A2300E27791 /* AppIconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8E63F2E2F2A2300E27791 /* AppIconButton.swift */; };
 		ABB99DEB2E2EA1C500CFBD05 /* AppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB99DEA2E2EA1C500CFBD05 /* AppIconPicker.swift */; };
 		B16C760DB291CFAB5335EADB /* TAKCertificateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09936BEBD6D82479B2360FDC /* TAKCertificateManager.swift */; };
@@ -434,6 +435,7 @@
 		8D3F8A402D44C2A6009EAAA4 /* PowerMetricsLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerMetricsLog.swift; sourceTree = "<group>"; };
 		9155703C39B55FC9DDF3E4C1 /* TAKDataPackageGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKDataPackageGenerator.swift; sourceTree = "<group>"; };
 		AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeListItemCompact.swift; sourceTree = "<group>"; };
+		AB6E72752E3FC85A00639328 /* LayoutEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutEnums.swift; sourceTree = "<group>"; };
 		ABA8E63F2E2F2A2300E27791 /* AppIconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconButton.swift; sourceTree = "<group>"; };
 		ABB99DEA2E2EA1C500CFBD05 /* AppIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconPicker.swift; sourceTree = "<group>"; };
 		B399E8A32B6F486400E4488E /* RetryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryButton.swift; sourceTree = "<group>"; };
@@ -1145,6 +1147,7 @@
 				DD5D0A9B2931B9F200F7EA61 /* EthernetModes.swift */,
 				DDB6ABE528B1406100384BA1 /* LoraConfigEnums.swift */,
 				DD3CC6BF28E7A60700FA9159 /* MessagingEnums.swift */,
+				AB6E72752E3FC85A00639328 /* LayoutEnums.swift */,
 				DDB6ABE128B13FB500384BA1 /* PositionConfigEnums.swift */,
 				DD268D8D2BCC90E2008073AE /* RouteEnums.swift */,
 				DD8ED9C7289CE4B900B3B0AB /* RoutingError.swift */,
@@ -1696,6 +1699,7 @@
 				DD77093D2AA1AFA3007A8BF0 /* ChannelTips.swift in Sources */,
 				6D825E622C34786C008DBEE4 /* CommonRegex.swift in Sources */,
 				DD913639270DFF4C00D7ACF3 /* LocalNotificationManager.swift in Sources */,
+				AB6E72762E3FC85A00639328 /* LayoutEnums.swift in Sources */,
 				DDDB444C29F8AAA600EE2349 /* Color.swift in Sources */,
 				DDDFE73F2D0D48FF0044463C /* IgnoreNodeButton.swift in Sources */,
 				3D3417D42E2DC293006A988B /* MapDataFiles.swift in Sources */,

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		8EED425B7820DA4FEB40C375 /* CoTXMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748E4806582595DE80D455CD /* CoTXMLParser.swift */; };
 		9604373EEB96801AA89DF48C /* EXICodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0A8ABAEF1E587683970927 /* EXICodec.swift */; };
 		A5339E2F74E83F8FC41EEE33 /* TAKServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0618E6D0DF90B74EE32E6C06 /* TAKServerConfig.swift */; };
+		AB61EBF12E3326DC00B35962 /* NodeListItemCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */; };
 		ABA8E6402E2F2A2300E27791 /* AppIconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8E63F2E2F2A2300E27791 /* AppIconButton.swift */; };
 		ABB99DEB2E2EA1C500CFBD05 /* AppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB99DEA2E2EA1C500CFBD05 /* AppIconPicker.swift */; };
 		B16C760DB291CFAB5335EADB /* TAKCertificateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09936BEBD6D82479B2360FDC /* TAKCertificateManager.swift */; };
@@ -432,6 +433,7 @@
 		8D3F8A3E2D44BB02009EAAA4 /* PowerMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerMetrics.swift; sourceTree = "<group>"; };
 		8D3F8A402D44C2A6009EAAA4 /* PowerMetricsLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerMetricsLog.swift; sourceTree = "<group>"; };
 		9155703C39B55FC9DDF3E4C1 /* TAKDataPackageGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKDataPackageGenerator.swift; sourceTree = "<group>"; };
+		AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeListItemCompact.swift; sourceTree = "<group>"; };
 		ABA8E63F2E2F2A2300E27791 /* AppIconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconButton.swift; sourceTree = "<group>"; };
 		ABB99DEA2E2EA1C500CFBD05 /* AppIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconPicker.swift; sourceTree = "<group>"; };
 		B399E8A32B6F486400E4488E /* RetryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryButton.swift; sourceTree = "<group>"; };
@@ -1396,6 +1398,7 @@
 				DDDB26432AAC0206003AFCB7 /* NodeDetail.swift */,
 				DDDB26452AACC0B7003AFCB7 /* NodeInfoItem.swift */,
 				DDDB26412AABF655003AFCB7 /* NodeListItem.swift */,
+				AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */,
 				DDDCD56F2BB26F5C00BE6B60 /* NodeListFilter.swift */,
 				231A53772E69ADB900216B99 /* NodeFilterParameters.swift */,
 				251926882C3BAF2E00249DF5 /* Actions */,
@@ -1711,6 +1714,7 @@
 				2373AE172D0A26620086C749 /* EnvironmentDefaultSeries.swift in Sources */,
 				233E99B82D849C6500CC3A77 /* HumidityCompactWidget.swift in Sources */,
 				DD4640202AFF10F4002A5ECB /* WaypointForm.swift in Sources */,
+				AB61EBF12E3326DC00B35962 /* NodeListItemCompact.swift in Sources */,
 				233E99C12D849D6000CC3A77 /* DistanceCompactWidget.swift in Sources */,
 				DD769E0328D18BF1001A3F05 /* DeviceMetricsLog.swift in Sources */,
 				108FFECD2DD4005600BFAA81 /* NodeInfoEntityToNodeInfo.swift in Sources */,

--- a/Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "25240dd07109fa832be10093f5d97529f872f18e8d9df6468e5e4212bc0b487e",
+  "originHash" : "ea3042103c1c704c9bd1d7bfaac2700c237b95babf400fe97bacf42aac6d910d",
   "pins" : [
     {
       "identity" : "cocoamqtt",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DataDog/dd-sdk-ios.git",
       "state" : {
-        "revision" : "8d67e973ff4a958cb536263cb816646ee904c508",
-        "version" : "3.3.0"
+        "revision" : "3e2a5583661cdca6aaf600c80aea4c856b64d854",
+        "version" : "2.30.2"
       }
     },
     {

--- a/Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/DataDog/dd-sdk-ios.git",
       "state" : {
-        "revision" : "3e2a5583661cdca6aaf600c80aea4c856b64d854",
-        "version" : "2.30.2"
+        "revision" : "80fe7e5fe83d2184b50e1e0ccbb3fa6b0051c33d",
+        "version" : "3.8.2"
+      }
+    },
+    {
+      "identity" : "kscrash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kstenerud/KSCrash.git",
+      "state" : {
+        "revision" : "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
+        "version" : "2.5.1"
       }
     },
     {
@@ -29,21 +38,12 @@
       }
     },
     {
-      "identity" : "opentelemetry-swift-packages",
+      "identity" : "opentelemetry-swift-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/DataDog/opentelemetry-swift-packages.git",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift-core",
       "state" : {
-        "revision" : "4a7295600d4ebb9525a23c11586c5fdb74ae8b7e",
-        "version" : "1.13.1"
-      }
-    },
-    {
-      "identity" : "plcrashreporter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/plcrashreporter.git",
-      "state" : {
-        "revision" : "8c61e5e38e9f737dd68512ed1ea5ab081244ad65",
-        "version" : "1.12.0"
+        "revision" : "240c8d5e36c3c7b774ed961325369f0b1f2c965f",
+        "version" : "2.3.0"
       }
     },
     {
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "c6bfd1af48efcc9a9ad203665db12375ba6b145a",
         "version" : "4.0.8"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Meshtastic/Enums/LayoutEnums.swift
+++ b/Meshtastic/Enums/LayoutEnums.swift
@@ -1,0 +1,39 @@
+//
+//  LayoutEnums.swift
+//  Meshtastic
+//
+//  Copyright(c) Chase Christiansen Houwen 8/3/25.
+//
+import Foundation
+
+enum NodeListDensity: Int, CaseIterable, Identifiable {
+
+	case standard = 0
+	case compact = 1
+
+	var id: Int { self.rawValue }
+	var description: String {
+		switch self {
+		case .standard:
+			return "Standard".localized
+		case .compact:
+			return "Compact".localized
+		}
+	}
+}
+
+enum NodeFavoritesLayout: Int, CaseIterable, Identifiable {
+
+	case standard = 0
+	case above = 1
+
+	var id: Int { self.rawValue }
+	var description: String {
+		switch self {
+		case .standard:
+			return "Standard".localized
+		case .above:
+			return "Above".localized
+		}
+	}
+}

--- a/Meshtastic/Enums/LayoutEnums.swift
+++ b/Meshtastic/Enums/LayoutEnums.swift
@@ -7,33 +7,27 @@
 import Foundation
 
 enum NodeListDensity: Int, CaseIterable, Identifiable {
+    case standard = 0
+    case compact = 1
 
-	case standard = 0
-	case compact = 1
-
-	var id: Int { self.rawValue }
-	var description: String {
-		switch self {
-		case .standard:
-			return "Standard".localized
-		case .compact:
-			return "Compact".localized
-		}
-	}
+    var id: Int { self.rawValue }
+    var description: String {
+        switch self {
+        case .standard:
+            return "Standard".localized
+        case .compact:
+            return "Compact".localized
+        }
+    }
 }
 
-enum NodeFavoritesLayout: Int, CaseIterable, Identifiable {
-
-	case standard = 0
-	case above = 1
-
-	var id: Int { self.rawValue }
-	var description: String {
-		switch self {
-		case .standard:
-			return "Standard".localized
-		case .above:
-			return "Above".localized
-		}
-	}
+/**
+ This enum contains the keys for different UserDefault preferences for convenience
+ */
+enum NodeListPreferences: String {
+	case shouldShowLocation
+	case shouldShowTelemetry
+	case shouldShowPower
+	case lastHeardIsRelative
+	case shouldShowLastHeard
 }

--- a/Meshtastic/Enums/LayoutEnums.swift
+++ b/Meshtastic/Enums/LayoutEnums.swift
@@ -25,6 +25,7 @@ enum NodeListDensity: Int, CaseIterable, Identifiable {
  This enum contains the keys for different UserDefault preferences for convenience
  */
 enum NodeListPreferences: String {
+	case shouldShowRole
 	case shouldShowLocation
 	case shouldShowTelemetry
 	case shouldShowPower

--- a/Meshtastic/Views/Helpers/DistanceText.swift
+++ b/Meshtastic/Views/Helpers/DistanceText.swift
@@ -12,11 +12,25 @@ import MapKit
 struct DistanceText: View {
 
 	var meters: CLLocationDistance
+	var isCompact = false
+	let distanceFormatter = MKDistanceFormatter()
+	
+	init(meters: CLLocationDistance, isCompact: Bool = false) {
+		self.meters = meters
+		self.isCompact = isCompact
+		
+		if isCompact {
+			distanceFormatter.unitStyle = .abbreviated
+		}
+	}
 
 	var body: some View {
 
-		let distanceFormatter = MKDistanceFormatter()
-		Text("\(distanceFormatter.string(fromDistance: Double(meters))) away")
+		if isCompact {
+			Text("\(distanceFormatter.string(fromDistance: Double(meters)))")
+		} else {
+			Text("\(distanceFormatter.string(fromDistance: Double(meters))) away")
+		}
 	}
 }
 struct DistanceText_Previews: PreviewProvider {

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -294,9 +294,7 @@ struct IconAndText: View {
 }
 
 #Preview {
-	VStack(alignment: .leading) {
-		IconAndText(systemName: "antenna.radiowaves.left.and.right.circle.fill", text: "foo")
-		IconAndText(systemName: "antenna.radiowaves.left.and.right.circle", text: "bar")
+	List {
 		NodeListItem(node: {
 			let context = PersistenceController.preview.container.viewContext
 			let nodeInfo = NodeInfoEntity(context: context)

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -134,11 +134,11 @@ struct NodeListItemCompact: View {
 	
 	var lineNums: Int {
 		var lines = 1
-		if (shouldShowRole || shouldShowLocation || shouldShowTelemetry) {
+		if shouldShowRole || shouldShowLocation || shouldShowTelemetry {
 			lines += 1
 		}
 		
-		if (shouldShowLastHeard) {
+		if shouldShowLastHeard {
 			lines += 1
 		}
 		
@@ -150,9 +150,18 @@ struct NodeListItemCompact: View {
 		LazyVStack(alignment: .leading) {
 			HStack {
 				// First Column
-				VStack(alignment: .center) {
-					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: CGFloat(circleSize))
-						.padding(.trailing, 5)
+				if lineNums == 1 {
+					let color = Color(hex: UInt32(node.num).toHex()).opacity(100)
+					Text(node.user?.shortName ?? "?")
+						.foregroundColor(color.isLight() ? .black : .white)
+						.bold()
+						.padding(.all, 4)
+						.background(color, in: .capsule)
+				} else {
+					VStack(alignment: .center) {
+						CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: CGFloat(circleSize))
+							.padding(.trailing, 5)
+					}
 				}
 				// End First Column
 				// Second Column
@@ -255,8 +264,8 @@ struct NodeListItemCompact: View {
 					if node.favorite {
 						Image(systemName: "star.fill")
 							.symbolRenderingMode(.multicolor)
+						Spacer()
 					}
-					Spacer()
 					// Hops Away
 					if node.hopsAway > 0 {
 						DefaultIconCompact(systemName: "\(node.hopsAway).square")

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -1,0 +1,249 @@
+//
+//  NodeListItem.swift
+//  Meshtastic
+//
+//  Created by Garth Vander Houwen on 9/8/23.
+//
+
+import SwiftUI
+import CoreLocation
+import Foundation
+
+struct NodeListItemCompact: View {
+
+    // Accessibility: Synthesized description for VoiceOver
+    private var accessibilityDescription: String {
+        var desc = ""
+        if let shortName = node.user?.shortName {
+            // Format the shortName using the String extension method
+            desc = shortName.formatNodeNameForVoiceOver()
+        } else if let longName = node.user?.longName {
+            desc = longName
+        } else {
+			desc = "Unknown".localized + " " + "Node".localized
+        }
+        if connected {
+            desc += ", currently connected"
+        }
+        if node.favorite {
+            desc += ", favorite"
+        }
+        if node.lastHeard != nil {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .full
+            let relative = formatter.localizedString(for: node.lastHeard!, relativeTo: Date())
+            desc += ", last heard " + relative
+        }
+        if node.isOnline {
+            desc += ", online"
+        } else {
+            desc += ", offline"
+        }
+        let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
+        if let roleName = role?.name {
+            desc += ", role: \(roleName)"
+        }
+        if node.hopsAway > 0 {
+            desc += ", \(node.hopsAway) hops away"
+        }
+        if let battery = node.latestDeviceMetrics?.batteryLevel {
+            // Check for plugged in and charging states, same logic as in BatteryCompact and BatteryGauge
+            if battery > 100 {
+				desc += ", " + "Plugged in".localized
+            } else if battery == 100 {
+				desc += ", " + "Charging".localized
+            } else {
+                desc += ", battery \(battery)%"
+            }
+        }
+        // Add distance and heading/bearing if available, but only for non-connected nodes
+        if !connected, let (lastPosition, myCoord) = locationData {
+            let nodeCoord = CLLocation(latitude: lastPosition.nodeCoordinate!.latitude, longitude: lastPosition.nodeCoordinate!.longitude)
+            let metersAway = nodeCoord.distance(from: myCoord)
+            // Distance information
+            let distanceFormatter = LengthFormatter()
+            distanceFormatter.unitStyle = .medium
+            let formattedDistance = distanceFormatter.string(fromMeters: metersAway)
+            // For VoiceOver, prepend 'Distance' (localized)
+			desc += ", " + String(format: "%@: %@", "Distance".localized, formattedDistance)
+            // Add bearing/heading information for VoiceOver
+            let trueBearing = getBearingBetweenTwoPoints(point1: myCoord, point2: nodeCoord)
+            let heading = Measurement(value: trueBearing, unit: UnitAngle.degrees)
+            let formattedHeading = heading.formatted(.measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0))))
+            // Using a direct format without requiring a new localization key
+			desc += ", " + "Heading".localized + " " + formattedHeading
+        }
+        // Add signal strength if available
+        if node.snr != 0 && !node.viaMqtt {
+            let signalStrength: BLESignalStrength
+            if node.snr < -10 {
+                signalStrength = .weak
+            } else if node.snr < 5 {
+                signalStrength = .normal
+            } else {
+                signalStrength = .strong
+            }
+            let signalString: String
+            switch signalStrength {
+            case .weak:
+                signalString = "Signal strength weak".localized
+            case .normal:
+                signalString = "Signal strength normal".localized
+            case .strong:
+                signalString = "Signal strength strong".localized
+            }
+            desc += ", " + signalString
+        }
+        return desc
+    }
+
+	@ObservedObject var node: NodeInfoEntity
+	var connected: Bool
+	var connectedNode: Int64
+	var modemPreset: ModemPresets = ModemPresets(rawValue: UserDefaults.modemPreset) ?? ModemPresets.longFast
+
+	var userKeyStatus: (String, Color) {
+		var image = "lock.open.fill"
+		var color = Color.yellow
+		if node.user?.pkiEncrypted ?? false {
+			if !(node.user?.keyMatch ?? false) {
+				/// Public Key on the User and the Public Key on the Last Message don't match
+				image = "key.slash"
+				color = .red
+			} else {
+				image = "lock.fill"
+				color = .green
+			}
+		}
+		return (image, color)
+	}
+
+	var locationData: (PositionEntity, CLLocation)? {
+		guard let lastPostion = node.positions?.lastObject as? PositionEntity else {
+			return nil
+		}
+		guard let currentLocation = LocationsHandler.shared.locationsArray.last else {
+			return nil
+		}
+
+		let myCoord = CLLocation(latitude: currentLocation.coordinate.latitude, longitude: currentLocation.coordinate.longitude)
+
+		if lastPostion.nodeCoordinate != nil && myCoord.coordinate.longitude != LocationsHandler.DefaultLocation.longitude && myCoord.coordinate.latitude != LocationsHandler.DefaultLocation.latitude {
+				return (lastPostion, myCoord)
+		}
+		return nil
+	}
+
+	var body: some View {
+		NavigationLink(value: node) {
+			LazyVStack(alignment: .leading) {
+				HStack {
+//					User Icon
+					VStack(alignment: .center) {
+						CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 50)
+							.padding(.trailing, 5)
+						if node.latestDeviceMetrics != nil {
+							BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
+								.padding(.trailing, 5)
+						}
+					}
+//					User Info
+					VStack(alignment: .leading) {
+//						User name/encryption
+						HStack {
+							let (image, color) = userKeyStatus
+							IconAndText(systemName: image,
+										imageColor: color,
+										text: node.user?.longName?.addingVariationSelectors ?? "Unknown".localized,
+										textColor: .primary)
+							if node.favorite {
+								Spacer()
+								Image(systemName: "star.fill")
+									.symbolRenderingMode(.multicolor)
+							}
+						}
+						if connected {
+							IconAndText(systemName: "antenna.radiowaves.left.and.right.circle.fill",
+										imageColor: .green,
+										text: "Connected".localized)
+						}
+						if node.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && node.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
+							IconAndText(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
+										imageColor: node.isOnline ? .green : .orange,
+										text: node.lastHeard?.formatted() ?? "Unknown Age".localized)
+						}
+
+						if node.positions?.count ?? 0 > 0 && connectedNode != node.num {
+							HStack {
+								if let (lastPostion, myCoord) = locationData {
+									let nodeCoord = CLLocation(latitude: lastPostion.nodeCoordinate!.latitude, longitude: lastPostion.nodeCoordinate!.longitude)
+									let metersAway = nodeCoord.distance(from: myCoord)
+									Image(systemName: "lines.measurement.horizontal")
+										.font(.callout)
+										.symbolRenderingMode(.multicolor)
+										.frame(width: 30)
+									DistanceText(meters: metersAway)
+										.font(UIDevice.current.userInterfaceIdiom == .phone ? .callout : .caption)
+										.foregroundColor(.gray)
+								}
+							}
+						}
+						HStack {
+							if node.channel > 0 {
+								IconAndText(systemName: "\(node.channel).circle.fill", text: "Channel")
+							}
+
+							if node.viaMqtt && connectedNode != node.num {
+								IconAndText(systemName: "dot.radiowaves.up.forward",
+											renderingMode: .multicolor,
+											text: "MQTT")
+							}
+						}
+						let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
+
+//						Compact Info Stack
+						HStack {
+							Spacer()
+							Image(systemName: role?.systemName ?? "figure")
+							if node.user?.unmessagable ?? false {
+								Image(systemName: "iphone.slash")
+							}
+							if node.isStoreForwardRouter {
+								Image(systemName: "envelope.arrow.triangle.branch")
+							}
+							if node.hopsAway > 0 {
+								Image(systemName: "\(node.hopsAway).square")
+									.font(.title2)
+							} else {
+								Image(systemName: "dot.radiowaves.left.and.right")
+									.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
+							}
+						}
+					}
+					.frame(maxWidth: .infinity, alignment: .leading)
+				}
+			}
+		}
+		.padding(.top, 4)
+		.padding(.bottom, 4)
+        // Accessibility: Make the whole row a single element for VoiceOver
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
+    }
+}
+
+#Preview {
+	List {
+		NodeListItemCompact(node: {
+			let context = PersistenceController.preview.container.viewContext
+			let nodeInfo = NodeInfoEntity(context: context)
+			let user = UserEntity(context: context)
+			user.longName = "Test User"
+			user.shortName = "TU"
+			user.unmessagable = true
+			nodeInfo.user = user
+			nodeInfo.lastHeard = Date.now
+			return nodeInfo
+		}(), connected: true, connectedNode: 0, modemPreset: .longFast)
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -132,15 +132,32 @@ struct NodeListItemCompact: View {
 		return nil
 	}
 	
+	var lineNums: Int {
+		var lines = 1
+		if (shouldShowRole || shouldShowLocation || shouldShowTelemetry) {
+			lines += 1
+		}
+		
+		if (shouldShowLastHeard) {
+			lines += 1
+		}
+		
+		return lines
+	}
+	
 	var body: some View {
+		let circleSize = min(70, 24 * lineNums)
 		LazyVStack(alignment: .leading) {
 			HStack {
+				// First Column
 				VStack(alignment: .center) {
-					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 70)
+					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: CGFloat(circleSize))
 						.padding(.trailing, 5)
 				}
+				// End First Column
+				// Second Column
 				VStack(alignment: .leading) {
-					HStack {
+					HStack(alignment: .firstTextBaseline) {
 						let (image, color) = userKeyStatus
 						IconAndText(systemName: image,
 									imageColor: color,
@@ -149,10 +166,6 @@ struct NodeListItemCompact: View {
 						Spacer()
 						if shouldShowPower && node.latestDeviceMetrics != nil {
 							BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
-						}
-						if node.favorite {
-							Image(systemName: "star.fill")
-								.symbolRenderingMode(.multicolor)
 						}
 					}
 					if shouldShowLastHeard && node.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && node.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
@@ -232,22 +245,30 @@ struct NodeListItemCompact: View {
 							}
 						}
 
-						Spacer()
-						// Hops Away
-						if node.hopsAway > 0 {
-							DefaultIconCompact(systemName: "\(node.hopsAway).square")
-
-						} else {
-							if node.snr != 0 && !node.viaMqtt {
-								DefaultIconCompact(systemName: "dot.radiowaves.left.and.right")
-									.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
-							}
-						}
-
 					}
 					.padding(EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 0))
 				}
 				.frame(maxWidth: .infinity, alignment: .leading)
+				// End Second Column
+				// Third Column
+				VStack {
+					if node.favorite {
+						Image(systemName: "star.fill")
+							.symbolRenderingMode(.multicolor)
+					}
+					Spacer()
+					// Hops Away
+					if node.hopsAway > 0 {
+						DefaultIconCompact(systemName: "\(node.hopsAway).square")
+
+					} else {
+						if node.snr != 0 && !node.viaMqtt {
+							DefaultIconCompact(systemName: "dot.radiowaves.left.and.right")
+								.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
+						}
+					}
+				}
+				// End Third Column
 			}
 		}
 		.accessibilityElement(children: .ignore)

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -12,11 +12,12 @@ import Foundation
 
 struct NodeListItemCompact: View {
 	
-	@AppStorage(NodeListPreferences.shouldShowLocation.rawValue) private var shouldShowLocation: Bool = true
-	@AppStorage(NodeListPreferences.shouldShowPower.rawValue) private var shouldShowPower: Bool = true
-	@AppStorage(NodeListPreferences.shouldShowTelemetry.rawValue) private var shouldShowTelemetry: Bool = true
-	@AppStorage(NodeListPreferences.shouldShowLastHeard.rawValue) private var shouldShowLastHeard: Bool = true
-	@AppStorage(NodeListPreferences.lastHeardIsRelative.rawValue) private var lastHeardIsRelative: Bool = false
+	@AppStorage(NodeListPreferences.shouldShowLocation.rawValue) private var shouldShowLocation = true
+	@AppStorage(NodeListPreferences.shouldShowPower.rawValue) private var shouldShowPower = true
+	@AppStorage(NodeListPreferences.shouldShowTelemetry.rawValue) private var shouldShowTelemetry = true
+	@AppStorage(NodeListPreferences.shouldShowLastHeard.rawValue) private var shouldShowLastHeard = true
+	@AppStorage(NodeListPreferences.lastHeardIsRelative.rawValue) private var lastHeardIsRelative = false
+	@AppStorage(NodeListPreferences.shouldShowRole.rawValue) private var shouldShowRole = true
 	
 	private var accessibilityDescription: String {
 		var desc = ""
@@ -174,17 +175,19 @@ struct NodeListItemCompact: View {
 					// Display easy to differentiate information in a more compact list
 					HStack(alignment: .bottom) {
 						// Device Role
-						let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
-						DefaultIconCompact(systemName: role?.systemName ?? "figure")
+						if shouldShowRole {
+							let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
+							DefaultIconCompact(systemName: role?.systemName ?? "figure")
 
-						if node.user?.unmessagable ?? false {
-							DefaultIconCompact(systemName: "iphone.slash")
-						}
-						if node.isStoreForwardRouter {
-							DefaultIconCompact(systemName: "envelope.arrow.triangle.branch")
-						}
-						if node.viaMqtt && connectedNode != node.num {
-							DefaultIconCompact(systemName: "dot.radiowaves.up.forward")
+							if node.user?.unmessagable ?? false {
+								DefaultIconCompact(systemName: "iphone.slash")
+							}
+							if node.isStoreForwardRouter {
+								DefaultIconCompact(systemName: "envelope.arrow.triangle.branch")
+							}
+							if node.viaMqtt && connectedNode != node.num {
+								DefaultIconCompact(systemName: "dot.radiowaves.up.forward")
+							}
 						}
 						// Telemetry
 						if shouldShowTelemetry && (node.hasPositions || node.hasEnvironmentMetrics || node.hasDetectionSensorMetrics || node.hasTraceRoutes) {

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -153,33 +153,6 @@ struct NodeListItemCompact: View {
 									imageColor: node.isOnline ? .green : .orange,
 									text: node.lastHeard?.formatted() ?? "Unknown Age".localized)
 					}
-					
-					if node.positions?.count ?? 0 > 0 && connectedNode != node.num {
-						HStack {
-							if let (lastPostion, myCoord) = locationData {
-								let nodeCoord = CLLocation(latitude: lastPostion.nodeCoordinate!.latitude, longitude: lastPostion.nodeCoordinate!.longitude)
-								let metersAway = nodeCoord.distance(from: myCoord)
-								Image(systemName: "lines.measurement.horizontal")
-									.font(.callout)
-									.symbolRenderingMode(.multicolor)
-									.frame(width: 30)
-								DistanceText(meters: metersAway)
-									.font(UIDevice.current.userInterfaceIdiom == .phone ? .callout : .caption)
-									.foregroundColor(.gray)
-								let trueBearing = getBearingBetweenTwoPoints(point1: myCoord, point2: nodeCoord)
-								let headingDegrees = Measurement(value: trueBearing, unit: UnitAngle.degrees)
-								Image(systemName: "location.north")
-									.font(.callout)
-									.symbolRenderingMode(.multicolor)
-									.clipShape(Circle())
-									.rotationEffect(Angle(degrees: headingDegrees.value))
-								let heading = Measurement(value: trueBearing, unit: UnitAngle.degrees)
-								Text("\(heading.formatted(.measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0)))))")
-									.font(UIDevice.current.userInterfaceIdiom == .phone ? .callout : .caption)
-									.foregroundColor(.gray)
-							}
-						}
-					}
 					HStack {
 						if node.channel > 0 {
 							IconAndText(systemName: "\(node.channel).circle.fill", text: "Channel")
@@ -218,6 +191,27 @@ struct NodeListItemCompact: View {
 								}
 								if node.hasTraceRoutes {
 									DefaultIconCompact(systemName: "signpost.right.and.left")
+								}
+							}
+						}
+						// Location
+						if node.positions?.count ?? 0 > 0 && connectedNode != node.num {
+							Divider().frame(height: 15)
+							HStack {
+								if let (lastPostion, myCoord) = locationData {
+									let nodeCoord = CLLocation(latitude: lastPostion.nodeCoordinate!.latitude, longitude: lastPostion.nodeCoordinate!.longitude)
+									let metersAway = nodeCoord.distance(from: myCoord)
+
+									DistanceText(meters: metersAway, isCompact: true)
+										.font(UIDevice.current.userInterfaceIdiom == .phone ? .callout : .caption)
+										.foregroundColor(.gray)
+									let trueBearing = getBearingBetweenTwoPoints(point1: myCoord, point2: nodeCoord)
+									let headingDegrees = Measurement(value: trueBearing, unit: UnitAngle.degrees)
+									Image(systemName: "location.north")
+										.font(.callout)
+										.symbolRenderingMode(.multicolor)
+										.clipShape(Circle())
+										.rotationEffect(Angle(degrees: headingDegrees.value))
 								}
 							}
 						}

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -12,6 +12,12 @@ import Foundation
 
 struct NodeListItemCompact: View {
 	
+	@AppStorage(NodeListPreferences.shouldShowLocation.rawValue) private var shouldShowLocation: Bool = true
+	@AppStorage(NodeListPreferences.shouldShowPower.rawValue) private var shouldShowPower: Bool = true
+	@AppStorage(NodeListPreferences.shouldShowTelemetry.rawValue) private var shouldShowTelemetry: Bool = true
+	@AppStorage(NodeListPreferences.shouldShowLastHeard.rawValue) private var shouldShowLastHeard: Bool = true
+	@AppStorage(NodeListPreferences.lastHeardIsRelative.rawValue) private var lastHeardIsRelative: Bool = false
+	
 	private var accessibilityDescription: String {
 		var desc = ""
 		if let shortName = node.user?.shortName {
@@ -140,7 +146,7 @@ struct NodeListItemCompact: View {
 									text: node.user?.longName?.addingVariationSelectors ?? "Unknown".localized,
 									textColor: .primary)
 						Spacer()
-						if node.latestDeviceMetrics != nil {
+						if shouldShowPower && node.latestDeviceMetrics != nil {
 							BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
 						}
 						if node.favorite {
@@ -148,10 +154,17 @@ struct NodeListItemCompact: View {
 								.symbolRenderingMode(.multicolor)
 						}
 					}
-					if node.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && node.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
-						IconAndText(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
-									imageColor: node.isOnline ? .green : .orange,
-									text: node.lastHeard?.formatted() ?? "Unknown Age".localized)
+					if shouldShowLastHeard && node.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && node.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
+						
+						let lastHeardText = lastHeardIsRelative ?
+						node.lastHeard?.formatted(Date.RelativeFormatStyle()) :
+						node.lastHeard?.formatted()
+						
+						IconAndText(
+							systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
+							imageColor: node.isOnline ? .green : .orange,
+							text: lastHeardText ?? "Unknown Age".localized
+						)
 					}
 					HStack {
 						if node.channel > 0 {
@@ -174,7 +187,7 @@ struct NodeListItemCompact: View {
 							DefaultIconCompact(systemName: "dot.radiowaves.up.forward")
 						}
 						// Telemetry
-						if node.hasPositions || node.hasEnvironmentMetrics || node.hasDetectionSensorMetrics || node.hasTraceRoutes {
+						if shouldShowTelemetry && (node.hasPositions || node.hasEnvironmentMetrics || node.hasDetectionSensorMetrics || node.hasTraceRoutes) {
 							HStack(alignment: .bottom) {
 								Divider().frame(height: 15)
 								if node.hasDeviceMetrics {
@@ -195,7 +208,7 @@ struct NodeListItemCompact: View {
 							}
 						}
 						// Location
-						if node.positions?.count ?? 0 > 0 && connectedNode != node.num {
+						if shouldShowLocation && node.positions?.count ?? 0 > 0 && connectedNode != node.num {
 							Divider().frame(height: 15)
 							HStack {
 								if let (lastPostion, myCoord) = locationData {

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -1,8 +1,9 @@
 //
-//  NodeListItem.swift
+//  NodeListItemCompact.swift
 //  Meshtastic
 //
-//  Created by Garth Vander Houwen on 9/8/23.
+//  Created by Chase Christiansen on 3/20/26.
+//  Branched from NodeListItem.swift on 3/20/26.
 //
 
 import SwiftUI
@@ -10,104 +11,94 @@ import CoreLocation
 import Foundation
 
 struct NodeListItemCompact: View {
-
-    // Accessibility: Synthesized description for VoiceOver
-    private var accessibilityDescription: String {
-        var desc = ""
-        if let shortName = node.user?.shortName {
-            // Format the shortName using the String extension method
-            desc = shortName.formatNodeNameForVoiceOver()
-        } else if let longName = node.user?.longName {
-            desc = longName
-        } else {
+	
+	private var accessibilityDescription: String {
+		var desc = ""
+		if let shortName = node.user?.shortName {
+			desc = shortName.formatNodeNameForVoiceOver()
+		} else if let longName = node.user?.longName {
+			desc = longName
+		} else {
 			desc = "Unknown".localized + " " + "Node".localized
-        }
-        if connected {
-            desc += ", currently connected"
-        }
-        if node.favorite {
-            desc += ", favorite"
-        }
-        if node.lastHeard != nil {
-            let formatter = RelativeDateTimeFormatter()
-            formatter.unitsStyle = .full
-            let relative = formatter.localizedString(for: node.lastHeard!, relativeTo: Date())
-            desc += ", last heard " + relative
-        }
-        if node.isOnline {
-            desc += ", online"
-        } else {
-            desc += ", offline"
-        }
-        let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
-        if let roleName = role?.name {
-            desc += ", role: \(roleName)"
-        }
-        if node.hopsAway > 0 {
-            desc += ", \(node.hopsAway) hops away"
-        }
-        if let battery = node.latestDeviceMetrics?.batteryLevel {
-            // Check for plugged in and charging states, same logic as in BatteryCompact and BatteryGauge
-            if battery > 100 {
+		}
+		if isDirectlyConnected {
+			desc += ", currently connected"
+		}
+		if node.favorite {
+			desc += ", favorite"
+		}
+		if node.lastHeard != nil {
+			let formatter = RelativeDateTimeFormatter()
+			formatter.unitsStyle = .full
+			let relative = formatter.localizedString(for: node.lastHeard!, relativeTo: Date())
+			desc += ", last heard " + relative
+		}
+		if node.isOnline {
+			desc += ", online"
+		} else {
+			desc += ", offline"
+		}
+		let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
+		if let roleName = role?.name {
+			desc += ", role: \(roleName)"
+		}
+		if node.hopsAway > 0 {
+			desc += ", \(node.hopsAway) hops away"
+		}
+		if let battery = node.latestDeviceMetrics?.batteryLevel {
+			if battery > 100 {
 				desc += ", " + "Plugged in".localized
-            } else if battery == 100 {
+			} else if battery == 100 {
 				desc += ", " + "Charging".localized
-            } else {
-                desc += ", battery \(battery)%"
-            }
-        }
-        // Add distance and heading/bearing if available, but only for non-connected nodes
-        if !connected, let (lastPosition, myCoord) = locationData {
-            let nodeCoord = CLLocation(latitude: lastPosition.nodeCoordinate!.latitude, longitude: lastPosition.nodeCoordinate!.longitude)
-            let metersAway = nodeCoord.distance(from: myCoord)
-            // Distance information
-            let distanceFormatter = LengthFormatter()
-            distanceFormatter.unitStyle = .medium
-            let formattedDistance = distanceFormatter.string(fromMeters: metersAway)
-            // For VoiceOver, prepend 'Distance' (localized)
+			} else {
+				desc += ", battery \(battery)%"
+			}
+		}
+		if !isDirectlyConnected, let (lastPosition, myCoord) = locationData {
+			let nodeCoord = CLLocation(latitude: lastPosition.nodeCoordinate!.latitude, longitude: lastPosition.nodeCoordinate!.longitude)
+			let metersAway = nodeCoord.distance(from: myCoord)
+			let distanceFormatter = LengthFormatter()
+			distanceFormatter.unitStyle = .medium
+			let formattedDistance = distanceFormatter.string(fromMeters: metersAway)
 			desc += ", " + String(format: "%@: %@", "Distance".localized, formattedDistance)
-            // Add bearing/heading information for VoiceOver
-            let trueBearing = getBearingBetweenTwoPoints(point1: myCoord, point2: nodeCoord)
-            let heading = Measurement(value: trueBearing, unit: UnitAngle.degrees)
-            let formattedHeading = heading.formatted(.measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0))))
-            // Using a direct format without requiring a new localization key
+			let trueBearing = getBearingBetweenTwoPoints(point1: myCoord, point2: nodeCoord)
+			let heading = Measurement(value: trueBearing, unit: UnitAngle.degrees)
+			let formattedHeading = heading.formatted(.measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0))))
 			desc += ", " + "Heading".localized + " " + formattedHeading
-        }
-        // Add signal strength if available
-        if node.snr != 0 && !node.viaMqtt {
-            let signalStrength: BLESignalStrength
-            if node.snr < -10 {
-                signalStrength = .weak
-            } else if node.snr < 5 {
-                signalStrength = .normal
-            } else {
-                signalStrength = .strong
-            }
-            let signalString: String
-            switch signalStrength {
-            case .weak:
-                signalString = "Signal strength weak".localized
-            case .normal:
-                signalString = "Signal strength normal".localized
-            case .strong:
-                signalString = "Signal strength strong".localized
-            }
-            desc += ", " + signalString
-        }
-        return desc
-    }
-
+		}
+		if node.snr != 0 && !node.viaMqtt {
+			let signalStrength: BLESignalStrength
+			if node.snr < -10 {
+				signalStrength = .weak
+			} else if node.snr < 5 {
+				signalStrength = .normal
+			} else {
+				signalStrength = .strong
+			}
+			let signalString: String
+			switch signalStrength {
+			case .weak:
+				signalString = "Signal strength weak".localized
+			case .normal:
+				signalString = "Signal strength normal".localized
+			case .strong:
+				signalString = "Signal strength strong".localized
+			}
+			desc += ", " + signalString
+		}
+		return desc
+	}
+	
 	@ObservedObject var node: NodeInfoEntity
-	var connected: Bool
+	var isDirectlyConnected: Bool
 	var connectedNode: Int64
 	var modemPreset: ModemPresets = ModemPresets(rawValue: UserDefaults.modemPreset) ?? ModemPresets.longFast
-
+	
 	var userKeyStatus: (String, Color) {
 		var image = "lock.open.fill"
 		var color = Color.yellow
 		if node.user?.pkiEncrypted ?? false {
 			if !(node.user?.keyMatch ?? false) {
-				/// Public Key on the User and the Public Key on the Last Message don't match
 				image = "key.slash"
 				color = .red
 			} else {
@@ -117,7 +108,7 @@ struct NodeListItemCompact: View {
 		}
 		return (image, color)
 	}
-
+	
 	var locationData: (PositionEntity, CLLocation)? {
 		guard let lastPostion = node.positions?.lastObject as? PositionEntity else {
 			return nil
@@ -125,115 +116,144 @@ struct NodeListItemCompact: View {
 		guard let currentLocation = LocationsHandler.shared.locationsArray.last else {
 			return nil
 		}
-
+		
 		let myCoord = CLLocation(latitude: currentLocation.coordinate.latitude, longitude: currentLocation.coordinate.longitude)
-
+		
 		if lastPostion.nodeCoordinate != nil && myCoord.coordinate.longitude != LocationsHandler.DefaultLocation.longitude && myCoord.coordinate.latitude != LocationsHandler.DefaultLocation.latitude {
-				return (lastPostion, myCoord)
+			return (lastPostion, myCoord)
 		}
 		return nil
 	}
-
+	
 	var body: some View {
-		NavigationLink(value: node) {
-			LazyVStack(alignment: .leading) {
-				HStack {
-//					User Icon
-					VStack(alignment: .center) {
-						CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 50)
-							.padding(.trailing, 5)
+		LazyVStack(alignment: .leading) {
+			HStack {
+				VStack(alignment: .center) {
+					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 70)
+						.padding(.trailing, 5)
+				}
+				VStack(alignment: .leading) {
+					HStack {
+						let (image, color) = userKeyStatus
+						IconAndText(systemName: image,
+									imageColor: color,
+									text: node.user?.longName?.addingVariationSelectors ?? "Unknown".localized,
+									textColor: .primary)
+						Spacer()
+						if node.latestDeviceMetrics != nil {
+							BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
+						}
+						if node.favorite {
+							Image(systemName: "star.fill")
+								.symbolRenderingMode(.multicolor)
+						}
 					}
-//					User Info
-					VStack(alignment: .leading) {
-//						User name/encryption
+					if node.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && node.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
+						IconAndText(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
+									imageColor: node.isOnline ? .green : .orange,
+									text: node.lastHeard?.formatted() ?? "Unknown Age".localized)
+					}
+					
+					if node.positions?.count ?? 0 > 0 && connectedNode != node.num {
 						HStack {
-							let (image, color) = userKeyStatus
-							IconAndText(systemName: image,
-										imageColor: color,
-										text: node.user?.longName?.addingVariationSelectors ?? "Unknown".localized,
-										textColor: .primary)
-							if node.favorite {
-								Spacer()
-								Image(systemName: "star.fill")
+							if let (lastPostion, myCoord) = locationData {
+								let nodeCoord = CLLocation(latitude: lastPostion.nodeCoordinate!.latitude, longitude: lastPostion.nodeCoordinate!.longitude)
+								let metersAway = nodeCoord.distance(from: myCoord)
+								Image(systemName: "lines.measurement.horizontal")
+									.font(.callout)
 									.symbolRenderingMode(.multicolor)
+									.frame(width: 30)
+								DistanceText(meters: metersAway)
+									.font(UIDevice.current.userInterfaceIdiom == .phone ? .callout : .caption)
+									.foregroundColor(.gray)
+								let trueBearing = getBearingBetweenTwoPoints(point1: myCoord, point2: nodeCoord)
+								let headingDegrees = Measurement(value: trueBearing, unit: UnitAngle.degrees)
+								Image(systemName: "location.north")
+									.font(.callout)
+									.symbolRenderingMode(.multicolor)
+									.clipShape(Circle())
+									.rotationEffect(Angle(degrees: headingDegrees.value))
+								let heading = Measurement(value: trueBearing, unit: UnitAngle.degrees)
+								Text("\(heading.formatted(.measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0)))))")
+									.font(UIDevice.current.userInterfaceIdiom == .phone ? .callout : .caption)
+									.foregroundColor(.gray)
 							}
 						}
-						if connected {
-							IconAndText(systemName: "antenna.radiowaves.left.and.right.circle.fill",
-										imageColor: .green,
-										text: "Connected".localized)
+					}
+					HStack {
+						if node.channel > 0 {
+							IconAndText(systemName: "\(node.channel).circle.fill", text: "Channel")
 						}
-						if node.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && node.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
-							IconAndText(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
-										imageColor: node.isOnline ? .green : .orange,
-										text: node.lastHeard?.formatted() ?? "Unknown Age".localized)
-						}
+					}
+					// Display easy to differentiate information in a more compact list
+					HStack(alignment: .bottom) {
+						// Device Role
+						let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
+						DefaultIconCompact(systemName: role?.systemName ?? "figure")
 
-						if node.positions?.count ?? 0 > 0 && connectedNode != node.num {
-							HStack {
-								if let (lastPostion, myCoord) = locationData {
-									let nodeCoord = CLLocation(latitude: lastPostion.nodeCoordinate!.latitude, longitude: lastPostion.nodeCoordinate!.longitude)
-									let metersAway = nodeCoord.distance(from: myCoord)
-									Image(systemName: "lines.measurement.horizontal")
-										.font(.callout)
-										.symbolRenderingMode(.multicolor)
-										.frame(width: 30)
-									DistanceText(meters: metersAway)
-										.font(UIDevice.current.userInterfaceIdiom == .phone ? .callout : .caption)
-										.foregroundColor(.gray)
+						if node.user?.unmessagable ?? false {
+							DefaultIconCompact(systemName: "iphone.slash")
+						}
+						if node.isStoreForwardRouter {
+							DefaultIconCompact(systemName: "envelope.arrow.triangle.branch")
+						}
+						if node.viaMqtt && connectedNode != node.num {
+							DefaultIconCompact(systemName: "dot.radiowaves.up.forward")
+						}
+						// Telemetry
+						if node.hasPositions || node.hasEnvironmentMetrics || node.hasDetectionSensorMetrics || node.hasTraceRoutes {
+							HStack(alignment: .bottom) {
+								Divider().frame(height: 15)
+								if node.hasDeviceMetrics {
+									DefaultIconCompact(systemName: "flipphone")
+								}
+								if node.hasPositions {
+									DefaultIconCompact(systemName: "mappin.and.ellipse")
+								}
+								if node.hasEnvironmentMetrics {
+									DefaultIconCompact(systemName: "cloud.sun.rain")
+								}
+								if node.hasDetectionSensorMetrics {
+									DefaultIconCompact(systemName: "sensor")
+								}
+								if node.hasTraceRoutes {
+									DefaultIconCompact(systemName: "signpost.right.and.left")
 								}
 							}
 						}
-						HStack {
-							if node.channel > 0 {
-								IconAndText(systemName: "\(node.channel).circle.fill", text: "Channel")
-							}
 
-							if node.viaMqtt && connectedNode != node.num {
-								IconAndText(systemName: "dot.radiowaves.up.forward",
-											renderingMode: .multicolor,
-											text: "MQTT")
+						Spacer()
+						// Hops Away
+						if node.hopsAway > 0 {
+							DefaultIconCompact(systemName: "\(node.hopsAway).square")
+
+						} else {
+							if node.snr != 0 && !node.viaMqtt {
+								DefaultIconCompact(systemName: "dot.radiowaves.left.and.right")
+									.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
 							}
 						}
-					}
-					.frame(maxWidth: .infinity, alignment: .leading)
-				}
-				let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
 
-//					Compact Info Stack
-				HStack(alignment: .center) {
-					if node.latestDeviceMetrics != nil {
-						BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
 					}
-					Spacer()
-					//	Node Unmessagable Indicator
-					if node.user?.unmessagable ?? false {
-						Image(systemName: "iphone.slash")
-					}
-					//	Node Store/Forward Indicator
-					if node.isStoreForwardRouter {
-						Image(systemName: "envelope.arrow.triangle.branch")
-					}
-					//	Node Role Image
-					Image(systemName: role?.systemName ?? "figure")
-					//	Node Hops/Signal Indicator
-					if node.hopsAway > 0 {
-						Image(systemName: "\(node.hopsAway).square")
-							.font(.title2)
-							.scaledToFit()
-					} else {
-						Image(systemName: "dot.radiowaves.left.and.right")
-							.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
-					}
+					.padding(EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 0))
 				}
+				.frame(maxWidth: .infinity, alignment: .leading)
 			}
 		}
-		.padding(.top, 4)
-		.padding(.bottom, 4)
-        // Accessibility: Make the whole row a single element for VoiceOver
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityDescription)
-    }
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel(accessibilityDescription)
+	}
+}
+
+struct DefaultIconCompact: View {
+	let systemName: String
+	
+	var body: some View {
+		Image(systemName: systemName)
+			.symbolRenderingMode(.hierarchical)
+			.padding(.top, 2)
+			.font(.callout)
+	}
 }
 
 #Preview {
@@ -242,30 +262,97 @@ struct NodeListItemCompact: View {
 			let context = PersistenceController.preview.container.viewContext
 			let nodeInfo = NodeInfoEntity(context: context)
 			let user = UserEntity(context: context)
-			user.longName = "Test User"
-			user.shortName = "TU"
+			let telemetryEntity = TelemetryEntity(context: context)
+			let positionEntity = PositionEntity(context: context)
+			
+			user.longName = "Hopscotch"
+			user.shortName = "HS01"
 			user.unmessagable = true
-			nodeInfo.favorite = true
-			nodeInfo.channel = 2
-			nodeInfo.num = 2
-			nodeInfo.viaMqtt = true
+			user.pkiEncrypted = true
+			user.role = 11
 			nodeInfo.user = user
-			nodeInfo.lastHeard = Date.now
+			
+			telemetryEntity.batteryLevel = 100
+			telemetryEntity.distance = 100
+			nodeInfo.telemetries = [telemetryEntity]
+			
+			positionEntity.latitudeI = 30
+			positionEntity.longitudeI = -90
+			nodeInfo.positions = [positionEntity]
+
+			nodeInfo.hopsAway = 0
+			nodeInfo.snr = -17
+			nodeInfo.viaMqtt = false
+			nodeInfo.favorite = true
+			nodeInfo.lastHeard = Date(timeIntervalSinceNow: 0)
+			
 			return nodeInfo
-		}(), connected: true, connectedNode: 0, modemPreset: .longFast)
+		}(), isDirectlyConnected: true, connectedNode: 0, modemPreset: .medFast)
+		
+		NodeListItemCompact(node: {
+			let context = PersistenceController.preview.container.viewContext
+			let nodeInfo = NodeInfoEntity(context: context)
+			let storeForwardConfig = StoreForwardConfigEntity(context: context)
+			let telemetryEntity = TelemetryEntity(context: context)
+			let user = UserEntity(context: context)
+			
+			user.longName = "Brad!!"
+			user.shortName = "B"
+			user.unmessagable = false
+			nodeInfo.user = user
+			
+			storeForwardConfig.enabled = true
+			nodeInfo.storeForwardConfig = storeForwardConfig
+			
+			telemetryEntity.batteryLevel = 99
+			telemetryEntity.distance = 100.0
+			nodeInfo.telemetries = [telemetryEntity]
+
+			nodeInfo.hopsAway = 7
+			nodeInfo.lastHeard = Date(timeIntervalSinceNow: -3600)
+			
+			return nodeInfo
+		}(), isDirectlyConnected: false, connectedNode: 1, modemPreset: .medFast)
+		
 		NodeListItemCompact(node: {
 			let context = PersistenceController.preview.container.viewContext
 			let nodeInfo = NodeInfoEntity(context: context)
 			let user = UserEntity(context: context)
-			user.longName = "Test User 2"
-			user.shortName = "TU2"
-			user.unmessagable = true
-			nodeInfo.favorite = true
-			nodeInfo.num = 2
+			
+			user.longName = "MQTT Matt"
+			user.shortName = "MQTM"
+			user.unmessagable = false
+			user.role = 3
 			nodeInfo.user = user
-			nodeInfo.lastHeard = Date.now - 8192
-			nodeInfo.hopsAway = 5
+
+			nodeInfo.hopsAway = 3
+			nodeInfo.viaMqtt = true
+			nodeInfo.lastHeard = Date(timeIntervalSinceNow: -98200)
+			
 			return nodeInfo
-		}(), connected: false, connectedNode: 0, modemPreset: .longFast)
+		}(), isDirectlyConnected: false, connectedNode: 1, modemPreset: .medFast)
+		
+		NodeListItemCompact(node: {
+			let context = PersistenceController.preview.container.viewContext
+			let nodeInfo = NodeInfoEntity(context: context)
+			let user = UserEntity(context: context)
+			let telemetryEntity = TelemetryEntity(context: context)
+			
+			user.longName = "Sneaky Little Roof Node 03"
+			user.shortName = "SLN"
+			user.unmessagable = false
+			
+			telemetryEntity.batteryLevel = 99
+			telemetryEntity.distance = 100.0
+			nodeInfo.telemetries = [telemetryEntity]
+
+			nodeInfo.hopsAway = 1
+			nodeInfo.lastHeard = Date(timeIntervalSinceNow: -300600)
+			nodeInfo.favorite = true
+
+			nodeInfo.user = user
+			
+			return nodeInfo
+		}(), isDirectlyConnected: false, connectedNode: 1, modemPreset: .medFast)
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -142,10 +142,6 @@ struct NodeListItemCompact: View {
 					VStack(alignment: .center) {
 						CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 50)
 							.padding(.trailing, 5)
-						if node.latestDeviceMetrics != nil {
-							BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
-								.padding(.trailing, 5)
-						}
 					}
 //					User Info
 					VStack(alignment: .leading) {
@@ -199,28 +195,36 @@ struct NodeListItemCompact: View {
 											text: "MQTT")
 							}
 						}
-						let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
-
-//						Compact Info Stack
-						HStack {
-							Spacer()
-							Image(systemName: role?.systemName ?? "figure")
-							if node.user?.unmessagable ?? false {
-								Image(systemName: "iphone.slash")
-							}
-							if node.isStoreForwardRouter {
-								Image(systemName: "envelope.arrow.triangle.branch")
-							}
-							if node.hopsAway > 0 {
-								Image(systemName: "\(node.hopsAway).square")
-									.font(.title2)
-							} else {
-								Image(systemName: "dot.radiowaves.left.and.right")
-									.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
-							}
-						}
 					}
 					.frame(maxWidth: .infinity, alignment: .leading)
+				}
+				let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
+
+//					Compact Info Stack
+				HStack(alignment: .center) {
+					if node.latestDeviceMetrics != nil {
+						BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
+					}
+					Spacer()
+					//	Node Unmessagable Indicator
+					if node.user?.unmessagable ?? false {
+						Image(systemName: "iphone.slash")
+					}
+					//	Node Store/Forward Indicator
+					if node.isStoreForwardRouter {
+						Image(systemName: "envelope.arrow.triangle.branch")
+					}
+					//	Node Role Image
+					Image(systemName: role?.systemName ?? "figure")
+					//	Node Hops/Signal Indicator
+					if node.hopsAway > 0 {
+						Image(systemName: "\(node.hopsAway).square")
+							.font(.title2)
+							.scaledToFit()
+					} else {
+						Image(systemName: "dot.radiowaves.left.and.right")
+							.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
+					}
 				}
 			}
 		}
@@ -241,9 +245,27 @@ struct NodeListItemCompact: View {
 			user.longName = "Test User"
 			user.shortName = "TU"
 			user.unmessagable = true
+			nodeInfo.favorite = true
+			nodeInfo.channel = 2
+			nodeInfo.num = 2
+			nodeInfo.viaMqtt = true
 			nodeInfo.user = user
 			nodeInfo.lastHeard = Date.now
 			return nodeInfo
 		}(), connected: true, connectedNode: 0, modemPreset: .longFast)
+		NodeListItemCompact(node: {
+			let context = PersistenceController.preview.container.viewContext
+			let nodeInfo = NodeInfoEntity(context: context)
+			let user = UserEntity(context: context)
+			user.longName = "Test User 2"
+			user.shortName = "TU2"
+			user.unmessagable = true
+			nodeInfo.favorite = true
+			nodeInfo.num = 2
+			nodeInfo.user = user
+			nodeInfo.lastHeard = Date.now - 8192
+			nodeInfo.hopsAway = 5
+			return nodeInfo
+		}(), connected: false, connectedNode: 0, modemPreset: .longFast)
 	}
 }

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -41,7 +41,8 @@ struct NodeList: View {
 				connectedNode: connectedNode,
 				isPresentingDeleteNodeAlert: $isPresentingDeleteNodeAlert,
 				deleteNodeId: $deleteNodeId,
-				shareContactNode: $shareContactNode
+				shareContactNode: $shareContactNode,
+				nodeListDensity: $nodeListDensity
 			)
 			.sheet(isPresented: $isEditingFilters) {
 				NodeListFilter(
@@ -161,6 +162,7 @@ fileprivate struct FilteredNodeList: View {
 	@Binding var isPresentingDeleteNodeAlert: Bool
 	@Binding var deleteNodeId: Int64
 	@Binding var shareContactNode: NodeInfoEntity?
+	@Binding var nodeListDensity: NodeListDensity
 
 	// The initializer for the FetchRequest
 	init(
@@ -169,7 +171,8 @@ fileprivate struct FilteredNodeList: View {
 		connectedNode: NodeInfoEntity?,
 		isPresentingDeleteNodeAlert: Binding<Bool>,
 		deleteNodeId: Binding<Int64>,
-		shareContactNode: Binding<NodeInfoEntity?>
+		shareContactNode: Binding<NodeInfoEntity?>,
+		nodeListDensity: Binding<NodeListDensity>
 	) {
 		let request: NSFetchRequest<NodeInfoEntity> = NodeInfoEntity.fetchRequest()
 		request.sortDescriptors = [
@@ -186,6 +189,7 @@ fileprivate struct FilteredNodeList: View {
 		self._isPresentingDeleteNodeAlert = isPresentingDeleteNodeAlert
 		self._deleteNodeId = deleteNodeId
 		self._shareContactNode = shareContactNode
+		self._nodeListDensity = nodeListDensity
 	}
 
 	// The body of the view
@@ -194,11 +198,19 @@ fileprivate struct FilteredNodeList: View {
 		let nodesWithConnectedFirst = nodes.filter { $0.num == accessoryManager.activeDeviceNum } + nodes.filter { $0.num != accessoryManager.activeDeviceNum }
 		List(nodesWithConnectedFirst, id: \.self, selection: $selectedNode) { node in
 			NavigationLink(value: node) {
-				NodeListItem(
-					node: node,
-					isDirectlyConnected: node.num == accessoryManager.activeDeviceNum,
-					connectedNode: accessoryManager.activeConnection?.device.num ?? -1
-				)
+				switch nodeListDensity {
+				case .compact:
+					NodeListItemCompact(
+						node: node,
+						isDirectlyConnected: node.num == accessoryManager.activeDeviceNum,
+						connectedNode: accessoryManager.activeConnection?.device.num ?? -1)
+				case .standard:
+					NodeListItem(
+						node: node,
+						isDirectlyConnected: node.num == accessoryManager.activeDeviceNum,
+						connectedNode: accessoryManager.activeConnection?.device.num ?? -1
+					)
+				}
 			}
 			.contextMenu {
 				contextMenuActions(

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -14,7 +14,7 @@ struct NodeList: View {
 	@Environment(\.managedObjectContext) var context
 	@EnvironmentObject var accessoryManager: AccessoryManager
 	@StateObject var router: Router
-	@AppStorage("enableCompactLayout") private var enableCompactLayout: Bool = false
+	@AppStorage("nodeListDensity") private var nodeListDensity: NodeListDensity = .standard
 	@State private var selectedNode: NodeInfoEntity?
 	@State private var isPresentingTraceRouteSentAlert = false
 	@State private var isPresentingPositionSentAlert = false

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -14,6 +14,7 @@ struct NodeList: View {
 	@Environment(\.managedObjectContext) var context
 	@EnvironmentObject var accessoryManager: AccessoryManager
 	@StateObject var router: Router
+	@AppStorage("enableCompactLayout") private var enableCompactLayout: Bool = false
 	@State private var selectedNode: NodeInfoEntity?
 	@State private var isPresentingTraceRouteSentAlert = false
 	@State private var isPresentingPositionSentAlert = false

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -5,6 +5,7 @@ import SwiftProtobuf
 import MapKit
 import DatadogCore
 import OSLog
+import CoreData
 
 struct AppSettings: View {
 	private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
@@ -20,7 +21,13 @@ struct AppSettings: View {
 	@AppStorage("environmentEnableWeatherKit") private var  environmentEnableWeatherKit: Bool = true
 	@AppStorage("enableAdministration") private var  enableAdministration: Bool = false
 	@AppStorage("usageDataAndCrashReporting") private var usageDataAndCrashReporting: Bool = true
+	// Node Layout Preferences
 	@AppStorage("nodeListDensity") private var nodeListDensity: NodeListDensity = .standard
+	@AppStorage(NodeListPreferences.shouldShowLocation.rawValue) private var shouldShowLocation: Bool = true
+	@AppStorage(NodeListPreferences.shouldShowPower.rawValue) private var shouldShowPower: Bool = true
+	@AppStorage(NodeListPreferences.shouldShowTelemetry.rawValue) private var shouldShowTelemetry: Bool = true
+	@AppStorage(NodeListPreferences.shouldShowLastHeard.rawValue) private var shouldShowLastHeard: Bool = true
+	@AppStorage(NodeListPreferences.lastHeardIsRelative.rawValue) private var lastHeardIsRelative: Bool = false
 
 	let autoconnectBinding = Binding<Bool>(get: {
 		return UserDefaults.autoconnectOnDiscovery
@@ -71,13 +78,35 @@ struct AppSettings: View {
 					}
 #endif
 				}
-				Section(header: Text("Node List Density")) {
-					Picker("Node List Density", selection: $nodeListDensity) {
-						ForEach(NodeListDensity.allCases) { item in
-							Text(item.description).tag(item)
+				Section(header: Text("Node Layout")) {
+					List {
+						Picker("Node List Density", selection: $nodeListDensity) {
+							ForEach(NodeListDensity.allCases) { item in
+								Text(item.description).tag(item)
+							}
 						}
+						.pickerStyle(.segmented)
+						if nodeListDensity == .compact {
+							Toggle(isOn: $shouldShowLocation) {
+								Text("Show Location")
+							}
+							Toggle(isOn: $shouldShowPower) {
+								Text("Show Power")
+							}
+							Toggle(isOn: $shouldShowTelemetry) {
+								Text("Show Telemetry Icons")
+							}
+							Toggle(isOn: $shouldShowLastHeard) {
+								Text("Show Last Heard Time")
+							}
+							if shouldShowLastHeard {
+								Toggle(isOn: $lastHeardIsRelative) {
+									Text("Relative Last Heard Time")
+								}
+							}
+						}
+						BuildTestNode(nodeListDensity: $nodeListDensity)
 					}
-					.pickerStyle(.segmented)
 				}
 				Section(header: Text("Environment")) {
 					VStack(alignment: .leading) {
@@ -188,5 +217,43 @@ struct AppSettings: View {
 								ZStack {
 			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
 		})
+	}
+}
+
+struct BuildTestNode: View {
+	@FetchRequest private var nodes: FetchedResults<NodeInfoEntity>
+	@Binding var nodeListDensity: NodeListDensity
+	
+	init(nodeListDensity: Binding<NodeListDensity>) {
+		let request: NSFetchRequest<NodeInfoEntity> = NodeInfoEntity.fetchRequest()
+		request.sortDescriptors = [
+			NSSortDescriptor(key: "ignored", ascending: true),
+			NSSortDescriptor(key: "favorite", ascending: false),
+			NSSortDescriptor(key: "lastHeard", ascending: false),
+			NSSortDescriptor(key: "user.longName", ascending: true)
+		]
+		self._nodes = FetchRequest(fetchRequest: request)
+		self._nodeListDensity = nodeListDensity
+	}
+
+	var body: some View {
+		VStack {
+			if let exampleNode = nodes.first {
+				switch nodeListDensity {
+				case .standard:
+					NodeListItem(
+						node: exampleNode,
+						isDirectlyConnected: true,
+						connectedNode: 0,
+					)
+				case .compact:
+					NodeListItemCompact(
+						node: exampleNode,
+						isDirectlyConnected: true,
+						connectedNode: 0
+					)
+				}
+			}
+		}
 	}
 }

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -23,11 +23,12 @@ struct AppSettings: View {
 	@AppStorage("usageDataAndCrashReporting") private var usageDataAndCrashReporting: Bool = true
 	// Node Layout Preferences
 	@AppStorage("nodeListDensity") private var nodeListDensity: NodeListDensity = .standard
-	@AppStorage(NodeListPreferences.shouldShowLocation.rawValue) private var shouldShowLocation: Bool = true
-	@AppStorage(NodeListPreferences.shouldShowPower.rawValue) private var shouldShowPower: Bool = true
-	@AppStorage(NodeListPreferences.shouldShowTelemetry.rawValue) private var shouldShowTelemetry: Bool = true
-	@AppStorage(NodeListPreferences.shouldShowLastHeard.rawValue) private var shouldShowLastHeard: Bool = true
-	@AppStorage(NodeListPreferences.lastHeardIsRelative.rawValue) private var lastHeardIsRelative: Bool = false
+	@AppStorage(NodeListPreferences.shouldShowLocation.rawValue) private var shouldShowLocation = true
+	@AppStorage(NodeListPreferences.shouldShowPower.rawValue) private var shouldShowPower = true
+	@AppStorage(NodeListPreferences.shouldShowTelemetry.rawValue) private var shouldShowTelemetry = true
+	@AppStorage(NodeListPreferences.shouldShowLastHeard.rawValue) private var shouldShowLastHeard = true
+	@AppStorage(NodeListPreferences.lastHeardIsRelative.rawValue) private var lastHeardIsRelative = false
+	@AppStorage(NodeListPreferences.shouldShowRole.rawValue) private var shouldShowRole = true
 
 	let autoconnectBinding = Binding<Bool>(get: {
 		return UserDefaults.autoconnectOnDiscovery
@@ -87,6 +88,9 @@ struct AppSettings: View {
 						}
 						.pickerStyle(.segmented)
 						if nodeListDensity == .compact {
+							Toggle(isOn: $shouldShowRole) {
+								Text("Show Role")
+							}
 							Toggle(isOn: $shouldShowLocation) {
 								Text("Show Location")
 							}

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -22,7 +22,6 @@ struct AppSettings: View {
 	@AppStorage("usageDataAndCrashReporting") private var usageDataAndCrashReporting: Bool = true
 	@AppStorage("nodeListDensity") private var nodeListDensity: NodeListDensity = .standard
 
-	
 	let autoconnectBinding = Binding<Bool>(get: {
 		return UserDefaults.autoconnectOnDiscovery
 	}, set: { newValue in
@@ -71,25 +70,6 @@ struct AppSettings: View {
 							.presentationDetents([.medium])
 					}
 #endif
-				}
-				Section(header: Text("Layout")) {
-					Toggle(isOn: $enableCompactLayout) {
-						Label("Compact Layout", systemImage: "arrowshape.right.arrowshape.left")
-					}
-#endif
-				}
-				Section(header: Text("Node List Density")) {
-					Picker("Node List Density", selection: $enableCompactLayout) {
-						Text("Standard").tag(false)
-						Text("Compact").tag(true)
-					}
-					.pickerStyle(.segmented)
-				}
-				Section(header: Text("Layout")) {
-					Toggle(isOn: $enableCompactLayout) {
-						Label("Compact Layout", systemImage: "arrowshape.right.arrowshape.left")
-					}
-					.pickerStyle(.segmented)
 				}
 				Section(header: Text("Node List Density")) {
 					Picker("Node List Density", selection: $nodeListDensity) {

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -20,6 +20,8 @@ struct AppSettings: View {
 	@AppStorage("environmentEnableWeatherKit") private var  environmentEnableWeatherKit: Bool = true
 	@AppStorage("enableAdministration") private var  enableAdministration: Bool = false
 	@AppStorage("usageDataAndCrashReporting") private var usageDataAndCrashReporting: Bool = true
+	@AppStorage("enableCompactLayout") private var enableCompactLayout: Bool = false
+
 	
 	let autoconnectBinding = Binding<Bool>(get: {
 		return UserDefaults.autoconnectOnDiscovery
@@ -69,6 +71,17 @@ struct AppSettings: View {
 							.presentationDetents([.medium])
 					}
 #endif
+				}
+				Section(header: Text("Layout")) {
+					Toggle(isOn: $enableCompactLayout) {
+						Label("Compact Layout", systemImage: "arrowshape.right.arrowshape.left")
+					}
+#endif
+				}
+				Section(header: Text("Layout")) {
+					Toggle(isOn: $enableCompactLayout) {
+						Label("Compact Layout", systemImage: "arrowshape.right.arrowshape.left")
+					}
 				}
 				Section(header: Text("environment")) {
 					VStack(alignment: .leading) {

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -81,7 +81,7 @@ struct AppSettings: View {
 				}
 				Section(header: Text("Node Layout")) {
 					List {
-						Picker("Node List Density", selection: $nodeListDensity) {
+						Picker("Node List Density", selection: $nodeListDensity.animation()) {
 							ForEach(NodeListDensity.allCases) { item in
 								Text(item.description).tag(item)
 							}
@@ -100,14 +100,13 @@ struct AppSettings: View {
 							Toggle(isOn: $shouldShowTelemetry) {
 								Text("Show Telemetry Icons")
 							}
-							Toggle(isOn: $shouldShowLastHeard) {
+							Toggle(isOn: $shouldShowLastHeard.animation()) {
 								Text("Show Last Heard Time")
 							}
-							if shouldShowLastHeard {
-								Toggle(isOn: $lastHeardIsRelative) {
-									Text("Relative Last Heard Time")
-								}
+							Toggle(isOn: $lastHeardIsRelative) {
+								Text("Relative Last Heard Time")
 							}
+							.disabled(!shouldShowLastHeard)
 						}
 						BuildTestNode(nodeListDensity: $nodeListDensity)
 					}

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -20,7 +20,7 @@ struct AppSettings: View {
 	@AppStorage("environmentEnableWeatherKit") private var  environmentEnableWeatherKit: Bool = true
 	@AppStorage("enableAdministration") private var  enableAdministration: Bool = false
 	@AppStorage("usageDataAndCrashReporting") private var usageDataAndCrashReporting: Bool = true
-	@AppStorage("enableCompactLayout") private var enableCompactLayout: Bool = false
+	@AppStorage("nodeListDensity") private var nodeListDensity: NodeListDensity = .standard
 
 	
 	let autoconnectBinding = Binding<Bool>(get: {
@@ -78,10 +78,26 @@ struct AppSettings: View {
 					}
 #endif
 				}
+				Section(header: Text("Node List Density")) {
+					Picker("Node List Density", selection: $enableCompactLayout) {
+						Text("Standard").tag(false)
+						Text("Compact").tag(true)
+					}
+					.pickerStyle(.segmented)
+				}
 				Section(header: Text("Layout")) {
 					Toggle(isOn: $enableCompactLayout) {
 						Label("Compact Layout", systemImage: "arrowshape.right.arrowshape.left")
 					}
+					.pickerStyle(.segmented)
+				}
+				Section(header: Text("Node List Density")) {
+					Picker("Node List Density", selection: $nodeListDensity) {
+						ForEach(NodeListDensity.allCases) { item in
+							Text(item.description).tag(item)
+						}
+					}
+					.pickerStyle(.segmented)
 				}
 				Section(header: Text("environment")) {
 					VStack(alignment: .leading) {

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -79,7 +79,7 @@ struct AppSettings: View {
 					}
 					.pickerStyle(.segmented)
 				}
-				Section(header: Text("environment")) {
+				Section(header: Text("Environment")) {
 					VStack(alignment: .leading) {
 						Toggle(isOn: $environmentEnableWeatherKit) {
 							Label("Weather Conditions", systemImage: "cloud.sun")


### PR DESCRIPTION
## What changed?
I've added a setting to allow users to see the node list in either compact or standard formats. Standard is what we have now. The intension of the compact view is to move any information which can be easily conveyed via icon into a more compact layout. This will allow more advanced users to choose to have more information density.

## How is this tested?
Tested on simulated devices, a physical iPad, and physical iPhone. I also added to the nodeListItem previews to get a better idea of the different types of nodes in the wild.

## Screenshots/Videos (when applicable)

<img width="482" height="662" alt="Screenshot 2026-03-21 at 10 26 34 AM" src="https://github.com/user-attachments/assets/0c32b566-f402-4b94-8fed-460e8d0147c9" />

<img width="483" height="663" alt="Screenshot 2026-03-21 at 10 27 20 AM" src="https://github.com/user-attachments/assets/734d7d39-8901-40d0-adc7-561e6e9c130f" />

## Help Needed

Since this is a design change, my hope was to open this PR as a WIP and collect feedback. In particular, what information is absolutely necessary and what information should be excluded from the compact view. Other ideas I had was to move the search bar to an iOS 26-centric floating button, and allowing users to separate their favorited nodes into pinned notes similar to how iMessage allows pinned messages.

## Checklist

- [X] My code adheres to the project's coding and style guidelines.
- [X] I have conducted a self-review of my code.
- [X] I have commented my code, particularly in complex areas.
- [X] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.

