### PR TITLE
Polish docs landing pages and fix footer copyright year

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Meshtastic Apple App Documentation
+title: Meshtastic Apple
 description: "User and developer documentation for the Meshtastic iOS, iPadOS, and macOS app."
 
 # just-the-docs theme (v0.11+)
@@ -17,8 +17,7 @@ nav_enabled: true
 search_enabled: true
 search_tokenizer_separator: /[\s\-/]+/
 
-# Footer
-footer_content: "Copyright &copy; 2024 Garth Vander Houwen. Distributed under the <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GPL v3 License.</a>"
+# Footer (rendered via _includes/footer_custom.html for dynamic year)
 
 # Heading anchors
 heading_anchors: true

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+  Copyright &copy; {{ "now" | date: "%Y" }} Garth Vander Houwen. Distributed under the <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPL v3 License.</a>
+</footer>

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -7,3 +7,32 @@ has_children: true
 # Developer Guide
 
 Technical documentation for contributing to the Meshtastic Apple app.
+
+---
+
+## Before You Open a PR
+
+Things that trip up first-time contributors — check these before requesting review:
+
+- **SwiftLint passes** — run `bash scripts/setup-hooks.sh` once to install the pre-commit hook, then verify no new warnings with `swiftlint lint`
+- **Snapshot tests pass** — if you touched any SwiftUI view, run `MeshtasticTests/SwiftUIViewSnapshotTests` and commit updated reference PNGs
+- **Protos regenerated** — if the `protobufs/` submodule changed, run `./scripts/gen_protos.sh` and commit the generated Swift sources
+- **SwiftData migration** — if you added or changed any `@Model` type, add a new `VersionedSchema` and `MigrationStage` in `MeshtasticSchema.swift`
+- **Docs updated** — if you changed user-visible UI, update the corresponding page under `docs/user/`. The `docs-staleness` CI check will flag the PR if you didn't. Add the `skip-docs-check` label if it genuinely isn't needed.
+- **Commit message** — imperative mood subject line, explain *what* and *why* in the body
+
+---
+
+## What's New for Developers
+
+<!-- DEV_WHATS_NEW_START -->
+<!-- Add new entries at the top. Format:
+**Month YYYY** — [Page or area](relative/path) — One sentence on what changed architecturally or procedurally.
+Keep the last 5–8 entries and trim older ones from the bottom.
+-->
+
+**May 2026** — [Testing](developer/testing) — Snapshot test conventions established: consolidated multi-state views into single combined images (light + dark pairs), use `assertViewSnapshot` helper with explicit `width`/`height` and `transparent: true` for icon snapshots.
+
+**May 2026** — [Architecture](developer/architecture) — In-app documentation system added (`003-app-docs-markdown`): markdown source under `docs/user/` and `docs/developer/` is converted to HTML by `scripts/build-docs.sh` and bundled at `Meshtastic/Resources/docs/`. Navigation is driven by `index.json`.
+
+<!-- DEV_WHATS_NEW_END -->

--- a/docs/user.md
+++ b/docs/user.md
@@ -7,3 +7,19 @@ has_children: true
 # User Guide
 
 Documentation for using the Meshtastic iOS, iPadOS, macOS, watchOS, and visionOS app.
+
+---
+
+## What's New in the Docs
+
+<!-- WHATS_NEW_START -->
+<!-- Add new entries at the top. Format:
+**Month YYYY** — [Page title](relative/path) — One sentence describing what changed or why it matters.
+Keep the last 5–8 entries and archive older ones by removing them.
+-->
+
+**May 2026** — [Signal Meter](user/signal-meter) — New deep-dive page explaining how the LoRa signal quality meter works, why negative SNR values are normal, and how to interpret RSSI vs. SNR for your mesh.
+
+**May 2026** — [Apple Watch App](user/watch) — New page covering the companion watch app: node list, fox hunt compass, and how it syncs with your iPhone.
+
+<!-- WHATS_NEW_END -->


### PR DESCRIPTION
## What changed

- **Site title** shortened from "Meshtastic Apple App Documentation" to "Meshtastic Apple" — reduces sidebar nav height
- **User Guide landing page** (): added a "What's New in the Docs" section highlighting the Signal Meter and Apple Watch pages
- **Developer Guide landing page** (): added a "Before You Open a PR" checklist (SwiftLint, snapshots, protos, SwiftData, docs staleness, commit format) and a "What's New for Developers" rolling changelog
- **Footer copyright year**: replaced the static  string in  (hardcoded 2024) with a  that uses `{{ "now" | date: "%Y" }}` — year now updates automatically at build time

## Why

The footer was showing 2024 and needed to be future-proof. The landing pages were sparse and didn't help users or contributors orient themselves quickly.

## How it was tested

- Jekyll build runs in the docs-deploy CI workflow
- All doc markdown lints cleanly
- No Swift source changes; no snapshot updates required

## Screenshots

N/A — text-only doc changes