### PR TITLE
Fix dark/light image pairs showing simultaneously on Jekyll site

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -164,6 +164,14 @@ The app ships a complete offline documentation system (feature `003-app-docs-mar
 ### Doc authoring conventions
 
 - **Screenshots**: Sourced exclusively from `MeshtasticTests/__Snapshots__/SwiftUIViewSnapshotTests/`. Copy PNGs to `docs/assets/screenshots/` and reference them with `![alt](../assets/screenshots/NAME.png)`.
+- **Dark/light image pairs**: When a view is snapshotted in both light and dark mode (e.g. `foo_light.png` + `foo_dark.png`), never embed both `![]()` tags side-by-side — both will render simultaneously. Instead use an HTML `<picture>` element with a `prefers-color-scheme` media query:
+  ```html
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/foo_dark.png">
+    <img src="../assets/screenshots/foo_light.png" alt="Description">
+  </picture>
+  ```
+  `cmark-gfm` is invoked with `--unsafe` so raw HTML passes through to both the Jekyll site and the in-app `WKWebView` renderer.
 - **Icons in tables**: Use `![icon](../assets/screenshots/NAME.png)` inside a markdown table with at minimum `| Icon | Description |` columns. Do not use standalone `![]()` blocks for icon references — use tables (FR-032).
 - **Icon snapshots**: Use `transparent: true`, plain `Image` views (not `Button`/wrapper components), `.font(.title).padding(2)`. Connection-status icons use `systemOrange`. Lock icons use portrait canvas widths (`lockClosed/Open/Red` → `width: 30`).
 - **Callout blocks**: Use `> **Tip — …**` and `> **Warning — …**` blockquote syntax — the build script converts these to styled `<div class="tips-callout">` / `<div class="warning-callout">` elements.

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -69,6 +69,19 @@ struct MyViewSnapshotTests {
 - For views with `ScrollView` or no intrinsic height, pass an explicit `height:` parameter to `renderImage`.
 - Commit reference PNGs alongside the test file.
 
+### Embedding Dark/Light Snapshot Pairs in Docs
+
+When a view is snapshotted in both colour schemes (e.g. `foo_light.png` + `foo_dark.png`), embedding both `![]()` tags side-by-side causes both images to appear simultaneously on the Jekyll site and in the in-app viewer. Use an HTML `<picture>` element instead:
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/foo_dark.png">
+  <img src="../assets/screenshots/foo_light.png" alt="Description">
+</picture>
+```
+
+This works in both contexts because `build-docs.sh` invokes `cmark-gfm --unsafe` (raw HTML is passed through) and `WKWebView` (used for in-app display) is full WebKit and respects `prefers-color-scheme`.
+
 ### Regenerating Snapshots
 
 Delete the reference PNG and run the test once — it records a new reference. Commit the new reference with your PR.

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -49,25 +49,47 @@ Each node is configured with a role that determines how it behaves on the mesh. 
 
 The full node row shows the circle avatar, battery level, encryption status, last-heard time, device role, signal strength, and log indicators all at once.
 
-![Directly connected node, favorite, with signal meter](../assets/screenshots/standard_directConnected.png)
-![Directly connected node, favorite, with signal meter — dark mode](../assets/screenshots/standard_directConnected_dark.png)
-![Multi-hop node 4 hops away](../assets/screenshots/standard_multiHop.png)
-![Multi-hop node 4 hops away — dark mode](../assets/screenshots/standard_multiHop_dark.png)
-![MQTT-bridged node](../assets/screenshots/standard_mqtt.png)
-![MQTT-bridged node — dark mode](../assets/screenshots/standard_mqtt_dark.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_directConnected_dark.png">
+  <img src="../assets/screenshots/standard_directConnected.png" alt="Directly connected node, favorite, with signal meter">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_multiHop_dark.png">
+  <img src="../assets/screenshots/standard_multiHop.png" alt="Multi-hop node 4 hops away">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_mqtt_dark.png">
+  <img src="../assets/screenshots/standard_mqtt.png" alt="MQTT-bridged node">
+</picture>
 
 ## Compact Node Row Examples
 
-![Directly connected node with all telemetry info](../assets/screenshots/compact_directConnected_allInfo.png)
-![Directly connected node with all telemetry info](../assets/screenshots/compact_directConnected_allInfo_dark.png)
-![Multi-hop node 7 hops away](../assets/screenshots/compact_multiHop.png)
-![Multi-hop node 7 hops away](../assets/screenshots/compact_multiHop_dark.png)
-![Node with position, 1 hop](../assets/screenshots/compact_withPosition.png)
-![Node with position, 1 hop](../assets/screenshots/compact_withPosition_dark.png)
-![PKI key mismatch node](../assets/screenshots/compact_pkiMismatch.png)
-![PKI key mismatch node](../assets/screenshots/compact_pkiMismatch_dark.png)
-![MQTT-bridged node](../assets/screenshots/compact_mqtt.png)
-![MQTT-bridged node](../assets/screenshots/compact_mqtt_dark.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_directConnected_allInfo_dark.png">
+  <img src="../assets/screenshots/compact_directConnected_allInfo.png" alt="Directly connected node with all telemetry info">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_multiHop_dark.png">
+  <img src="../assets/screenshots/compact_multiHop.png" alt="Multi-hop node 7 hops away">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_withPosition_dark.png">
+  <img src="../assets/screenshots/compact_withPosition.png" alt="Node with position, 1 hop">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_pkiMismatch_dark.png">
+  <img src="../assets/screenshots/compact_pkiMismatch.png" alt="PKI key mismatch node">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_mqtt_dark.png">
+  <img src="../assets/screenshots/compact_mqtt.png" alt="MQTT-bridged node">
+</picture>
 
 ## Additional Icons
 

--- a/docs/user/telemetry.md
+++ b/docs/user/telemetry.md
@@ -32,8 +32,10 @@ Meshtastic nodes can report sensor data across the mesh, giving you visibility i
 
 The Indoor Air Quality scale shows category bands from Excellent (green) through Hazardous (maroon). The app supports multiple display modes for air quality readings:
 
-![Air Quality Index — all display modes](../assets/screenshots/aqi_all_modes_light.png)
-![Air Quality Index — all display modes (dark)](../assets/screenshots/aqi_all_modes_dark.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/aqi_all_modes_dark.png">
+  <img src="../assets/screenshots/aqi_all_modes_light.png" alt="Air Quality Index — all display modes">
+</picture>
 
 ### Environment
 


### PR DESCRIPTION
## What changed

Replaced side-by-side light+dark PNG pairs with HTML `<picture>` elements using `prefers-color-scheme` media queries. Previously both images rendered on the page at once; now the browser picks the one matching the user's colour scheme.

**Affected pages:**
- `docs/user/nodes.md` — 3 complete node row pairs + 5 compact node row pairs
- `docs/user/telemetry.md` — AQI all-modes image pair

## Why

Users reported both dark and light mode images appearing on the Jekyll docs site simultaneously.

## How it was tested

`<picture>`/`prefers-color-scheme` is standard HTML5 supported by all modern browsers and is rendered correctly by Jekyll (just-the-docs passes HTML through as-is).

## Screenshots

N/A — visible fix on the live site after deploy.