### PR TITLE
Copy screenshots into docs/assets/screenshots/ for Jekyll build

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -74,6 +74,11 @@ jobs:
           name: doc-snapshots
           path: Meshtastic/Resources/docs/assets/screenshots/
 
+      - name: Copy snapshots for Jekyll
+        run: |
+          mkdir -p docs/assets/screenshots
+          cp Meshtastic/Resources/docs/assets/screenshots/*.png docs/assets/screenshots/
+
       - name: Install cmark-gfm
         run: sudo apt-get install -y cmark-gfm
 


### PR DESCRIPTION
## What changed
Added a workflow step to copy screenshots from `Meshtastic/Resources/docs/assets/screenshots/` into `docs/assets/screenshots/` before Jekyll builds the site.

## Why
Jekyll builds from the `docs/` directory and all markdown image references use `../assets/screenshots/` which resolves to `docs/assets/screenshots/`. However, the workflow was downloading the snapshot artifact into `Meshtastic/Resources/docs/assets/screenshots/` — a completely different path. All images were 404ing on the deployed site.

## How it was tested
Confirmed by checking that `docs/assets/screenshots/` only had 1 file locally (manually copied) while `Meshtastic/Resources/docs/assets/screenshots/` had 99.

## Screenshots
N/A — fixes broken images on the deployed docs site.