### PR TITLE
Tips are now ephemeral. They will appear until dismissed.

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -35,10 +35,11 @@ struct Connect: View {
 					Section {
 						if let connectedDevice = accessoryManager.activeConnection?.device,
 						   accessoryManager.isConnected || accessoryManager.isConnecting {
-							TipView(ConnectionTip(), arrowEdge: .bottom)
-								.tipViewStyle(PersistentTip())
-								.tipBackground(colorScheme == .dark ? Color(.systemBackground) : Color(.secondarySystemBackground))
-								.listRowSeparator(.hidden)
+							if accessoryManager.isConnected {
+								TipView(ConnectionTip(), arrowEdge: .bottom)
+									.tipBackground(colorScheme == .dark ? Color(.systemBackground) : Color(.secondarySystemBackground))
+									.listRowSeparator(.hidden)
+							}
 							VStack(alignment: .leading) {
 								HStack {
 									VStack(alignment: .center) {

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -64,7 +64,6 @@ struct Messages: View {
 				}
 				Spacer()
 				TipView(MessagesTip(), arrowEdge: .top)
-					.tipViewStyle(PersistentTip())
 					.listRowSeparator(.hidden)
 				Spacer()
 					.listRowSeparator(.hidden)

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -452,7 +452,6 @@ struct Settings: View {
 									}
 								}
 								TipView(AdminChannelTip(), arrowEdge: .top)
-									.tipViewStyle(PersistentTip())
 									.tipBackground(colorScheme == .dark ? Color(.systemBackground) : Color(.secondarySystemBackground))
 									.listRowSeparator(.hidden)
 							} else {


### PR DESCRIPTION
## What changed?
Tips now appear until dismissed.

## Why did it change?
Tips had been persisted indefinitely using PersistentTip. Tips also appeared inconsistently due to an issue with re-displaying tips when the view reloaded on connection events in Connect.swift.

## How is this tested?
Run in release or comment out `try? Tips.resetDatastore()` on MeshtasticApp.swift:96 in debug.

## Checklist

-  My code adheres to the project's coding and style guidelines.
- I have conducted a self-review of my code.
- I have commented my code, particularly in complex areas.
- I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- I have tested the change to ensure that it works as intended.

