### PR TITLE
Add timestamp to exported application log filename

### DIFF
--- a/Meshtastic/Views/Settings/AppLog.swift
+++ b/Meshtastic/Views/Settings/AppLog.swift
@@ -21,9 +21,15 @@ struct AppLog: View {
 	@State private var levels: Set<Int> =  []
 	@State var isExporting = false
 	@State var exportString = ""
+	@State var exportFilename = "Meshtastic Application Logs"
 	@State var isEditingFilters = false
 
 	private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
+	private static let logFileDateFormatter: DateFormatter = {
+		let f = DateFormatter()
+		f.dateFormat = "yyyy-MM-dd_HHmmss"
+		return f
+	}()
 	private let dateFormatStyle = Date.FormatStyle()
 		.hour(.twoDigits(amPM: .omitted))
 		.minute()
@@ -171,7 +177,7 @@ struct AppLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: "Meshtastic Application Logs \({ let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd_HHmmss"; return f.string(from: .now) }())",
+			defaultFilename: exportFilename,
 			onCompletion: { result in
 				switch result {
 				case .success:
@@ -200,6 +206,7 @@ struct AppLog: View {
 				ToolbarItem(placement: .navigationBarTrailing) {
 					Button(action: {
 						exportString = logToCsvFile(log: logs)
+						exportFilename = "Meshtastic Application Logs \(Self.logFileDateFormatter.string(from: .now))"
 						isExporting = true
 					}) {
 						Image(systemName: "square.and.arrow.down")

--- a/Meshtastic/Views/Settings/AppLog.swift
+++ b/Meshtastic/Views/Settings/AppLog.swift
@@ -25,11 +25,6 @@ struct AppLog: View {
 	@State var isEditingFilters = false
 
 	private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
-	private static let logFileDateFormatter: DateFormatter = {
-		let f = DateFormatter()
-		f.dateFormat = "yyyy-MM-dd_HHmmss"
-		return f
-	}()
 	private let dateFormatStyle = Date.FormatStyle()
 		.hour(.twoDigits(amPM: .omitted))
 		.minute()
@@ -206,7 +201,11 @@ struct AppLog: View {
 				ToolbarItem(placement: .navigationBarTrailing) {
 					Button(action: {
 						exportString = logToCsvFile(log: logs)
-						exportFilename = "Meshtastic Application Logs \(Self.logFileDateFormatter.string(from: .now))"
+						let localeDateFormat = DateFormatter.dateFormat(fromTemplate: "yyMMddjmma", options: 0, locale: Locale.current)
+						let dateFormatString = (localeDateFormat ?? "MM/dd/YY j:mma").replacingOccurrences(of: ",", with: "")
+						let formatter = DateFormatter()
+						formatter.dateFormat = dateFormatString
+						exportFilename = "Meshtastic Application Logs \(formatter.string(from: .now))"
 						isExporting = true
 					}) {
 						Image(systemName: "square.and.arrow.down")

--- a/Meshtastic/Views/Settings/AppLog.swift
+++ b/Meshtastic/Views/Settings/AppLog.swift
@@ -171,7 +171,7 @@ struct AppLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: String("Meshtastic Application Logs"),
+			defaultFilename: "Meshtastic Application Logs \({ let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd_HHmmss"; return f.string(from: .now) }())",
 			onCompletion: { result in
 				switch result {
 				case .success:


### PR DESCRIPTION
Exported logs were always named "Meshtastic Application Logs.csv", making it difficult to differentiate between multiple exports. With this PR, the default filename would now include a timestamp in `yyyy-MM-dd_HHmmss` format.

## What changed?
The `defaultFilename` parameter in the `.fileExporter` for application logs now includes a timestamp. Previously, all exports used the static name `Meshtastic Application Logs.csv.` The filename now includes the current date and time in `yyyy-MM-dd_HHmmss` format (e.g., `Meshtastic Application Logs 2026-04-14_153045.csv`).

## Why did it change?
When exporting logs multiple times, every file was named identically, making it hard to tell which export was which or when it was saved. Adding a timestamp lets users differentiate between exports at a glance without needing to manually rename each file.

## How is this tested?
- Built and ran the app in Xcode
- Navigated to Settings > Debug Logs and tapped the export button
- Verified the suggested filename in the save dialog includes the current date and time
- Exported multiple times and confirmed each filename reflects a different timestamp

## Screenshots/Videos (when applicable)

N/A

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [x] I have tested the change to ensure that it works as intended.

