### PR TITLE
Fix Jekyll docs navigation and dead links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,15 +23,7 @@ footer_content: "Copyright &copy; 2024 Garth Vander Houwen. Distributed under th
 # Heading anchors
 heading_anchors: true
 
-# Collections for nav ordering
-collections:
-  user:
-    output: true
-    permalink: /user/:name/
-  developer:
-    output: true
-    permalink: /developer/:name/
-
+# Default front-matter for pages in subdirectories
 defaults:
   - scope:
       path: "user"

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,9 @@
+---
+title: Developer Guide
+nav_order: 2
+has_children: true
+---
+
+# Developer Guide
+
+Technical documentation for contributing to the Meshtastic Apple app.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,33 +1,22 @@
 ---
-title: Meshtastic App Documentation
+title: Home
 layout: default
 nav_order: 0
 ---
 
-# Meshtastic App Documentation
+# Meshtastic Apple App Documentation
 
-Welcome to the documentation for the Meshtastic iOS, iPadOS, and macOS app.
+User and developer documentation for the Meshtastic iOS, iPadOS, and macOS app.
 
-## User Guide
+Use the sidebar navigation to browse the **User Guide** for app features and the **Developer Guide** for contributing to the project.
 
-- [Getting Started](user/getting-started.md)
-- [Bluetooth Device Connection](user/bluetooth.md)
-- [Messages & Channels](user/messages.md)
-- [Nodes List](user/nodes.md)
-- [Firmware Updates](user/firmware.md)
-- [Map & Waypoints](user/map.md)
-- [Settings](user/settings.md)
-- [Telemetry & Sensors](user/telemetry.md)
-- [Signal Meter](user/signal-meter.md)
-- [TAK Integration](user/tak.md)
-- [MQTT](user/mqtt.md)
-- [Local Mesh Discovery](user/discovery.md)
-- [Apple Watch App](user/watch.md)
+---
 
-## Developer Guide
+## Quick Links
 
-- [Architecture](developer/architecture.md)
-- [Adding Features](developer/adding-features.md)
-- [Testing](developer/testing.md)
-- [SwiftData](developer/swiftdata.md)
-- [Transport](developer/transport.md)
+| Guide | Description |
+|-------|-------------|
+| [Getting Started](user/getting-started) | Connect your first radio and send a message |
+| [Nodes List](user/nodes) | Understanding the mesh network node list |
+| [Signal Meter](user/signal-meter) | How the LoRa signal quality meter works |
+| [Architecture](developer/architecture) | App architecture overview for contributors |

--- a/docs/user.md
+++ b/docs/user.md
@@ -1,0 +1,9 @@
+---
+title: User Guide
+nav_order: 1
+has_children: true
+---
+
+# User Guide
+
+Documentation for using the Meshtastic iOS, iPadOS, and macOS app.


### PR DESCRIPTION
## What changed
- Added parent navigation pages (`docs/user.md`, `docs/developer.md`) with `has_children: true` so the just-the-docs theme builds proper sidebar navigation
- Removed Jekyll `collections` config from `_config.yml` — it conflicted with just-the-docs parent/child hierarchy and generated incorrect permalinks
- Rewrote `docs/index.md` as a clean landing page with a quick-links table using correct relative paths (no `.md` extensions)

## Why
- The sidebar was empty because `just-the-docs` requires parent pages with `has_children: true` for child pages that declare `parent:`
- All links on the index page were dead because they used `.md` extensions and the collections config generated different permalink paths
- The page was unstyled because the theme's navigation structure wasn't configured

## How it was tested
Verified the just-the-docs theme documentation for parent/child page configuration. The deploy action will validate the Jekyll build succeeds.

## Screenshots
N/A — will be visible once deployed.