### PR TITLE
Fix CarPlay unbounded UserEntity fetch

### DIFF
--- a/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
+++ b/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
@@ -302,7 +302,12 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 
 	private func fetchDirectMessageItems() -> [CPMessageListItem] {
 		do {
-			let users = try context.fetch(FetchDescriptor<UserEntity>())
+			var descriptor = FetchDescriptor<UserEntity>(
+				predicate: #Predicate<UserEntity> { $0.userNode != nil },
+				sortBy: [SortDescriptor(\UserEntity.lastMessage, order: .reverse)]
+			)
+			descriptor.fetchLimit = 200
+			let users = try context.fetch(descriptor)
 			let connectedNum = AccessoryManager.shared.activeDeviceNum ?? 0
 			let filteredUsers = users
 				.filter { user in
@@ -327,7 +332,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 					return (lhs.longName ?? lhs.shortName ?? "") < (rhs.longName ?? rhs.shortName ?? "")
 				}
 				.prefix(24)
-			let nodeNums = users.compactMap { $0.userNode?.num }
+			let nodeNums = filteredUsers.compactMap { $0.userNode?.num }
 			let unreadCounts = fetchUnreadCountsForDMs(nodeNums: nodeNums)
 			let now = Date()
 


### PR DESCRIPTION
## What changed
- Added `#Predicate` filter (`userNode != nil`) and `SortDescriptor` (by `lastMessage` descending) to the `FetchDescriptor<UserEntity>` in `fetchDirectMessageItems()`
- Added `fetchLimit = 200` to prevent loading the entire UserEntity table
- Changed unread count computation to use `filteredUsers` instead of the full `users` array, avoiding unnecessary work for users not displayed

## Why
Part of the SwiftData performance audit (P2). The previous code at line 305 did `context.fetch(FetchDescriptor<UserEntity>())` with no predicate, no sort, and no limit — loading every user in the database into memory for CarPlay's direct message list. On large meshes this wastes memory and CPU.

## How it was tested
- Code review and diff verification
- CarPlay DM list still shows non-favorite users sorted by most recent message
- Favorites section remains separate and unaffected

## Related PRs
- PR #1748 — Save consolidation and debouncing
- PR #1749 — SwiftData indexes
- PR #1750 — Query optimizations
- PR #1751 — Position/telemetry/message caps
- PR #1752 — CoreData-to-SwiftData rename and cleanup
- PR #1753 — MeshMapContent double iteration fix