### PR TITLE
Cap positions, telemetry, and messages to prevent unbounded growth

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -798,6 +798,20 @@ actor MeshPackets {
 						telemetry.rssi = packet.rxRssi
 						telemetry.time = Date(timeIntervalSince1970: TimeInterval(Int64(truncatingIfNeeded: telemetryMessage.time)))
 						fetchedNode[0].telemetries.append(telemetry)
+
+						// Prune old telemetry to prevent unbounded memory growth
+						let metricsType = telemetry.metricsType
+						let maxTelemetryPerType = 5000
+						let sameTelemetries = fetchedNode[0].telemetries
+							.filter { $0.metricsType == metricsType }
+							.sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
+						if sameTelemetries.count > maxTelemetryPerType {
+							let excess = sameTelemetries.count - maxTelemetryPerType
+							for i in 0..<excess {
+								modelContext.delete(sameTelemetries[i])
+							}
+						}
+
 						if packet.rxTime > 0 {
 							fetchedNode[0].lastHeard = Date(timeIntervalSince1970: TimeInterval(packet.rxTime))
 						} else {
@@ -1021,6 +1035,24 @@ actor MeshPackets {
 						}
 						Logger.data.info("💾 Saved a new message for \(newMessage.messageId, privacy: .public)")
 						messageSaved = true
+
+						// Prune old messages to prevent unbounded growth
+						let maxTotalMessages = 50000
+						let countDescriptor = FetchDescriptor<MessageEntity>()
+						let totalMessages = (try? modelContext.fetchCount(countDescriptor)) ?? 0
+						if totalMessages > maxTotalMessages {
+							var oldestDescriptor = FetchDescriptor<MessageEntity>(
+								sortBy: [SortDescriptor(\MessageEntity.messageTimestamp, order: .forward)]
+							)
+							oldestDescriptor.fetchLimit = totalMessages - maxTotalMessages
+							if let oldMessages = try? modelContext.fetch(oldestDescriptor) {
+								for old in oldMessages {
+									modelContext.delete(old)
+								}
+								try modelContext.save()
+								Logger.data.info("🗑️ Pruned \(oldMessages.count) old messages (cap: \(maxTotalMessages))")
+							}
+						}
 					} catch {
 						Logger.data.error("💥 Failed to save new MessageEntity: \(error.localizedDescription, privacy: .public)")
 					}

--- a/Meshtastic/Persistence/UpdateCoreData.swift
+++ b/Meshtastic/Persistence/UpdateCoreData.swift
@@ -534,7 +534,7 @@ extension MeshPackets {
 						mutablePositions.append(position)
 						
 						// Prune old positions to prevent unbounded memory growth
-						let maxPositionsPerNode = 500
+						let maxPositionsPerNode = 5000
 						while mutablePositions.count > maxPositionsPerNode {
 							let oldest = mutablePositions[0]
 							if !oldest.latest {

--- a/Meshtastic/Persistence/UpdateHelpers.swift
+++ b/Meshtastic/Persistence/UpdateHelpers.swift
@@ -549,7 +549,7 @@ extension MeshPackets {
 						mutablePositions.append(position)
 						
 						// Prune old positions to prevent unbounded memory growth
-						let maxPositionsPerNode = 500
+						let maxPositionsPerNode = 5000
 						while mutablePositions.count > maxPositionsPerNode {
 							let oldest = mutablePositions[0]
 							if !oldest.latest {


### PR DESCRIPTION
## What changed

- **Positions**: Raised pruning cap from 500 to 5,000 per node (in UpdateCoreData and UpdateHelpers)
- **Telemetry**: Added pruning at 5,000 entries per metrics type per node (device=0, environment=1, power=2, localStats=4). Previously telemetry grew without any limit.
- **Messages**: Added pruning at 50,000 total messages. Oldest messages (by timestamp) are deleted first when the cap is exceeded.

## Why

Telemetry and messages had no pruning, leading to unbounded database growth. On a mesh with 50 nodes reporting telemetry every 15 minutes, that's ~4,800 telemetry rows/day — over 33,000/week per node with no cap. This degrades query performance and increases memory/battery usage over time.

## How it was tested

- All 1,774 tests pass (351 suites)
- Build succeeds for iOS