### PR TITLE
Move SwiftData schema migration how-to from README to developer docs

### DIFF
--- a/Meshtastic/Resources/docs/developer/swiftdata.html
+++ b/Meshtastic/Resources/docs/developer/swiftdata.html
@@ -71,21 +71,41 @@ final class NodeInfoEntity {
 </tbody>
 </table>
 <h2>Schema Migrations</h2>
-<p>When you add, rename, or remove properties on a <code>@Model</code> type, you must provide a migration:</p>
+<p>When you add, rename, or remove properties on a <code>@Model</code> type, you must provide a migration. Schema files live in <code>Meshtastic/Model/Schema/</code>.</p>
+<h3>Adding a New Schema Version</h3>
 <ol>
-<li>Add a new <code>VersionedSchema</code> in <code>MeshtasticSchema.swift</code>.</li>
-<li>Add a <code>MigrationStage</code> to the <code>SchemaMigrationPlan</code>.</li>
-<li>Use <code>.lightweight</code> for additive changes (new optional properties); use <code>.custom</code> for destructive changes.</li>
+<li>Create <code>Meshtastic/Model/Schema/MeshtasticSchemaV2.swift</code> with the updated models:</li>
 </ol>
 <pre><code class="language-swift">enum MeshtasticSchemaV2: VersionedSchema {
     static var versionIdentifier = Schema.Version(2, 0, 0)
-    static var models: [any PersistentModel.Type] = [NodeInfoEntity.self, ...]
+    static var models: [any PersistentModel.Type] { ... }
 }
-
-// In the migration plan:
-.lightweight(fromVersion: MeshtasticSchemaV1.self, toVersion: MeshtasticSchemaV2.self)
 </code></pre>
-<p><strong>Never delete a <code>VersionedSchema</code>.</strong> Migration history must be preserved.</p>
+<ol start="2">
+<li>Append <code>MeshtasticSchemaV2.self</code> to <code>MeshtasticMigrationPlan.schemas</code> (newest last).</li>
+<li>Add a migration stage to <code>MeshtasticMigrationPlan.stages</code>:</li>
+</ol>
+<pre><code class="language-swift">// Lightweight — SwiftData infers additive changes automatically (new optional properties)
+static let migrateV1toV2 = MigrationStage.lightweight(
+    fromVersion: MeshtasticSchemaV1.self,
+    toVersion: MeshtasticSchemaV2.self
+)
+
+// Custom — when you need to transform or backfill data
+static let migrateV1toV2 = MigrationStage.custom(
+    fromVersion: MeshtasticSchemaV1.self,
+    toVersion: MeshtasticSchemaV2.self,
+    willMigrate: { context in },
+    didMigrate: { context in
+        // Transform data, populate new fields, etc.
+        try context.save()
+    }
+)
+</code></pre>
+<ol start="4">
+<li>Update <code>MeshtasticSchema.current</code> to point to the new version.</li>
+</ol>
+<div class="warning-callout"><strong>Warning — Never delete a <code>VersionedSchema</code>.</strong> Migration history must be preserved or the migration plan will fail on devices that skipped intermediate versions.</div>
 <h2>Query Helpers</h2>
 <p><code>QueryCoreData.swift</code> contains helper functions for common fetches:</p>
 <pre><code class="language-swift">let node = getNodeInfo(id: nodeNum, context: context)

--- a/README.md
+++ b/README.md
@@ -58,41 +58,6 @@ The last two major operating system versions are supported on iOS, iPadOS and ma
 - Use SFSymbols for icons
 - Use SwiftData for persistence
 
-## SwiftData Schema Versioning
-
-The app uses SwiftData with `VersionedSchema` and `SchemaMigrationPlan` for database versioning. Schema files live in `Meshtastic/Model/Schema/`.
-
-### Adding a New Schema Version
-
-1. Create `Meshtastic/Model/Schema/MeshtasticSchemaV2.swift` with the updated models:
-```swift
-enum MeshtasticSchemaV2: VersionedSchema {
-    static var versionIdentifier = Schema.Version(2, 0, 0)
-    static var models: [any PersistentModel.Type] { ... }
-}
-```
-2. Append `MeshtasticSchemaV2.self` to `MeshtasticMigrationPlan.schemas` (newest last).
-3. Add a migration stage to `MeshtasticMigrationPlan.stages`:
-```swift
-// Lightweight (SwiftData infers changes automatically)
-static let migrateV1toV2 = MigrationStage.lightweight(
-    fromVersion: MeshtasticSchemaV1.self,
-    toVersion: MeshtasticSchemaV2.self
-)
-
-// Custom (when you need to transform data)
-static let migrateV1toV2 = MigrationStage.custom(
-    fromVersion: MeshtasticSchemaV1.self,
-    toVersion: MeshtasticSchemaV2.self,
-    willMigrate: { context in },
-    didMigrate: { context in
-        // Transform data, populate new fields, etc.
-        try context.save()
-    }
-)
-```
-4. Update `MeshtasticSchema.current` to point to the new version.
-
 ## Updating Protobufs:
 
 1. run

--- a/docs/developer/swiftdata.md
+++ b/docs/developer/swiftdata.md
@@ -62,23 +62,44 @@ Key model types:
 
 ## Schema Migrations
 
-When you add, rename, or remove properties on a `@Model` type, you must provide a migration:
+When you add, rename, or remove properties on a `@Model` type, you must provide a migration. Schema files live in `Meshtastic/Model/Schema/`.
 
-1. Add a new `VersionedSchema` in `MeshtasticSchema.swift`.
-2. Add a `MigrationStage` to the `SchemaMigrationPlan`.
-3. Use `.lightweight` for additive changes (new optional properties); use `.custom` for destructive changes.
+### Adding a New Schema Version
+
+1. Create `Meshtastic/Model/Schema/MeshtasticSchemaV2.swift` with the updated models:
 
 ```swift
 enum MeshtasticSchemaV2: VersionedSchema {
     static var versionIdentifier = Schema.Version(2, 0, 0)
-    static var models: [any PersistentModel.Type] = [NodeInfoEntity.self, ...]
+    static var models: [any PersistentModel.Type] { ... }
 }
-
-// In the migration plan:
-.lightweight(fromVersion: MeshtasticSchemaV1.self, toVersion: MeshtasticSchemaV2.self)
 ```
 
-**Never delete a `VersionedSchema`.** Migration history must be preserved.
+2. Append `MeshtasticSchemaV2.self` to `MeshtasticMigrationPlan.schemas` (newest last).
+3. Add a migration stage to `MeshtasticMigrationPlan.stages`:
+
+```swift
+// Lightweight — SwiftData infers additive changes automatically (new optional properties)
+static let migrateV1toV2 = MigrationStage.lightweight(
+    fromVersion: MeshtasticSchemaV1.self,
+    toVersion: MeshtasticSchemaV2.self
+)
+
+// Custom — when you need to transform or backfill data
+static let migrateV1toV2 = MigrationStage.custom(
+    fromVersion: MeshtasticSchemaV1.self,
+    toVersion: MeshtasticSchemaV2.self,
+    willMigrate: { context in },
+    didMigrate: { context in
+        // Transform data, populate new fields, etc.
+        try context.save()
+    }
+)
+```
+
+4. Update `MeshtasticSchema.current` to point to the new version.
+
+> **Warning — Never delete a `VersionedSchema`.** Migration history must be preserved or the migration plan will fail on devices that skipped intermediate versions.
 
 ## Query Helpers
 


### PR DESCRIPTION
## What changed

- **`docs/developer/swiftdata.md`**: expanded the existing "Schema Migrations" section with the full step-by-step guide from the README — `VersionedSchema` stub, appending to the schemas list, lightweight vs. custom `MigrationStage` examples, and a Warning callout about never deleting a `VersionedSchema`
- **`README.md`**: removed the ~30-line "SwiftData Schema Versioning" section
- **Bundled HTML regenerated** via `build-docs.sh` (21 pages, 4.0 MB)

## Why

The README is not the right place for detailed implementation how-tos. The swiftdata.md developer doc is the canonical home for SwiftData guidance and is searchable in the in-app docs viewer.

## How it was tested

- `build-docs.sh` completed successfully
- No Swift source changes; no snapshot updates required