### PR TITLE
Add PAGES_REPO_NWO env var for Jekyll docs build

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -95,6 +95,7 @@ jobs:
         run: bundle exec jekyll build --destination ../_site --baseurl ""
         env:
           JEKYLL_ENV: production
+          PAGES_REPO_NWO: meshtastic/Meshtastic-Apple
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## What changed
Added `PAGES_REPO_NWO: meshtastic/Meshtastic-Apple` to the Jekyll build step environment in `docs-deploy.yml`.

## Why
After the previous fix (#1722), the Jekyll build now finds the Gemfile but fails with:
```
No repo name found. Specify using PAGES_REPO_NWO environment variables,
'repository' in your configuration, or set up an 'origin' git remote
pointing to your github.com repository.
```
The `github-pages` gem bundles `jekyll-github-metadata` which needs the repo identifier.

## How it was tested
CI will validate on merge — this is the follow-up fix to the error observed after #1722 merged.

## Screenshots
N/A — CI workflow fix only.