### PR TITLE
Reduce SwiftData save frequency for battery and performance

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -327,6 +327,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		// Cancel ongoing connection task if it exists
 		await self.connectionStepper?.cancel()
 
+		// Flush any debounced position/telemetry saves before disconnecting
+		await MeshPackets.shared.flushDebouncedSaves()
+
 		// Close out the connection
 		if let activeConnection = activeConnection {
 			try await activeConnection.connection.disconnect(withError: nil, shouldReconnect: false)
@@ -706,6 +709,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 					Logger.mesh.warning("🕸️ MESH PACKET received for unknown App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
 				}
 			}
+			// Save any pending updateAnyPacketFrom changes for packets that
+			// don't have a dedicated handler (UNHANDLED cases above).
+			await MeshPackets.shared.savePendingChanges()
 
 		case .nodeInfo(let nodeInfo):
 			await handleNodeInfo(nodeInfo)

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -61,7 +61,59 @@ actor MeshPackets {
 		let container = MainActor.assumeIsolated { PersistenceController.shared.container }
 		return MeshPackets(modelContainer: container)
 	}()
-	
+
+	// MARK: - Save Helpers
+
+	/// Saves any pending changes in the model context. Call once at the end of each
+	/// top-level packet handler to batch all mutations from a single packet into one write.
+	func savePendingChanges(caller: String = #function) {
+		guard modelContext.hasChanges else { return }
+		do {
+			try modelContext.save()
+			Logger.data.info("💾 [\(caller, privacy: .public)] Saved pending changes")
+		} catch {
+			Logger.data.error("💥 [\(caller, privacy: .public)] Error saving: \(error.localizedDescription, privacy: .public)")
+		}
+	}
+
+	// MARK: - Debounced Save for High-Frequency Packets
+
+	/// Timer task for debounced saves (position/telemetry).
+	private var debounceSaveTask: Task<Void, Never>?
+	/// Tracks when we last flushed debounced changes to enforce a maximum delay.
+	private var lastDebouncedSaveTime: ContinuousClock.Instant = .now
+	/// How long to wait after the last mutation before flushing.
+	private static let debounceInterval: Duration = .seconds(2)
+	/// Maximum wall-clock time between flushes, even if packets keep arriving.
+	private static let maxDebounceDelay: Duration = .seconds(5)
+
+	/// Schedules a debounced save. Each call resets the 2-second timer. If packets
+	/// keep arriving continuously, a save is forced every 5 seconds.
+	/// Use for high-frequency packet types (position, telemetry) instead of `savePendingChanges`.
+	func scheduleDebouncedSave() {
+		debounceSaveTask?.cancel()
+		let elapsed = ContinuousClock.now - lastDebouncedSaveTime
+		if elapsed >= Self.maxDebounceDelay {
+			savePendingChanges(caller: "debouncedFlush-maxDelay")
+			lastDebouncedSaveTime = .now
+			return
+		}
+		debounceSaveTask = Task {
+			try? await Task.sleep(for: Self.debounceInterval)
+			guard !Task.isCancelled else { return }
+			self.savePendingChanges(caller: "debouncedFlush")
+			self.lastDebouncedSaveTime = .now
+		}
+	}
+
+	/// Immediately flushes any debounced saves. Call on disconnect or when entering background.
+	func flushDebouncedSaves() {
+		debounceSaveTask?.cancel()
+		debounceSaveTask = nil
+		savePendingChanges(caller: "flushDebouncedSaves")
+		lastDebouncedSaveTime = .now
+	}
+
 	func localConfig (config: Config, nodeNum: Int64, nodeLongName: String) {
 		switch config.payloadVariant {
 		case .bluetooth:
@@ -139,14 +191,9 @@ actor MeshPackets {
 				if !myInfo.pioEnv.isEmpty {
 					myInfoEntity.pioEnv = myInfo.pioEnv
 				}
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 Saved a new myInfo for node: \(myInfo.myNodeNum.toHex(), privacy: .public)")
-					return myInfoEntity.persistentModelID
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 Error Inserting New Core Data MyInfoEntity: \(nsError, privacy: .public)")
-				}
+				Logger.data.info("💾 Saved a new myInfo for node: \(myInfo.myNodeNum.toHex(), privacy: .public)")
+				savePendingChanges()
+				return myInfoEntity.persistentModelID
 			} else {
 				
 				fetchedMyInfo[0].peripheralId = peripheralId
@@ -156,14 +203,9 @@ actor MeshPackets {
 					fetchedMyInfo[0].pioEnv = myInfo.pioEnv
 				}
 				
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 Updated myInfo for node: \(myInfo.myNodeNum.toHex(), privacy: .public)")
-					return fetchedMyInfo[0].persistentModelID
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 Error Updating Core Data MyInfoEntity: \(nsError, privacy: .public)")
-				}
+				Logger.data.info("💾 Updated myInfo for node: \(myInfo.myNodeNum.toHex(), privacy: .public)")
+				savePendingChanges()
+				return fetchedMyInfo[0].persistentModelID
 			}
 		} catch {
 			Logger.data.error("💥 Fetch MyInfo Error")
@@ -201,11 +243,7 @@ actor MeshPackets {
 						newChannel.positionPrecision = Int32(truncatingIfNeeded: channel.settings.moduleSettings.positionPrecision)
 						newChannel.mute = channel.settings.moduleSettings.isMuted
 					}
-					do {
-						try modelContext.save()
-					} catch {
-						Logger.data.error("💥 Failed to save channel: \(error.localizedDescription, privacy: .public)")
-					}
+					savePendingChanges()
 					Logger.data.info("💾 Updated MyInfo channel \(channel.index, privacy: .public) from Channel App Packet For: \(fetchedMyInfo[0].myNodeNum, privacy: .public)")
 				} else if channel.role.rawValue > 0 {
 					Logger.data.error("💥Trying to save a channel to a MyInfo that does not exist: \(fromNum.toHex(), privacy: .public)")
@@ -254,11 +292,7 @@ actor MeshPackets {
 						newNode.metadata = newMetadata
 					}
 				}
-				do {
-					try modelContext.save()
-				} catch {
-					Logger.data.error("💥 Failed to save device metadata: \(error.localizedDescription, privacy: .public)")
-				}
+				savePendingChanges()
 				Logger.data.info("💾 Updated Device Metadata from Admin App Packet For: \(fromNum.toHex(), privacy: .public)")
 			} catch {
 				let nsError = error as NSError
@@ -377,16 +411,11 @@ actor MeshPackets {
 						if fetchedMyInfo.count > 0 {
 							newNode.myInfo = fetchedMyInfo[0]
 						}
-						do {
-							if !deferSave {
-								try modelContext.save()
-								Logger.data.info("💾 Saved a new Node Info For: \(String(nodeInfo.num), privacy: .public)")
-							}
-							return newNode.persistentModelID
-						} catch {
-							let nsError = error as NSError
-							Logger.data.error("Error Saving Core Data NodeInfoEntity: \(nsError, privacy: .public)")
+						if !deferSave {
+							savePendingChanges()
+							Logger.data.info("💾 Saved a new Node Info For: \(String(nodeInfo.num), privacy: .public)")
 						}
+						return newNode.persistentModelID
 					} catch {
 						Logger.data.error("Fetch MyInfo Error")
 					}
@@ -491,16 +520,11 @@ actor MeshPackets {
 						if fetchedMyInfo.count > 0 {
 							fetchedNode[0].myInfo = fetchedMyInfo[0]
 						}
-						do {
-							if !deferSave {
-								try modelContext.save()
-								Logger.data.info("💾 [NodeInfo] saved for \(nodeInfo.num.toHex(), privacy: .public)")
-							}
-							return fetchedNode[0].persistentModelID
-						} catch {
-							let nsError = error as NSError
-							Logger.data.error("💥 Error Saving Core Data NodeInfoEntity: \(nsError, privacy: .public)")
+						if !deferSave {
+							savePendingChanges()
+							Logger.data.info("💾 [NodeInfo] saved for \(nodeInfo.num.toHex(), privacy: .public)")
 						}
+						return fetchedNode[0].persistentModelID
 					} catch {
 						Logger.data.error("💥 Fetch MyInfo Error")
 					}
@@ -532,13 +556,8 @@ actor MeshPackets {
 								.trimmingCharacters(in: .whitespacesAndNewlines)
 								.components(separatedBy: "\n").first ?? ""
 							fetchedNode[0].cannedMessageConfig?.messages = messages
-							do {
-								try modelContext.save()
-								Logger.data.info("💾 Updated Canned Messages Messages For: \(fetchedNode.first?.num.toHex() ?? "Unknown".localized, privacy: .public)")
-							} catch {
-								let nsError = error as NSError
-								Logger.data.error("💥 Error Saving NodeInfoEntity from POSITION_APP \(nsError, privacy: .public)")
-							}
+							savePendingChanges()
+							Logger.data.info("💾 Updated Canned Messages Messages For: \(fetchedNode.first?.num.toHex() ?? "Unknown".localized, privacy: .public)")
 						}
 					} catch {
 						Logger.data.error("💥 Error Deserializing ADMIN_APP packet.")
@@ -615,11 +634,7 @@ actor MeshPackets {
 				fetchedMessage[0].relayNode = Int64(packet.relayNode)
 				fetchedMessage[0].ackSNR = packet.rxSnr
 	
-				do {
-					try modelContext.save()
-				} catch {
-					Logger.data.error("Failed to save admin message response as an ack: \(error.localizedDescription, privacy: .public)")
-				}
+				savePendingChanges()
 			}
 		} catch {
 			Logger.data.error("Failed to fetch admin message by requestID: \(error.localizedDescription, privacy: .public)")
@@ -647,11 +662,7 @@ actor MeshPackets {
 				
 				if fetchedNode.count > 0 {
 					fetchedNode[0].pax.append(newPax)
-					do {
-						try modelContext.save()
-					} catch {
-						Logger.data.error("Failed to save pax: \(error.localizedDescription, privacy: .public)")
-					}
+					savePendingChanges()
 				} else {
 					Logger.data.info("Node Info Not Found")
 				}
@@ -699,7 +710,7 @@ actor MeshPackets {
 				} else {
 					return
 				}
-				try modelContext.save()
+				savePendingChanges()
 				Logger.data.info("💾 ACK Saved for Message: \(packet.decoded.requestID, privacy: .public)")
 			} catch {
 				let nsError = error as NSError
@@ -793,8 +804,8 @@ actor MeshPackets {
 							fetchedNode[0].lastHeard = Date()
 						}
 					}
-					try modelContext.save()
-					Logger.data.info("💾 [TelemetryEntity] of type \(MetricsTypes(rawValue: Int(telemetry.metricsType))?.name ?? "Unknown Metrics Type", privacy: .public) Saved for Node: \(packet.from.toHex(), privacy: .public)")
+					scheduleDebouncedSave()
+					Logger.data.info("📈 [TelemetryEntity] of type \(MetricsTypes(rawValue: Int(telemetry.metricsType))?.name ?? "Unknown Metrics Type", privacy: .public) buffered for Node: \(packet.from.toHex(), privacy: .public)")
 					if telemetry.metricsType == 0 {
 						// Connected Device Metrics
 						// ------------------------
@@ -1005,12 +1016,13 @@ actor MeshPackets {
 					}
 					var messageSaved = false
 					do {
-						try modelContext.save()
+						if modelContext.hasChanges {
+							try modelContext.save()
+						}
 						Logger.data.info("💾 Saved a new message for \(newMessage.messageId, privacy: .public)")
 						messageSaved = true
 					} catch {
-						let nsError = error as NSError
-						Logger.data.error("Failed to save new MessageEntity \(nsError, privacy: .public)")
+						Logger.data.error("💥 Failed to save new MessageEntity: \(error.localizedDescription, privacy: .public)")
 					}
 					// Send notifications if the message saved properly to core data
 					if messageSaved {
@@ -1141,11 +1153,10 @@ actor MeshPackets {
 						waypoint.expire = nil
 					}
 					waypoint.created = Date()
-					do {
-						try modelContext.save()
-						Logger.data.info("💾 Added Node Waypoint App Packet For: \(waypoint.id, privacy: .public)")
-						
-						Task { @MainActor in
+					savePendingChanges()
+					Logger.data.info("💾 Added Node Waypoint App Packet For: \(waypoint.id, privacy: .public)")
+					
+					Task { @MainActor in
 							let manager = LocalNotificationManager()
 							let icon = String(UnicodeScalar(Int(waypoint.icon)) ?? "📍")
 							let latitude = Double(waypoint.latitudeI) / 1e7
@@ -1163,10 +1174,6 @@ actor MeshPackets {
 							Logger.data.debug("meshtastic:///map?waypointid=\(waypoint.id, privacy: .public)")
 							manager.schedule()
 						}
-					} catch {
-						let nsError = error as NSError
-						Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
-					}
 				} else {
 					// Update existing waypoint
 					let existingWaypoint = fetchedWaypoint[0]
@@ -1174,13 +1181,8 @@ actor MeshPackets {
 						let currentTime = Int64(Date().timeIntervalSince1970)
 						if waypointMessage.expire > 0 && waypointMessage.expire <= currentTime {
 							modelContext.delete(existingWaypoint)
-							do {
-								try modelContext.save()
-								Logger.data.info("💾 Deleted a waypoint")
-							} catch {
-								let nsError = error as NSError
-								Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
-							}
+							savePendingChanges()
+							Logger.data.info("💾 Deleted a waypoint")
 						} else {
 							existingWaypoint.name = waypointMessage.name
 							existingWaypoint.longDescription = waypointMessage.description_p
@@ -1195,13 +1197,8 @@ actor MeshPackets {
 								existingWaypoint.expire = nil
 							}
 							existingWaypoint.lastUpdated = Date()
-							do {
-								try modelContext.save()
-								Logger.data.info("💾 Updated Node Waypoint App Packet For: \(existingWaypoint.id, privacy: .public)")
-							} catch {
-								let nsError = error as NSError
-								Logger.data.error("Error Saving WaypointEntity from WAYPOINT_APP \(nsError, privacy: .public)")
-							}
+							savePendingChanges()
+							Logger.data.info("💾 Updated Node Waypoint App Packet For: \(existingWaypoint.id, privacy: .public)")
 						}
 					}
 				}

--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -57,7 +57,7 @@ class PersistenceController {
 					configurations: config
 				)
 			}
-			container.mainContext.autosaveEnabled = !isTestEnvironment
+			container.mainContext.autosaveEnabled = false
 			Logger.data.info("💾 SwiftData store initialized successfully")
 		} catch {
 			Logger.data.error("SwiftData Error: \(error.localizedDescription, privacy: .public). Attempting to recreate database.")

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -218,13 +218,8 @@ extension MeshPackets {
 					Logger.data.info("💾 [updateAnyPacketFrom] Updating node \(packet.from.toHex(), privacy: .public) hopsAway=\(node.hopsAway)")
 				}
 				
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 [updateAnyPacketFrom] Updating node \(node.num.toHex(), privacy: .public) snr=\(node.snr), rssi=\(node.rssi) from packet \(packet.id.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [updateAnyPacketFrom] Error Saving node \(node.num.toHex(), privacy: .public) from packet \(packet.id.toHex(), privacy: .public)  \(nsError, privacy: .public)")
-				}
+				// Changes are saved by the subsequent packet handler's save call
+				Logger.data.info("💾 [updateAnyPacketFrom] Updated node \(node.num.toHex(), privacy: .public) snr=\(node.snr), rssi=\(node.rssi) from packet \(packet.id.toHex(), privacy: .public)")
 			}
 		} catch {
 			Logger.data.error("💥 [updateAnyPacketFrom] fetch data error")
@@ -370,13 +365,8 @@ extension MeshPackets {
 					}
 				}
 				
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 [NodeInfo] Saved a NodeInfo for node number: \(packet.from.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [NodeInfoEntity] Error Inserting New Core Data: \(nsError, privacy: .public)")
-				}
+				savePendingChanges()
+				Logger.data.info("💾 [NodeInfo] Saved a NodeInfo for node number: \(packet.from.toHex(), privacy: .public)")
 				
 			} else {
 				// Update an existing node
@@ -473,13 +463,8 @@ extension MeshPackets {
 						Logger.data.error("Error Creating a new UserEntity on an existing node from node number: \(packet.from, privacy: .public) Error:  \(error.localizedDescription, privacy: .public)")
 					}
 				}
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 [NodeInfoEntity] Updated from Node Info App Packet For: \(fetchedNode[0].num.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [NodeInfoEntity] Error Saving from NODEINFO_APP \(nsError, privacy: .public)")
-				}
+				savePendingChanges()
+				Logger.data.info("💾 [NodeInfoEntity] Updated from Node Info App Packet For: \(fetchedNode[0].num.toHex(), privacy: .public)")
 			}
 		} catch {
 			Logger.data.error("💥 [NodeInfoEntity] fetch data error for NODEINFO_APP")
@@ -563,13 +548,8 @@ extension MeshPackets {
 						fetchedNode[0].channel = Int32(packet.channel)
 						fetchedNode[0].positions = mutablePositions
 						
-						do {
-							try modelContext.save()
-							Logger.data.info("💾 [Position] Saved from Position App Packet For: \(fetchedNode[0].num.toHex(), privacy: .public)")
-						} catch {
-							let nsError = error as NSError
-							Logger.data.error("💥 Error Saving NodeInfoEntity from POSITION_APP \(nsError, privacy: .public)")
-						}
+						scheduleDebouncedSave()
+						Logger.data.info("📍 [Position] buffered for Node: \(fetchedNode[0].num.toHex(), privacy: .public)")
 					}
 				} else {
 					Logger.data.error("💥 Empty POSITION_APP Packet: \((try? packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
@@ -608,13 +588,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [BluetoothConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [BluetoothConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [BluetoothConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Bluetooth Config")
 			}
@@ -665,13 +640,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [DeviceConfigEntity] Updated Device Config for node number: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [DeviceConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			}
 		} catch {
 			let nsError = error as NSError
@@ -721,15 +691,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					
-					try modelContext.save()
-					Logger.data.info("💾 [DisplayConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-					
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [DisplayConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
+				savePendingChanges()
+				Logger.data.info("💾 [DisplayConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
 			} else {
 				Logger.data.error("💥 [DisplayConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Display Config")
 			}
@@ -796,13 +759,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [LoRaConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [LoRaConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [LoRaConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Lora Config")
 			}
@@ -844,14 +802,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 [NetworkConfigEntity] Updated Network Config for node: \(nodeNum.toHex(), privacy: .public)")
-					
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [NetworkConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
+				savePendingChanges()
+				Logger.data.info("💾 [NetworkConfigEntity] Updated Network Config for node: \(nodeNum.toHex(), privacy: .public)")
 			} else {
 				Logger.data.error("💥 [NetworkConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Network Config")
 			}
@@ -909,13 +861,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [PositionConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [PositionConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [PositionConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Position Config")
 			}
@@ -960,13 +907,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [PowerConfigEntity] Updated Power Config for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [PowerConfigEntity] Error Updating Core Data PowerConfigEntity: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [PowerConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Power Config")
 			}
@@ -1022,14 +964,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 [SecurityConfigEntity] Updated Security Config for node: \(nodeNum.toHex(), privacy: .public)")
-					
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [SecurityConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
+				savePendingChanges()
+				Logger.data.info("💾 [SecurityConfigEntity] Updated Security Config for node: \(nodeNum.toHex(), privacy: .public)")
 			} else {
 				Logger.data.error("💥 [SecurityConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Security Config")
 			}
@@ -1078,13 +1014,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [AmbientLightingConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [AmbientLightingConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [AmbientLightingConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Ambient Lighting Module Config")
 			}
@@ -1137,13 +1068,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [CannedMessageConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [CannedMessageConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [CannedMessageConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Canned Message Module Config")
 			}
@@ -1191,14 +1117,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 [DetectionSensorConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-					
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [DetectionSensorConfigEntity] Error Updating Core Data : \(nsError, privacy: .public)")
-				}
+				savePendingChanges()
+				Logger.data.info("💾 [DetectionSensorConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
 				
 			} else {
 				Logger.data.error("💥 [DetectionSensorConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Detection Sensor Module Config")
@@ -1263,13 +1183,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [ExternalNotificationConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [ExternalNotificationConfigEntity] Error Updating Core Data : \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [ExternalNotificationConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save External Notification Module Config")
 			}
@@ -1305,13 +1220,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [PaxCounterConfigEntity] Updated for node number: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [PaxCounterConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [PaxCounterConfigEntity] No Nodes found in local database matching node number \(nodeNum.toHex(), privacy: .public) unable to save PAX Counter Module Config")
 			}
@@ -1345,13 +1255,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [RtttlConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [RtttlConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [RtttlConfigEntity] No nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save RTTTL Ringtone Config")
 			}
@@ -1408,13 +1313,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [MQTTConfigEntity] Updated for node number: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [MQTTConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [MQTTConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save MQTT Module Config")
 			}
@@ -1452,13 +1352,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [RangeTestConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [RangeTestConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [RangeTestConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Range Test Module Config")
 			}
@@ -1504,14 +1399,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 [SerialConfigEntity]Updated Serial Module Config for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					
-					let nsError = error as NSError
-					Logger.data.error("💥 [SerialConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
+				savePendingChanges()
+				Logger.data.info("💾 [SerialConfigEntity]Updated Serial Module Config for node: \(nodeNum.toHex(), privacy: .public)")
 			} else {
 				Logger.data.error("💥 [SerialConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Serial Module Config")
 			}
@@ -1555,13 +1444,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [StoreForwardConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [StoreForwardConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [StoreForwardConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Store & Forward Module Config")
 			}
@@ -1611,14 +1495,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
-					Logger.data.info("💾 [TelemetryConfigEntity] Updated Telemetry Module Config for node: \(nodeNum.toHex(), privacy: .public)")
-					
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [TelemetryConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
+				savePendingChanges()
+				Logger.data.info("💾 [TelemetryConfigEntity] Updated Telemetry Module Config for node: \(nodeNum.toHex(), privacy: .public)")
 				
 			} else {
 				Logger.data.error("💥 [TelemetryConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Telemetry Module Config")
@@ -1655,13 +1533,8 @@ extension MeshPackets {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
-				do {
-					try modelContext.save()
+				savePendingChanges()
 					Logger.data.info("💾 [TAKConfigEntity] Updated TAK Module Config for node: \(nodeNum.toHex(), privacy: .public)")
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [TAKConfigEntity] Error Updating Core Data: \(nsError, privacy: .public)")
-				}
 			} else {
 				Logger.data.error("💥 [TAKConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save TAK Module Config")
 			}


### PR DESCRIPTION
## What changed?

- Disabled `autosaveEnabled` globally — the app now relies entirely on explicit saves
- Removed the redundant `save()` from `updateAnyPacketFrom()` which was double-saving (once there, once in the subsequent packet handler)
- Consolidated 46 scattered `try modelContext.save()` blocks into a shared `savePendingChanges()` helper with guard-on-changes and centralized error logging
- Added debounced saves for position and telemetry packets: 2-second debounce timer with a 5-second max-delay ceiling, so bursts of packets coalesce into a single write
- Added `flushDebouncedSaves()` called on disconnect to prevent data loss
- Kept direct save in `textMessageAppPacket` where success tracking (`messageSaved` bool) gates notification dispatch
- Kept saves in user-initiated bulk operations (clearStaleNodes, clearPax, clearPositions, clearTelemetry, deleteChannelMessages, deleteUserMessages, clearDatabase)

## Why did it change?

Users reported higher battery usage and UI sluggishness. Root cause: every incoming BLE packet triggered 2–8 SQLite writes (autosave + `updateAnyPacketFrom` save + handler save). Position and telemetry packets arrive every few seconds from every node on the mesh, compounding the problem.

**Before:** 3–8 SQLite writes per incoming packet
**After:** 1 write per low-frequency packet, ~1 write per 2–5 seconds for position/telemetry bursts (~60–70% reduction in SQLite I/O on the hot path)

## How is this tested?

- All 1774 tests across 351 suites pass with zero failures
- Build compiles cleanly (only pre-existing sandbox script warnings)
- Internal refactor only — no user-facing UI changes, no schema changes

## Screenshots/Videos (when applicable)

N/A — internal persistence layer changes only.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. No doc update needed — internal persistence refactor with no user-facing changes.
- [x] I have tested the change to ensure that it works as intended.