### PR TITLE
Fix tapback keyboard covering target message

### DIFF
--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,166 +1,22 @@
 {
   "files": {
-    "pico.svg": {
-      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
-    },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
-    },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
-    },
-    "thinknode_m4.svg": {
-      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
-    },
-    "heltec-vision-master-t190.svg": {
-      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
-    },
-    "wio-tracker-wm1110.svg": {
-      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
     },
     "heltec-v3.svg": {
       "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
     },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
-    },
-    "seeed_solar.svg": {
-      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
-    },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
-    },
-    "seeed-sensecap-indicator.svg": {
-      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
-    },
-    "thinknode_m3.svg": {
-      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
-    },
-    "m5_c6l.svg": {
-      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
-    },
-    "meteor_pro.svg": {
-      "etag": "\"db5044328b825421851b963479fab9ca\""
-    },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
-    },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
-    },
-    "crowpanel_7_0.svg": {
-      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
-    },
-    "rak-wismeshtap.svg": {
-      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
-    },
-    "tbeam.svg": {
-      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
-    },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
-    },
-    "tbeam-1w.svg": {
-      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
-    },
-    "heltec_v4.svg": {
-      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
-    },
-    "heltec-ht62-esp32c3-sx1262.svg": {
-      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
-    },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
     },
     "heltec-mesh-solar.svg": {
       "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
     },
-    "crowpanel_2_8.svg": {
-      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
-    },
-    "crowpanel_5_0.svg": {
-      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    "crowpanel_7_0.svg": {
+      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
     },
     "crowpanel_3_5.svg": {
       "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
-    },
-    "t5s3_epaper.svg": {
-      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
-    },
-    "heltec-mesh-node-t114-case.svg": {
-      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
-    },
-    "t-watch-s3.svg": {
-      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
-    },
-    "crowpanel_2_4.svg": {
-      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
-    },
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
-    },
-    "techo_lite.svg": {
-      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
-    },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
-    },
-    "heltec-wireless-paper.svg": {
-      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
-    },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
-    },
-    "station-g2.svg": {
-      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
-    },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
-    },
-    "tlora-t3s3-v1.svg": {
-      "etag": "\"bbf44e526676ad298698d1387af57c15\""
-    },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
-    },
-    "t-echo.svg": {
-      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
-    },
-    "rak_wismesh_tag.svg": {
-      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
-    },
-    "rak4631.svg": {
-      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
-    },
-    "rak-wismesh-tap-v2.svg": {
-      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
-    },
-    "seeed_xiao_nrf52_kit.svg": {
-      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
-    },
-    "muzi_base.svg": {
-      "etag": "\"be887c289c63af434835279b75f0879e\""
-    },
-    "heltec-wsl-v3.svg": {
-      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
-    },
-    "thinknode_m2.svg": {
-      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
     },
     "heltec-v3-case.svg": {
       "etag": "\"5319a951380495a93daab78d33ebc9a1\""
@@ -168,44 +24,188 @@
     "rak11200.svg": {
       "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
     },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
     },
-    "rak4631_case.svg": {
-      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
     },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    "heltec-wsl-v3.svg": {
+      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
     },
-    "rak3401.svg": {
-      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
-    },
-    "promicro.svg": {
-      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
-    },
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
-    },
-    "tlora-t3s3-epaper.svg": {
-      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
-    },
-    "rak2560.svg": {
-      "etag": "\"e425adc49058399a2a7f8517093192f0\""
-    },
-    "muzi_r1_neo.svg": {
-      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
-    },
-    "t-deck.svg": {
-      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
     },
     "rak11310.svg": {
       "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
     },
+    "crowpanel_2_8.svg": {
+      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
+    },
+    "heltec-vision-master-t190.svg": {
+      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
+    },
+    "tbeam-1w.svg": {
+      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
+    },
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    },
+    "rak3401.svg": {
+      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
+    },
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "seeed_solar.svg": {
+      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "tlora-t3s3-v1.svg": {
+      "etag": "\"bbf44e526676ad298698d1387af57c15\""
+    },
     "tlora-v2-1-1_6.svg": {
       "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
     },
+    "rak2560.svg": {
+      "etag": "\"e425adc49058399a2a7f8517093192f0\""
+    },
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
+    },
+    "muzi_base.svg": {
+      "etag": "\"be887c289c63af434835279b75f0879e\""
+    },
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
+    },
+    "meteor_pro.svg": {
+      "etag": "\"db5044328b825421851b963479fab9ca\""
+    },
+    "rak4631.svg": {
+      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    },
+    "seeed_xiao_nrf52_kit.svg": {
+      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
+    },
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    },
+    "wio-tracker-wm1110.svg": {
+      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    },
+    "techo_lite.svg": {
+      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
+    },
+    "thinknode_m2.svg": {
+      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
+    },
+    "rak_wismesh_tag.svg": {
+      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
+    },
+    "heltec_v4.svg": {
+      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
+    },
+    "t-watch-s3.svg": {
+      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
+    },
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    },
+    "tbeam.svg": {
+      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
+    },
+    "station-g2.svg": {
+      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    },
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "rak-wismesh-tap-v2.svg": {
+      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
+    },
+    "thinknode_m4.svg": {
+      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
+    },
+    "t-deck.svg": {
+      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    },
+    "heltec-wireless-paper.svg": {
+      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
+    },
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    },
+    "promicro.svg": {
+      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    },
+    "heltec-ht62-esp32c3-sx1262.svg": {
+      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
+    },
+    "t-echo.svg": {
+      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    },
+    "thinknode_m3.svg": {
+      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    },
+    "pico.svg": {
+      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    },
+    "tlora-t3s3-epaper.svg": {
+      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    },
+    "crowpanel_5_0.svg": {
+      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    },
+    "m5_c6l.svg": {
+      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
+    },
+    "t5s3_epaper.svg": {
+      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
+    },
+    "rak4631_case.svg": {
+      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
+    },
     "heltec_wireless_tracker_v2.svg": {
       "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    },
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
+    },
+    "heltec-mesh-node-t114-case.svg": {
+      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    },
+    "rak-wismeshtap.svg": {
+      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
+    },
+    "crowpanel_2_4.svg": {
+      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
+    },
+    "seeed-sensecap-indicator.svg": {
+      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
+    },
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
+    },
+    "muzi_r1_neo.svg": {
+      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
     }
   },
   "api_hash": "da281fe426e5989c17ce8933916f4c7367f90a5e15a1672f4b0b53f541c016be"

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -130,18 +130,21 @@ struct ChannelMessageList: View {
 							  scrollView: scrollView,
 							  onInteractionComplete: handleInteractionComplete,
 							  onTapback: { message in
+								  tapbackFocused = false
 								  tapbackTargetMessage = message
-								  tapbackFocused = true
-								  #if targetEnvironment(macCatalyst)
-								  DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-									  if let nsApp = NSClassFromString("NSApplication")?.value(forKeyPath: "sharedApplication") as? NSObject {
-										  let selector = NSSelectorFromString("orderFrontCharacterPalette:")
-										  if nsApp.responds(to: selector) {
-											  nsApp.perform(selector, with: nil)
+								  DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+									  tapbackFocused = true
+									  #if targetEnvironment(macCatalyst)
+									  DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+										  if let nsApp = NSClassFromString("NSApplication")?.value(forKeyPath: "sharedApplication") as? NSObject {
+											  let selector = NSSelectorFromString("orderFrontCharacterPalette:")
+											  if nsApp.responds(to: selector) {
+												  nsApp.perform(selector, with: nil)
+											  }
 										  }
 									  }
+									  #endif
 								  }
-								  #endif
 							  }
 						  )
 						  .onAppear {

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -24,6 +24,9 @@ struct ChannelMessageList: View {
 	@State private var messageToHighlight: Int64 = 0
 	@State private var needsReadSync: Bool = false
 	@State private var messageLimit: Int = 50
+	@State private var tapbackTargetMessage: MessageEntity?
+	@State private var tapbackText = ""
+	@FocusState var tapbackFocused: Bool
 	@Query private var allPrivateMessages: [MessageEntity]
 	
 	init(myInfo: MyInfoEntity, channel: ChannelEntity) {
@@ -60,6 +63,30 @@ struct ChannelMessageList: View {
 	private func routerIsShowingThisChannel() -> Bool {
 		guard appState.router.selectedTab == .messages else { return false }
 		return scenePhase == .active
+	}
+
+	private func processTapback() {
+		guard !tapbackText.isEmpty, let target = tapbackTargetMessage else { return }
+		let emojiToSend = tapbackText
+		let destination = MessageDestination.channel(channel)
+
+		Task {
+			do {
+				try await accessoryManager.sendMessage(
+					message: emojiToSend,
+					toUserNum: destination.userNum,
+					channel: destination.channelNum,
+					isEmoji: true,
+					replyID: target.messageId
+				)
+			} catch {
+				Logger.services.warning("Failed to send tapback.")
+			}
+		}
+
+		tapbackText = ""
+		tapbackFocused = false
+		tapbackTargetMessage = nil
 	}
 
 	var body: some View {
@@ -101,7 +128,21 @@ struct ChannelMessageList: View {
 							  messageFieldFocused: $messageFieldFocused,
 							  messageToHighlight: $messageToHighlight,
 							  scrollView: scrollView,
-							  onInteractionComplete: handleInteractionComplete
+							  onInteractionComplete: handleInteractionComplete,
+							  onTapback: { message in
+								  tapbackTargetMessage = message
+								  tapbackFocused = true
+								  #if targetEnvironment(macCatalyst)
+								  DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+									  if let nsApp = NSClassFromString("NSApplication")?.value(forKeyPath: "sharedApplication") as? NSObject {
+										  let selector = NSSelectorFromString("orderFrontCharacterPalette:")
+										  if nsApp.responds(to: selector) {
+											  nsApp.perform(selector, with: nil)
+										  }
+									  }
+								  }
+								  #endif
+							  }
 						  )
 						  .onAppear {
 							  if !message.read && UIApplication.shared.applicationState == .active {
@@ -134,6 +175,26 @@ struct ChannelMessageList: View {
 						scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 					}
 				}
+			}
+			.onChange(of: tapbackFocused) {
+				if tapbackFocused, let target = tapbackTargetMessage {
+					DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+						withAnimation {
+							scrollView.scrollTo(target.messageId, anchor: .center)
+						}
+					}
+				}
+			}
+			.background {
+				TextField("", text: $tapbackText)
+					.keyboardType(.emoji)
+					.focused($tapbackFocused)
+					.frame(width: 1, height: 1)
+					.opacity(0.01)
+					.allowsHitTesting(false)
+					.onChange(of: tapbackText) {
+						processTapback()
+					}
 			}
 			TextMessageField(
 				destination: .channel(channel),

--- a/Meshtastic/Views/Messages/ChannelMessageRow.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageRow.swift
@@ -18,6 +18,7 @@ struct ChannelMessageRow: View {
 	@Binding var messageToHighlight: Int64
 	let scrollView: ScrollViewProxy
 	let onInteractionComplete: () -> Void
+	let onTapback: (MessageEntity) -> Void
 
 	private var isCurrentUser: Bool {
 		Int64(preferredPeripheralNum) == message.fromUser?.num
@@ -32,7 +33,8 @@ struct ChannelMessageRow: View {
 	     messageFieldFocused: FocusState<Bool>.Binding,
 	     messageToHighlight: Binding<Int64>,
 	     scrollView: ScrollViewProxy,
-	     onInteractionComplete: @escaping () -> Void) {
+	     onInteractionComplete: @escaping () -> Void,
+	     onTapback: @escaping (MessageEntity) -> Void) {
 		// Initialize ObservedObject with the concrete instance
 		self.message = message
 		self.allMessages = allMessages
@@ -44,6 +46,7 @@ struct ChannelMessageRow: View {
 		self._messageToHighlight = messageToHighlight
 		self.scrollView = scrollView
 		self.onInteractionComplete = onInteractionComplete
+		self.onTapback = onTapback
 	}
 
 	var body: some View {
@@ -122,6 +125,8 @@ struct ChannelMessageRow: View {
 						) {
 							self.replyMessageId = message.messageId
 							self.messageFieldFocused = true
+						} onTapback: {
+							onTapback(message)
 						}
 						
 						if isCurrentUser && message.canRetry {

--- a/Meshtastic/Views/Messages/MessageContextMenuItems.swift
+++ b/Meshtastic/Views/Messages/MessageContextMenuItems.swift
@@ -10,7 +10,7 @@ struct MessageContextMenuItems: View {
 	let tapBackDestination: MessageDestination
 	let isCurrentUser: Bool
 	@Binding var isShowingDeleteConfirmation: Bool
-	@Binding var isShowingTapbackInput: Bool
+	let onTapback: () -> Void
 	let onReply: () -> Void
 	let canTranslate: Bool
 	let hasTranslatedText: Bool
@@ -39,19 +39,7 @@ struct MessageContextMenuItems: View {
 		Button("Tapback") {
 			// The context menu needs a moment to dismiss before the focus state can be changed.
 			DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-				isShowingTapbackInput = true
-				#if targetEnvironment(macCatalyst)
-				// On Mac Catalyst, open the system Character Palette (emoji picker)
-				// by calling orderFrontCharacterPalette: directly on NSApplication.
-				DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-					if let nsApp = NSClassFromString("NSApplication")?.value(forKeyPath: "sharedApplication") as? NSObject {
-						let selector = NSSelectorFromString("orderFrontCharacterPalette:")
-						if nsApp.responds(to: selector) {
-							nsApp.perform(selector, with: nil)
-						}
-					}
-				}
-				#endif
+				onTapback()
 			}
 		}
 

--- a/Meshtastic/Views/Messages/MessageText.swift
+++ b/Meshtastic/Views/Messages/MessageText.swift
@@ -15,12 +15,11 @@ struct MessageText: View {
 	let tapBackDestination: MessageDestination
 	let isCurrentUser: Bool
 	let onReply: () -> Void
+	let onTapback: () -> Void
 	// State for handling channel URL sheet
 	@State private var saveChannelLink: SaveChannelLinkData?
 	@State private var isShowingDeleteConfirmation = false
 	@State private var isShowingTranslationPresentation = false
-	@State private var tapbackText = ""
-	@FocusState private var isTapbackInputFocused: Bool
 	
 	var body: some View {
 		SessionReplayPrivacyView(textAndInputPrivacy: .maskAll) {
@@ -104,18 +103,6 @@ struct MessageText: View {
 			.foregroundColor(isCurrentUser ? .white : Color("Colors/MeshtasticBubbleText"))
 			.background(isCurrentUser ? .accentColor : Color("Colors/MeshtasticBubble"))
 			.cornerRadius(15)
-			.background {
-				TextField("", text: $tapbackText)
-					.keyboardType(.emoji)
-					.scrollDismissesKeyboard(.immediately)
-					.focused($isTapbackInputFocused)
-					.frame(width: 1, height: 1)
-					.opacity(0.01)
-					.allowsHitTesting(false)
-					.onChange(of: tapbackText) {
-						processTapback()
-					}
-			}
 			.overlay(messageOverlays)
 			.contextMenu {
 				MessageContextMenuItems(
@@ -123,10 +110,7 @@ struct MessageText: View {
 					tapBackDestination: tapBackDestination,
 					isCurrentUser: isCurrentUser,
 					isShowingDeleteConfirmation: $isShowingDeleteConfirmation,
-					isShowingTapbackInput: Binding(
-						get: { isTapbackInputFocused },
-						set: { isTapbackInputFocused = $0 }
-					),
+					onTapback: onTapback,
 					onReply: onReply,
 					canTranslate: canTranslate,
 						hasTranslatedText: hasTranslatedText,
@@ -256,36 +240,6 @@ struct MessageText: View {
 		} catch {
 			Logger.data.error("Failed to clear translated message \(message.messageId, privacy: .public): \(error.localizedDescription, privacy: .public)")
 		}
-	}
-	
-	private func processTapback() {
-		guard !tapbackText.isEmpty else { return }
-		let emojiToSend = tapbackText
-		
-		Task {
-			do {
-				try await accessoryManager.sendMessage(
-					message: emojiToSend,
-					toUserNum: tapBackDestination.userNum,
-					channel: tapBackDestination.channelNum,
-					isEmoji: true,
-					replyID: message.messageId
-				)
-				await MainActor.run {
-					switch tapBackDestination {
-					case .channel:
-						break
-					case .user:
-						break
-					}
-				}
-			} catch {
-				Logger.services.warning("Failed to send tapback.")
-			}
-		}
-		
-		tapbackText = ""
-		isTapbackInputFocused = false
 	}
 }
 

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -115,18 +115,21 @@ struct UserMessageList: View {
 								scrollView: scrollView,
 								onInteractionComplete: handleInteractionComplete,
 								onTapback: { message in
+									tapbackFocused = false
 									tapbackTargetMessage = message
-									tapbackFocused = true
-									#if targetEnvironment(macCatalyst)
-									DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-										if let nsApp = NSClassFromString("NSApplication")?.value(forKeyPath: "sharedApplication") as? NSObject {
-											let selector = NSSelectorFromString("orderFrontCharacterPalette:")
-											if nsApp.responds(to: selector) {
-												nsApp.perform(selector, with: nil)
+									DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+										tapbackFocused = true
+										#if targetEnvironment(macCatalyst)
+										DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+											if let nsApp = NSClassFromString("NSApplication")?.value(forKeyPath: "sharedApplication") as? NSObject {
+												let selector = NSSelectorFromString("orderFrontCharacterPalette:")
+												if nsApp.responds(to: selector) {
+													nsApp.perform(selector, with: nil)
+												}
 											}
 										}
+										#endif
 									}
-									#endif
 								}
 							)
 							.onAppear {

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -21,6 +21,9 @@ struct UserMessageList: View {
 	@State private var messageToHighlight: Int64 = 0
 	@State private var redrawTapbacksTrigger = UUID()
 	@AppStorage("preferredPeripheralNum") private var preferredPeripheralNum = -1
+	@State private var tapbackTargetMessage: MessageEntity?
+	@State private var tapbackText = ""
+	@FocusState var tapbackFocused: Bool
 	private var allPrivateMessages: [MessageEntity] {
 		let sent = user.sentMessages ?? []
 		let received = user.receivedMessages ?? []
@@ -57,6 +60,30 @@ struct UserMessageList: View {
 		return scenePhase == .active
 	}
 
+	private func processTapback() {
+		guard !tapbackText.isEmpty, let target = tapbackTargetMessage else { return }
+		let emojiToSend = tapbackText
+		let destination = MessageDestination.user(user)
+
+		Task {
+			do {
+				try await accessoryManager.sendMessage(
+					message: emojiToSend,
+					toUserNum: destination.userNum,
+					channel: destination.channelNum,
+					isEmoji: true,
+					replyID: target.messageId
+				)
+			} catch {
+				Logger.services.warning("Failed to send tapback.")
+			}
+		}
+
+		tapbackText = ""
+		tapbackFocused = false
+		tapbackTargetMessage = nil
+	}
+
 	var body: some View {
 		// Cast user.messageList to an array for easier indexing and ForEach.
 		let messages: [MessageEntity] = Array(allPrivateMessages)
@@ -86,7 +113,21 @@ struct UserMessageList: View {
 								messageFieldFocused: $messageFieldFocused,
 								messageToHighlight: $messageToHighlight,
 								scrollView: scrollView,
-								onInteractionComplete: handleInteractionComplete
+								onInteractionComplete: handleInteractionComplete,
+								onTapback: { message in
+									tapbackTargetMessage = message
+									tapbackFocused = true
+									#if targetEnvironment(macCatalyst)
+									DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+										if let nsApp = NSClassFromString("NSApplication")?.value(forKeyPath: "sharedApplication") as? NSObject {
+											let selector = NSSelectorFromString("orderFrontCharacterPalette:")
+											if nsApp.responds(to: selector) {
+												nsApp.perform(selector, with: nil)
+											}
+										}
+									}
+									#endif
+								}
 							)
 							.onAppear {
 								// Only mark as read if the app is in the foreground
@@ -118,6 +159,26 @@ struct UserMessageList: View {
 							scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 						}
 					}
+				}
+				.onChange(of: tapbackFocused) {
+					if tapbackFocused, let target = tapbackTargetMessage {
+						DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+							withAnimation {
+								scrollView.scrollTo(target.messageId, anchor: .center)
+							}
+						}
+					}
+				}
+				.background {
+					TextField("", text: $tapbackText)
+						.keyboardType(.emoji)
+						.focused($tapbackFocused)
+						.frame(width: 1, height: 1)
+						.opacity(0.01)
+						.allowsHitTesting(false)
+						.onChange(of: tapbackText) {
+							processTapback()
+						}
 				}
 			}
 			TextMessageField(

--- a/Meshtastic/Views/Messages/UserMessageRow.swift
+++ b/Meshtastic/Views/Messages/UserMessageRow.swift
@@ -22,6 +22,7 @@ struct UserMessageRow: View {
 	@Binding var messageToHighlight: Int64
 	let scrollView: ScrollViewProxy
 	let onInteractionComplete: () -> Void
+	let onTapback: (MessageEntity) -> Void
 	
 	private var isCurrentUser: Bool {
 		Int64(preferredPeripheralNum) == message.fromUser?.num
@@ -36,7 +37,8 @@ struct UserMessageRow: View {
 	     messageFieldFocused: FocusState<Bool>.Binding,
 	     messageToHighlight: Binding<Int64>,
 	     scrollView: ScrollViewProxy,
-	     onInteractionComplete: @escaping () -> Void) {
+	     onInteractionComplete: @escaping () -> Void,
+	     onTapback: @escaping (MessageEntity) -> Void) {
 		// Initialize ObservedObject with the concrete instance
 		self.message = message
 		self.allMessages = allMessages
@@ -48,6 +50,7 @@ struct UserMessageRow: View {
 		self._messageToHighlight = messageToHighlight
 		self.scrollView = scrollView
 		self.onInteractionComplete = onInteractionComplete
+		self.onTapback = onTapback
 	}
 	
 	var body: some View {
@@ -127,8 +130,8 @@ struct UserMessageRow: View {
 							isCurrentUser: isCurrentUser
 						) {
 							self.replyMessageId = message.messageId
-							self.messageFieldFocused = true
-						}
+							self.messageFieldFocused = true						} onTapback: {
+							onTapback(message)						}
 						
 						if isCurrentUser && message.canRetry || (isCurrentUser && message.receivedACK && !message.realACK) {
 							RetryButton(message: message, destination: .user(user))


### PR DESCRIPTION
## What changed
Moved the hidden emoji TextField from per-message-row (MessageText) to the list level (ChannelMessageList / UserMessageList).

## Why
When a user triggered tapback on a message in the lower half of the screen, the emoji keyboard would cover the target message. The root cause was that each MessageText row owned its own `@FocusState` — the parent list only watched `messageFieldFocused` for scroll adjustments, so no scroll-to-target occurred when the tapback keyboard opened.

Additionally, N hidden TextFields (one per message row) were unnecessarily inflating the view hierarchy.

## How
- **MessageText**: Removed `tapbackText`, `@FocusState`, hidden TextField, and `processTapback()`. Accepts an `onTapback` closure instead.
- **MessageContextMenuItems**: Replaced `isShowingTapbackInput` binding with an `onTapback` closure.
- **ChannelMessageRow / UserMessageRow**: Accept and forward the `onTapback` closure.
- **ChannelMessageList / UserMessageList**: Own a single hidden emoji TextField, `tapbackTargetMessage`, and `tapbackFocused`. `onChange(of: tapbackFocused)` scrolls the target message to `.center` via ScrollViewReader. Focus is explicitly reset before re-focusing to ensure reliable toggling on subsequent uses. Mac Catalyst character palette support preserved.

## How it was tested
- Tested tapback on messages at top, middle, and bottom of conversation on iOS Simulator
- Verified emoji keyboard scrolls target message into view
- Confirmed repeated tapbacks work reliably (focus reset fix)
- Tested on Mac Catalyst — character palette opens correctly on each use
- Verified both channel and direct message conversations