### PR TITLE
Replace dSYM upload workflow with official Datadog action

### DIFF
--- a/.github/workflows/macos-dSYM.yml
+++ b/.github/workflows/macos-dSYM.yml
@@ -6,72 +6,57 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  upload-dsyms:
     runs-on: macos-15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Select Xcode Version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-        
-      - name: Show Xcode Version
-        run: xcodebuild -version
-        
-      - name: Setup Environment Variables
+
+      - name: Resolve Package Dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -workspace Meshtastic.xcworkspace \
+            -scheme Meshtastic
+
+      - name: Build for iOS Device (Release) and Generate dSYMs
         env:
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
         run: |
-          echo "DATADOG_CLIENT_TOKEN=${DATADOG_CLIENT_TOKEN}" >> $GITHUB_ENV
-          
-      - name: Build iOS App and Generate dSYMs
-        env:
-          DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
-        run: |
-          # Create build directory
-          mkdir -p ./build/dSYMs
-          
-          # Build for iOS Simulator to generate dSYMs without code signing
           xcodebuild \
             -workspace Meshtastic.xcworkspace \
             -scheme Meshtastic \
             -configuration Release \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination 'generic/platform=iOS' \
             -derivedDataPath ./build/DerivedData \
+            -skipPackagePluginValidation \
             DATADOG_CLIENT_TOKEN="${DATADOG_CLIENT_TOKEN}" \
             DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY=- \
             build
-            
-      - name: Extract dSYMs from Build
-        run: |
-          # Find and copy all dSYM files from the build
-          find ./build/DerivedData -name "*.dSYM" -exec cp -R {} ./build/dSYMs/ \;
-          
-          # List what we found
-          echo "Found dSYM files:"
-          find ./build/dSYMs -name "*.dSYM" -type d
 
-      - name: Install Datadog CI
+      - name: Collect dSYM Files
         run: |
-          npm install -g @datadog/datadog-ci
-          
+          mkdir -p ./build/dSYMs
+          find ./build/DerivedData -name "*.dSYM" -exec cp -R {} ./build/dSYMs/ \;
+          echo "Found $(find ./build/dSYMs -name '*.dSYM' -type d | wc -l | tr -d ' ') dSYM bundles:"
+          find ./build/dSYMs -name "*.dSYM" -type d | sort
+
       - name: Upload dSYMs to Datadog
-        env:
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-          DATADOG_SITE: us5.datadoghq.com
-        run: |
-          # Upload all dSYM files to Datadog
-          if [ -d "./build/dSYMs" ] && [ "$(find ./build/dSYMs -name "*.dSYM" -type d | wc -l)" -gt 0 ]; then
-            echo "Uploading dSYM files to Datadog..."
-            datadog-ci dsyms upload ./build/dSYMs
-          else
-            echo "No dSYM files found to upload"
-            exit 1
-          fi
-          
+        uses: DataDog/upload-dsyms-github-action@v1
+        with:
+          api_key: ${{ secrets.DATADOG_API_KEY }}
+          site: us5.datadoghq.com
+          dsym_paths: |
+            ./build/dSYMs
+
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## What changed
- Replaced manual `npm install -g @datadog/datadog-ci` + CLI invocation with the official `DataDog/upload-dsyms-github-action@v1`
- Changed build destination from `generic/platform=iOS Simulator` to `generic/platform=iOS` so dSYM UUIDs match device crash reports
- Added `submodules: recursive` to check out `protobufs/`
- Added explicit SPM dependency resolution step
- Added `-skipPackagePluginValidation` for CI plugin trust
- Added `CODE_SIGN_IDENTITY=-` for ad-hoc signing without provisioning profiles

## Why
The previous workflow was failing repeatedly — it used a fragile npm-based CLI installation and built for Simulator architecture, producing dSYMs whose UUIDs don't match the App Store / TestFlight device binaries.

## How it was tested
Validated against Datadog's official documentation and the `DataDog/upload-dsyms-github-action` README. The workflow can be verified via `workflow_dispatch` trigger.