### PR TITLE
Fix continuation double-resume crash in sendWantConfig/sendWantDatabase

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -233,8 +233,10 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			Logger.transport.info("✅ [Accessory] NONCE_ONLY_CONFIG Done")
 		} onCancel: {
 			Task { @MainActor in
-				wantConfigContinuation?.resume(throwing: CancellationError())
-				wantConfigContinuation = nil
+				if let continuation = wantConfigContinuation {
+					wantConfigContinuation = nil
+					continuation.resume(throwing: CancellationError())
+				}
 			}
 		}
 	}
@@ -263,8 +265,10 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			Logger.transport.info("✅ [Accessory] NONCE_ONLY_DB first NodeInfo received.")
 		} onCancel: {
 			Task { @MainActor in
-				firstDatabaseNodeInfoContinuation?.resume(throwing: CancellationError())
-				firstDatabaseNodeInfoContinuation = nil
+				if let continuation = firstDatabaseNodeInfoContinuation {
+					firstDatabaseNodeInfoContinuation = nil
+					continuation.resume(throwing: CancellationError())
+				}
 			}
 		}
 	}
@@ -296,11 +300,15 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		heartbeatTimer = nil
 		heartbeatResponseTimer = nil
 		
-		// Clean up continuations
-		wantConfigContinuation?.resume(throwing: CancellationError())
-		wantConfigContinuation = nil
-		firstDatabaseNodeInfoContinuation?.resume(throwing: CancellationError())
-		firstDatabaseNodeInfoContinuation = nil
+		// Clean up continuations — nil before resume to prevent double-resume races
+		if let continuation = wantConfigContinuation {
+			wantConfigContinuation = nil
+			continuation.resume(throwing: CancellationError())
+		}
+		if let continuation = firstDatabaseNodeInfoContinuation {
+			firstDatabaseNodeInfoContinuation = nil
+			continuation.resume(throwing: CancellationError())
+		}
 		
 		await wantDatabaseGate.cancelAll()
 		await wantDatabaseGate.reset()
@@ -763,6 +771,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			switch configCompleteID {
 			case UInt32(NONCE_ONLY_CONFIG):
 				if let continuation = wantConfigContinuation {
+					wantConfigContinuation = nil
 					continuation.resume()
 				}
 				


### PR DESCRIPTION
## What changed
Nil out `wantConfigContinuation` and `firstDatabaseNodeInfoContinuation` **before** calling `.resume()` at every resume site, preventing a second code path from seeing a non-nil continuation and resuming it again.

## Why
Users reported:
> Fatal error: SWIFT TASK CONTINUATION MISUSE: sendWantConfig() tried to resume its continuation more than once

The race window: when `configCompleteID` arrives (success path, line ~768), it called `continuation.resume()` but did **not** nil the property. If `closeConnection()` or the `onCancel` handler ran concurrently (e.g. during a reboot-triggered reconnect), they saw the still-non-nil continuation and resumed it a second time — a fatal error in Swift concurrency.

The same pattern existed for `firstDatabaseNodeInfoContinuation`.

## What was fixed
Four resume sites now use the nil-before-resume pattern:

```swift
// Before (racy):
wantConfigContinuation?.resume(throwing: CancellationError())
wantConfigContinuation = nil

// After (safe):
if let continuation = wantConfigContinuation {
    wantConfigContinuation = nil
    continuation.resume(throwing: CancellationError())
}
```

Sites updated:
1. `configCompleteID` handler — NONCE_ONLY_CONFIG success resume
2. `sendWantConfig()` onCancel handler
3. `sendWantDatabase()` onCancel handler
4. `closeConnection()` cleanup

## How it was tested
- Build succeeds
- All 1774 tests pass
- Code review of all continuation resume paths