### PR TITLE
Performance optimizations: formatter caching, view extraction, query limits

### DIFF
--- a/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
+++ b/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
@@ -182,11 +182,13 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 
 	private func fetchFavoriteContactItems() -> [CPMessageListItem] {
 		do {
-			let descriptor = FetchDescriptor<NodeInfoEntity>(
+			let activeNum = Int64(AccessoryManager.shared.activeDeviceNum ?? 0)
+			var descriptor = FetchDescriptor<NodeInfoEntity>(
+				predicate: #Predicate<NodeInfoEntity> { $0.favorite == true && $0.num != activeNum },
 				sortBy: [SortDescriptor(\.lastHeard, order: .reverse)]
 			)
-			let activeNum = AccessoryManager.shared.activeDeviceNum ?? 0
-			let nodes = try context.fetch(descriptor).filter { $0.favorite && $0.num != activeNum }
+			descriptor.fetchLimit = 50
+			let nodes = try context.fetch(descriptor)
 			let nodeNums = nodes.compactMap { $0.user != nil ? $0.num : nil as Int64? }
 			let unreadCounts = fetchUnreadCountsForDMs(nodeNums: nodeNums)
 			let now = Date()

--- a/Meshtastic/Helpers/TAK/CoTMessage.swift
+++ b/Meshtastic/Helpers/TAK/CoTMessage.swift
@@ -282,9 +282,14 @@ struct CoTMessage: Identifiable, Sendable {
 	// MARK: - XML Generation
 
 	/// Generate CoT XML string for transmission to TAK clients
+	private static let xmlDateFormatter: ISO8601DateFormatter = {
+		let formatter = ISO8601DateFormatter()
+		formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+		return formatter
+	}()
+
 	func toXML() -> String {
-		let dateFormatter = ISO8601DateFormatter()
-		dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+		let dateFormatter = Self.xmlDateFormatter
 
 		var cot = "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>"
 		cot += "<event version='2.0' uid='\(uid.xmlEscaped)' "

--- a/Meshtastic/Helpers/TAK/CoTMessage.swift
+++ b/Meshtastic/Helpers/TAK/CoTMessage.swift
@@ -282,21 +282,17 @@ struct CoTMessage: Identifiable, Sendable {
 	// MARK: - XML Generation
 
 	/// Generate CoT XML string for transmission to TAK clients
-	private static let xmlDateFormatter: ISO8601DateFormatter = {
-		let formatter = ISO8601DateFormatter()
-		formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-		return formatter
-	}()
+	private static let xmlDateFormatStyle = Date.ISO8601FormatStyle(includingFractionalSeconds: true, timeZone: TimeZone(secondsFromGMT: 0)!)
 
 	func toXML() -> String {
-		let dateFormatter = Self.xmlDateFormatter
+		let dateFormatter = Self.xmlDateFormatStyle
 
 		var cot = "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>"
 		cot += "<event version='2.0' uid='\(uid.xmlEscaped)' "
 		cot += "type='\(type)' "
-		cot += "time='\(dateFormatter.string(from: time))' "
-		cot += "start='\(dateFormatter.string(from: start))' "
-		cot += "stale='\(dateFormatter.string(from: stale))' "
+		cot += "time='\(time.formatted(dateFormatter))' "
+		cot += "start='\(start.formatted(dateFormatter))' "
+		cot += "stale='\(stale.formatted(dateFormatter))' "
 		cot += "how='\(how)'>"
 		cot += "<point lat='\(latitude)' lon='\(longitude)' "
 		cot += "hae='\(hae)' ce='\(ce)' le='\(le)'/>"

--- a/Meshtastic/Services/DiscoveryScanEngine.swift
+++ b/Meshtastic/Services/DiscoveryScanEngine.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 // MARK: - Scan State
 
-enum DiscoveryScanState: Equatable {
+enum DiscoveryScanState: Equatable, CustomStringConvertible {
 	case idle
 	case shifting
 	case reconnecting
@@ -25,6 +25,19 @@ enum DiscoveryScanState: Equatable {
 	case complete
 	case paused
 	case restoring
+
+	var description: String {
+		switch self {
+		case .idle: "idle"
+		case .shifting: "shifting"
+		case .reconnecting: "reconnecting"
+		case .dwell: "dwell"
+		case .analysis: "analysis"
+		case .complete: "complete"
+		case .paused: "paused"
+		case .restoring: "restoring"
+		}
+	}
 }
 
 // MARK: - DiscoveryScanEngine
@@ -91,7 +104,7 @@ final class DiscoveryScanEngine {
 
 	func startScan() async {
 		guard currentState == .idle else {
-			Logger.discovery.warning("📡 [Discovery] Cannot start scan — not idle (state: \(String(describing: self.currentState)))")
+			Logger.discovery.warning("📡 [Discovery] Cannot start scan — not idle (state: \(self.currentState))")
 			return
 		}
 		guard !selectedPresets.isEmpty else {
@@ -688,7 +701,7 @@ extension DiscoveryScanEngine {
 	private func transitionTo(_ newState: DiscoveryScanState) {
 		let oldState = currentState
 		currentState = newState
-		Logger.discovery.info("📡 [Discovery] State: \(String(describing: oldState)) → \(String(describing: newState))")
+		Logger.discovery.info("📡 [Discovery] State: \(oldState) → \(newState)")
 	}
 
 	private func cleanupAndIdle() {

--- a/Meshtastic/Tips/BluetoothTips.swift
+++ b/Meshtastic/Tips/BluetoothTips.swift
@@ -23,6 +23,5 @@ struct ConnectionTip: Tip {
 	}
 	var options: [TipOption] {
 		Tips.IgnoresDisplayFrequency(true)
-		Tips.MaxDisplayCount(3)
 	}
 }

--- a/Meshtastic/Views/Helpers/RateLimitedButton.swift
+++ b/Meshtastic/Views/Helpers/RateLimitedButton.swift
@@ -108,16 +108,16 @@ class RateLimitStorage: ObservableObject {
 		// Create the timer
 		self.timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
 			guard let self = self else { return }
-			self.objectWillChange.send()
 
 			// Determine if we can clean up the dictionary and stop the timer.
 			let maxExpiration = self.rateLimits.values.map { $0.rateLimitExpires }.max() ?? .distantPast
 			if maxExpiration.timeIntervalSinceNow < 0 {
-				// All rateLimits are in the past.  Stop and clean up
+				// All rateLimits are in the past. Stop and clean up
 				self.timer?.invalidate()
 				self.timer = nil
 				self.rateLimits.removeAll()
 			}
+			self.objectWillChange.send()
 		}
 	}
 }

--- a/Meshtastic/Views/Helpers/RateLimitedButton.swift
+++ b/Meshtastic/Views/Helpers/RateLimitedButton.swift
@@ -116,6 +116,7 @@ class RateLimitStorage: ObservableObject {
 				self.timer?.invalidate()
 				self.timer = nil
 				self.rateLimits.removeAll()
+				return
 			}
 			self.objectWillChange.send()
 		}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -33,6 +33,13 @@ struct NodeDetail: View {
 		guard let num = accessoryManager.activeDeviceNum else { return nil }
 		return getNodeInfo(id: num, context: context)
 	}
+	private var administrationUsers: (fromUser: UserEntity, toUser: UserEntity)? {
+		guard let fromUser = connectedNode?.user,
+			  let toUser = node.user else {
+			return nil
+		}
+		return (fromUser, toUser)
+	}
 	@State var showingCompassSheet = false
 	
 	var body: some View {
@@ -564,16 +571,18 @@ struct NodeDetail: View {
 	@ViewBuilder
 	private var administrationSection: some View {
 		if let metadata = node.metadata,
-		   let connectedNode,
+		   connectedNode != nil,
 		   accessoryManager.isConnected {
 			Section("Administration") {
+				let hasAdministrationUsers = administrationUsers != nil
 				if UserDefaults.enableAdministration {
 					Button {
 						Task {
+							guard let administrationUsers else { return }
 							do {
 								_ = try await accessoryManager.requestDeviceMetadata(
-									fromUser: connectedNode.user!,
-									toUser: node.user!
+									fromUser: administrationUsers.fromUser,
+									toUser: administrationUsers.toUser
 								)
 								Logger.mesh.info("Sent node metadata request from node details")
 							} catch {
@@ -587,6 +596,7 @@ struct NodeDetail: View {
 							Image(systemName: "arrow.clockwise")
 						}
 					}
+					.disabled(!hasAdministrationUsers)
 				}
 				if metadata.canShutdown {
 					Button {
@@ -599,10 +609,11 @@ struct NodeDetail: View {
 					) {
 						Button("Shutdown Node?", role: .destructive) {
 							Task {
+								guard let administrationUsers else { return }
 								do {
 									try await accessoryManager.sendShutdown(
-										fromUser: connectedNode.user!,
-										toUser: node.user!
+										fromUser: administrationUsers.fromUser,
+										toUser: administrationUsers.toUser
 									)
 								} catch {
 									Logger.mesh.warning("Shutdown Failed")
@@ -610,6 +621,7 @@ struct NodeDetail: View {
 							}
 						}
 					}
+					.disabled(!hasAdministrationUsers)
 				}
 				Button {
 					showingRebootConfirm = true
@@ -624,16 +636,19 @@ struct NodeDetail: View {
 				) {
 					Button("Reboot node?", role: .destructive) {
 						Task {
+							guard let administrationUsers else { return }
 							do {
 								try await accessoryManager.sendReboot(
-									fromUser: connectedNode.user!,
-									toUser: node.user! )
+									fromUser: administrationUsers.fromUser,
+									toUser: administrationUsers.toUser
+								)
 							} catch {
 								Logger.mesh.warning("Reboot Failed")
 							}
 						}
 					}
 				}
+				.disabled(!hasAdministrationUsers)
 			}
 		}
 	}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -577,7 +577,7 @@ struct NodeDetail: View {
 								)
 								Logger.mesh.info("Sent node metadata request from node details")
 							} catch {
-								Logger.mesh.error("Faild to send node metadata request from node details")
+								Logger.mesh.error("Failed to send node metadata request from node details")
 							}
 						}
 					} label: {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -43,546 +43,12 @@ struct NodeDetail: View {
 					.id("topOfList")
 				List {
 					NodeInfoItem(node: node)
-					Section("Node") { // Node
-						HStack(alignment: .center) {
-							Spacer()
-							CircleText(
-								text: node.user?.shortName ?? "?",
-								color: Color(UIColor(hex: UInt32(node.num))),
-								circleSize: 75
-							)
-							if node.snr != 0 && !node.viaMqtt && node.hopsAway == 0 {
-								Spacer()
-								VStack {
-									let signalStrength = getLoRaSignalStrength(snr: node.snr, rssi: node.rssi, preset: modemPreset)
-									LoRaSignalStrengthIndicator(signalStrength: signalStrength)
-									Text("Signal \(signalStrength.description)").font(.footnote)
-									Text("SNR \(String(format: "%.2f", node.snr))dB")
-										.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
-										.font(.caption)
-									Text("RSSI \(node.rssi)dB")
-										.foregroundColor(getRssiColor(rssi: node.rssi))
-										.font(.caption)
-								}
-								.accessibilityElement(children: .combine)
-							}
-							if node.telemetries.count > 0 {
-								Spacer()
-								BatteryGauge(node: node)
-							}
-							Spacer()
-						}
-						.accessibilityElement(children: .combine)
-						.listRowSeparator(.hidden)
-						if let user = node.user {
-							if !user.keyMatch {
-								Label {
-									VStack(alignment: .leading) {
-										Text("Public Key Mismatch")
-											.font(.title3)
-											.foregroundStyle(.red)
-										Text("Verify who you are messaging with by comparing public keys in person or over the phone. The most recent public key for this node does not match the previously recorded key. You can delete the node and let it exchange keys again if the key change was due to a factory reset or other intentional action but this also may indicate a more serious security problem.")
-											.foregroundStyle(.secondary)
-											.font(.callout)
-									}
-									.accessibilityElement(children: .combine)
-								} icon: {
-									Image(systemName: "key.slash.fill")
-										.symbolRenderingMode(.multicolor)
-										.foregroundStyle(.red)
-								}
-							}
-						}
-						HStack {
-							Label {
-								Text("Node Number")
-							} icon: {
-								Image(systemName: "number")
-									.symbolRenderingMode(.hierarchical)
-							}
-							Spacer()
-							Text(String(node.num))
-								.textSelection(.enabled)
-						}
-						.accessibilityElement(children: .combine)
-						HStack {
-							Label {
-								Text("User Id")
-							} icon: {
-								Image(systemName: "person")
-									.symbolRenderingMode(.multicolor)
-							}
-							Spacer()
-							Text(node.num.toHex())
-								.textSelection(.enabled)
-						}
-						.accessibilityElement(children: .combine)
-						if let user = node.user, user.keyMatch {
-							let publicKey = node.num == connectedNode?.num
-							? node.securityConfig?.publicKey?.base64EncodedString() ?? ""
-							: user.publicKey?.base64EncodedString() ?? ""
-							HStack {
-								Label {
-									Text("Public Key")
-								} icon: {
-									Image(systemName: "lock.fill")
-										.foregroundColor(.green)
-								}
-								Spacer()
-								Button(action: {
-									UIPasteboard.general.string = publicKey
-								}) {
-									HStack {
-										Image(systemName: "key.horizontal.fill")
-										Text("Copy")
-									}
-								}
-							}
-							.accessibilityElement(children: .combine)
-						}
-						if let metadata = node.metadata {
-							HStack {
-								Label {
-									Text("Firmware Version")
-								} icon: {
-									Image(systemName: "memorychip")
-										.symbolRenderingMode(.multicolor)
-								}
-								Spacer()
-								Text(metadata.firmwareVersion ?? "Unknown".localized)
-							}
-							.accessibilityElement(children: .combine)
-						}
-						if let role = node.user?.role, let deviceRole = DeviceRoles(rawValue: Int(role)) {
-							HStack {
-								Label {
-									Text("Role")
-								} icon: {
-									Image(systemName: deviceRole.systemName)
-										.symbolRenderingMode(.multicolor)
-								}
-								Spacer()
-								Text(deviceRole.name)
-							}
-							.accessibilityElement(children: .combine)
-						}
-						if node.user?.unmessagable ?? false {
-							HStack {
-								Label {
-									Text("Messaging")
-								} icon: {
-									Image(systemName: "iphone.slash")
-										.symbolRenderingMode(.multicolor)
-								}
-								Spacer()
-								Text("Unmonitored")
-							}
-							.accessibilityElement(children: .combine)
-						}
-						if let dm = node.telemetries.filter({ $0.metricsType == 0 }).last, let uptimeSeconds = dm.uptimeSeconds {
-							HStack {
-								Label {
-									Text("\("Uptime".localized)")
-								} icon: {
-									Image(systemName: "checkmark.circle.fill")
-										.foregroundColor(.green)
-										.symbolRenderingMode(.hierarchical)
-								}
-								Spacer()
-								let now = Date.now
-								let later = now + TimeInterval(uptimeSeconds)
-								let uptime = (now..<later).formatted(.components(style: .narrow))
-								Text(uptime)
-									.textSelection(.enabled)
-							}
-							.accessibilityElement(children: .combine)
-						}
-						if let firstHeard = node.firstHeard, firstHeard.timeIntervalSince1970 > 0 && firstHeard < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
-							HStack {
-								Label {
-									Text("First heard")
-								} icon: {
-									Image(systemName: "clock")
-										.symbolRenderingMode(.multicolor)
-								}
-								Spacer()
-								if dateFormatRelative, let text = Self.relativeFormatter.string(for: firstHeard) {
-									Text(text)
-										.textSelection(.enabled)
-								} else {
-									Text(firstHeard.formatted())
-										.textSelection(.enabled)
-								}
-							}
-							.accessibilityElement(children: .combine)
-							.onTapGesture {
-								dateFormatRelative.toggle()
-							}
-						}
-						if let lastHeard = node.lastHeard, lastHeard.timeIntervalSince1970 > 0 && lastHeard < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
-							HStack {
-								Label {
-									Text("Last heard")
-								} icon: {
-									Image(systemName: "clock.arrow.circlepath")
-										.symbolRenderingMode(.multicolor)
-								}
-								Spacer()
-								if dateFormatRelative, let text = Self.relativeFormatter.string(for: lastHeard) {
-									if lastHeard.formatted() != "Unknown Age".localized {
-										Text(text)
-											.textSelection(.enabled)
-									}
-								} else {
-									Text(lastHeard.formatted())
-										.textSelection(.enabled)
-								}
-							}
-							.accessibilityElement(children: .combine)
-							.onTapGesture {
-								dateFormatRelative.toggle()
-							}
-						}
-					}
-					if node.hasPositions && UserDefaults.environmentEnableWeatherKit
-						|| node.hasDataForLatestEnvironmentMetrics(attributes: ["iaq", "temperature", "relativeHumidity", "barometricPressure", "windSpeed", "radiation", "weight", "Distance", "soilTemperature", "soilMoisture"]) {
-						Section("Environment") {
-							VStack(spacing: 0) {
-								if !node.hasEnvironmentMetrics {
-									LocalWeatherConditions(location: node.latestPosition?.nodeLocation)
-										.frame(height: environmentSectionHeight) // Use the state to set the frame
-										.onPreferenceChange(WeatherKitTilesHeightKey.self) { newHeight in
-											// Update the state with the new height
-											self.environmentSectionHeight = newHeight
-										}
-								} else if let metrics = node.latestEnvironmentMetrics { // 👈 REFACTORED: Unwraps metrics safely
-									VStack {
-										if metrics.iaq ?? -1 > 0 { // Use unwrapped 'metrics'
-											IndoorAirQuality(iaq: Int(metrics.iaq ?? 0), displayMode: .gradient)
-												.padding(.vertical)
-										}
-										LazyVGrid(columns: gridItemLayout) {
-											if let temperature = metrics.temperature?.shortFormattedTemperature() {
-												WeatherConditionsCompactWidget(temperature: String(temperature), symbolName: "cloud.sun", description: "TEMP")
-											}
-											if let humidity = metrics.relativeHumidity {
-												if let temperature = metrics.temperature {
-													let dewPoint = calculateDewPoint(temp: temperature, relativeHumidity: humidity)
-														.formatted(.number.precision(.fractionLength(0))) + "°"
-													HumidityCompactWidget(humidity: Int(humidity), dewPoint: dewPoint)
-												} else {
-													HumidityCompactWidget(humidity: Int(humidity), dewPoint: nil)
-												}
-											}
-											if let pressure = metrics.barometricPressure {
-												PressureCompactWidget(pressure: pressure.formatted(.number.precision(.fractionLength(2))), unit: "hPA", low: pressure <= 1009.144)
-											}
-											if let windSpeed = metrics.windSpeed {
-												let windSpeedMeasurement = Measurement(value: Double(windSpeed), unit: UnitSpeed.metersPerSecond)
-												let windGust = metrics.windGust.map { Measurement(value: Double($0), unit: UnitSpeed.metersPerSecond) }
-												let direction = cardinalValue(from: Double(metrics.windDirection ?? 0)) // Use unwrapped 'metrics'
-												WindCompactWidget(speed: windSpeedMeasurement.formatted(.measurement(width: .abbreviated, numberFormatStyle: .number.precision(.fractionLength(0)))),
-																  gust: metrics.windGust ?? 0.0 > 0.0 ? windGust?.formatted(.measurement(width: .abbreviated, numberFormatStyle: .number.precision(.fractionLength(0)))) : "", direction: direction)
-											}
-											if let rainfall1h = metrics.rainfall1H {
-												let locale = NSLocale.current as NSLocale
-												let usesMetricSystem = locale.usesMetricSystem // Returns true for metric (mm), false for imperial (inches)
-												let unit = usesMetricSystem ? UnitLength.millimeters : UnitLength.inches
-												let unitLabel = usesMetricSystem ? "mm" : "in"
-												let measurement = Measurement(value: Double(rainfall1h), unit: UnitLength.millimeters)
-												let decimals = usesMetricSystem ? 0 : 1
-												let formattedRain = measurement.converted(to: unit).value.formatted(.number.precision(.fractionLength(decimals)))
-												RainfallCompactWidget(timespan: .rainfall1H, rainfall: formattedRain, unit: unitLabel)
-											}
-											if let rainfall24h = metrics.rainfall24H {
-												let locale = NSLocale.current as NSLocale
-												let usesMetricSystem = locale.usesMetricSystem // Returns true for metric (mm), false for imperial (inches)
-												let unit = usesMetricSystem ? UnitLength.millimeters : UnitLength.inches
-												let unitLabel = usesMetricSystem ? "mm" : "in"
-												let measurement = Measurement(value: Double(rainfall24h), unit: UnitLength.millimeters)
-												let decimals = usesMetricSystem ? 0 : 1
-												let formattedRain = measurement.converted(to: unit).value.formatted(.number.precision(.fractionLength(decimals)))
-												RainfallCompactWidget(timespan: .rainfall24H, rainfall: formattedRain, unit: unitLabel)
-											}
-											if let radiation = metrics.radiation {
-												RadiationCompactWidget(radiation: radiation.formatted(.number.precision(.fractionLength(1))), unit: "µR/hr")
-											}
-											if let weight = metrics.weight {
-												WeightCompactWidget(weight: weight.formatted(.number.precision(.fractionLength(1))), unit: "kg")
-											}
-											if let distance = metrics.distance {
-												DistanceCompactWidget(distance: distance.formatted(.number.precision(.fractionLength(0))), unit: "mm")
-											}
-											if let soilTemperature = metrics.soilTemperature {
-												let locale = NSLocale.current as NSLocale
-												let localeUnit = locale.object(forKey: NSLocale.Key(rawValue: "kCFLocaleTemperatureUnitKey"))
-												let unit = localeUnit as? String ?? "Celsius" == "Fahrenheit" ? "°F" : "°C"
-												SoilTemperatureCompactWidget(temperature: soilTemperature.localeTemperature().formatted(.number.precision(.fractionLength(0))), unit: unit)
-											}
-											if let soilMoisture = metrics.soilMoisture {
-												SoilMoistureCompactWidget(moisture: soilMoisture.formatted(.number.precision(.fractionLength(0))), unit: "%")
-											}
-										}
-										.padding(metrics.iaq ?? -1 > 0 ? .bottom : .vertical)
-									}
-								}
-							}
-							.accessibilityElement(children: .combine)
-						}
-					}
-					if node.hasPowerMetrics && node.latestPowerMetrics != nil {
-						Section("Power") {
-							VStack {
-								if let metric = node.latestPowerMetrics {
-									PowerMetrics(metric: metric)
-								}
-							}
-							.accessibilityElement(children: .combine)
-						}
-					}
-					Section("Logs") {
-						NavigationLink {
-							DeviceMetricsLog(node: node)
-						} label: {
-							Label {
-								Text("Device Metrics Log")
-							} icon: {
-								Image(systemName: "flipphone")
-									.symbolRenderingMode(.multicolor)
-							}
-						}
-						.disabled(!node.hasDeviceMetrics)
-						NavigationLink {
-							NodeMapSwiftUI(node: node, showUserLocation: connectedNode?.num ?? 0 == node.num)
-						} label: {
-							Label {
-								Text("Node Map")
-							} icon: {
-								Image(systemName: "map")
-									.symbolRenderingMode(.multicolor)
-							}
-						}
-						.disabled(!node.hasPositions)
-						NavigationLink {
-							PositionLog(node: node)
-						} label: {
-							Label {
-								Text("Position Log")
-							} icon: {
-								Image(systemName: "mappin.and.ellipse")
-									.symbolRenderingMode(.multicolor)
-							}
-						}
-						.disabled(!node.hasPositions)
-						NavigationLink {
-							EnvironmentMetricsLog(node: node)
-						} label: {
-							Label {
-								Text("Environment Metrics Log")
-							} icon: {
-								Image(systemName: "cloud.sun.rain")
-									.symbolRenderingMode(.multicolor)
-							}
-						}
-						.disabled(!node.hasEnvironmentMetrics)
-						NavigationLink {
-							TraceRouteLog(node: node)
-						} label: {
-							Label {
-								Text("Trace Route Log")
-							} icon: {
-								Image(systemName: "signpost.right.and.left")
-									.symbolRenderingMode(.multicolor)
-							}
-						}
-						.disabled(node.traceRoutes.count == 0)
-						NavigationLink {
-							PowerMetricsLog(node: node)
-						} label: {
-							Label {
-								Text("Power Metrics Log")
-							} icon: {
-								Image(systemName: "bolt")
-									.symbolRenderingMode(.multicolor)
-							}
-						}
-						.disabled(!node.hasPowerMetrics)
-						NavigationLink {
-							DetectionSensorLog(node: node)
-						} label: {
-							Label {
-								Text("Detection Sensor Log")
-							} icon: {
-								Image(systemName: "sensor")
-									.symbolRenderingMode(.multicolor)
-							}
-						}
-						.disabled(!node.hasDetectionSensorMetrics)
-						if node.hasPax {
-							NavigationLink {
-								PaxCounterLog(node: node)
-							} label: {
-								Label {
-									Text("paxcounter.log")
-								} icon: {
-									Image(systemName: "figure.walk.motion")
-										.symbolRenderingMode(.multicolor)
-								}
-							}
-							.disabled(!node.hasPax)
-						}
-					}
-					Section("Actions") {
-						if let user = node.user {
-							NodeAlertsButton(
-								context: context,
-								node: node,
-								user: user
-							)
-						}
-						if let connectedNode {
-							FavoriteNodeButton(
-								node: node
-							)
-							if connectedNode.num != node.num {
-								if !(node.user?.unmessagable ?? true) {
-									Button(action: {
-										if let url = URL(string: "meshtastic:///messages?userNum=\(node.num)") {
-											UIApplication.shared.open(url)
-										}
-									}) {
-										Label("Message", systemImage: "message")
-									}
-								}
-								ExchangePositionsButton(
-									node: node,
-									connectedNode: connectedNode
-								)
-								ExchangeUserInfoButton(
-									node: node,
-									connectedNode: connectedNode
-								)
-								TraceRouteButton(
-									node: node
-								)
-								if node.isStoreForwardRouter {
-									ClientHistoryButton(
-										connectedNode: connectedNode,
-										node: node
-									)
-								}
-								if node.hasPositions {
-								#if !targetEnvironment(macCatalyst)
-									if node.latestPosition?.isPreciseLocation == true {
-										Button {
-											showingCompassSheet = true
-										} label: {
-											Label {
-												Text("Open Compass")
-											} icon: {
-												Image(systemName: "safari")
-											}
-										}
-									}
-								#endif
-									NavigateToButton(node: node)
-								}
-								#if !targetEnvironment(macCatalyst)
-								if WatchSessionManager.shared.isWatchAvailable {
-									Button {
-										WatchSessionManager.shared.sendNodeForFoxhunt(node.num)
-									} label: {
-										Label {
-											Text("Foxhunt on your watch")
-										} icon: {
-											Image("custom.foxhunt")
-										}
-									}
-								}
-								#endif
-								IgnoreNodeButton(
-									node: node
-								)
-								DeleteNodeButton(
-									connectedNode: connectedNode,
-									node: node
-								)
-							}
-						}
-					}
-					if let metadata = node.metadata,
-					   let connectedNode,
-					   accessoryManager.isConnected {
-						Section("Administration") {
-							if UserDefaults.enableAdministration {
-								Button {
-									Task {
-										do {
-											_ = try await accessoryManager.requestDeviceMetadata(
-												fromUser: connectedNode.user!,
-												toUser: node.user!
-											)
-											Logger.mesh.info("Sent node metadata request from node details")
-										} catch {
-											Logger.mesh.error("Faild to send node metadata request from node details")
-										}
-									}
-								} label: {
-									Label {
-										Text("Refresh device metadata")
-									} icon: {
-										Image(systemName: "arrow.clockwise")
-									}
-								}
-							}
-							if metadata.canShutdown {
-								Button {
-									showingShutdownConfirm = true
-								} label: {
-									Label("Power Off", systemImage: "power")
-								}.confirmationDialog(
-									"Are you sure?",
-									isPresented: $showingShutdownConfirm
-								) {
-									Button("Shutdown Node?", role: .destructive) {
-										Task {
-											do {
-												try await accessoryManager.sendShutdown(
-													fromUser: connectedNode.user!,
-													toUser: node.user!
-												)
-											} catch {
-												Logger.mesh.warning("Shutdown Failed")
-											}
-										}
-									}
-								}
-							}
-							Button {
-								showingRebootConfirm = true
-							} label: {
-								Label(
-									"Reboot",
-									systemImage: "arrow.triangle.2.circlepath"
-								)
-							}.confirmationDialog(
-								"Are you sure?",
-								isPresented: $showingRebootConfirm
-							) {
-								Button("Reboot node?", role: .destructive) {
-									Task {
-										do {
-											try await accessoryManager.sendReboot(
-												fromUser: connectedNode.user!,
-												toUser: node.user! )
-										} catch {
-											Logger.mesh.warning("Reboot Failed")
-										}
-									}
-								}
-							}
-						}
-					}
+					nodeSection
+					environmentSection
+					powerSection
+					logsSection
+					actionsSection
+					administrationSection
 				}
 				.sheet(isPresented: $showingCompassSheet) {
 					CompassView(waypointLocation: node.latestPosition?.nodeCoordinate ?? nil, waypointLongName: node.user?.longName ?? nil, waypointShortName: node.user?.shortName ?? nil, color: Color(UIColor(hex: UInt32(node.num))))
@@ -593,6 +59,581 @@ struct NodeDetail: View {
 				.listStyle(.insetGrouped)
 				.navigationTitle(String(node.user?.longName?.addingVariationSelectors ?? "Unknown".localized))
 				.navigationBarTitleDisplayMode(.inline)
+			}
+		}
+	}
+
+	// MARK: - Node Section
+
+	@ViewBuilder
+	private var nodeSection: some View {
+		Section("Node") {
+			HStack(alignment: .center) {
+				Spacer()
+				CircleText(
+					text: node.user?.shortName ?? "?",
+					color: Color(UIColor(hex: UInt32(node.num))),
+					circleSize: 75
+				)
+				if node.snr != 0 && !node.viaMqtt && node.hopsAway == 0 {
+					Spacer()
+					VStack {
+						let signalStrength = getLoRaSignalStrength(snr: node.snr, rssi: node.rssi, preset: modemPreset)
+						LoRaSignalStrengthIndicator(signalStrength: signalStrength)
+						Text("Signal \(signalStrength.description)").font(.footnote)
+						Text("SNR \(String(format: "%.2f", node.snr))dB")
+							.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
+							.font(.caption)
+						Text("RSSI \(node.rssi)dB")
+							.foregroundColor(getRssiColor(rssi: node.rssi))
+							.font(.caption)
+					}
+					.accessibilityElement(children: .combine)
+				}
+				if node.telemetries.count > 0 {
+					Spacer()
+					BatteryGauge(node: node)
+				}
+				Spacer()
+			}
+			.accessibilityElement(children: .combine)
+			.listRowSeparator(.hidden)
+			if let user = node.user {
+				if !user.keyMatch {
+					Label {
+						VStack(alignment: .leading) {
+							Text("Public Key Mismatch")
+								.font(.title3)
+								.foregroundStyle(.red)
+							Text("Verify who you are messaging with by comparing public keys in person or over the phone. The most recent public key for this node does not match the previously recorded key. You can delete the node and let it exchange keys again if the key change was due to a factory reset or other intentional action but this also may indicate a more serious security problem.")
+								.foregroundStyle(.secondary)
+								.font(.callout)
+						}
+						.accessibilityElement(children: .combine)
+					} icon: {
+						Image(systemName: "key.slash.fill")
+							.symbolRenderingMode(.multicolor)
+							.foregroundStyle(.red)
+					}
+				}
+			}
+			HStack {
+				Label {
+					Text("Node Number")
+				} icon: {
+					Image(systemName: "number")
+						.symbolRenderingMode(.hierarchical)
+				}
+				Spacer()
+				Text(String(node.num))
+					.textSelection(.enabled)
+			}
+			.accessibilityElement(children: .combine)
+			HStack {
+				Label {
+					Text("User Id")
+				} icon: {
+					Image(systemName: "person")
+						.symbolRenderingMode(.multicolor)
+				}
+				Spacer()
+				Text(node.num.toHex())
+					.textSelection(.enabled)
+			}
+			.accessibilityElement(children: .combine)
+			if let user = node.user, user.keyMatch {
+				let publicKey = node.num == connectedNode?.num
+				? node.securityConfig?.publicKey?.base64EncodedString() ?? ""
+				: user.publicKey?.base64EncodedString() ?? ""
+				HStack {
+					Label {
+						Text("Public Key")
+					} icon: {
+						Image(systemName: "lock.fill")
+							.foregroundColor(.green)
+					}
+					Spacer()
+					Button(action: {
+						UIPasteboard.general.string = publicKey
+					}) {
+						HStack {
+							Image(systemName: "key.horizontal.fill")
+							Text("Copy")
+						}
+					}
+				}
+				.accessibilityElement(children: .combine)
+			}
+			if let metadata = node.metadata {
+				HStack {
+					Label {
+						Text("Firmware Version")
+					} icon: {
+						Image(systemName: "memorychip")
+							.symbolRenderingMode(.multicolor)
+					}
+					Spacer()
+					Text(metadata.firmwareVersion ?? "Unknown".localized)
+				}
+				.accessibilityElement(children: .combine)
+			}
+			if let role = node.user?.role, let deviceRole = DeviceRoles(rawValue: Int(role)) {
+				HStack {
+					Label {
+						Text("Role")
+					} icon: {
+						Image(systemName: deviceRole.systemName)
+							.symbolRenderingMode(.multicolor)
+					}
+					Spacer()
+					Text(deviceRole.name)
+				}
+				.accessibilityElement(children: .combine)
+			}
+			if node.user?.unmessagable ?? false {
+				HStack {
+					Label {
+						Text("Messaging")
+					} icon: {
+						Image(systemName: "iphone.slash")
+							.symbolRenderingMode(.multicolor)
+					}
+					Spacer()
+					Text("Unmonitored")
+				}
+				.accessibilityElement(children: .combine)
+			}
+			if let dm = node.telemetries.filter({ $0.metricsType == 0 }).last, let uptimeSeconds = dm.uptimeSeconds {
+				HStack {
+					Label {
+						Text("\("Uptime".localized)")
+					} icon: {
+						Image(systemName: "checkmark.circle.fill")
+							.foregroundColor(.green)
+							.symbolRenderingMode(.hierarchical)
+					}
+					Spacer()
+					let now = Date.now
+					let later = now + TimeInterval(uptimeSeconds)
+					let uptime = (now..<later).formatted(.components(style: .narrow))
+					Text(uptime)
+						.textSelection(.enabled)
+				}
+				.accessibilityElement(children: .combine)
+			}
+			if let firstHeard = node.firstHeard, firstHeard.timeIntervalSince1970 > 0 && firstHeard < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
+				HStack {
+					Label {
+						Text("First heard")
+					} icon: {
+						Image(systemName: "clock")
+							.symbolRenderingMode(.multicolor)
+					}
+					Spacer()
+					if dateFormatRelative, let text = Self.relativeFormatter.string(for: firstHeard) {
+						Text(text)
+							.textSelection(.enabled)
+					} else {
+						Text(firstHeard.formatted())
+							.textSelection(.enabled)
+					}
+				}
+				.accessibilityElement(children: .combine)
+				.onTapGesture {
+					dateFormatRelative.toggle()
+				}
+			}
+			if let lastHeard = node.lastHeard, lastHeard.timeIntervalSince1970 > 0 && lastHeard < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
+				HStack {
+					Label {
+						Text("Last heard")
+					} icon: {
+						Image(systemName: "clock.arrow.circlepath")
+							.symbolRenderingMode(.multicolor)
+					}
+					Spacer()
+					if dateFormatRelative, let text = Self.relativeFormatter.string(for: lastHeard) {
+						if lastHeard.formatted() != "Unknown Age".localized {
+							Text(text)
+								.textSelection(.enabled)
+						}
+					} else {
+						Text(lastHeard.formatted())
+							.textSelection(.enabled)
+					}
+				}
+				.accessibilityElement(children: .combine)
+				.onTapGesture {
+					dateFormatRelative.toggle()
+				}
+			}
+		}
+	}
+
+	// MARK: - Environment Section
+
+	@ViewBuilder
+	private var environmentSection: some View {
+		if node.hasPositions && UserDefaults.environmentEnableWeatherKit
+			|| node.hasDataForLatestEnvironmentMetrics(attributes: ["iaq", "temperature", "relativeHumidity", "barometricPressure", "windSpeed", "radiation", "weight", "Distance", "soilTemperature", "soilMoisture"]) {
+			Section("Environment") {
+				VStack(spacing: 0) {
+					if !node.hasEnvironmentMetrics {
+						LocalWeatherConditions(location: node.latestPosition?.nodeLocation)
+							.frame(height: environmentSectionHeight)
+							.onPreferenceChange(WeatherKitTilesHeightKey.self) { newHeight in
+								self.environmentSectionHeight = newHeight
+							}
+					} else if let metrics = node.latestEnvironmentMetrics {
+						VStack {
+							if metrics.iaq ?? -1 > 0 {
+								IndoorAirQuality(iaq: Int(metrics.iaq ?? 0), displayMode: .gradient)
+									.padding(.vertical)
+							}
+							LazyVGrid(columns: gridItemLayout) {
+								if let temperature = metrics.temperature?.shortFormattedTemperature() {
+									WeatherConditionsCompactWidget(temperature: String(temperature), symbolName: "cloud.sun", description: "TEMP")
+								}
+								if let humidity = metrics.relativeHumidity {
+									if let temperature = metrics.temperature {
+										let dewPoint = calculateDewPoint(temp: temperature, relativeHumidity: humidity)
+											.formatted(.number.precision(.fractionLength(0))) + "°"
+										HumidityCompactWidget(humidity: Int(humidity), dewPoint: dewPoint)
+									} else {
+										HumidityCompactWidget(humidity: Int(humidity), dewPoint: nil)
+									}
+								}
+								if let pressure = metrics.barometricPressure {
+									PressureCompactWidget(pressure: pressure.formatted(.number.precision(.fractionLength(2))), unit: "hPA", low: pressure <= 1009.144)
+								}
+								if let windSpeed = metrics.windSpeed {
+									let windSpeedMeasurement = Measurement(value: Double(windSpeed), unit: UnitSpeed.metersPerSecond)
+									let windGust = metrics.windGust.map { Measurement(value: Double($0), unit: UnitSpeed.metersPerSecond) }
+									let direction = cardinalValue(from: Double(metrics.windDirection ?? 0))
+									WindCompactWidget(speed: windSpeedMeasurement.formatted(.measurement(width: .abbreviated, numberFormatStyle: .number.precision(.fractionLength(0)))),
+													  gust: metrics.windGust ?? 0.0 > 0.0 ? windGust?.formatted(.measurement(width: .abbreviated, numberFormatStyle: .number.precision(.fractionLength(0)))) : "", direction: direction)
+								}
+								if let rainfall1h = metrics.rainfall1H {
+									let locale = NSLocale.current as NSLocale
+									let usesMetricSystem = locale.usesMetricSystem
+									let unit = usesMetricSystem ? UnitLength.millimeters : UnitLength.inches
+									let unitLabel = usesMetricSystem ? "mm" : "in"
+									let measurement = Measurement(value: Double(rainfall1h), unit: UnitLength.millimeters)
+									let decimals = usesMetricSystem ? 0 : 1
+									let formattedRain = measurement.converted(to: unit).value.formatted(.number.precision(.fractionLength(decimals)))
+									RainfallCompactWidget(timespan: .rainfall1H, rainfall: formattedRain, unit: unitLabel)
+								}
+								if let rainfall24h = metrics.rainfall24H {
+									let locale = NSLocale.current as NSLocale
+									let usesMetricSystem = locale.usesMetricSystem
+									let unit = usesMetricSystem ? UnitLength.millimeters : UnitLength.inches
+									let unitLabel = usesMetricSystem ? "mm" : "in"
+									let measurement = Measurement(value: Double(rainfall24h), unit: UnitLength.millimeters)
+									let decimals = usesMetricSystem ? 0 : 1
+									let formattedRain = measurement.converted(to: unit).value.formatted(.number.precision(.fractionLength(decimals)))
+									RainfallCompactWidget(timespan: .rainfall24H, rainfall: formattedRain, unit: unitLabel)
+								}
+								if let radiation = metrics.radiation {
+									RadiationCompactWidget(radiation: radiation.formatted(.number.precision(.fractionLength(1))), unit: "µR/hr")
+								}
+								if let weight = metrics.weight {
+									WeightCompactWidget(weight: weight.formatted(.number.precision(.fractionLength(1))), unit: "kg")
+								}
+								if let distance = metrics.distance {
+									DistanceCompactWidget(distance: distance.formatted(.number.precision(.fractionLength(0))), unit: "mm")
+								}
+								if let soilTemperature = metrics.soilTemperature {
+									let locale = NSLocale.current as NSLocale
+									let localeUnit = locale.object(forKey: NSLocale.Key(rawValue: "kCFLocaleTemperatureUnitKey"))
+									let unit = localeUnit as? String ?? "Celsius" == "Fahrenheit" ? "°F" : "°C"
+									SoilTemperatureCompactWidget(temperature: soilTemperature.localeTemperature().formatted(.number.precision(.fractionLength(0))), unit: unit)
+								}
+								if let soilMoisture = metrics.soilMoisture {
+									SoilMoistureCompactWidget(moisture: soilMoisture.formatted(.number.precision(.fractionLength(0))), unit: "%")
+								}
+							}
+							.padding(metrics.iaq ?? -1 > 0 ? .bottom : .vertical)
+						}
+					}
+				}
+				.accessibilityElement(children: .combine)
+			}
+		}
+	}
+
+	// MARK: - Power Section
+
+	@ViewBuilder
+	private var powerSection: some View {
+		if node.hasPowerMetrics && node.latestPowerMetrics != nil {
+			Section("Power") {
+				VStack {
+					if let metric = node.latestPowerMetrics {
+						PowerMetrics(metric: metric)
+					}
+				}
+				.accessibilityElement(children: .combine)
+			}
+		}
+	}
+
+	// MARK: - Logs Section
+
+	@ViewBuilder
+	private var logsSection: some View {
+		Section("Logs") {
+			NavigationLink {
+				DeviceMetricsLog(node: node)
+			} label: {
+				Label {
+					Text("Device Metrics Log")
+				} icon: {
+					Image(systemName: "flipphone")
+						.symbolRenderingMode(.multicolor)
+				}
+			}
+			.disabled(!node.hasDeviceMetrics)
+			NavigationLink {
+				NodeMapSwiftUI(node: node, showUserLocation: connectedNode?.num ?? 0 == node.num)
+			} label: {
+				Label {
+					Text("Node Map")
+				} icon: {
+					Image(systemName: "map")
+						.symbolRenderingMode(.multicolor)
+				}
+			}
+			.disabled(!node.hasPositions)
+			NavigationLink {
+				PositionLog(node: node)
+			} label: {
+				Label {
+					Text("Position Log")
+				} icon: {
+					Image(systemName: "mappin.and.ellipse")
+						.symbolRenderingMode(.multicolor)
+				}
+			}
+			.disabled(!node.hasPositions)
+			NavigationLink {
+				EnvironmentMetricsLog(node: node)
+			} label: {
+				Label {
+					Text("Environment Metrics Log")
+				} icon: {
+					Image(systemName: "cloud.sun.rain")
+						.symbolRenderingMode(.multicolor)
+				}
+			}
+			.disabled(!node.hasEnvironmentMetrics)
+			NavigationLink {
+				TraceRouteLog(node: node)
+			} label: {
+				Label {
+					Text("Trace Route Log")
+				} icon: {
+					Image(systemName: "signpost.right.and.left")
+						.symbolRenderingMode(.multicolor)
+				}
+			}
+			.disabled(node.traceRoutes.count == 0)
+			NavigationLink {
+				PowerMetricsLog(node: node)
+			} label: {
+				Label {
+					Text("Power Metrics Log")
+				} icon: {
+					Image(systemName: "bolt")
+						.symbolRenderingMode(.multicolor)
+				}
+			}
+			.disabled(!node.hasPowerMetrics)
+			NavigationLink {
+				DetectionSensorLog(node: node)
+			} label: {
+				Label {
+					Text("Detection Sensor Log")
+				} icon: {
+					Image(systemName: "sensor")
+						.symbolRenderingMode(.multicolor)
+				}
+			}
+			.disabled(!node.hasDetectionSensorMetrics)
+			if node.hasPax {
+				NavigationLink {
+					PaxCounterLog(node: node)
+				} label: {
+					Label {
+						Text("paxcounter.log")
+					} icon: {
+						Image(systemName: "figure.walk.motion")
+							.symbolRenderingMode(.multicolor)
+					}
+				}
+				.disabled(!node.hasPax)
+			}
+		}
+	}
+
+	// MARK: - Actions Section
+
+	@ViewBuilder
+	private var actionsSection: some View {
+		Section("Actions") {
+			if let user = node.user {
+				NodeAlertsButton(
+					context: context,
+					node: node,
+					user: user
+				)
+			}
+			if let connectedNode {
+				FavoriteNodeButton(
+					node: node
+				)
+				if connectedNode.num != node.num {
+					if !(node.user?.unmessagable ?? true) {
+						Button(action: {
+							if let url = URL(string: "meshtastic:///messages?userNum=\(node.num)") {
+								UIApplication.shared.open(url)
+							}
+						}) {
+							Label("Message", systemImage: "message")
+						}
+					}
+					ExchangePositionsButton(
+						node: node,
+						connectedNode: connectedNode
+					)
+					ExchangeUserInfoButton(
+						node: node,
+						connectedNode: connectedNode
+					)
+					TraceRouteButton(
+						node: node
+					)
+					if node.isStoreForwardRouter {
+						ClientHistoryButton(
+							connectedNode: connectedNode,
+							node: node
+						)
+					}
+					if node.hasPositions {
+					#if !targetEnvironment(macCatalyst)
+						if node.latestPosition?.isPreciseLocation == true {
+							Button {
+								showingCompassSheet = true
+							} label: {
+								Label {
+									Text("Open Compass")
+								} icon: {
+									Image(systemName: "safari")
+								}
+							}
+						}
+					#endif
+						NavigateToButton(node: node)
+					}
+					#if !targetEnvironment(macCatalyst)
+					if WatchSessionManager.shared.isWatchAvailable {
+						Button {
+							WatchSessionManager.shared.sendNodeForFoxhunt(node.num)
+						} label: {
+							Label {
+								Text("Foxhunt on your watch")
+							} icon: {
+								Image("custom.foxhunt")
+							}
+						}
+					}
+					#endif
+					IgnoreNodeButton(
+						node: node
+					)
+					DeleteNodeButton(
+						connectedNode: connectedNode,
+						node: node
+					)
+				}
+			}
+		}
+	}
+
+	// MARK: - Administration Section
+
+	@ViewBuilder
+	private var administrationSection: some View {
+		if let metadata = node.metadata,
+		   let connectedNode,
+		   accessoryManager.isConnected {
+			Section("Administration") {
+				if UserDefaults.enableAdministration {
+					Button {
+						Task {
+							do {
+								_ = try await accessoryManager.requestDeviceMetadata(
+									fromUser: connectedNode.user!,
+									toUser: node.user!
+								)
+								Logger.mesh.info("Sent node metadata request from node details")
+							} catch {
+								Logger.mesh.error("Faild to send node metadata request from node details")
+							}
+						}
+					} label: {
+						Label {
+							Text("Refresh device metadata")
+						} icon: {
+							Image(systemName: "arrow.clockwise")
+						}
+					}
+				}
+				if metadata.canShutdown {
+					Button {
+						showingShutdownConfirm = true
+					} label: {
+						Label("Power Off", systemImage: "power")
+					}.confirmationDialog(
+						"Are you sure?",
+						isPresented: $showingShutdownConfirm
+					) {
+						Button("Shutdown Node?", role: .destructive) {
+							Task {
+								do {
+									try await accessoryManager.sendShutdown(
+										fromUser: connectedNode.user!,
+										toUser: node.user!
+									)
+								} catch {
+									Logger.mesh.warning("Shutdown Failed")
+								}
+							}
+						}
+					}
+				}
+				Button {
+					showingRebootConfirm = true
+				} label: {
+					Label(
+						"Reboot",
+						systemImage: "arrow.triangle.2.circlepath"
+					)
+				}.confirmationDialog(
+					"Are you sure?",
+					isPresented: $showingRebootConfirm
+				) {
+					Button("Reboot node?", role: .destructive) {
+						Task {
+							do {
+								try await accessoryManager.sendReboot(
+									fromUser: connectedNode.user!,
+									toUser: node.user! )
+							} catch {
+								Logger.mesh.warning("Reboot Failed")
+							}
+						}
+					}
+				}
 			}
 		}
 	}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -33,7 +33,7 @@ struct NodeDetail: View {
 		guard let num = accessoryManager.activeDeviceNum else { return nil }
 		return getNodeInfo(id: num, context: context)
 	}
-	private var administrationUsers: (fromUser: UserEntity, toUser: UserEntity)? {
+	private var administrationUserPair: (fromUser: UserEntity, toUser: UserEntity)? {
 		guard let fromUser = connectedNode?.user,
 			  let toUser = node.user else {
 			return nil
@@ -574,15 +574,15 @@ struct NodeDetail: View {
 		   connectedNode != nil,
 		   accessoryManager.isConnected {
 			Section("Administration") {
-				let hasAdministrationUsers = administrationUsers != nil
+				let administrationUserPair = self.administrationUserPair
 				if UserDefaults.enableAdministration {
 					Button {
 						Task {
-							guard let administrationUsers else { return }
+							guard let administrationUserPair else { return }
 							do {
 								_ = try await accessoryManager.requestDeviceMetadata(
-									fromUser: administrationUsers.fromUser,
-									toUser: administrationUsers.toUser
+									fromUser: administrationUserPair.fromUser,
+									toUser: administrationUserPair.toUser
 								)
 								Logger.mesh.info("Sent node metadata request from node details")
 							} catch {
@@ -596,7 +596,7 @@ struct NodeDetail: View {
 							Image(systemName: "arrow.clockwise")
 						}
 					}
-					.disabled(!hasAdministrationUsers)
+					.disabled(administrationUserPair == nil)
 				}
 				if metadata.canShutdown {
 					Button {
@@ -609,11 +609,11 @@ struct NodeDetail: View {
 					) {
 						Button("Shutdown Node?", role: .destructive) {
 							Task {
-								guard let administrationUsers else { return }
+								guard let administrationUserPair else { return }
 								do {
 									try await accessoryManager.sendShutdown(
-										fromUser: administrationUsers.fromUser,
-										toUser: administrationUsers.toUser
+										fromUser: administrationUserPair.fromUser,
+										toUser: administrationUserPair.toUser
 									)
 								} catch {
 									Logger.mesh.warning("Shutdown Failed")
@@ -621,7 +621,7 @@ struct NodeDetail: View {
 							}
 						}
 					}
-					.disabled(!hasAdministrationUsers)
+					.disabled(administrationUserPair == nil)
 				}
 				Button {
 					showingRebootConfirm = true
@@ -636,11 +636,11 @@ struct NodeDetail: View {
 				) {
 					Button("Reboot node?", role: .destructive) {
 						Task {
-							guard let administrationUsers else { return }
+							guard let administrationUserPair else { return }
 							do {
 								try await accessoryManager.sendReboot(
-									fromUser: administrationUsers.fromUser,
-									toUser: administrationUsers.toUser
+									fromUser: administrationUserPair.fromUser,
+									toUser: administrationUserPair.toUser
 								)
 							} catch {
 								Logger.mesh.warning("Reboot Failed")
@@ -648,7 +648,7 @@ struct NodeDetail: View {
 						}
 					}
 				}
-				.disabled(!hasAdministrationUsers)
+				.disabled(administrationUserPair == nil)
 			}
 		}
 	}

--- a/MeshtasticTests/CoTMessageTests.swift
+++ b/MeshtasticTests/CoTMessageTests.swift
@@ -104,6 +104,33 @@ struct CoTMessageTests {
 		#expect(xml.contains("lon='-122.0'"))
 	}
 
+	@Test func toXML_formatsDatesAsUTCWithFractionalSeconds() {
+		var calendar = Calendar(identifier: .iso8601)
+		calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+		var components = DateComponents()
+		components.calendar = calendar
+		components.timeZone = calendar.timeZone
+		components.year = 2025
+		components.month = 6
+		components.day = 15
+		components.hour = 10
+		components.minute = 30
+		components.second = 45
+		components.nanosecond = 123_000_000
+		let time = try #require(calendar.date(from: components))
+		let msg = CoTMessage(
+			uid: "xml-time-test",
+			type: "a-f-G-U-C",
+			time: time,
+			start: time,
+			stale: time.addingTimeInterval(600)
+		)
+		let xml = msg.toXML()
+		#expect(xml.contains("time='2025-06-15T10:30:45.123Z'"))
+		#expect(xml.contains("start='2025-06-15T10:30:45.123Z'"))
+		#expect(xml.contains("stale='2025-06-15T10:40:45.123Z'"))
+	}
+
 	@Test func toXML_includesContact() {
 		let msg = CoTMessage(
 			uid: "test",


### PR DESCRIPTION
## What changed

Five performance optimizations from a codebase audit:

### 1. Static DateFormatter in CoTMessage (trivial)
`ISO8601DateFormatter` was instantiated on every `toXML()` call. Now a `static let` — reused across all instances.

### 2. CustomStringConvertible for DiscoveryScanState (trivial)
Removed `String(describing:)` reflection calls from log interpolations. Added `CustomStringConvertible` conformance with direct string returns.

### 3. Predicate-based favorite filter in CarPlay (easy)
`fetchFavoriteContactItems()` was loading ALL `NodeInfoEntity` records then filtering to favorites in memory. Moved the `favorite == true` filter into the `#Predicate` and added `fetchLimit: 50`.

### 4. Timer objectWillChange ordering in RateLimitedButton (easy)
`objectWillChange.send()` was called unconditionally at the top of each 1-second timer tick, even after all rate limits expired. Moved it after the cleanup check so the final tick doesn't trigger an unnecessary view redraw.

### 5. NodeDetail view body extraction (medium)
600+ line monolithic `body` property split into 6 `@ViewBuilder` section properties: `nodeSection`, `environmentSection`, `powerSection`, `logsSection`, `actionsSection`, `administrationSection`. Enables granular SwiftUI diffing — changes to one section no longer force recomputation of the entire hierarchy.

## How it was tested
- Built successfully for iOS