### PR TITLE
Add predicates and fetchLimit to TAK/API unbounded fetches

### DIFF
--- a/Meshtastic/API/MeshtasticAPI.swift
+++ b/Meshtastic/API/MeshtasticAPI.swift
@@ -445,9 +445,11 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 	}
 	
 	private static func deleteOrphanedTags(context: ModelContext) {
-		let descriptor = FetchDescriptor<DeviceHardwareTagEntity>()
+		let descriptor = FetchDescriptor<DeviceHardwareTagEntity>(
+			predicate: #Predicate<DeviceHardwareTagEntity> { $0.devices.isEmpty }
+		)
 		if let tags = try? context.fetch(descriptor) {
-			for tag in tags where tag.devices.isEmpty {
+			for tag in tags {
 				context.delete(tag)
 			}
 		}

--- a/Meshtastic/API/MeshtasticAPI.swift
+++ b/Meshtastic/API/MeshtasticAPI.swift
@@ -445,11 +445,9 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 	}
 	
 	private static func deleteOrphanedTags(context: ModelContext) {
-		let descriptor = FetchDescriptor<DeviceHardwareTagEntity>(
-			predicate: #Predicate<DeviceHardwareTagEntity> { $0.devices.isEmpty }
-		)
+		let descriptor = FetchDescriptor<DeviceHardwareTagEntity>()
 		if let tags = try? context.fetch(descriptor) {
-			for tag in tags {
+			for tag in tags where tag.devices.isEmpty {
 				context.delete(tag)
 			}
 		}

--- a/Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift
+++ b/Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift
@@ -528,25 +528,23 @@ final class TAKMeshtasticBridge {
 		
 		Logger.tak.info("Starting broadcast of all mesh nodes to TAK (excluding node \(connectedNodeNum))")
 		
-		// Fetch all nodes - be more lenient, include any node that's been heard from
-		// We'll check positions when creating CoT messages
-		let descriptor = FetchDescriptor<NodeInfoEntity>()
+		// Fetch nodes heard within the last 2 hours that have user info
+		let descriptor = FetchDescriptor<NodeInfoEntity>(
+			predicate: #Predicate<NodeInfoEntity> { $0.user != nil && $0.lastHeard != nil && $0.lastHeard! >= twoHoursAgo },
+			sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)]
+		)
 		
 		do {
 			let nodes = try context.fetch(descriptor)
-				.filter { $0.user != nil }
-				.sorted { ($0.lastHeard ?? .distantPast) > ($1.lastHeard ?? .distantPast) }
 			Logger.tak.info("Found \(nodes.count) total nodes with user info, connected node: \(connectedNodeNum)")
 			
 			var broadcastCount = 0
 			var skippedNoPosition = 0
 			var skippedConnected = 0
 			var skippedInvalidPosition = 0
-			var skippedTooOld = 0
 			
 			for node in nodes {
 				// Skip the connected node - it's our own device
-				// Use the same pattern as other parts of the codebase: node.num == accessoryManager.activeDeviceNum
 				if node.num == connectedNodeNum {
 					Logger.tak.info("Skipping connected node \(node.num)")
 					skippedConnected += 1
@@ -567,12 +565,6 @@ final class TAKMeshtasticBridge {
 					continue
 				}
 				
-				// Check if node has been heard from recently (within last 2 hours)
-				if let lastHeard = node.lastHeard, lastHeard < twoHoursAgo {
-					skippedTooOld += 1
-					continue
-				}
-				
 				if let cotMessage = createCoTFromNode(node) {
 					await takServerManager.broadcast(cotMessage)
 					broadcastCount += 1
@@ -582,7 +574,7 @@ final class TAKMeshtasticBridge {
 				}
 			}
 
-			Logger.tak.info("Broadcast complete: \(broadcastCount) nodes sent, \(skippedConnected) skipped (connected), \(skippedNoPosition) skipped (no position), \(skippedInvalidPosition) skipped (invalid position), \(skippedTooOld) skipped (too old)")
+			Logger.tak.info("Broadcast complete: \(broadcastCount) nodes sent, \(skippedConnected) skipped (connected), \(skippedNoPosition) skipped (no position), \(skippedInvalidPosition) skipped (invalid position)")
 		} catch {
 			Logger.tak.error("Failed to fetch nodes for TAK broadcast: \(error.localizedDescription)")
 		}
@@ -591,14 +583,15 @@ final class TAKMeshtasticBridge {
 	// MARK: - Helper Methods
 
 	private func lookupNodeInfo(nodeNum: UInt32) -> NodeInfoEntity? {
-		// Use PersistenceController's viewContext directly to ensure we can find nodes
 		let context = PersistenceController.shared.context
-
-		let descriptor = FetchDescriptor<NodeInfoEntity>()
+		let nodeNumInt64 = Int64(nodeNum)
+		var descriptor = FetchDescriptor<NodeInfoEntity>(
+			predicate: #Predicate<NodeInfoEntity> { $0.num == nodeNumInt64 }
+		)
+		descriptor.fetchLimit = 1
 
 		do {
-			let nodeNumInt64 = Int64(nodeNum)
-			return try context.fetch(descriptor).first { $0.num == nodeNumInt64 }
+			return try context.fetch(descriptor).first
 		} catch {
 			Logger.tak.warning("Failed to lookup node info for \(nodeNum): \(error.localizedDescription)")
 			return nil

--- a/Meshtastic/Helpers/TAK/TAKServerManager.swift
+++ b/Meshtastic/Helpers/TAK/TAKServerManager.swift
@@ -141,7 +141,8 @@ final class TAKServerManager: ObservableObject {
 	/// Returns true if the primary channel is valid for TAK server operation
 	func checkPrimaryChannelValidity() {
 		let context = PersistenceController.shared.context
-		let descriptor = FetchDescriptor<MyInfoEntity>()
+		var descriptor = FetchDescriptor<MyInfoEntity>()
+		descriptor.fetchLimit = 1
 		
 		var issues: [PrimaryChannelIssue] = []
 		var isValid = true
@@ -596,7 +597,8 @@ final class TAKServerManager: ObservableObject {
 			return false
 		}
 
-		let descriptor = FetchDescriptor<MyInfoEntity>()
+		var descriptor = FetchDescriptor<MyInfoEntity>()
+		descriptor.fetchLimit = 1
 
 		do {
 			let myInfos = try context.fetch(descriptor)


### PR DESCRIPTION
## What changed

### TAKMeshtasticBridge.swift
- **`broadcastAllNodesToTAK()`**: Replaced bare `FetchDescriptor<NodeInfoEntity>()` with a predicate (`user != nil && lastHeard >= twoHoursAgo`) and sort (`lastHeard` descending). Removes the in-memory `.filter` and `.sorted` that operated on the full table.
- **`lookupNodeInfo()`**: Replaced `FetchDescriptor<NodeInfoEntity>()` + `.first { $0.num == nodeNumInt64 }` with a predicate on `num` and `fetchLimit = 1`. Previously fetched **every node** just to find one.

### TAKServerManager.swift
- **`checkPrimaryChannelValidity()`**: Added `fetchLimit = 1` to `MyInfoEntity` fetch (only needs `.first`).
- **`autoFixPrimaryChannel()`**: Same — added `fetchLimit = 1`.

### MeshtasticAPI.swift
- **`deleteOrphanedTags()`**: Kept in-memory filter (`tag.devices.isEmpty`). Initial attempt to push this into a `#Predicate` was reverted because SwiftData does not reliably translate `.isEmpty` on to-many relationship arrays to SQL — it could incorrectly match all tags and delete them.

## Why
Part of the SwiftData performance audit (P2). These fetches had no predicates or limits, loading entire tables into memory when only a subset or single record was needed.

## How it was tested
- Build succeeds
- All tests pass

## Related PRs
- PR #1748 — Save consolidation and debouncing
- PR #1749 — SwiftData indexes
- PR #1750 — Query optimizations
- PR #1751 — Position/telemetry/message caps
- PR #1752 — CoreData-to-SwiftData rename and cleanup
- PR #1753 — MeshMapContent double iteration fix
- PR #1754 — CarPlay unbounded fetch fix
- PR #1755 — Continuation double-resume crash fix