### PR TITLE
Fix theme assets: set baseurl to /Meshtastic-Apple

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Build with Jekyll
         working-directory: docs
-        run: bundle exec jekyll build --destination ../_site --baseurl ""
+        run: bundle exec jekyll build --destination ../_site --baseurl "/Meshtastic-Apple"
         env:
           JEKYLL_ENV: production
           PAGES_REPO_NWO: meshtastic/Meshtastic-Apple

--- a/docs/user.md
+++ b/docs/user.md
@@ -6,4 +6,4 @@ has_children: true
 
 # User Guide
 
-Documentation for using the Meshtastic iOS, iPadOS, and macOS app.
+Documentation for using the Meshtastic iOS, iPadOS, macOS, watchOS, and visionOS app.


### PR DESCRIPTION
## What changed
- Set `--baseurl "/Meshtastic-Apple"` in the Jekyll build step
- Updated `docs/user.md` to list watchOS and visionOS

## Why
GitHub Pages project sites serve from `/<repo-name>/`. The theme's CSS and JS assets were 404ing because they were requested from `meshtastic.github.io/assets/...` instead of `meshtastic.github.io/Meshtastic-Apple/assets/...`.

## How it was tested
Confirmed the 404 errors in browser DevTools (attached in previous discussion). This change prefixes all asset URLs correctly.

## Screenshots
N/A — fixes unstyled page rendering on the deployed docs site.