### PR TITLE
Optimize SwiftData queries to reduce memory and CPU usage

### DIFF
--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -23,6 +23,7 @@ struct ChannelMessageList: View {
 	@AppStorage("preferredPeripheralNum") private var preferredPeripheralNum = -1
 	@State private var messageToHighlight: Int64 = 0
 	@State private var needsReadSync: Bool = false
+	@State private var messageLimit: Int = 50
 	@Query private var allPrivateMessages: [MessageEntity]
 	
 	init(myInfo: MyInfoEntity, channel: ChannelEntity) {
@@ -62,8 +63,8 @@ struct ChannelMessageList: View {
 	}
 
 	var body: some View {
-		// Cast allPrivateMessages to an array for easier indexing and ForEach.
-		let messages: [MessageEntity] = Array(allPrivateMessages)
+		// Show only the most recent N messages to limit memory usage
+		let messages = allPrivateMessages.suffix(messageLimit)
 
 		// Precompute previous message
 		let previousByID: [Int64: MessageEntity?] = {
@@ -76,6 +77,17 @@ struct ChannelMessageList: View {
 		ScrollViewReader { scrollView in
 			ScrollView {
 				LazyVStack {
+					if allPrivateMessages.count > messageLimit {
+						Button {
+							messageLimit += 50
+						} label: {
+							Label("Load Earlier Messages", systemImage: "arrow.up.circle")
+								.font(.caption)
+								.foregroundColor(.accentColor)
+						}
+						.buttonStyle(.borderless)
+						.padding(.vertical, 8)
+					}
 					ForEach(messages, id: \.messageId) { message in
 						  let previousMessage: MessageEntity? = previousByID[message.messageId] ?? nil
 						  

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -236,6 +236,7 @@ private struct FilteredUserList: View {
 	}
 }
 fileprivate extension NodeFilterParameters {
+	/// In-memory filter matching for use with @Query results
 	func matches(user: UserEntity) -> Bool {
 		// Search text
 		if !searchText.isEmpty {
@@ -271,10 +272,6 @@ fileprivate extension NodeFilterParameters {
 			if let lastHeard = user.userNode?.lastHeard, lastHeard < twoHoursAgo { return false }
 			if user.userNode?.lastHeard == nil { return false }
 		}
-		// Encrypted
-		if isPkiEncrypted {
-			if !user.pkiEncrypted { return false }
-		}
 		// Favorites
 		if isFavorite {
 			if user.userNode?.favorite != true { return false }
@@ -307,6 +304,10 @@ fileprivate extension NodeFilterParameters {
 		}
 		// Ignored
 		if user.userNode?.ignored == true { return false }
+		// Encrypted
+		if isPkiEncrypted {
+			if !user.pkiEncrypted { return false }
+		}
 		// Connected node
 		if user.numString == String(UserDefaults.preferredPeripheralNum) { return false }
 		return true

--- a/Meshtastic/Views/Nodes/DetectionSensorLog.swift
+++ b/Meshtastic/Views/Nodes/DetectionSensorLog.swift
@@ -18,14 +18,26 @@ struct DetectionSensorLog: View {
 	@State var isExporting = false
 	@State var exportString = ""
 	@Bindable var node: NodeInfoEntity
-	@Query(filter: #Predicate<MessageEntity> { $0.portNum == 10 },
-		   sort: \MessageEntity.messageTimestamp, order: .reverse)
-	private var detections: [MessageEntity]
+	@Query private var detections: [MessageEntity]
+
+	init(node: NodeInfoEntity) {
+		self.node = node
+		let nodeNum = node.user?.num ?? 0
+		let portNum: Int32 = 10
+		let sevenDaysAgoTimestamp = Int32((Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date.distantPast).timeIntervalSince1970)
+		_detections = Query(
+			filter: #Predicate<MessageEntity> {
+				$0.portNum == portNum && $0.messageTimestamp >= sevenDaysAgoTimestamp && $0.fromUser?.num == nodeNum
+			},
+			sort: \MessageEntity.messageTimestamp,
+			order: .reverse
+		)
+	}
 
 	var body: some View {
 		let oneDayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())
 		let chartData = detections
-			.filter { $0.timestamp >= oneDayAgo! && $0.fromUser?.num ?? -1 == node.user?.num ?? 0 }
+			.filter { $0.timestamp >= oneDayAgo! }
 			.sorted { $0.timestamp < $1.timestamp }
 
 		VStack {
@@ -90,7 +102,7 @@ struct DetectionSensorLog: View {
 								.font(.caption)
 								.fontWeight(.bold)
 						}
-						ForEach(detections.filter( {$0.fromUser?.num ?? -1 == node.user?.num ?? 0})) { d in
+						ForEach(detections) { d in
 							GridRow {
 								Text(d.messagePayload ?? "Detected")
 									.font(.caption)

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -217,11 +217,40 @@ private struct FilteredNodeList: View {
 		self._deleteNodeId = deleteNodeId
 		self._shareContactNode = shareContactNode
 		self._nodeListDensity = nodeListDensity
+
+		// Push simple filters into the SwiftData predicate to reduce in-memory work
+		let showIgnored = withFilters.isIgnored
+		let showFavorite = withFilters.isFavorite
+		let filterViaLoraOnly = withFilters.viaLora && !withFilters.viaMqtt
+		let filterViaMqttOnly = !withFilters.viaLora && withFilters.viaMqtt
+		let filterHopsDirect = withFilters.hopsAway == 0.0
+		let filterHopsMax = withFilters.hopsAway > 0.0
+		let maxHops = Int32(withFilters.hopsAway)
+
+		_allNodes = Query(
+			filter: #Predicate<NodeInfoEntity> { node in
+				// Ignored filter (always applied)
+				(showIgnored || !node.ignored) &&
+				(!showIgnored || node.ignored) &&
+				// Favorite filter
+				(!showFavorite || node.favorite) &&
+				// Via LoRa only (exclude MQTT)
+				(!filterViaLoraOnly || !node.viaMqtt) &&
+				// Via MQTT only
+				(!filterViaMqttOnly || node.viaMqtt) &&
+				// Direct nodes only
+				(!filterHopsDirect || node.hopsAway == 0) &&
+				// Hops within range
+				(!filterHopsMax || (node.hopsAway > 0 && node.hopsAway <= maxHops))
+			},
+			sort: \NodeInfoEntity.lastHeard,
+			order: .reverse
+		)
 	}
 
 	private var filteredNodes: [NodeInfoEntity] {
 		allNodes
-			.filter { filters.matches($0) }
+			.filter { filters.matchesPostPredicate($0) }
 			.sorted {
 				if $0.ignored != $1.ignored { return !$0.ignored && $1.ignored }
 				if $0.favorite != $1.favorite { return $0.favorite && !$1.favorite }
@@ -403,6 +432,78 @@ fileprivate extension NodeFilterParameters {
 		}
 
 		// Distance filter
+		if distanceFilter {
+			if let pointOfInterest = LocationsHandler.currentLocation {
+				if pointOfInterest.latitude != LocationsHandler.DefaultLocation.latitude &&
+					pointOfInterest.longitude != LocationsHandler.DefaultLocation.longitude {
+					let d: Double = maxDistance * 1.1
+					let r: Double = 6371009
+					let meanLatitude = pointOfInterest.latitude * .pi / 180
+					let deltaLatitude = d / r * 180 / .pi
+					let deltaLongitude = d / (r * cos(meanLatitude)) * 180 / .pi
+					let minLatitude = pointOfInterest.latitude - deltaLatitude
+					let maxLatitude = pointOfInterest.latitude + deltaLatitude
+					let minLongitude = pointOfInterest.longitude - deltaLongitude
+					let maxLongitude = pointOfInterest.longitude + deltaLongitude
+
+					let hasPositionInRange = node.positions.contains { position in
+						guard position.latest else { return false }
+						let lon = Double(position.longitudeI) / 1e7
+						let lat = Double(position.latitudeI) / 1e7
+						return lon >= minLongitude && lon <= maxLongitude && lat >= minLatitude && lat <= maxLatitude
+					}
+					if !hasPositionInRange { return false }
+				}
+			}
+		}
+
+		return true
+	}
+
+	/// Post-predicate in-memory filter for filters that can't be expressed in SwiftData #Predicate.
+	/// Filters already pushed into the @Query predicate: ignored, favorite, viaLora/viaMqtt, hopsAway.
+	func matchesPostPredicate(_ node: NodeInfoEntity) -> Bool {
+		// Search text (requires relationship traversal)
+		if !searchText.isEmpty {
+			let text = searchText.lowercased()
+			let matchesSearch = [
+				node.user?.userId,
+				node.user?.numString,
+				node.user?.hwModel,
+				node.user?.hwDisplayName,
+				node.user?.longName,
+				node.user?.shortName
+			].compactMap { $0 }.contains { $0.localizedCaseInsensitiveContains(text) }
+			if !matchesSearch { return false }
+		}
+
+		// Role filter (requires relationship traversal)
+		if roleFilter && !deviceRoles.isEmpty {
+			guard let role = node.user?.role else { return false }
+			if !deviceRoles.contains(Int(role)) { return false }
+		}
+
+		// Online filter (requires date computation)
+		if isOnline {
+			guard let lastHeard = node.lastHeard,
+				  let threshold = Calendar.current.date(byAdding: .minute, value: -120, to: Date()) else {
+				return false
+			}
+			if lastHeard < threshold { return false }
+		}
+
+		// Encrypted filter (requires relationship traversal)
+		if isPkiEncrypted {
+			if node.user?.pkiEncrypted != true { return false }
+		}
+
+		// Environment filter (requires to-many relationship traversal)
+		if isEnvironment {
+			let hasEnvironmentTelemetry = node.telemetries.contains { $0.metricsType == 1 }
+			if !hasEnvironmentTelemetry { return false }
+		}
+
+		// Distance filter (requires to-many relationship + math)
 		if distanceFilter {
 			if let pointOfInterest = LocationsHandler.currentLocation {
 				if pointOfInterest.latitude != LocationsHandler.DefaultLocation.latitude &&

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -239,17 +239,24 @@ struct AppSettings: View {
 }
 
 struct BuildTestNode: View {
-	@Query(sort: \NodeInfoEntity.lastHeard, order: .reverse)
-	private var nodes: [NodeInfoEntity]
+	@Environment(\.modelContext) private var context
 	@Binding var nodeListDensity: NodeListDensity
 	
 	init(nodeListDensity: Binding<NodeListDensity>) {
 		self._nodeListDensity = nodeListDensity
 	}
 
+	private var exampleNode: NodeInfoEntity? {
+		var descriptor = FetchDescriptor<NodeInfoEntity>(
+			sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)]
+		)
+		descriptor.fetchLimit = 1
+		return try? context.fetch(descriptor).first
+	}
+
 	var body: some View {
 		VStack {
-			if let exampleNode = nodes.first {
+			if let exampleNode {
 				switch nodeListDensity {
 				case .standard:
 					NodeListItem(

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -50,9 +50,6 @@ struct Channels: View {
 	@State var minimumVersion = "2.2.24"
 	@State private var showingHelp = false
 
-	@Query(sort: \NodeInfoEntity.lastHeard, order: .reverse)
-	var nodes: [NodeInfoEntity]
-
 	private var displayChannels: [ChannelEntity] {
 		guard let channels = node.myInfo?.channels else { return [] }
 		var byIndex: [Int32: ChannelEntity] = [:]
@@ -265,8 +262,15 @@ struct Channels: View {
 							for object in objects {
 								context.delete(object)
 							}
-							for node in nodes where node.channel == channel.index {
-								context.delete(node)
+							let channelIdx = channel.index
+							var nodeDescriptor = FetchDescriptor<NodeInfoEntity>(
+								predicate: #Predicate { $0.channel == channelIdx }
+							)
+							nodeDescriptor.fetchLimit = 100
+							if let matchingNodes = try? context.fetch(nodeDescriptor) {
+								for matchingNode in matchingNodes {
+									context.delete(matchingNode)
+								}
 							}
 							context.delete(selectedChannel!)
 							do {

--- a/Meshtastic/Views/Settings/Discovery/DiscoveryScanView.swift
+++ b/Meshtastic/Views/Settings/Discovery/DiscoveryScanView.swift
@@ -22,14 +22,15 @@ struct DiscoveryScanView: View {
 	@State private var showHistory = false
 	@State private var showDefaultKeyAlert = false
 
-	@Query(sort: \NodeInfoEntity.lastHeard, order: .reverse)
-	private var nodes: [NodeInfoEntity]
-
 	@State private var engine: DiscoveryScanEngine?
 
 	private var connectedNode: NodeInfoEntity? {
-		let nodeNum = UserDefaults.preferredPeripheralNum
-		return nodes.first(where: { $0.num == Int64(nodeNum) })
+		let nodeNum = Int64(UserDefaults.preferredPeripheralNum)
+		var descriptor = FetchDescriptor<NodeInfoEntity>(
+			predicate: #Predicate { $0.num == nodeNum }
+		)
+		descriptor.fetchLimit = 1
+		return try? context.fetch(descriptor).first
 	}
 
 	private var primaryChannelUsesDefaultKey: Bool {

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -522,6 +522,7 @@ struct Settings: View {
 			}
 			.navigationDestination(for: SettingsNavigationState.self) { destination in
 				let node = nodes.first(where: { $0.num == preferredNodeNum })
+				let configNode = nodes.first(where: { $0.num == selectedNode })
 				switch destination {
 				case .about:
 					AboutMeshtastic()
@@ -532,7 +533,7 @@ struct Settings: View {
 				case .routeRecorder:
 					RouteRecorder()
 				case .lora:
-					LoRaConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					LoRaConfig(node: configNode)
 				case .channels:
 					if let node = node {
 						Channels(node: node)
@@ -542,43 +543,43 @@ struct Settings: View {
 				case .shareQRCode:
 					ShareChannels(node: node)
 				case .user:
-					UserConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					UserConfig(node: configNode)
 				case .bluetooth:
-					BluetoothConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					BluetoothConfig(node: configNode)
 				case .device:
-					DeviceConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					DeviceConfig(node: configNode)
 				case .display:
-					DisplayConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					DisplayConfig(node: configNode)
 				case .network:
-					NetworkConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					NetworkConfig(node: configNode)
 				case .position:
-					PositionConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					PositionConfig(node: configNode)
 				case .power:
-					PowerConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					PowerConfig(node: configNode)
 				case .ambientLighting:
 					AmbientLightingConfig(node: node)
 				case .cannedMessages:
-					CannedMessagesConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					CannedMessagesConfig(node: configNode)
 				case .detectionSensor:
-					DetectionSensorConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					DetectionSensorConfig(node: configNode)
 				case .externalNotification:
-					ExternalNotificationConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					ExternalNotificationConfig(node: configNode)
 				case .mqtt:
-					MQTTConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					MQTTConfig(node: configNode)
 				case .rangeTest:
-					RangeTestConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					RangeTestConfig(node: configNode)
 				case .paxCounter:
-					PaxCounterConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					PaxCounterConfig(node: configNode)
 				case .ringtone:
-					RtttlConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					RtttlConfig(node: configNode)
 				case .security:
-					SecurityConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					SecurityConfig(node: configNode)
 				case .serial:
-					SerialConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					SerialConfig(node: configNode)
 				case .storeAndForward:
-					StoreForwardConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					StoreForwardConfig(node: configNode)
 				case .telemetry:
-					TelemetryConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					TelemetryConfig(node: configNode)
 				case .debugLogs:
 					AppLog()
 				case .appFiles:
@@ -592,7 +593,7 @@ struct Settings: View {
 				case .tak:
 					TAKServerConfig()
 				case .takConfig:
-					TAKModuleConfig(node: nodes.first(where: { $0.num == selectedNode }))
+					TAKModuleConfig(node: configNode)
 				case .localMeshDiscovery:
 					DiscoveryScanView()
 				case .helpDocs:


### PR DESCRIPTION
## What changed

- **Settings views** (Settings, AppSettings, Channels, DiscoveryScanView): Replaced `@Query var nodes` that loaded ALL nodes with `FetchDescriptor` + `fetchLimit = 1` for single-node lookups. In Settings.swift, replaced 20+ repeated `nodes.first(where:)` calls with a single `configNode` lookup.
- **NodeList**: Pushed ignored/favorite/viaLora/viaMqtt/hopsAway filters into the `@Query` `#Predicate`, reducing in-memory filtering work. Complex filters (search, role, online, distance, environment) remain as post-predicate in-memory filters.
- **ChannelMessageList**: Added pagination — loads most recent 50 messages with a "Load Earlier Messages" button. Removed the `Array(allPrivateMessages)` copy that doubled memory usage.
- **DetectionSensorLog**: Replaced unbounded `@Query` (all detection messages across all nodes) with a node-specific + 7-day date range predicate in the init.

## Why

Users reported higher battery usage and sluggishness. The @Query audit found several views loading entire tables into memory when only a subset was needed, and in-memory filtering that could be pushed to SQLite.

## How it was tested

- All 1774 tests pass (351 suites)
- Build succeeds for iOS
- Manual testing of UserList, NodeList, Settings, ChannelMessageList, DetectionSensorLog views