### PR TITLE
Eliminate double iteration of positions in MeshMapContent

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -52,66 +52,61 @@ struct MeshMapContent: MapContent {
 		   sort: \RouteEntity.name)
 	private var routes: [RouteEntity]
 
+	/// Single filtered pass over positions — used by annotations, circles, and convex hull.
+	private var filteredPositions: [PositionEntity] {
+		positions.filter { position in
+			(!showFavorites || (position.nodePosition?.favorite == true)) && !(position.nodePosition?.ignored == true)
+		}
+	}
+
 	@MapContentBuilder
 	var positionAnnotations: some MapContent {
-		ForEach(positions, id: \.id) { position in
-			/// Apply favorites filter and don't show ignored nodes
-			if (!showFavorites || (position.nodePosition?.favorite == true)) && !(position.nodePosition?.ignored == true) {
-				let coordinateForNodePin: CLLocationCoordinate2D = if position.isPreciseLocation {
-					// Precise location: place node pin at actual location.
-					position.nodeCoordinate ?? LocationsHandler.DefaultLocation
-				} else {
-					// Imprecise location: fuzz slightly so overlapping nodes are visible and clickable at highest zoom levels.
-					position.fuzzedNodeCoordinate ?? LocationsHandler.DefaultLocation
-				}
-				if 12...15 ~= position.precisionBits || position.precisionBits == 32 {
-					
-					let nodeColor = UIColor(hex: UInt32(position.nodePosition?.num ?? 0))
-					let positionName = position.nodePosition?.user?.longName ?? "?"
+		ForEach(filteredPositions, id: \.id) { position in
+			let coordinateForNodePin: CLLocationCoordinate2D = if position.isPreciseLocation {
+				position.nodeCoordinate ?? LocationsHandler.DefaultLocation
+			} else {
+				position.fuzzedNodeCoordinate ?? LocationsHandler.DefaultLocation
+			}
+			if 12...15 ~= position.precisionBits || position.precisionBits == 32 {
 
-					// Use a hash of the position ID to stagger animation delays for each node, preventing synchronized animations and improving visual distinction.
-					let calculatedDelay = Double(position.id.hashValue % 100) / 100.0 * 0.5
-					
-					Annotation(positionName, coordinate: coordinateForNodePin) {
-						LazyVStack {
-							AnimatedNodePin(
-								nodeColor: nodeColor,
-								shortName: position.nodePosition?.user?.shortName,
-								hasDetectionSensorMetrics: position.nodePosition?.hasDetectionSensorMetrics ?? false,
-								isOnline: position.nodePosition?.isOnline ?? false,
-								calculatedDelay: calculatedDelay
-							)
-						}
-						.highPriorityGesture(TapGesture().onEnded { _ in
-							selectedPosition = (selectedPosition == position ? nil : position)
-						})
+				let nodeColor = UIColor(hex: UInt32(position.nodePosition?.num ?? 0))
+				let positionName = position.nodePosition?.user?.longName ?? "?"
+
+				// Use a hash of the position ID to stagger animation delays for each node, preventing synchronized animations and improving visual distinction.
+				let calculatedDelay = Double(position.id.hashValue % 100) / 100.0 * 0.5
+
+				Annotation(positionName, coordinate: coordinateForNodePin) {
+					LazyVStack {
+						AnimatedNodePin(
+							nodeColor: nodeColor,
+							shortName: position.nodePosition?.user?.shortName,
+							hasDetectionSensorMetrics: position.nodePosition?.hasDetectionSensorMetrics ?? false,
+							isOnline: position.nodePosition?.isOnline ?? false,
+							calculatedDelay: calculatedDelay
+						)
 					}
+					.highPriorityGesture(TapGesture().onEnded { _ in
+						selectedPosition = (selectedPosition == position ? nil : position)
+					})
 				}
 			}
 		}
 	}
 
 	private var reducedPrecisionCircleItems: [(nodeNum: Int64, circleKey: ReducedPrecisionMapCircleKey)] {
-		// Precompute *unique* reduced-precision circles so we don't have to redraw tons of identical (center, radius) circles in dense map areas. (Since they're all transparent, this causes severe FPS drop when zoomed into areas where there are a ton of overlapping circles.)
 		var lowestNumForKey: [ReducedPrecisionMapCircleKey: Int64] = [:]
-		// Populate a dict where the key is (lat, lon, bits) and the value is the *lowest* node.num seen for that key.
-		// That lowest node.num value is used to create a stable color for the MapCircle and stable id for ForEach.
-		for position in positions {
-			// Same filter criteria as positionAnnotations:
-			if (!showFavorites || (position.nodePosition?.favorite == true)) && !(position.nodePosition?.ignored == true) {
-				if 12...15 ~= position.precisionBits {
-					let nodeNum = position.nodePosition?.num ?? 0
-					let key = ReducedPrecisionMapCircleKey(latitudeI: position.latitudeI, longitudeI: position.longitudeI, precisionBits: position.precisionBits)
-					if let existing = lowestNumForKey[key] {
-						if nodeNum < existing { lowestNumForKey[key] = nodeNum }
-					} else {
-						lowestNumForKey[key] = nodeNum
-					}
+		for position in filteredPositions {
+			if 12...15 ~= position.precisionBits {
+				let nodeNum = position.nodePosition?.num ?? 0
+				let key = ReducedPrecisionMapCircleKey(latitudeI: position.latitudeI, longitudeI: position.longitudeI, precisionBits: position.precisionBits)
+				if let existing = lowestNumForKey[key] {
+					if nodeNum < existing { lowestNumForKey[key] = nodeNum }
+				} else {
+					lowestNumForKey[key] = nodeNum
 				}
 			}
 		}
-		// Sort by nodeNum just to keep draw order stable.
-        return lowestNumForKey.map { ($0.value, $0.key) }.sorted { $0.nodeNum < $1.nodeNum }
+		return lowestNumForKey.map { ($0.value, $0.key) }.sorted { $0.nodeNum < $1.nodeNum }
 	}
 
     @MapContentBuilder
@@ -188,9 +183,8 @@ struct MeshMapContent: MapContent {
 	@MapContentBuilder
 	var meshMap: some MapContent {
 		// Only compute LoRa node coordinates when the convex hull is actually displayed.
-		// The filter scans the entire positions array on every render, so guard it.
 		let loraCoords: [CLLocationCoordinate2D] = showConvexHull
-			? positions
+			? filteredPositions
 				.filter { !($0.nodePosition?.viaMqtt ?? true) }
 				.compactMap { $0.nodeCoordinate ?? LocationsHandler.DefaultLocation }
 			: []


### PR DESCRIPTION
## What changed
Extracted a shared `filteredPositions` computed property that applies the favorites/ignored filter once. Previously, `positionAnnotations`, `reducedPrecisionCircleItems`, and the convex hull each independently re-filtered the raw `positions` array on every render.

## Why
On meshes with many nodes, iterating and filtering the positions array 3 times per render is wasteful. This reduces it to a single pass.

## How it was tested
- Full build: **BUILD SUCCEEDED**
- All 1774 tests: **TEST SUCCEEDED**

## Labels
`skip-docs-check`