### PR TITLE
Remove redirect_to /beta/ from docs index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,33 @@
 ---
 title: Meshtastic App Documentation
 layout: default
-redirect_to: /beta/
+nav_order: 0
 ---
 
 # Meshtastic App Documentation
 
-Redirecting to the latest documentation…
+Welcome to the documentation for the Meshtastic iOS, iPadOS, and macOS app.
 
-If you are not redirected automatically, [click here](/beta/).
+## User Guide
+
+- [Getting Started](user/getting-started.md)
+- [Bluetooth Device Connection](user/bluetooth.md)
+- [Messages & Channels](user/messages.md)
+- [Nodes List](user/nodes.md)
+- [Firmware Updates](user/firmware.md)
+- [Map & Waypoints](user/map.md)
+- [Settings](user/settings.md)
+- [Telemetry & Sensors](user/telemetry.md)
+- [Signal Meter](user/signal-meter.md)
+- [TAK Integration](user/tak.md)
+- [MQTT](user/mqtt.md)
+- [Local Mesh Discovery](user/discovery.md)
+- [Apple Watch App](user/watch.md)
+
+## Developer Guide
+
+- [Architecture](developer/architecture.md)
+- [Adding Features](developer/adding-features.md)
+- [Testing](developer/testing.md)
+- [SwiftData](developer/swiftdata.md)
+- [Transport](developer/transport.md)


### PR DESCRIPTION
## What changed
Replaced `docs/index.md` redirect to `/beta/` with a proper documentation landing page.

## Why
The `redirect_to: /beta/` frontmatter was causing visitors to `meshtastic.github.io/Meshtastic-Apple/` to be redirected to `meshtastic.github.io/beta/` — an unrelated GitHub user's page.

## How it was tested
Verified `docs/index.md` is only consumed by Jekyll for GitHub Pages and does not affect the in-app documentation system (which uses `Meshtastic/Resources/docs/index.json`).

## Screenshots
N/A — fixes a broken redirect on the deployed docs site.