### PR TITLE
Optimize SwiftData queries in node list rows

### DIFF
--- a/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
@@ -10,34 +10,83 @@ import SwiftData
 
 extension NodeInfoEntity {
 
+	// MARK: - Targeted Fetch Helpers
+	// These use FetchDescriptor with fetchLimit to avoid loading entire relationship arrays.
+
 	var latestPosition: PositionEntity? {
-		return self.positions.sorted(by: { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }).last
+		guard let ctx = modelContext else { return nil }
+		let nodeNum = self.num
+		var descriptor = FetchDescriptor<PositionEntity>(
+			predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == nodeNum },
+			sortBy: [SortDescriptor(\PositionEntity.time, order: .reverse)]
+		)
+		descriptor.fetchLimit = 1
+		return try? ctx.fetch(descriptor).first
 	}
 
 	var latestDeviceMetrics: TelemetryEntity? {
-		return self.telemetries.filter { $0.metricsType == 0 }.sorted(by: { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }).last
+		guard let ctx = modelContext else { return nil }
+		let nodeNum = self.num
+		let metricsType: Int32 = 0
+		var descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType },
+			sortBy: [SortDescriptor(\TelemetryEntity.time, order: .reverse)]
+		)
+		descriptor.fetchLimit = 1
+		return try? ctx.fetch(descriptor).first
 	}
 
 	var latestEnvironmentMetrics: TelemetryEntity? {
-		return self.telemetries.filter { $0.metricsType == 1 }.sorted(by: { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }).last
+		guard let ctx = modelContext else { return nil }
+		let nodeNum = self.num
+		let metricsType: Int32 = 1
+		var descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType },
+			sortBy: [SortDescriptor(\TelemetryEntity.time, order: .reverse)]
+		)
+		descriptor.fetchLimit = 1
+		return try? ctx.fetch(descriptor).first
 	}
 
 	var latestPowerMetrics: TelemetryEntity? {
-		return self.telemetries.filter { $0.metricsType == 2 }.sorted(by: { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }).last
+		guard let ctx = modelContext else { return nil }
+		let nodeNum = self.num
+		let metricsType: Int32 = 2
+		var descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType },
+			sortBy: [SortDescriptor(\TelemetryEntity.time, order: .reverse)]
+		)
+		descriptor.fetchLimit = 1
+		return try? ctx.fetch(descriptor).first
 	}
 
 	var hasPositions: Bool {
-		return self.positions.count > 0
+		guard let ctx = modelContext else { return false }
+		let nodeNum = self.num
+		let descriptor = FetchDescriptor<PositionEntity>(
+			predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == nodeNum }
+		)
+		return (try? ctx.fetchCount(descriptor)) ?? 0 > 0
 	}
 
 	var hasDeviceMetrics: Bool {
-		let deviceMetrics = telemetries.filter { $0.metricsType == 0 }
-		return deviceMetrics.count > 0
+		guard let ctx = modelContext else { return false }
+		let nodeNum = self.num
+		let metricsType: Int32 = 0
+		let descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType }
+		)
+		return (try? ctx.fetchCount(descriptor)) ?? 0 > 0
 	}
 
 	var hasEnvironmentMetrics: Bool {
-		let environmentMetrics = telemetries.filter { $0.metricsType == 1 }
-		return environmentMetrics.count > 0
+		guard let ctx = modelContext else { return false }
+		let nodeNum = self.num
+		let metricsType: Int32 = 1
+		let descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType }
+		)
+		return (try? ctx.fetchCount(descriptor)) ?? 0 > 0
 	}
 
 	func hasDataForLatestEnvironmentMetrics(attributes: [String]) -> Bool {
@@ -60,17 +109,31 @@ extension NodeInfoEntity {
 
 	@MainActor
 	var hasDetectionSensorMetrics: Bool {
-		return user?.sensorMessageList.count ?? 0 > 0
+		guard let ctx = modelContext, let userNum = user?.num else { return false }
+		let portNum: Int32 = 10
+		let descriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> { $0.fromUser?.num == userNum && $0.portNum == portNum }
+		)
+		return (try? ctx.fetchCount(descriptor)) ?? 0 > 0
 	}
 
 	var hasPowerMetrics: Bool {
-		let powerMetrics = telemetries.filter { $0.metricsType == 2 }
-		return powerMetrics.count > 0
+		guard let ctx = modelContext else { return false }
+		let nodeNum = self.num
+		let metricsType: Int32 = 2
+		let descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType }
+		)
+		return (try? ctx.fetchCount(descriptor)) ?? 0 > 0
 	}
 
 	var hasTraceRoutes: Bool {
-		let routes = traceRoutes.filter { $0.response }
-		return routes.count > 0
+		guard let ctx = modelContext else { return false }
+		let nodeNum = self.num
+		let descriptor = FetchDescriptor<TraceRouteEntity>(
+			predicate: #Predicate<TraceRouteEntity> { $0.node?.num == nodeNum && $0.response == true }
+		)
+		return (try? ctx.fetchCount(descriptor)) ?? 0 > 0
 	}
 
 	var hasPax: Bool {

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -23,7 +23,7 @@ struct NodeListItem: View {
 		return f
 	}()
 
-	private var accessibilityDescription: String {
+	private func accessibilityDescription(cachedMetrics: TelemetryEntity?, cachedLocationData: (PositionEntity, CLLocation)?) -> String {
 		var desc = ""
 		if let shortName = node.user?.shortName {
 			desc = shortName.formatNodeNameForVoiceOver()
@@ -54,7 +54,7 @@ struct NodeListItem: View {
 		if node.hopsAway > 0 {
 			desc += ", \(node.hopsAway) hops away"
 		}
-		if let battery = node.latestDeviceMetrics?.batteryLevel {
+		if let battery = cachedMetrics?.batteryLevel {
 			if battery > 100 {
 				desc += ", " + "Plugged in".localized
 			} else if battery == 100 {
@@ -63,7 +63,7 @@ struct NodeListItem: View {
 				desc += ", battery \(battery)%"
 			}
 		}
-		if !isDirectlyConnected, let (lastPosition, myCoord) = locationData {
+		if !isDirectlyConnected, let (lastPosition, myCoord) = cachedLocationData {
 			let nodeCoord = CLLocation(latitude: lastPosition.nodeCoordinate!.latitude, longitude: lastPosition.nodeCoordinate!.longitude)
 			let metersAway = nodeCoord.distance(from: myCoord)
 			let formattedDistance = Self.distanceFormatter.string(fromMeters: metersAway)
@@ -117,7 +117,7 @@ struct NodeListItem: View {
 	}
 	
 	var locationData: (PositionEntity, CLLocation)? {
-		guard let lastPostion = node.positions.last else {
+		guard let lastPostion = node.latestPosition else {
 			return nil
 		}
 		guard let currentLocation = LocationsHandler.shared.locationsArray.last else {
@@ -133,14 +133,22 @@ struct NodeListItem: View {
 	}
 	
 	var body: some View {
+		// Cache all expensive computed properties ONCE to avoid repeated FetchDescriptor queries
+		let cachedMetrics = node.latestDeviceMetrics
 		let cachedLocationData = locationData
+		let cachedHasPositions = node.hasPositions
+		let cachedHasDeviceMetrics = cachedMetrics != nil
+		let cachedHasEnvironmentMetrics = node.hasEnvironmentMetrics
+		let cachedHasDetectionSensorMetrics = node.hasDetectionSensorMetrics
+		let cachedHasTraceRoutes = node.hasTraceRoutes
+		let cachedHasLogs = cachedHasPositions || cachedHasEnvironmentMetrics || cachedHasDetectionSensorMetrics || cachedHasTraceRoutes
 		LazyVStack(alignment: .leading) {
 			HStack {
 				VStack(alignment: .center) {
 					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 70)
 						.padding(.trailing, 5)
-					if node.latestDeviceMetrics != nil {
-						BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
+					if let batteryLevel = cachedMetrics?.batteryLevel {
+						BatteryCompact(batteryLevel: batteryLevel, font: .caption, iconFont: .callout, color: .accentColor)
 							.padding(.trailing, 5)
 					}
 				}
@@ -218,22 +226,22 @@ struct NodeListItem: View {
 										text: "MQTT")
 						}
 					}
-					if node.hasPositions || node.hasEnvironmentMetrics || node.hasDetectionSensorMetrics || node.hasTraceRoutes {
+					if cachedHasLogs {
 						HStack {
 							IconAndText(systemName: "scroll", text: "Logs:")
-							if node.hasDeviceMetrics {
+							if cachedHasDeviceMetrics {
 								DefaultIcon(systemName: "flipphone")
 							}
-							if node.hasPositions {
+							if cachedHasPositions {
 								DefaultIcon(systemName: "mappin.and.ellipse")
 							}
-							if node.hasEnvironmentMetrics {
+							if cachedHasEnvironmentMetrics {
 								DefaultIcon(systemName: "cloud.sun.rain")
 							}
-							if node.hasDetectionSensorMetrics {
+							if cachedHasDetectionSensorMetrics {
 								DefaultIcon(systemName: "sensor")
 							}
-							if node.hasTraceRoutes {
+							if cachedHasTraceRoutes {
 								DefaultIcon(systemName: "signpost.right.and.left")
 							}
 						}
@@ -247,7 +255,7 @@ struct NodeListItem: View {
 					} else {
 						if node.snr != 0 && !node.viaMqtt {
 							LoRaSignalStrengthMeter(snr: node.snr, rssi: node.rssi, preset: modemPreset, compact: true)
-								.padding(.top, node.hasPositions || node.hasEnvironmentMetrics || node.hasDetectionSensorMetrics || node.hasTraceRoutes ? 0 : 15)
+								.padding(.top, cachedHasLogs ? 0 : 15)
 						}
 					}
 				}
@@ -257,7 +265,7 @@ struct NodeListItem: View {
 		.padding(.top, 3)
 		.padding(.bottom, 3)
 		.accessibilityElement(children: .ignore)
-		.accessibilityLabel(accessibilityDescription)
+		.accessibilityLabel(accessibilityDescription(cachedMetrics: cachedMetrics, cachedLocationData: cachedLocationData))
 	}
 }
 

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -39,7 +39,7 @@ struct NodeListItemCompact: View {
 		return f
 	}()
 
-	private var accessibilityDescription: String {
+	private func accessibilityDescription(cachedMetrics: TelemetryEntity?, cachedLocationData: (PositionEntity, CLLocation)?) -> String {
 		var desc = ""
 		if let shortName = node.user?.shortName {
 			desc = shortName.formatNodeNameForVoiceOver()
@@ -70,7 +70,7 @@ struct NodeListItemCompact: View {
 		if node.hopsAway > 0 {
 			desc += ", \(node.hopsAway) hops away"
 		}
-		if let battery = node.latestDeviceMetrics?.batteryLevel {
+		if let battery = cachedMetrics?.batteryLevel {
 			if battery > 100 {
 				desc += ", " + "Plugged in".localized
 			} else if battery == 100 {
@@ -79,7 +79,7 @@ struct NodeListItemCompact: View {
 				desc += ", battery \(battery)%"
 			}
 		}
-		if !isDirectlyConnected, let (lastPosition, myCoord) = locationData {
+		if !isDirectlyConnected, let (lastPosition, myCoord) = cachedLocationData {
 			let nodeCoord = CLLocation(latitude: lastPosition.nodeCoordinate!.latitude, longitude: lastPosition.nodeCoordinate!.longitude)
 			let metersAway = nodeCoord.distance(from: myCoord)
 			let formattedDistance = Self.distanceFormatter.string(fromMeters: metersAway)
@@ -133,7 +133,7 @@ struct NodeListItemCompact: View {
 	}
 	
 	var locationData: (PositionEntity, CLLocation)? {
-		guard let lastPostion = node.positions.last else {
+		guard let lastPostion = node.latestPosition else {
 			return nil
 		}
 		guard let currentLocation = LocationsHandler.shared.locationsArray.last else {
@@ -163,15 +163,22 @@ struct NodeListItemCompact: View {
 	
 	var body: some View {
 		let circleSize = max(minCircle, min(maxCircle, baseUnit * CGFloat(lineNums)))
+		// Cache all expensive computed properties ONCE to avoid repeated FetchDescriptor queries
+		let cachedMetrics = node.latestDeviceMetrics
 		let cachedLocationData = locationData
+		let cachedHasPositions = node.hasPositions
+		let cachedHasDeviceMetrics = cachedMetrics != nil
+		let cachedHasEnvironmentMetrics = node.hasEnvironmentMetrics
+		let cachedHasDetectionSensorMetrics = node.hasDetectionSensorMetrics
+		let cachedHasTraceRoutes = node.hasTraceRoutes
 		LazyVStack(alignment: .leading) {
 			HStack {
 				// First Column
 				VStack(alignment: .center) {
 					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: circleSize)
 						.padding(.trailing, 5)
-					if shouldShowPower && node.latestDeviceMetrics != nil {
-						BatteryCompact(batteryLevel: node.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption2, iconFont: .caption, color: .accentColor)
+					if shouldShowPower, let batteryLevel = cachedMetrics?.batteryLevel {
+						BatteryCompact(batteryLevel: batteryLevel, font: .caption2, iconFont: .caption, color: .accentColor)
 							.padding(.trailing, 5)
 					}
 				}
@@ -249,21 +256,21 @@ struct NodeListItemCompact: View {
 							}
 						}
 						// Telemetry
-						if shouldShowTelemetry && (node.hasPositions || node.hasEnvironmentMetrics || node.hasDetectionSensorMetrics || node.hasTraceRoutes) {
+						if shouldShowTelemetry && (cachedHasPositions || cachedHasEnvironmentMetrics || cachedHasDetectionSensorMetrics || cachedHasTraceRoutes) {
 							Divider().frame(height: 15)
-							if node.hasDeviceMetrics {
+							if cachedHasDeviceMetrics {
 								DefaultIconCompact(systemName: "flipphone")
 							}
-							if node.hasPositions {
+							if cachedHasPositions {
 								DefaultIconCompact(systemName: "mappin.and.ellipse")
 							}
-							if node.hasEnvironmentMetrics {
+							if cachedHasEnvironmentMetrics {
 								DefaultIconCompact(systemName: "cloud.sun.rain")
 							}
-							if node.hasDetectionSensorMetrics {
+							if cachedHasDetectionSensorMetrics {
 								DefaultIconCompact(systemName: "sensor")
 							}
-							if node.hasTraceRoutes {
+							if cachedHasTraceRoutes {
 								DefaultIconCompact(systemName: "signpost.right.and.left")
 							}
 						}
@@ -277,7 +284,7 @@ struct NodeListItemCompact: View {
 		.padding(.top, 2)
 		.padding(.bottom, 2)
 		.accessibilityElement(children: .ignore)
-		.accessibilityLabel(accessibilityDescription)
+		.accessibilityLabel(accessibilityDescription(cachedMetrics: cachedMetrics, cachedLocationData: cachedLocationData))
 	}
 }
 


### PR DESCRIPTION
## What changed

Replaced relationship array traversal with targeted `FetchDescriptor` queries in `NodeInfoEntity` computed properties, and cached expensive computed properties in node list row views.

### NodeInfoEntityExtension.swift

**Before:** Properties like `latestPosition`, `latestDeviceMetrics`, `hasPositions`, etc. accessed full relationship arrays (`self.positions.sorted().last`, `self.telemetries.filter().count > 0`), faulting every related object into the SwiftData row cache.

**After:** Each property uses a `FetchDescriptor` with `fetchLimit: 1` (for "latest" queries) or `fetchCount` (for "has" checks), loading only what's needed:

| Property | Before | After |
|----------|--------|-------|
| `latestPosition` | Load all positions, sort, take last | `FetchDescriptor` + `fetchLimit = 1` |
| `latestDeviceMetrics` | Load all telemetries, filter, sort, take last | `FetchDescriptor` + `fetchLimit = 1` |
| `hasPositions` | `self.positions.count > 0` (faults all) | `fetchCount` (SQL COUNT) |
| `hasDeviceMetrics` | `telemetries.filter().count > 0` (faults all) | `fetchCount` (SQL COUNT) |
| `hasDetectionSensorMetrics` | `user?.sensorMessageList.count` (faults all) | `fetchCount` with predicate |

### NodeListItem.swift & NodeListItemCompact.swift

- Cache all expensive computed properties (`latestDeviceMetrics`, `hasPositions`, `hasEnvironmentMetrics`, etc.) as `let` bindings at the top of `body` to prevent redundant `FetchDescriptor` queries when the same property is referenced multiple times
- Pass cached values to `accessibilityDescription` function instead of re-fetching
- Use `node.latestPosition` (new FetchDescriptor-based) instead of `node.positions.last` (full array fault)

## Why it changed

With 100+ nodes in the mesh, each node list row was faulting entire relationship arrays (positions, telemetries, trace routes, messages) into the SwiftData `ModelContext` row cache just to check existence or get the latest record. This caused significant memory growth when scrolling the node list.

## How it was tested

- Manual testing on device with active mesh (~100+ nodes)
- Monitored memory usage while scrolling node list
- Verified all node list data displays correctly (battery, position, telemetry icons, signal, etc.)
- Verified accessibility labels read correctly with cached values
