### PR TITLE
Fix MDX self-closing tags in picture elements; add Translate page to user guide

### DIFF
--- a/Meshtastic/Resources/docs/developer/testing.html
+++ b/Meshtastic/Resources/docs/developer/testing.html
@@ -64,8 +64,8 @@ struct MyViewSnapshotTests {
 <h3>Embedding Dark/Light Snapshot Pairs in Docs</h3>
 <p>When a view is snapshotted in both colour schemes (e.g. <code>foo_light.png</code> + <code>foo_dark.png</code>), embedding both <code>![]()</code> tags side-by-side causes both images to appear simultaneously on the Jekyll site and in the in-app viewer. Use an HTML <code>&lt;picture&gt;</code> element instead:</p>
 <pre><code class="language-html">&lt;picture&gt;
-  &lt;source media=&quot;(prefers-color-scheme: dark)&quot; srcset=&quot;../assets/screenshots/foo_dark.png&quot;&gt;
-  &lt;img src=&quot;../assets/screenshots/foo_light.png&quot; alt=&quot;Description&quot;&gt;
+  &lt;source media=&quot;(prefers-color-scheme: dark)&quot; srcset=&quot;../assets/screenshots/foo_dark.png&quot; /&gt;
+  &lt;img src=&quot;../assets/screenshots/foo_light.png&quot; alt=&quot;Description&quot; /&gt;
 &lt;/picture&gt;
 </code></pre>
 <p>This works in both contexts because <code>build-docs.sh</code> invokes <code>cmark-gfm --unsafe</code> (raw HTML is passed through) and <code>WKWebView</code> (used for in-app display) is full WebKit and respects <code>prefers-color-scheme</code>.</p>

--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -507,6 +507,45 @@
         "charCount": 2811
     },
     {
+        "id": "translate",
+        "title": "Translate the App",
+        "section": "user",
+        "navOrder": 14,
+        "keywords": [
+            "project",
+            "meshtastic",
+            "app",
+            "translations",
+            "apple",
+            "xcode",
+            "new",
+            "language",
+            "xcstrings",
+            "steps",
+            "release",
+            "open",
+            "localizable",
+            "locale",
+            "follow",
+            "adding",
+            "add",
+            "yet",
+            "xcworkspace",
+            "wider",
+            "uses",
+            "upon",
+            "updating",
+            "update",
+            "translation",
+            "translate",
+            "tip",
+            "thank",
+            "subject",
+            "string"
+        ],
+        "charCount": 1115
+    },
+    {
         "id": "watch",
         "title": "Apple Watch App",
         "section": "user",
@@ -855,7 +894,7 @@
             "snapshots",
             "scale"
         ],
-        "charCount": 3510
+        "charCount": 3514
     },
     {
         "id": "transport",

--- a/Meshtastic/Resources/docs/user/nodes.html
+++ b/Meshtastic/Resources/docs/user/nodes.html
@@ -131,37 +131,37 @@
 <h2>Complete Node Row Examples</h2>
 <p>The full node row shows the circle avatar, battery level, encryption status, last-heard time, device role, signal strength, and log indicators all at once.</p>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_directConnected_dark.png">
-  <img src="../assets/screenshots/standard_directConnected.png" alt="Directly connected node, favorite, with signal meter">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_directConnected_dark.png" />
+  <img src="../assets/screenshots/standard_directConnected.png" alt="Directly connected node, favorite, with signal meter" />
 </picture>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_multiHop_dark.png">
-  <img src="../assets/screenshots/standard_multiHop.png" alt="Multi-hop node 4 hops away">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_multiHop_dark.png" />
+  <img src="../assets/screenshots/standard_multiHop.png" alt="Multi-hop node 4 hops away" />
 </picture>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_mqtt_dark.png">
-  <img src="../assets/screenshots/standard_mqtt.png" alt="MQTT-bridged node">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_mqtt_dark.png" />
+  <img src="../assets/screenshots/standard_mqtt.png" alt="MQTT-bridged node" />
 </picture>
 <h2>Compact Node Row Examples</h2>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_directConnected_allInfo_dark.png">
-  <img src="../assets/screenshots/compact_directConnected_allInfo.png" alt="Directly connected node with all telemetry info">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_directConnected_allInfo_dark.png" />
+  <img src="../assets/screenshots/compact_directConnected_allInfo.png" alt="Directly connected node with all telemetry info" />
 </picture>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_multiHop_dark.png">
-  <img src="../assets/screenshots/compact_multiHop.png" alt="Multi-hop node 7 hops away">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_multiHop_dark.png" />
+  <img src="../assets/screenshots/compact_multiHop.png" alt="Multi-hop node 7 hops away" />
 </picture>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_withPosition_dark.png">
-  <img src="../assets/screenshots/compact_withPosition.png" alt="Node with position, 1 hop">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_withPosition_dark.png" />
+  <img src="../assets/screenshots/compact_withPosition.png" alt="Node with position, 1 hop" />
 </picture>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_pkiMismatch_dark.png">
-  <img src="../assets/screenshots/compact_pkiMismatch.png" alt="PKI key mismatch node">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_pkiMismatch_dark.png" />
+  <img src="../assets/screenshots/compact_pkiMismatch.png" alt="PKI key mismatch node" />
 </picture>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_mqtt_dark.png">
-  <img src="../assets/screenshots/compact_mqtt.png" alt="MQTT-bridged node">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_mqtt_dark.png" />
+  <img src="../assets/screenshots/compact_mqtt.png" alt="MQTT-bridged node" />
 </picture>
 <h2>Additional Icons</h2>
 <p>Tap a node and scroll to the Logs section for detailed metrics:</p>

--- a/Meshtastic/Resources/docs/user/telemetry.html
+++ b/Meshtastic/Resources/docs/user/telemetry.html
@@ -72,8 +72,8 @@
 <p><img src="../assets/screenshots/iaqScale.png" alt="IAQ Scale" /></p>
 <p>The Indoor Air Quality scale shows category bands from Excellent (green) through Hazardous (maroon). The app supports multiple display modes for air quality readings:</p>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/aqi_all_modes_dark.png">
-  <img src="../assets/screenshots/aqi_all_modes_light.png" alt="Air Quality Index — all display modes">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/aqi_all_modes_dark.png" />
+  <img src="../assets/screenshots/aqi_all_modes_light.png" alt="Air Quality Index — all display modes" />
 </picture>
 <h3>Environment</h3>
 <table>

--- a/Meshtastic/Resources/docs/user/translate.html
+++ b/Meshtastic/Resources/docs/user/translate.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Translate the App</title>
+  <link rel="stylesheet" href="../assets/docs.css">
+</head>
+<body data-page="translate">
+<div class="pre-release-banner">⚠️ <strong>Pre-release</strong> — subject to change</div><h1>Translate the App</h1>
+<p>Contributing translations to the Meshtastic Apple app helps make the project accessible to a wider audience. The app uses <a href="https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog">string catalogs</a> in Xcode to manage translations.</p>
+<h2>How to Contribute</h2>
+<p>If you would like to update the translations for an existing locale or add a new language, follow these steps:</p>
+<ol>
+<li>Fork the <a href="https://github.com/meshtastic/Meshtastic-Apple/tree/main">Meshtastic-Apple repository</a> to your GitHub account.</li>
+<li>Clone the project and open <code>Meshtastic.xcworkspace</code> in Xcode.</li>
+<li>Select the <code>Localizable.xcstrings</code> file in the project navigator.</li>
+<li>Follow the <a href="https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog">steps for adding or updating translations</a> in Apple's documentation.</li>
+<li>Create a pull request on the project with your changes.</li>
+</ol>
+<p>Your contribution will be reviewed, and upon approval, your translation will be included in the next release of the Meshtastic Apple app.</p>
+<div class="tips-callout"><strong>Tip — New language?</strong> If you are adding a language not yet present in the project, open the Xcode project settings, go to <strong>Info → Localizations</strong>, and add the new locale before editing <code>Localizable.xcstrings</code>.</div>
+<p>Thank you for helping expand the reach of Meshtastic!</p>
+</body>
+</html>

--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,22 +1,52 @@
 {
   "files": {
-    "heltec-wireless-paper.svg": {
-      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
-    },
-    "wio-tracker-wm1110.svg": {
-      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
-    },
-    "promicro.svg": {
-      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
-    },
-    "rak4631_case.svg": {
-      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
+    "rak11200.svg": {
+      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
     },
     "rak2560.svg": {
       "etag": "\"e425adc49058399a2a7f8517093192f0\""
     },
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    "seeed_solar.svg": {
+      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    },
+    "wio-tracker-wm1110.svg": {
+      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    },
+    "tbeam-1w.svg": {
+      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
+    },
+    "crowpanel_2_8.svg": {
+      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
+    },
+    "crowpanel_5_0.svg": {
+      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    },
+    "tbeam.svg": {
+      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
+    },
+    "heltec-mesh-solar.svg": {
+      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
+    },
+    "rak4631.svg": {
+      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    },
+    "tlora-t3s3-epaper.svg": {
+      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    },
+    "rak3401.svg": {
+      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
+    },
+    "promicro.svg": {
+      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
+    },
+    "techo_lite.svg": {
+      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
+    },
+    "t-watch-s3.svg": {
+      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
+    },
+    "rak-wismesh-tap-v2.svg": {
+      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
     },
     "heltec-mesh-node-t114-case.svg": {
       "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
@@ -24,188 +54,158 @@
     "heltec-vision-master-t190.svg": {
       "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
     },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
-    },
-    "tlora-v2-1-1_6.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
-    },
-    "rak-wismesh-tap-v2.svg": {
-      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
-    },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
-    },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
-    "station-g2.svg": {
-      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
-    },
-    "seeed-sensecap-indicator.svg": {
-      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
-    },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
-    },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    "thinknode_m2.svg": {
+      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
     },
     "seeed_xiao_nrf52_kit.svg": {
       "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
     },
-    "rak-wismeshtap.svg": {
-      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
-    },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
-    },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
-    },
-    "tbeam.svg": {
-      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
-    },
-    "crowpanel_2_8.svg": {
-      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
-    },
-    "tlora-t3s3-epaper.svg": {
-      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
-    },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
-    },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
-    },
-    "crowpanel_3_5.svg": {
-      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
-    },
-    "heltec-v3-case.svg": {
-      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
-    },
-    "thinknode_m4.svg": {
-      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
-    },
-    "rak11310.svg": {
-      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
-    },
-    "muzi_r1_neo.svg": {
-      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
-    },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
-    },
-    "heltec_v4.svg": {
-      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
-    },
-    "techo_lite.svg": {
-      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
-    },
-    "crowpanel_2_4.svg": {
-      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
-    },
-    "muzi_base.svg": {
-      "etag": "\"be887c289c63af434835279b75f0879e\""
-    },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
-    },
-    "thinknode_m3.svg": {
-      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
-    },
-    "heltec-mesh-solar.svg": {
-      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
-    },
-    "t-deck.svg": {
-      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
-    },
-    "rak11200.svg": {
-      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
-    },
-    "rak_wismesh_tag.svg": {
-      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
-    },
-    "crowpanel_7_0.svg": {
-      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
-    },
-    "t5s3_epaper.svg": {
-      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
-    },
-    "t-watch-s3.svg": {
-      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
-    },
-    "meteor_pro.svg": {
-      "etag": "\"db5044328b825421851b963479fab9ca\""
-    },
-    "m5_c6l.svg": {
-      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
-    },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
-    },
-    "heltec-ht62-esp32c3-sx1262.svg": {
-      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
-    },
-    "crowpanel_5_0.svg": {
-      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
-    },
-    "rak4631.svg": {
-      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
-    },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
-    },
-    "tbeam-1w.svg": {
-      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
-    },
-    "pico.svg": {
-      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
-    },
-    "tlora-t3s3-v1.svg": {
-      "etag": "\"bbf44e526676ad298698d1387af57c15\""
-    },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
-    },
-    "thinknode_m2.svg": {
-      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
-    },
-    "seeed_solar.svg": {
-      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
-    },
-    "rak3401.svg": {
-      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
-    },
-    "heltec-wsl-v3.svg": {
-      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
-    },
-    "heltec_wireless_tracker_v2.svg": {
-      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
     },
     "heltec-v3.svg": {
       "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
     },
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "muzi_base.svg": {
+      "etag": "\"be887c289c63af434835279b75f0879e\""
+    },
+    "crowpanel_3_5.svg": {
+      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
+    },
+    "t5s3_epaper.svg": {
+      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
+    },
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
+    },
+    "thinknode_m4.svg": {
+      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
+    },
+    "m5_c6l.svg": {
+      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
+    },
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    },
+    "seeed-sensecap-indicator.svg": {
+      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
+    },
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    },
+    "pico.svg": {
+      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    },
+    "crowpanel_2_4.svg": {
+      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
+    },
+    "station-g2.svg": {
+      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    },
+    "heltec_v4.svg": {
+      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
+    },
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
+    },
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    },
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
+    },
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
+    },
+    "tlora-v2-1-1_6.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "t-deck.svg": {
+      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    },
+    "rak_wismesh_tag.svg": {
+      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
+    },
+    "rak-wismeshtap.svg": {
+      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
+    },
+    "heltec-v3-case.svg": {
+      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
+    },
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    },
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
+    },
+    "heltec-wsl-v3.svg": {
+      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
+    },
+    "heltec_wireless_tracker_v2.svg": {
+      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    },
+    "crowpanel_7_0.svg": {
+      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
+    },
+    "heltec-ht62-esp32c3-sx1262.svg": {
+      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
+    },
     "t-echo.svg": {
       "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    },
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    },
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
+    },
+    "heltec-wireless-paper.svg": {
+      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
+    },
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    },
+    "muzi_r1_neo.svg": {
+      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
+    },
+    "thinknode_m3.svg": {
+      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    },
+    "rak11310.svg": {
+      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
+    },
+    "rak4631_case.svg": {
+      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "meteor_pro.svg": {
+      "etag": "\"db5044328b825421851b963479fab9ca\""
+    },
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    },
+    "tlora-t3s3-v1.svg": {
+      "etag": "\"bbf44e526676ad298698d1387af57c15\""
     }
   },
   "api_hash": "da281fe426e5989c17ce8933916f4c7367f90a5e15a1672f4b0b53f541c016be"

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -75,8 +75,8 @@ When a view is snapshotted in both colour schemes (e.g. `foo_light.png` + `foo_d
 
 ```html
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/foo_dark.png">
-  <img src="../assets/screenshots/foo_light.png" alt="Description">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/foo_dark.png" />
+  <img src="../assets/screenshots/foo_light.png" alt="Description" />
 </picture>
 ```
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -18,6 +18,8 @@ Documentation for using the Meshtastic iOS, iPadOS, macOS, watchOS, and visionOS
 Keep the last 5–8 entries and archive older ones by removing them.
 -->
 
+**May 2026** — [Translate the App](user/translate) — New page explaining how to contribute translations via Xcode string catalogs.
+
 **May 2026** — [Signal Meter](user/signal-meter) — New deep-dive page explaining how the LoRa signal quality meter works, why negative SNR values are normal, and how to interpret RSSI vs. SNR for your mesh.
 
 **May 2026** — [Apple Watch App](user/watch) — New page covering the companion watch app: node list, fox hunt compass, and how it syncs with your iPhone.

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -50,45 +50,45 @@ Each node is configured with a role that determines how it behaves on the mesh. 
 The full node row shows the circle avatar, battery level, encryption status, last-heard time, device role, signal strength, and log indicators all at once.
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_directConnected_dark.png">
-  <img src="../assets/screenshots/standard_directConnected.png" alt="Directly connected node, favorite, with signal meter">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_directConnected_dark.png" />
+  <img src="../assets/screenshots/standard_directConnected.png" alt="Directly connected node, favorite, with signal meter" />
 </picture>
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_multiHop_dark.png">
-  <img src="../assets/screenshots/standard_multiHop.png" alt="Multi-hop node 4 hops away">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_multiHop_dark.png" />
+  <img src="../assets/screenshots/standard_multiHop.png" alt="Multi-hop node 4 hops away" />
 </picture>
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_mqtt_dark.png">
-  <img src="../assets/screenshots/standard_mqtt.png" alt="MQTT-bridged node">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/standard_mqtt_dark.png" />
+  <img src="../assets/screenshots/standard_mqtt.png" alt="MQTT-bridged node" />
 </picture>
 
 ## Compact Node Row Examples
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_directConnected_allInfo_dark.png">
-  <img src="../assets/screenshots/compact_directConnected_allInfo.png" alt="Directly connected node with all telemetry info">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_directConnected_allInfo_dark.png" />
+  <img src="../assets/screenshots/compact_directConnected_allInfo.png" alt="Directly connected node with all telemetry info" />
 </picture>
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_multiHop_dark.png">
-  <img src="../assets/screenshots/compact_multiHop.png" alt="Multi-hop node 7 hops away">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_multiHop_dark.png" />
+  <img src="../assets/screenshots/compact_multiHop.png" alt="Multi-hop node 7 hops away" />
 </picture>
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_withPosition_dark.png">
-  <img src="../assets/screenshots/compact_withPosition.png" alt="Node with position, 1 hop">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_withPosition_dark.png" />
+  <img src="../assets/screenshots/compact_withPosition.png" alt="Node with position, 1 hop" />
 </picture>
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_pkiMismatch_dark.png">
-  <img src="../assets/screenshots/compact_pkiMismatch.png" alt="PKI key mismatch node">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_pkiMismatch_dark.png" />
+  <img src="../assets/screenshots/compact_pkiMismatch.png" alt="PKI key mismatch node" />
 </picture>
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_mqtt_dark.png">
-  <img src="../assets/screenshots/compact_mqtt.png" alt="MQTT-bridged node">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/compact_mqtt_dark.png" />
+  <img src="../assets/screenshots/compact_mqtt.png" alt="MQTT-bridged node" />
 </picture>
 
 ## Additional Icons

--- a/docs/user/telemetry.md
+++ b/docs/user/telemetry.md
@@ -33,8 +33,8 @@ Meshtastic nodes can report sensor data across the mesh, giving you visibility i
 The Indoor Air Quality scale shows category bands from Excellent (green) through Hazardous (maroon). The app supports multiple display modes for air quality readings:
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/aqi_all_modes_dark.png">
-  <img src="../assets/screenshots/aqi_all_modes_light.png" alt="Air Quality Index — all display modes">
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/aqi_all_modes_dark.png" />
+  <img src="../assets/screenshots/aqi_all_modes_light.png" alt="Air Quality Index — all display modes" />
 </picture>
 
 ### Environment

--- a/docs/user/translate.md
+++ b/docs/user/translate.md
@@ -1,0 +1,25 @@
+---
+title: Translate the App
+parent: User Guide
+nav_order: 14
+---
+
+# Translate the App
+
+Contributing translations to the Meshtastic Apple app helps make the project accessible to a wider audience. The app uses [string catalogs](https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog) in Xcode to manage translations.
+
+## How to Contribute
+
+If you would like to update the translations for an existing locale or add a new language, follow these steps:
+
+1. Fork the [Meshtastic-Apple repository](https://github.com/meshtastic/Meshtastic-Apple/tree/main) to your GitHub account.
+2. Clone the project and open `Meshtastic.xcworkspace` in Xcode.
+3. Select the `Localizable.xcstrings` file in the project navigator.
+4. Follow the [steps for adding or updating translations](https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog) in Apple's documentation.
+5. Create a pull request on the project with your changes.
+
+Your contribution will be reviewed, and upon approval, your translation will be included in the next release of the Meshtastic Apple app.
+
+> **Tip — New language?** If you are adding a language not yet present in the project, open the Xcode project settings, go to **Info → Localizations**, and add the new locale before editing `Localizable.xcstrings`.
+
+Thank you for helping expand the reach of Meshtastic!


### PR DESCRIPTION
## What changed

- Self-closed all `<img>` and `<source>` tags inside `<picture>` elements in `docs/user/nodes.md`, `docs/user/telemetry.md`, and `docs/developer/testing.md` (MDX/JSX requires void elements to be self-closed with `/>`)
- Added new `docs/user/translate.md` page (nav_order 14) adapted from the Docusaurus site, explaining how to contribute translations via Xcode string catalogs
- Updated `docs/user.md` What's New section with the new page entry
- Rebuilt all bundled HTML (24 pages, 4.0 MB)

## Why

The Docusaurus MDX parser errors on bare `<img>` and `<source>` tags — JSX requires void elements to be self-closed.

## How tested

`bash scripts/build-docs.sh --output Meshtastic/Resources/docs --beta` — 24 pages built cleanly, no errors.