### PR TITLE
Fix Jekyll build: run bundle exec from docs/ directory

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -91,7 +91,8 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --source docs --destination _site --baseurl ""
+        working-directory: docs
+        run: bundle exec jekyll build --destination ../_site --baseurl ""
         env:
           JEKYLL_ENV: production
 


### PR DESCRIPTION
## What changed
The `bundle exec jekyll build` step in the `docs-deploy.yml` workflow now runs with `working-directory: docs` and outputs to `../_site`.

## Why
The `Gemfile` lives in `docs/` but the build step was executing from the repo root, causing:
```
Could not locate Gemfile or .bundle/ directory
Error: Process completed with exit code 10.
```

## How it was tested
Verified the `ruby/setup-ruby` step already uses `working-directory: docs` for `bundler-cache: true`, so running Jekyll from the same directory is consistent.

## Screenshots
N/A — CI workflow fix only.