### PR TITLE
Fix dSYM upload: pin DataDog action to v0.4.0 (v1 tag does not exist)

### DIFF
--- a/.github/workflows/macos-dSYM.yml
+++ b/.github/workflows/macos-dSYM.yml
@@ -50,7 +50,7 @@ jobs:
           find ./build/dSYMs -name "*.dSYM" -type d | sort
 
       - name: Upload dSYMs to Datadog
-        uses: DataDog/upload-dsyms-github-action@v1
+        uses: DataDog/upload-dsyms-github-action@v0.4.0
         with:
           api_key: ${{ secrets.DATADOG_API_KEY }}
           site: us5.datadoghq.com


### PR DESCRIPTION
## What changed
Pin `DataDog/upload-dsyms-github-action` from `@v1` to `@v0.4.0`.

## Why
The action has no `v1` tag — available versions are `v0.1.0` through `v0.4.0`. GitHub Actions failed with:
```
Unable to resolve action datadog/upload-dsyms-github-action@v1, unable to find version v1
```

## How it was tested
Verified available tags at https://github.com/DataDog/upload-dsyms-github-action/tags — latest is `v0.4.0`.