### PR TITLE
Fix dSYM workflow: use xcodebuild archive to avoid code signing failure

### DIFF
--- a/.github/workflows/macos-dSYM.yml
+++ b/.github/workflows/macos-dSYM.yml
@@ -24,43 +24,43 @@ jobs:
             -workspace Meshtastic.xcworkspace \
             -scheme Meshtastic
 
-      - name: Build for iOS Device (Release) and Generate dSYMs
+      - name: Archive for iOS (Release) and Generate dSYMs
         env:
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
         run: |
-          xcodebuild \
+          xcodebuild archive \
             -workspace Meshtastic.xcworkspace \
             -scheme Meshtastic \
             -configuration Release \
             -destination 'generic/platform=iOS' \
-            -derivedDataPath ./build/DerivedData \
+            -archivePath ./build/Meshtastic.xcarchive \
             -skipPackagePluginValidation \
             DATADOG_CLIENT_TOKEN="${DATADOG_CLIENT_TOKEN}" \
             DEBUG_INFORMATION_FORMAT=dwarf-with-dsym \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGN_IDENTITY=- \
-            build
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGN_ENTITLEMENTS="" \
+            DEVELOPMENT_TEAM=""
 
       - name: Collect dSYM Files
         run: |
-          mkdir -p ./build/dSYMs
-          find ./build/DerivedData -name "*.dSYM" -exec cp -R {} ./build/dSYMs/ \;
-          echo "Found $(find ./build/dSYMs -name '*.dSYM' -type d | wc -l | tr -d ' ') dSYM bundles:"
-          find ./build/dSYMs -name "*.dSYM" -type d | sort
+          DSYM_DIR="./build/Meshtastic.xcarchive/dSYMs"
+          echo "Found $(find "$DSYM_DIR" -name '*.dSYM' -type d 2>/dev/null | wc -l | tr -d ' ') dSYM bundles:"
+          find "$DSYM_DIR" -name "*.dSYM" -type d | sort
 
       - name: Upload dSYMs to Datadog
-        uses: DataDog/upload-dsyms-github-action@v0.4.0
-        with:
-          api_key: ${{ secrets.DATADOG_API_KEY }}
-          site: us5.datadoghq.com
-          dsym_paths: |
-            ./build/dSYMs
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_SITE: us5.datadoghq.com
+        run: |
+          npx --yes @datadog/datadog-ci dsyms upload \
+            ./build/Meshtastic.xcarchive/dSYMs
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: dsym-files
-          path: ./build/dSYMs
+          path: ./build/Meshtastic.xcarchive/dSYMs
           retention-days: 30


### PR DESCRIPTION
## What changed
Replaced `xcodebuild build` with `xcodebuild archive` and switched from the DataDog GitHub Action to `npx @datadog/datadog-ci`.

## Why
`xcodebuild build` for `generic/platform=iOS` fails with exit code 65 in CI — the linker requires code signing even with `CODE_SIGNING_ALLOWED=NO`. The archive action separates compilation from signing, allowing dSYM generation without certificates.

Also replaced the `DataDog/upload-dsyms-github-action` (which had version tag issues) with a direct `npx @datadog/datadog-ci dsyms upload` call.

## Changes
- `xcodebuild archive` instead of `xcodebuild build`
- `CODE_SIGN_IDENTITY=""`, `CODE_SIGN_ENTITLEMENTS=""`, `DEVELOPMENT_TEAM=""` to fully clear signing
- dSYMs collected from `xcarchive/dSYMs/` (archive's known output path)
- `npx @datadog/datadog-ci dsyms upload` instead of GitHub Action

## How it was tested
Can be verified via workflow_dispatch trigger after merge.