### PR TITLE
fix: clear stale node data when switching connection types

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -27,6 +27,7 @@ extension AccessoryManager {
 		
 		// Clear any errors from last time
 		lastConnectionError = nil
+		activeDeviceNum = nil
 		packetsSent = 0
 		packetsReceived = 0
 		expectedNodeDBSize = nil

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -266,6 +266,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			updateDevice(deviceId: activeConnection.device.id, key: \.connectionState, value: .disconnected)
 			self.activeConnection = nil
 		}
+		self.activeDeviceNum = nil
 		
 		connectionEventTask?.cancel()
 		connectionEventTask = nil

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -45,7 +45,7 @@ struct Connect: View {
 							VStack(alignment: .leading) {
 								HStack {
 									VStack(alignment: .center) {
-										CircleText(text: node?.user?.shortName?.addingVariationSelectors ?? "?", color: Color(UIColor(hex: UInt32(node?.num ?? 0))), circleSize: 90)
+										CircleText(text: (node?.user?.shortName ?? connectedDevice.shortName)?.addingVariationSelectors ?? "?", color: Color(UIColor(hex: UInt32(node?.num ?? Int64(connectedDevice.num ?? 0)))), circleSize: 90)
 											.padding(.trailing, 5)
 										if node?.latestDeviceMetrics != nil {
 											BatteryCompact(batteryLevel: node?.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
@@ -54,14 +54,12 @@ struct Connect: View {
 									}
 									.padding(.trailing)
 									VStack(alignment: .leading) {
-										if node != nil {
-											HStack {
-												Text(connectedDevice.longName?.addingVariationSelectors ?? "Unknown".localized).font(.title2)
-												if connectedDevice.wasRestored {
-													Circle()
-														.fill(Color.gray)
-														.frame(width: 8, height: 8)
-												}
+										HStack {
+											Text(connectedDevice.longName?.addingVariationSelectors ?? "Unknown".localized).font(.title2)
+											if connectedDevice.wasRestored {
+												Circle()
+													.fill(Color.gray)
+													.frame(width: 8, height: 8)
 											}
 										}
 										Text("Connection Name").font(.callout)+Text(": \(connectedDevice.name.addingVariationSelectors)")
@@ -74,10 +72,8 @@ struct Connect: View {
 											Spacer()
 										}
 										.padding(0)
-										if node != nil {
-											Text("Firmware Version").font(.callout)+Text(": \(node?.metadata?.firmwareVersion ?? "Unknown".localized)")
-												.font(.callout).foregroundColor(Color.gray)
-										}
+										Text("Firmware Version").font(.callout)+Text(": \(node?.metadata?.firmwareVersion ?? connectedDevice.firmwareVersion ?? "Unknown".localized)")
+											.font(.callout).foregroundColor(Color.gray)
 										switch accessoryManager.state {
 										case .subscribed:
 											Text("Subscribed").font(.callout)
@@ -360,32 +356,52 @@ struct Connect: View {
 				.presentationDetents([.large])
 				.presentationDragIndicator(.automatic)
 		}
-		.onChange(of: self.accessoryManager.state) { _, state in
-			
-			if let deviceNum = accessoryManager.activeDeviceNum, UserDefaults.preferredPeripheralId.count > 0 && state == .subscribed {
-				
-				let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
-				fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", deviceNum)
-				
-				do {
-					node = try context.fetch(fetchNodeInfoRequest).first
-					if let loRaConfig = node?.loRaConfig, loRaConfig.regionCode == RegionCodes.unset.rawValue {
-						isUnsetRegion = true
-					} else {
-						isUnsetRegion = false
-					}
-				} catch {
-					Logger.data.error("💥 Error fetching node info: \(error.localizedDescription, privacy: .public)")
-				}
-			// Check firmware version on connection (only if version is known)
-			if let firmwareVersion = accessoryManager.activeConnection?.device.firmwareVersion, firmwareVersion != "?.?.?" && !firmwareVersion.isEmpty {
-				let meetsMinimumVersion = accessoryManager.checkIsVersionSupported(forVersion: accessoryManager.minimumVersion)
-				let meetsSecurityVersion = accessoryManager.checkIsVersionSupported(forVersion: accessoryManager.securityVersion)
-				invalidFirmwareVersion = !meetsMinimumVersion
-				showSecurityVersionNag = meetsMinimumVersion && !meetsSecurityVersion
-			}
+		.onChange(of: self.accessoryManager.activeDeviceNum) { _, deviceNum in
+			if let deviceNum {
+				refreshNode(for: deviceNum)
+			} else {
+				clearNode()
 			}
 		}
+		.onReceive(NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)) { _ in
+			// Re-trigger fetch if node is nil but activeDeviceNum exists (e.g., after manual connection DB wipe)
+			if node == nil, let deviceNum = accessoryManager.activeDeviceNum {
+				refreshNode(for: deviceNum)
+			}
+		}
+		.onChange(of: self.accessoryManager.state) { _, state in
+			if let deviceNum = accessoryManager.activeDeviceNum, UserDefaults.preferredPeripheralId.count > 0 && state == .subscribed {
+				refreshNode(for: deviceNum)
+			}
+		}
+	}
+	
+	private func refreshNode(for deviceNum: Int64) {
+		let fetchNodeInfoRequest = NodeInfoEntity.fetchRequest()
+		fetchNodeInfoRequest.predicate = NSPredicate(format: "num == %lld", deviceNum)
+		do {
+			node = try context.fetch(fetchNodeInfoRequest).first
+			if let loRaConfig = node?.loRaConfig, loRaConfig.regionCode == RegionCodes.unset.rawValue {
+				isUnsetRegion = true
+			} else {
+				isUnsetRegion = false
+			}
+		} catch {
+			Logger.data.error("💥 Error fetching node info: \(error.localizedDescription, privacy: .public)")
+		}
+
+		// Check firmware version on connection (only if version is known)
+		if let firmwareVersion = accessoryManager.activeConnection?.device.firmwareVersion, firmwareVersion != "?.?.?" && !firmwareVersion.isEmpty {
+			let meetsMinimumVersion = accessoryManager.checkIsVersionSupported(forVersion: accessoryManager.minimumVersion)
+			let meetsSecurityVersion = accessoryManager.checkIsVersionSupported(forVersion: accessoryManager.securityVersion)
+			invalidFirmwareVersion = !meetsMinimumVersion
+			showSecurityVersionNag = meetsMinimumVersion && !meetsSecurityVersion
+		}
+	}
+	
+	private func clearNode() {
+		node = nil
+		isUnsetRegion = false
 	}
 #if !targetEnvironment(macCatalyst)
 #if canImport(ActivityKit)


### PR DESCRIPTION


Changes:



Tested on:

- iPhone 16e running iOS 26.3.1 (23D771330a)

## What changed?
- Explicitly reset activeDeviceNum on disconnect and at the start of a new connection.

- Refactored Connect view to observe activeDeviceNum and metadata updates.

- Added UI fallbacks to use transport-layer device metadata when database entities are not yet available.

## Why did it change?
This fix addresses the issue where metadata from a previous BLE connection would persist when switching to a manual TCP connection.

Root cause: Previously, the UI identity failed to clear because manual TCP connections wipe the database, causing the initial CoreData fetch to return nil (since NodeInfo hadn't arrived yet). The UI then remained nil even after NodeInfo arrived because it was not correctly observing the metadata updates or re-triggering the fetch.

## How is this tested?
Ran unit tests.

Manually did repro steps on  iPhone 16e running iOS 26.3.1 (23D771330a) several times.

(1) Connect to previously used BLE node
(2) Disconnect
(3) Connect to manual TCP node

Verified UI now correctly has shortname prefix in the circle, and the correct longname.

## Screenshots/Videos (when applicable)

https://photos.app.goo.gl/2mVwAQhUCo84DqQg8

## Checklist

- [ X] My code adheres to the project's coding and style guidelines.
- [X ] I have conducted a self-review of my code.
- [X] I have commented my code, particularly in complex areas.
- [X ] I have verified whether these changes require an update to existing documentation or if new documentation is needed, and created an issue in the [docs repo](http://github.com/meshtastic/meshtastic/issues) if applicable.
- [X] I have tested the change to ensure that it works as intended.

