### PR TITLE
Performance optimizations, SessionReplay removal, and resource cleanup

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		102B5EB12E172F41003D191E /* DatadogRUM in Frameworks */ = {isa = PBXBuildFile; productRef = 102B5EB02E172F41003D191E /* DatadogRUM */; };
 		108FFECB2DD3F43C00BFAA81 /* ShareContactQRDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108FFECA2DD3F43C00BFAA81 /* ShareContactQRDialog.swift */; };
 		108FFECD2DD4005600BFAA81 /* NodeInfoEntityToNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108FFECC2DD4005600BFAA81 /* NodeInfoEntityToNodeInfo.swift */; };
-		10D109F22E2047D600536CE6 /* DatadogSessionReplay in Frameworks */ = {isa = PBXBuildFile; productRef = 10D109F12E2047D600536CE6 /* DatadogSessionReplay */; };
 		10D109F42E2047D600536CE6 /* DatadogTrace in Frameworks */ = {isa = PBXBuildFile; productRef = 10D109F32E2047D600536CE6 /* DatadogTrace */; };
 		10D80CF7AD2B4269BE0A4933 /* MeshtasticSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38DF7D72AA0A450399DBC592 /* MeshtasticSchema.swift */; };
 		1396606FC903D7DA662B6326 /* DiscoveryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C6057F9508D4356DAF411F /* DiscoveryModelTests.swift */; };
@@ -143,22 +142,19 @@
 		8D3F8A3F2D44BB02009EAAA4 /* PowerMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3F8A3E2D44BB02009EAAA4 /* PowerMetrics.swift */; };
 		8D3F8A412D44C2A6009EAAA4 /* PowerMetricsLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3F8A402D44C2A6009EAAA4 /* PowerMetricsLog.swift */; };
 		8E587743574CE17703E892C6 /* Certificates in Resources */ = {isa = PBXBuildFile; fileRef = 518D504DED9874EBF9D76578 /* Certificates */; };
-		AA003DOC0000004000000001 /* docs in Resources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000005000000001 /* docs */; };
 		8EED425B7820DA4FEB40C375 /* CoTXMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748E4806582595DE80D455CD /* CoTXMLParser.swift */; };
 		93FFCD83202042FB85B47CFD /* RouteModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55D64F064C45ADBD31ABF8 /* RouteModels.swift */; };
 		9604373EEB96801AA89DF48C /* EXICodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0A8ABAEF1E587683970927 /* EXICodec.swift */; };
 		9BC51D7EF97090D149658843 /* SetMessageAttributeIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA6A18109101FA06A9FBBFB /* SetMessageAttributeIntentHandler.swift */; };
 		9C744FC4C34549008EADCA4E /* NodeInfoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7101240749F24E96835A040A /* NodeInfoEntity.swift */; };
 		A5339E2F74E83F8FC41EEE33 /* TAKServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0618E6D0DF90B74EE32E6C06 /* TAKServerConfig.swift */; };
+		AA000001303050030000B001 /* Color+Brand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002303050030000B001 /* Color+Brand.swift */; };
 		AA0001012E2730EC00600001 /* ConnectViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00010022E2730EC0060000 /* ConnectViewTests.swift */; };
 		AA0001032F07A4B000600001 /* TAKModuleConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001042F07A4B000600001 /* TAKModuleConfig.swift */; };
 		AA000201CPLAY000000000002 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000201CPLAY000000000001 /* CarPlaySceneDelegate.swift */; };
 		AA000201CPLAY000000000004 /* CarPlayIntentDonation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000201CPLAY000000000003 /* CarPlayIntentDonation.swift */; };
 		AA000301CPTST000000000002 /* CarPlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000301CPTST000000000001 /* CarPlayTests.swift */; };
 		AA000401SIRI000000000002 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = AA000401SIRI000000000001 /* AppIntentVocabulary.plist */; };
-		AA0005WTCH00000000BF0009 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0009 /* Assets.xcassets */; };
-		AA0005WTCH00000000BF0011 /* Meshtastic Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0012 /* Meshtastic Watch App.app */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		AA0005WTCH00000000BF0013 /* WatchCircleText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0013 /* WatchCircleText.swift */; };
 		AA0005WTCH00000000BF0001 /* MeshtasticWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0001 /* MeshtasticWatchApp.swift */; };
 		AA0005WTCH00000000BF0002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0002 /* ContentView.swift */; };
 		AA0005WTCH00000000BF0003 /* MeshNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0003 /* MeshNode.swift */; };
@@ -167,12 +163,23 @@
 		AA0005WTCH00000000BF0006 /* FoxhuntCompassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0006 /* FoxhuntCompassView.swift */; };
 		AA0005WTCH00000000BF0007 /* NearbyNodesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0007 /* NearbyNodesListView.swift */; };
 		AA0005WTCH00000000BF0008 /* DeviceConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0008 /* DeviceConnectionView.swift */; };
+		AA0005WTCH00000000BF0009 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0009 /* Assets.xcassets */; };
+		AA0005WTCH00000000BF0011 /* Meshtastic Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0012 /* Meshtastic Watch App.app */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AA0005WTCH00000000BF0013 /* WatchCircleText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0005WTCH00000000FR0013 /* WatchCircleText.swift */; };
+		AA003DOC0000002000000001 /* DocModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000001 /* DocModels.swift */; };
+		AA003DOC0000002000000002 /* DocBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000002 /* DocBrowserView.swift */; };
+		AA003DOC0000002000000003 /* DocPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000003 /* DocPageView.swift */; };
+		AA003DOC0000002000000004 /* AIDocAssistantView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000004 /* AIDocAssistantView.swift */; };
+		AA003DOC0000002000000005 /* DocBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000005 /* DocBundleTests.swift */; };
+		AA003DOC0000004000000001 /* docs in Resources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000005000000001 /* docs */; };
 		AA00SDBF0001 /* DeviceHardwareImageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00SDRF0001 /* DeviceHardwareImageEntity.swift */; };
 		AA00SDBF0002 /* DeviceHardwareTagEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00SDRF0002 /* DeviceHardwareTagEntity.swift */; };
 		AA00SDBF0003 /* FirmwareReleaseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00SDRF0003 /* FirmwareReleaseEntity.swift */; };
 		AA10D0012D00000000000001 /* DiscoverySummaryPDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10D0002D00000000000001 /* DiscoverySummaryPDF.swift */; };
 		AA11223344556677AABB0001 /* DiscoveryTips.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11223344556677AABB0002 /* DiscoveryTips.swift */; };
 		AB4622DCF4B1D4115ED00312 /* SendMessageIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCB3877F157D9011FA5C6CF /* SendMessageIntentHandler.swift */; };
+		AB61EBF12E3326DC00B35962 /* NodeListItemCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */; };
+		AB6E72762E3FC85A00639328 /* LayoutEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E72752E3FC85A00639328 /* LayoutEnums.swift */; };
 		ABA8E6402E2F2A2300E27791 /* AppIconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA8E63F2E2F2A2300E27791 /* AppIconButton.swift */; };
 		ABB99DEB2E2EA1C500CFBD05 /* AppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB99DEA2E2EA1C500CFBD05 /* AppIconPicker.swift */; };
 		B0E4EEF2D2C41A884A5E949C /* SearchForMessagesIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E644AE784C52500A9241481 /* SearchForMessagesIntentHandler.swift */; };
@@ -198,11 +205,6 @@
 		BCE2D3C92C7C377F008E6199 /* FactoryResetNodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE2D3C82C7C377F008E6199 /* FactoryResetNodeIntent.swift */; };
 		BD7B1A838F8245A0B6BE56C5 /* WatchSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CCF00CDD3D48C9B9DCA554 /* WatchSessionManager.swift */; };
 		C1B995B38DC97D13D90D9C1A /* DiscoverySummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B6FB13C4D4E03503BB1DF8 /* DiscoverySummaryView.swift */; };
-		AA003DOC0000002000000001 /* DocModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000001 /* DocModels.swift */; };
-		AA003DOC0000002000000002 /* DocBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000002 /* DocBrowserView.swift */; };
-		AA003DOC0000002000000003 /* DocPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000003 /* DocPageView.swift */; };
-		AA003DOC0000002000000004 /* AIDocAssistantView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000004 /* AIDocAssistantView.swift */; };
-		AA003DOC0000002000000005 /* DocBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000005 /* DocBundleTests.swift */; };
 		C54AC9F4DA920A4F718CE21A /* DiscoveryScanEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD14FA280F0A130730DEB93 /* DiscoveryScanEngineTests.swift */; };
 		C79BFC99EDCC89DD45082753 /* DiscoveryScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CA8BAC814CF82E127EEABF /* DiscoveryScanView.swift */; };
 		D02589957BD040969FCB8663 /* PositionEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97241903A924144A3EEB679 /* PositionEntity.swift */; };
@@ -266,6 +268,7 @@
 		DD00002FSHRDTSTCNT000001 /* SharedTestContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00002FSHRDTSTCNT000000 /* SharedTestContainer.swift */; };
 		DD000030EVTFWNTST0000001 /* EventFirmwareNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000030EVTFWNTST0000000 /* EventFirmwareNotificationTests.swift */; };
 		DD000031FWEDTENUM0000001 /* FirmwareEditionEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000031FWEDTENUM0000000 /* FirmwareEditionEnum.swift */; };
+		DD00003ASUPPORTLVL0000001 /* SupportLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */; };
 		DD00003C000SNAP00000001 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DD00003B000SNAP00000000 /* SnapshotTesting */; };
 		DD007BAE2AA4E91200F5FA12 /* MyInfoEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD007BAD2AA4E91200F5FA12 /* MyInfoEntityExtension.swift */; };
 		DD007BB02AA5981000F5FA12 /* NodeInfoEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD007BAF2AA5981000F5FA12 /* NodeInfoEntityExtension.swift */; };
@@ -378,7 +381,6 @@
 		DDB6ABD928B0A4BA00384BA1 /* BluetoothModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABD828B0A4BA00384BA1 /* BluetoothModes.swift */; };
 		DDB6ABDB28B0AC6000384BA1 /* DistanceText.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABDA28B0AC6000384BA1 /* DistanceText.swift */; };
 		DDB6ABE028B13AC700384BA1 /* DeviceEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABDF28B13AC700384BA1 /* DeviceEnums.swift */; };
-		DD00003ASUPPORTLVL0000001 /* SupportLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */; };
 		DDB6ABE228B13FB500384BA1 /* PositionConfigEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABE128B13FB500384BA1 /* PositionConfigEnums.swift */; };
 		DDB6ABE428B13FFF00384BA1 /* DisplayEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABE328B13FFF00384BA1 /* DisplayEnums.swift */; };
 		DDB6ABE628B1406100384BA1 /* LoraConfigEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABE528B1406100384BA1 /* LoraConfigEnums.swift */; };
@@ -422,7 +424,6 @@
 		DDDB444829F8A9C900EE2349 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDB444729F8A9C900EE2349 /* String.swift */; };
 		DDDB444A29F8AA3A00EE2349 /* CLLocationCoordinate2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDB444929F8AA3A00EE2349 /* CLLocationCoordinate2D.swift */; };
 		DDDB444C29F8AAA600EE2349 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDB444B29F8AAA600EE2349 /* Color.swift */; };
-		AA000001303050030000B001 /* Color+Brand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002303050030000B001 /* Color+Brand.swift */; };
 		DDDB444E29F8AB0E00EE2349 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDB444D29F8AB0E00EE2349 /* Int.swift */; };
 		DDDB445029F8AC9C00EE2349 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDB444F29F8AC9C00EE2349 /* UIImage.swift */; };
 		DDDB445229F8ACF900EE2349 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDB445129F8ACF900EE2349 /* Date.swift */; };
@@ -454,8 +455,6 @@
 		E3ED80145D0E873011982556 /* TAKServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B37CCEE8B44A4BA123ED118 /* TAKServerManager.swift */; };
 		EE7E2D900ACAC8053153354A /* DiscoveryScanEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC99855DBF52EBBBE07CEBA9 /* DiscoveryScanEngine.swift */; };
 		FE508F9AF5AD5DA20AA64DBF /* AccessoryManager+TAK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82232A3CF2DD284ED5B9B8ED /* AccessoryManager+TAK.swift */; };
-		AB61EBF12E3326DC00B35962 /* NodeListItemCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */; };
-		AB6E72762E3FC85A00639328 /* LayoutEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E72752E3FC85A00639328 /* LayoutEnums.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -630,7 +629,6 @@
 		4E06A9BCC789BD452DFA9CFB /* RadarSweepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarSweepView.swift; sourceTree = "<group>"; };
 		509A1C42A695463093654617 /* DeviceMetadataEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceMetadataEntity.swift; sourceTree = "<group>"; };
 		518D504DED9874EBF9D76578 /* Certificates */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = Certificates; sourceTree = "<group>"; };
-		AA003DOC0000005000000001 /* docs */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = docs; sourceTree = "<group>"; };
 		5FCB3877F157D9011FA5C6CF /* SendMessageIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendMessageIntentHandler.swift; sourceTree = "<group>"; };
 		64C6057F9508D4356DAF411F /* DiscoveryModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryModelTests.swift; sourceTree = "<group>"; };
 		6D825E612C34786C008DBEE4 /* CommonRegex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonRegex.swift; sourceTree = "<group>"; };
@@ -650,6 +648,7 @@
 		9155703C39B55FC9DDF3E4C1 /* TAKDataPackageGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKDataPackageGenerator.swift; sourceTree = "<group>"; };
 		918722D2C1474B2D99ED01DC /* UserEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEntity.swift; sourceTree = "<group>"; };
 		A97241903A924144A3EEB679 /* PositionEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionEntity.swift; sourceTree = "<group>"; };
+		AA000002303050030000B001 /* Color+Brand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Brand.swift"; sourceTree = "<group>"; };
 		AA00010022E2730EC0060000 /* ConnectViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectViewTests.swift; sourceTree = "<group>"; };
 		AA0001022F07A4B000600001 /* MeshtasticDataModelV 57.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 57.xcdatamodel"; sourceTree = "<group>"; };
 		AA0001042F07A4B000600001 /* TAKModuleConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAKModuleConfig.swift; sourceTree = "<group>"; };
@@ -682,12 +681,20 @@
 		AA0005WTCH00000000FR0010 /* Meshtastic Watch App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Meshtastic Watch App.entitlements"; sourceTree = "<group>"; };
 		AA0005WTCH00000000FR0012 /* Meshtastic Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Meshtastic Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA0005WTCH00000000FR0013 /* WatchCircleText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchCircleText.swift; sourceTree = "<group>"; };
+		AA003DOC0000001000000001 /* DocModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocModels.swift; sourceTree = "<group>"; };
+		AA003DOC0000001000000002 /* DocBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocBrowserView.swift; sourceTree = "<group>"; };
+		AA003DOC0000001000000003 /* DocPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocPageView.swift; sourceTree = "<group>"; };
+		AA003DOC0000001000000004 /* AIDocAssistantView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDocAssistantView.swift; sourceTree = "<group>"; };
+		AA003DOC0000001000000005 /* DocBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocBundleTests.swift; sourceTree = "<group>"; };
+		AA003DOC0000005000000001 /* docs */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = docs; sourceTree = "<group>"; };
 		AA00SDRF0001 /* DeviceHardwareImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceHardwareImageEntity.swift; sourceTree = "<group>"; };
 		AA00SDRF0002 /* DeviceHardwareTagEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceHardwareTagEntity.swift; sourceTree = "<group>"; };
 		AA00SDRF0003 /* FirmwareReleaseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareReleaseEntity.swift; sourceTree = "<group>"; };
 		AA10D0002D00000000000001 /* DiscoverySummaryPDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverySummaryPDF.swift; sourceTree = "<group>"; };
 		AA11223344556677AABB0002 /* DiscoveryTips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryTips.swift; sourceTree = "<group>"; };
 		AAD14FA280F0A130730DEB93 /* DiscoveryScanEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryScanEngineTests.swift; sourceTree = "<group>"; };
+		AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeListItemCompact.swift; sourceTree = "<group>"; };
+		AB6E72752E3FC85A00639328 /* LayoutEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutEnums.swift; sourceTree = "<group>"; };
 		ABA8E63F2E2F2A2300E27791 /* AppIconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconButton.swift; sourceTree = "<group>"; };
 		ABB99DEA2E2EA1C500CFBD05 /* AppIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconPicker.swift; sourceTree = "<group>"; };
 		AF19C19E9E7EE08A3462338E /* DiscoveryPresetResultEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryPresetResultEntity.swift; sourceTree = "<group>"; };
@@ -773,6 +780,7 @@
 		DD00002FSHRDTSTCNT000000 /* SharedTestContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestContainer.swift; sourceTree = "<group>"; };
 		DD000030EVTFWNTST0000000 /* EventFirmwareNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventFirmwareNotificationTests.swift; sourceTree = "<group>"; };
 		DD000031FWEDTENUM0000000 /* FirmwareEditionEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareEditionEnum.swift; sourceTree = "<group>"; };
+		DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportLevel.swift; sourceTree = "<group>"; };
 		DD007BAD2AA4E91200F5FA12 /* MyInfoEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoEntityExtension.swift; sourceTree = "<group>"; };
 		DD007BAF2AA5981000F5FA12 /* NodeInfoEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeInfoEntityExtension.swift; sourceTree = "<group>"; };
 		DD04804A2E9295A5005F946C /* MeshtasticDataModelV 55.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 55.xcdatamodel"; sourceTree = "<group>"; };
@@ -923,7 +931,6 @@
 		DDB6ABD828B0A4BA00384BA1 /* BluetoothModes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothModes.swift; sourceTree = "<group>"; };
 		DDB6ABDA28B0AC6000384BA1 /* DistanceText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceText.swift; sourceTree = "<group>"; };
 		DDB6ABDF28B13AC700384BA1 /* DeviceEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceEnums.swift; sourceTree = "<group>"; };
-		DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportLevel.swift; sourceTree = "<group>"; };
 		DDB6ABE128B13FB500384BA1 /* PositionConfigEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionConfigEnums.swift; sourceTree = "<group>"; };
 		DDB6ABE328B13FFF00384BA1 /* DisplayEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayEnums.swift; sourceTree = "<group>"; };
 		DDB6ABE528B1406100384BA1 /* LoraConfigEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoraConfigEnums.swift; sourceTree = "<group>"; };
@@ -980,7 +987,6 @@
 		DDDB444729F8A9C900EE2349 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		DDDB444929F8AA3A00EE2349 /* CLLocationCoordinate2D.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocationCoordinate2D.swift; sourceTree = "<group>"; };
 		DDDB444B29F8AAA600EE2349 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
-		AA000002303050030000B001 /* Color+Brand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Brand.swift"; sourceTree = "<group>"; };
 		DDDB444D29F8AB0E00EE2349 /* Int.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
 		DDDB444F29F8AC9C00EE2349 /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		DDDB445129F8ACF900EE2349 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
@@ -1020,14 +1026,7 @@
 		F1B6FB13C4D4E03503BB1DF8 /* DiscoverySummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverySummaryView.swift; sourceTree = "<group>"; };
 		F3204EF969484E549C139730 /* MessageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEntity.swift; sourceTree = "<group>"; };
 		F5CA8BAC814CF82E127EEABF /* DiscoveryScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryScanView.swift; sourceTree = "<group>"; };
-		AA003DOC0000001000000001 /* DocModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocModels.swift; sourceTree = "<group>"; };
-		AA003DOC0000001000000002 /* DocBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocBrowserView.swift; sourceTree = "<group>"; };
-		AA003DOC0000001000000003 /* DocPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocPageView.swift; sourceTree = "<group>"; };
-		AA003DOC0000001000000004 /* AIDocAssistantView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDocAssistantView.swift; sourceTree = "<group>"; };
-		AA003DOC0000001000000005 /* DocBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocBundleTests.swift; sourceTree = "<group>"; };
 		FC99855DBF52EBBBE07CEBA9 /* DiscoveryScanEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryScanEngine.swift; sourceTree = "<group>"; };
-		AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeListItemCompact.swift; sourceTree = "<group>"; };
-		AB6E72752E3FC85A00639328 /* LayoutEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutEnums.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -1126,7 +1125,6 @@
 				102B5EAD2E172F41003D191E /* DatadogCrashReporting in Frameworks */,
 				25A978BA2C13F8ED0003AAE7 /* MeshtasticProtobufs in Frameworks */,
 				102B5EAB2E172F41003D191E /* DatadogCore in Frameworks */,
-				10D109F22E2047D600536CE6 /* DatadogSessionReplay in Frameworks */,
 				102B5EAF2E172F41003D191E /* DatadogLogs in Frameworks */,
 				102B5EB12E172F41003D191E /* DatadogRUM in Frameworks */,
 				2315D1A82EEF2ED400E0FAE7 /* SwiftDraw in Frameworks */,
@@ -1514,17 +1512,6 @@
 			path = Discovery;
 			sourceTree = "<group>";
 		};
-		AA003DOC0000003000000001 /* HelpAndDocumentation */ = {
-			isa = PBXGroup;
-			children = (
-				AA003DOC0000001000000001 /* DocModels.swift */,
-				AA003DOC0000001000000002 /* DocBrowserView.swift */,
-				AA003DOC0000001000000003 /* DocPageView.swift */,
-				AA003DOC0000001000000004 /* AIDocAssistantView.swift */,
-			);
-			path = HelpAndDocumentation;
-			sourceTree = "<group>";
-		};
 		AA000201CPLAY000000000005 /* CarPlay */ = {
 			isa = PBXGroup;
 			children = (
@@ -1574,6 +1561,17 @@
 				AA0005WTCH00000000FR0013 /* WatchCircleText.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		AA003DOC0000003000000001 /* HelpAndDocumentation */ = {
+			isa = PBXGroup;
+			children = (
+				AA003DOC0000001000000001 /* DocModels.swift */,
+				AA003DOC0000001000000002 /* DocBrowserView.swift */,
+				AA003DOC0000001000000003 /* DocPageView.swift */,
+				AA003DOC0000001000000004 /* AIDocAssistantView.swift */,
+			);
+			path = HelpAndDocumentation;
 			sourceTree = "<group>";
 		};
 		BCB6137F2C6728E700485544 /* AppIntents */ = {
@@ -2280,7 +2278,6 @@
 				102B5EAC2E172F41003D191E /* DatadogCrashReporting */,
 				102B5EAE2E172F41003D191E /* DatadogLogs */,
 				102B5EB02E172F41003D191E /* DatadogRUM */,
-				10D109F12E2047D600536CE6 /* DatadogSessionReplay */,
 				10D109F32E2047D600536CE6 /* DatadogTrace */,
 				2388EC372EDF88E900F6F982 /* NordicDFU */,
 				2315D1A72EEF2ED400E0FAE7 /* SwiftDraw */,
@@ -3504,11 +3501,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 102B5EA92E172F41003D191E /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
 			productName = DatadogRUM;
-		};
-		10D109F12E2047D600536CE6 /* DatadogSessionReplay */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 102B5EA92E172F41003D191E /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
-			productName = DatadogSessionReplay;
 		};
 		10D109F32E2047D600536CE6 /* DatadogTrace */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -173,6 +173,10 @@ extension AccessoryManager {
 				// We have an active connection
 				self.updateDevice(deviceId: device.id, key: \.connectionState, value: .connected)
 				self.updateState(.subscribed)
+
+				// Release accumulated ModelContext memory from DB retrieval
+				await MeshPackets.shared.flushDebouncedSaves()
+				MeshPackets.recreateShared()
 				
 				// If we successfully connected to a manual connection, then save it to the list
 				// Remember, Device is a value type (struct) so don't use use `device` here, thats

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -165,9 +165,10 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	var locationTask: Task<Void, Error>?
 	var connectionStepper: SequentialSteps?
 	
-	// Flash subjects
-	@Published var packetsSent: Int = 0
-	@Published var packetsReceived: Int = 0
+	// Flash counters — NOT @Published to avoid triggering re-renders of all observing views.
+	// RXTXIndicatorWidget observes these via onChange polling.
+	var packetsSent: Int = 0
+	var packetsReceived: Int = 0
 	
 	// Continuations
 	var wantConfigContinuation: CheckedContinuation<Void, Error>?

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -77,7 +77,7 @@ actor BLETransport: Transport {
 				try await self.setupCompleteGate.wait()
 				
 				if await !self.restoreInProgress {
-					centralManager.scanForPeripherals(withServices: [meshtasticServiceCBUUID], options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+					centralManager.scanForPeripherals(withServices: [meshtasticServiceCBUUID], options: [CBCentralManagerScanOptionAllowDuplicatesKey: false])
 					
 					let peripherals = await self.discoveredPeripherals.values.map({$0.peripheral})
 					for alreadyDiscoveredPeripheral in peripherals {
@@ -157,7 +157,7 @@ actor BLETransport: Transport {
 			if self.discoveredDeviceContinuation != nil && !restoreInProgress {
 				// We have someone already subscribed to our discovery event stream.
 				// Likely a powerOff event occcurred and need to now restore scanning.
-				central.scanForPeripherals(withServices: [meshtasticServiceCBUUID], options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
+				central.scanForPeripherals(withServices: [meshtasticServiceCBUUID], options: [CBCentralManagerScanOptionAllowDuplicatesKey: false])
 			}
 
 		case .poweredOff:

--- a/Meshtastic/Extensions/SwiftData/UserEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/UserEntityExtension.swift
@@ -10,31 +10,62 @@ import SwiftData
 import MeshtasticProtobufs
 
 extension UserEntity {
+	/// Builds a predicate for messages involving this user, excluding emoji/admin/sensor messages
+	@MainActor
+	private static func userMessagePredicate(userNum: Int64, portNum: Int32 = 10) -> Predicate<MessageEntity> {
+		return #Predicate<MessageEntity> {
+			($0.fromUser?.num == userNum || $0.toUser?.num == userNum)
+			&& $0.isEmoji == false && $0.admin == false && $0.portNum != portNum
+		}
+	}
+
 	@MainActor
 	var messageList: [MessageEntity] {
-		let context = PersistenceController.shared.context
-		let messages = (self.sentMessages ?? []) + (self.receivedMessages ?? [])
-		return messages.filter { msg in
-			msg.toUser != nil && msg.fromUser != nil && !msg.isEmoji && !msg.admin && msg.portNum != 10
-		}.sorted { $0.messageTimestamp < $1.messageTimestamp }
+		guard let ctx = modelContext else { return [] }
+		var descriptor = FetchDescriptor<MessageEntity>(
+			predicate: Self.userMessagePredicate(userNum: self.num),
+			sortBy: [SortDescriptor(\MessageEntity.messageTimestamp)]
+		)
+		return (try? ctx.fetch(descriptor)) ?? []
 	}
 
 	@MainActor
 	var mostRecentMessage: MessageEntity? {
-		guard self.lastMessage != nil else { return nil }
-		return messageList.last
+		guard let ctx = modelContext, self.lastMessage != nil else { return nil }
+		var descriptor = FetchDescriptor<MessageEntity>(
+			predicate: Self.userMessagePredicate(userNum: self.num),
+			sortBy: [SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse)]
+		)
+		descriptor.fetchLimit = 1
+		return try? ctx.fetch(descriptor).first
 	}
 
 	@MainActor
 	var sensorMessageList: [MessageEntity] {
-		return (self.sentMessages ?? []).filter { $0.portNum == 10 }
-			.sorted { $0.messageTimestamp < $1.messageTimestamp }
+		guard let ctx = modelContext else { return [] }
+		let userNum = self.num
+		let portNum: Int32 = 10
+		var descriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> { $0.fromUser?.num == userNum && $0.portNum == portNum },
+			sortBy: [SortDescriptor(\MessageEntity.messageTimestamp)]
+		)
+		return (try? ctx.fetch(descriptor)) ?? []
 	}
 
 	@MainActor
 	func unreadMessages(context: ModelContext, skipLastMessageCheck: Bool = false) -> Int {
 		guard self.lastMessage != nil || skipLastMessageCheck else { return 0 }
-		return messageList.filter { !$0.read }.count
+		guard let ctx = modelContext else { return 0 }
+		let userNum = self.num
+		let portNum: Int32 = 10
+		let descriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				($0.fromUser?.num == userNum || $0.toUser?.num == userNum)
+				&& $0.read == false
+				&& $0.isEmoji == false && $0.admin == false && $0.portNum != portNum
+			}
+		)
+		return (try? ctx.fetchCount(descriptor)) ?? 0
 	}
 
 	@MainActor

--- a/Meshtastic/Helpers/LocationsHandler.swift
+++ b/Meshtastic/Helpers/LocationsHandler.swift
@@ -21,7 +21,9 @@ import OSLog
 	@Published var locationsArray: [CLLocation] = [CLLocation]()
 	@Published var isStationary = false
 	@Published var count = 0
-	@Published var isRecording = false
+	@Published var isRecording = false {
+		didSet { updateAccuracyForRecordingState() }
+	}
 	@Published var isRecordingPaused = false
 	@Published var recordingStarted: Date?
 	@Published var distanceTraveled = 0.0
@@ -128,11 +130,10 @@ import OSLog
 		// Allow background location updates for continuous tracking.
 		self.manager.allowsBackgroundLocationUpdates = true
 		// Set desired accuracy for location updates.
-		// Consider your app's needs: kCLLocationAccuracyBestForNavigation, kCLLocationAccuracyBest, etc.
-		// For general tracking, kCLLocationAccuracyHundredMeters might be sufficient to save battery.
-		self.manager.desiredAccuracy = kCLLocationAccuracyBest
-		// Set the distance filter to only receive updates when the device has moved a certain distance.
-		self.manager.distanceFilter = kCLDistanceFilterNone // Receive all updates initially
+		// Use HundredMeters by default to save battery; escalate to Best during route recording.
+		self.manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+		// Only deliver updates when the device has moved at least 10 meters.
+		self.manager.distanceFilter = 10
 		if CLLocationManager.headingAvailable() {
 				self.manager.headingFilter = 1 // Update heading when it changes by 1 degree
 				self.manager.headingOrientation = .portrait // Adjust based on device orientation
@@ -223,6 +224,18 @@ import OSLog
 		// Setting `updatesStarted` to false will cause the `liveUpdates()` loop to break.
 		self.updatesStarted = false
 	}
+
+	/// Escalates to best accuracy during route recording; reverts to battery-friendly defaults otherwise.
+	private func updateAccuracyForRecordingState() {
+		if isRecording {
+			manager.desiredAccuracy = kCLLocationAccuracyBest
+			manager.distanceFilter = kCLDistanceFilterNone
+		} else {
+			manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+			manager.distanceFilter = 10
+		}
+	}
+
 	/// Adds a location to the array and updates tracking metrics, applying smart position filters if enabled.
 	/// - Parameters:
 	///   - location: The `CLLocation` object to add.

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -55,10 +55,29 @@ func generateMessageMarkdown(message: String) -> String {
 
 @ModelActor
 actor MeshPackets {
-	static let shared: MeshPackets = {
-		let container = MainActor.assumeIsolated { PersistenceController.shared.container }
-		return MeshPackets(modelContainer: container)
+	private static let _container: ModelContainer = {
+		MainActor.assumeIsolated { PersistenceController.shared.container }
 	}()
+
+	/// The current shared instance. Access via `MeshPackets.shared`.
+	/// Periodically recreated to release accumulated ModelContext memory.
+	nonisolated(unsafe) private static var _shared: MeshPackets = MeshPackets(modelContainer: _container)
+	private static let _lock = NSLock()
+
+	static var shared: MeshPackets {
+		_lock.lock()
+		defer { _lock.unlock() }
+		return _shared
+	}
+
+	/// Discards the current actor and creates a fresh one with a new ModelContext.
+	/// Call after DB retrieval completes or periodically to release accumulated memory.
+	static func recreateShared() {
+		_lock.lock()
+		_shared = MeshPackets(modelContainer: _container)
+		_lock.unlock()
+		Logger.data.info("♻️ [MeshPackets] Recreated shared instance to release ModelContext memory")
+	}
 
 	// MARK: - Save Helpers
 
@@ -329,7 +348,7 @@ actor MeshPackets {
 						telemetry.voltage = nodeInfo.deviceMetrics.voltage
 						telemetry.channelUtilization = nodeInfo.deviceMetrics.channelUtilization
 						telemetry.airUtilTx = nodeInfo.deviceMetrics.airUtilTx
-						newNode.telemetries.append(telemetry)
+						telemetry.nodeTelemetry = newNode
 					}
 					if nodeInfo.lastHeard > 0 {
 						newNode.firstHeard = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.lastHeard)))
@@ -397,7 +416,7 @@ actor MeshPackets {
 						position.speed = Int32(nodeInfo.position.groundSpeed)
 						position.heading = Int32(nodeInfo.position.groundTrack)
 						position.time = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.position.time)))
-						newNode.positions.append(position)
+						position.nodePosition = newNode
 					}
 					
 					// Look for a MyInfo
@@ -490,7 +509,7 @@ actor MeshPackets {
 						newTelemetry.voltage = nodeInfo.deviceMetrics.voltage
 						newTelemetry.channelUtilization = nodeInfo.deviceMetrics.channelUtilization
 						newTelemetry.airUtilTx = nodeInfo.deviceMetrics.airUtilTx
-						fetchedNode[0].telemetries.append(newTelemetry)
+						newTelemetry.nodeTelemetry = fetchedNode[0]
 					}
 					
 					if nodeInfo.hasPosition {
@@ -504,7 +523,7 @@ actor MeshPackets {
 							position.altitude = nodeInfo.position.altitude
 							position.satsInView = Int32(nodeInfo.position.satsInView)
 							position.time = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.position.time)))
-							fetchedNode[0].positions.append(position)
+							position.nodePosition = fetchedNode[0]
 						}
 						
 					}
@@ -795,18 +814,28 @@ actor MeshPackets {
 						telemetry.snr = packet.rxSnr
 						telemetry.rssi = packet.rxRssi
 						telemetry.time = Date(timeIntervalSince1970: TimeInterval(Int64(truncatingIfNeeded: telemetryMessage.time)))
-						fetchedNode[0].telemetries.append(telemetry)
+						// Assign via relationship without loading all telemetries
+						telemetry.nodeTelemetry = fetchedNode[0]
 
-						// Prune old telemetry to prevent unbounded memory growth
+						// Prune old telemetry using a targeted query instead of faulting the full relationship
 						let metricsType = telemetry.metricsType
 						let maxTelemetryPerType = 5000
-						let sameTelemetries = fetchedNode[0].telemetries
-							.filter { $0.metricsType == metricsType }
-							.sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
-						if sameTelemetries.count > maxTelemetryPerType {
-							let excess = sameTelemetries.count - maxTelemetryPerType
-							for i in 0..<excess {
-								modelContext.delete(sameTelemetries[i])
+						let nodeNum = packetFrom
+						var countDescriptor = FetchDescriptor<TelemetryEntity>(
+							predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType }
+						)
+						countDescriptor.fetchLimit = maxTelemetryPerType + 1
+						let currentCount = (try? modelContext.fetchCount(countDescriptor)) ?? 0
+						if currentCount > maxTelemetryPerType {
+							let excess = currentCount - maxTelemetryPerType
+							var pruneDescriptor = FetchDescriptor<TelemetryEntity>(
+								predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType },
+								sortBy: [SortDescriptor(\TelemetryEntity.time, order: .forward)]
+							)
+							pruneDescriptor.fetchLimit = excess
+							let toDelete = (try? modelContext.fetch(pruneDescriptor)) ?? []
+							for old in toDelete {
+								modelContext.delete(old)
 							}
 						}
 

--- a/Meshtastic/Helpers/WatchSessionManager.swift
+++ b/Meshtastic/Helpers/WatchSessionManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import WatchConnectivity
 import SwiftData
+import CoreLocation
 import os
 
 /// Manages the WatchConnectivity session on the iOS side, sending mesh node
@@ -21,6 +22,10 @@ final class WatchSessionManager: NSObject, ObservableObject {
 
 	private let logger = Logger(subsystem: "gvh.MeshtasticClient", category: "⌚ Watch")
 	private var session: WCSession?
+	private var watchUpdateTask: Task<Void, Never>?
+	private var lastWatchSendTime: Date = .distantPast
+	/// Minimum interval between Watch updates (seconds)
+	private static let watchUpdateInterval: TimeInterval = 60
 
 	override init() {
 		super.init()
@@ -64,27 +69,54 @@ final class WatchSessionManager: NSObject, ObservableObject {
 		logger.info("Sent foxhunt target \(nodeNum) to Watch")
 	}
 
-	/// Fetch nodes from SwiftData and push them to the Watch via application context.
+	/// Throttled: schedules a Watch update at most once per 60 seconds.
 	func sendNodesToWatch() {
 		guard let session, session.activationState == .activated, session.isPaired, session.isWatchAppInstalled else {
 			return
 		}
 
-		Task { @MainActor in
-			let nodes = fetchNodesForWatch()
-			guard !nodes.isEmpty else { return }
-
-			do {
-				let data = try JSONEncoder().encode(nodes)
-				try session.updateApplicationContext(["nodes": data])
-				logger.info("Sent \(nodes.count) nodes to Watch via applicationContext")
-			} catch {
-				logger.error("Failed to send nodes to Watch: \(error.localizedDescription, privacy: .public)")
+		// If we sent recently, coalesce into a single deferred send
+		let now = Date()
+		if now.timeIntervalSince(lastWatchSendTime) < Self.watchUpdateInterval {
+			if watchUpdateTask == nil {
+				watchUpdateTask = Task { @MainActor in
+					let delay = Self.watchUpdateInterval - Date().timeIntervalSince(self.lastWatchSendTime)
+					if delay > 0 {
+						try? await Task.sleep(for: .seconds(delay))
+					}
+					guard !Task.isCancelled else { return }
+					self.performSendNodesToWatch()
+					self.watchUpdateTask = nil
+				}
 			}
+			return
+		}
+
+		Task { @MainActor in
+			self.performSendNodesToWatch()
+		}
+	}
+
+	@MainActor
+	private func performSendNodesToWatch() {
+		lastWatchSendTime = Date()
+
+		let nodes = fetchNodesForWatch()
+		guard !nodes.isEmpty else { return }
+
+		do {
+			let data = try JSONEncoder().encode(nodes)
+			try session?.updateApplicationContext(["nodes": data])
+			logger.info("Sent \(nodes.count) nodes to Watch via applicationContext")
+		} catch {
+			logger.error("Failed to send nodes to Watch: \(error.localizedDescription, privacy: .public)")
 		}
 	}
 
 	// MARK: - SwiftData → Watch Node Serialization
+
+	/// Maximum distance in meters to include a node (0.5 miles).
+	private static let maxDistanceMeters: Double = 804.672
 
 	@MainActor
 	private func fetchNodesForWatch() -> [WatchNode] {
@@ -92,6 +124,11 @@ final class WatchSessionManager: NSObject, ObservableObject {
 		let descriptor = FetchDescriptor<NodeInfoEntity>(
 			predicate: #Predicate<NodeInfoEntity> { $0.user != nil }
 		)
+
+		guard let userLocation = LocationsHandler.shared.locationsArray.last else {
+			logger.info("No user location available, skipping Watch update")
+			return []
+		}
 
 		do {
 			let results = try context.fetch(descriptor)
@@ -104,12 +141,19 @@ final class WatchSessionManager: NSObject, ObservableObject {
 				let snr: Float? = nodeInfo.snr != 0 ? nodeInfo.snr : nil
 				let lastHeard = nodeInfo.lastHeard
 
+				// Find the latest position using a targeted fetch instead of faulting the entire relationship
+				let nodeNum = nodeInfo.num
+				var posDescriptor = FetchDescriptor<PositionEntity>(
+					predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == nodeNum && $0.latest == true }
+				)
+				posDescriptor.fetchLimit = 1
+				let latestPosition = try? context.fetch(posDescriptor).first
+
 				var latitude: Double?
 				var longitude: Double?
 				var altitude: Int32?
 				var lastPositionTime: Date?
 
-				let latestPosition = nodeInfo.positions.first(where: { $0.latest }) ?? nodeInfo.positions.last
 				if let pos = latestPosition {
 					let latI = pos.latitudeI
 					let lonI = pos.longitudeI
@@ -120,6 +164,12 @@ final class WatchSessionManager: NSObject, ObservableObject {
 						lastPositionTime = pos.time
 					}
 				}
+
+				// Only include nodes within 0.5 miles
+				guard let lat = latitude, let lon = longitude else { return nil }
+				let nodeLocation = CLLocation(latitude: lat, longitude: lon)
+				let distance = userLocation.distance(from: nodeLocation)
+				guard distance <= Self.maxDistanceMeters else { return nil }
 
 				return WatchNode(
 					num: UInt32(num),

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -11,7 +11,6 @@ import DatadogCrashReporting
 import DatadogRUM
 import DatadogTrace
 import DatadogLogs
-import DatadogSessionReplay
 
 @main
 struct MeshtasticAppleApp: App {
@@ -63,7 +62,7 @@ struct MeshtasticAppleApp: App {
 			Logs.enable()
 			Trace.enable(
 				with: Trace.Configuration(
-					sampleRate: 100, networkInfoEnabled: true // 100% sampling for development/testing, reduce for production
+					sampleRate: 20, networkInfoEnabled: true
 				)
 			)
 
@@ -75,18 +74,7 @@ struct MeshtasticAppleApp: App {
 					trackBackgroundEvents: true
 				)
 			)
-			if Bundle.main.isTestFlight {
-				SessionReplay.enable(
-					with: SessionReplay.Configuration(
-						replaySampleRate: 100,
-						textAndInputPrivacyLevel: .maskSensitiveInputs,
-						imagePrivacyLevel: .maskNone,
-						touchPrivacyLevel: .show,
-						startRecordingImmediately: true,
-						featureFlags: [.swiftui: true]
-					)
-				)
-			}
+
 		}
 
 		accessoryManager = AccessoryManager.shared
@@ -224,9 +212,6 @@ struct MeshtasticAppleApp: App {
 			switch newScenePhase {
 			case .background:
 				Logger.services.info("🎬 [App] Scene is in the background")
-				// Stop Session Replay when app goes to background to prevent crashes
-				// from accessing SwiftUI view hierarchy while backgrounded
-				SessionReplay.stopRecording()
 				accessoryManager.appDidEnterBackground()
 				do {
 					try persistenceController!.container.mainContext.save()
@@ -240,8 +225,6 @@ struct MeshtasticAppleApp: App {
 				Logger.services.info("🎬 [App] Scene is inactive")
 			case .active:
 				Logger.services.info("🎬 [App] Scene is active")
-				// Resume Session Replay when app becomes active
-				SessionReplay.startRecording()
 				accessoryManager.appDidBecomeActive()
 			@unknown default:
 				Logger.services.error("🍎 [App] Apple must have changed something")

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -385,7 +385,7 @@ extension MeshPackets {
 						telemetry.voltage = nodeInfoMessage.deviceMetrics.voltage
 						telemetry.channelUtilization = nodeInfoMessage.deviceMetrics.channelUtilization
 						telemetry.airUtilTx = nodeInfoMessage.deviceMetrics.airUtilTx
-						fetchedNode[0].telemetries.append(telemetry)
+						telemetry.nodeTelemetry = fetchedNode[0]
 					}
 					if nodeInfoMessage.hasUser {
 						fetchedNode[0].user?.userId = nodeInfoMessage.num.toHex()
@@ -490,7 +490,7 @@ extension MeshPackets {
 						
 						// Unset the current latest position for this node
 						let posNum = Int64(packet.from)
-											let fetchCurrentLatestPositionsRequest = FetchDescriptor<PositionEntity>(predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum && $0.latest == true })
+						let fetchCurrentLatestPositionsRequest = FetchDescriptor<PositionEntity>(predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum && $0.latest == true })
 						let fetchedPositions = try modelContext.fetch(fetchCurrentLatestPositionsRequest)
 						if fetchedPositions.count > 0 {
 							for position in fetchedPositions {
@@ -519,34 +519,57 @@ extension MeshPackets {
 						} else {
 							position.time = Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.time)))
 						}
-						var mutablePositions = fetchedNode[0].positions
-						/// Don't save nearly the same position over and over. If the next position is less than 10 meters from the new position, delete the previous position and save the new one.
-						if mutablePositions.count > 0 && (position.precisionBits == 32 || position.precisionBits == 0) {
-							if let mostRecentCoord = mutablePositions.last?.nodeCoordinate,
+
+						// Deduplication: fetch only the most recent position for this node
+						// instead of loading the entire positions array (which could be thousands)
+						var mostRecentDescriptor = FetchDescriptor<PositionEntity>(
+							predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum },
+							sortBy: [SortDescriptor(\PositionEntity.time, order: .reverse)]
+						)
+						mostRecentDescriptor.fetchLimit = 1
+						let mostRecentPositions = try modelContext.fetch(mostRecentDescriptor)
+
+						if position.precisionBits == 32 || position.precisionBits == 0 {
+							// Don't save nearly the same position. If within 9m of most recent, replace it.
+							if let mostRecent = mostRecentPositions.first,
+							   let mostRecentCoord = mostRecent.nodeCoordinate,
 							   let positionCoord = position.nodeCoordinate,
 							   mostRecentCoord.distance(from: positionCoord) < 9.0 {
-								mutablePositions.removeLast()
+								modelContext.delete(mostRecent)
 							}
-						} else if mutablePositions.count > 0 {
-							/// Don't store any history for reduced accuracy positions, we will just show a circle
-							mutablePositions.removeAll()
+						} else {
+							// Don't store any history for reduced accuracy positions — delete all non-latest
+							let deleteDescriptor = FetchDescriptor<PositionEntity>(
+								predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum && $0.latest == false }
+							)
+							let oldPositions = try modelContext.fetch(deleteDescriptor)
+							for old in oldPositions {
+								modelContext.delete(old)
+							}
 						}
-						mutablePositions.append(position)
-						
-						// Prune old positions to prevent unbounded memory growth
-						let maxPositionsPerNode = 5000
-						while mutablePositions.count > maxPositionsPerNode {
-							let oldest = mutablePositions[0]
-							if !oldest.latest {
-								modelContext.delete(oldest)
-								mutablePositions.removeFirst()
-							} else {
-								break
+
+						// Assign position to node via relationship
+						position.nodePosition = fetchedNode[0]
+
+						// Prune: keep at most 5000 positions per node
+						let countDescriptor = FetchDescriptor<PositionEntity>(
+							predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum }
+						)
+						let totalCount = try modelContext.fetchCount(countDescriptor)
+						if totalCount > 5000 {
+							let excess = totalCount - 5000
+							var pruneDescriptor = FetchDescriptor<PositionEntity>(
+								predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum && $0.latest == false },
+								sortBy: [SortDescriptor(\PositionEntity.time, order: .forward)]
+							)
+							pruneDescriptor.fetchLimit = excess
+							let toDelete = try modelContext.fetch(pruneDescriptor)
+							for old in toDelete {
+								modelContext.delete(old)
 							}
 						}
 
 						fetchedNode[0].channel = Int32(packet.channel)
-						fetchedNode[0].positions = mutablePositions
 						
 						scheduleDebouncedSave()
 						Logger.data.info("📍 [Position] buffered for Node: \(fetchedNode[0].num.toHex(), privacy: .public)")

--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,46 +1,7 @@
 {
   "files": {
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
-    },
-    "heltec-v3.svg": {
-      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
-    },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
-    },
-    "heltec-mesh-solar.svg": {
-      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
-    },
-    "crowpanel_7_0.svg": {
-      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
-    },
-    "crowpanel_3_5.svg": {
-      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
-    },
-    "heltec-v3-case.svg": {
-      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
-    },
-    "rak11200.svg": {
-      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
-    },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
-    },
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
-    },
-    "heltec-wsl-v3.svg": {
-      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
-    },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
-    },
-    "rak11310.svg": {
-      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
-    },
-    "crowpanel_2_8.svg": {
-      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
+    "tlora-t3s3-v1.svg": {
+      "etag": "\"bbf44e526676ad298698d1387af57c15\""
     },
     "heltec-vision-master-t190.svg": {
       "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
@@ -48,116 +9,164 @@
     "tbeam-1w.svg": {
       "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
     },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    "heltec_wireless_tracker_v2.svg": {
+      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
     },
-    "rak3401.svg": {
-      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
-    },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
-    },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
-    },
-    "seeed_solar.svg": {
-      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
-    },
-    "tlora-t3s3-v1.svg": {
-      "etag": "\"bbf44e526676ad298698d1387af57c15\""
-    },
-    "tlora-v2-1-1_6.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "rak2560.svg": {
-      "etag": "\"e425adc49058399a2a7f8517093192f0\""
-    },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
-    },
-    "muzi_base.svg": {
-      "etag": "\"be887c289c63af434835279b75f0879e\""
-    },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
-    },
-    "meteor_pro.svg": {
-      "etag": "\"db5044328b825421851b963479fab9ca\""
-    },
-    "rak4631.svg": {
-      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
-    },
-    "seeed_xiao_nrf52_kit.svg": {
-      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
-    },
-    "wio-tracker-wm1110.svg": {
-      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
-    },
-    "techo_lite.svg": {
-      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
-    },
-    "thinknode_m2.svg": {
-      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
-    },
-    "rak_wismesh_tag.svg": {
-      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
-    },
-    "heltec_v4.svg": {
-      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
-    },
-    "t-watch-s3.svg": {
-      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
-    },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
-    },
-    "tbeam.svg": {
-      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
     },
     "station-g2.svg": {
       "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
     },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
-    },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "rak-wismesh-tap-v2.svg": {
-      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
     },
     "thinknode_m4.svg": {
       "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
     },
-    "t-deck.svg": {
-      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
-    },
-    "heltec-wireless-paper.svg": {
-      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
     },
     "promicro.svg": {
       "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
     },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    "t-deck.svg": {
+      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    },
+    "heltec-v3-case.svg": {
+      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
+    },
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    },
+    "muzi_r1_neo.svg": {
+      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
+    },
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    },
+    "meteor_pro.svg": {
+      "etag": "\"db5044328b825421851b963479fab9ca\""
+    },
+    "t-watch-s3.svg": {
+      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
+    },
+    "seeed_xiao_nrf52_kit.svg": {
+      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
+    },
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
+    },
+    "crowpanel_7_0.svg": {
+      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
+    },
+    "rak11200.svg": {
+      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
+    },
+    "seeed_solar.svg": {
+      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    },
+    "m5_c6l.svg": {
+      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
+    },
+    "rak2560.svg": {
+      "etag": "\"e425adc49058399a2a7f8517093192f0\""
+    },
+    "heltec-v3.svg": {
+      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
+    },
+    "rak11310.svg": {
+      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
+    },
+    "t5s3_epaper.svg": {
+      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
     },
     "heltec-ht62-esp32c3-sx1262.svg": {
       "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
     },
-    "t-echo.svg": {
-      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    "crowpanel_5_0.svg": {
+      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "thinknode_m2.svg": {
+      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    },
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    },
+    "tlora-t3s3-epaper.svg": {
+      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    },
+    "heltec-mesh-node-t114-case.svg": {
+      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
+    },
+    "rak-wismeshtap.svg": {
+      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
+    },
+    "heltec-wireless-paper.svg": {
+      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
+    },
+    "rak_wismesh_tag.svg": {
+      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    },
+    "muzi_base.svg": {
+      "etag": "\"be887c289c63af434835279b75f0879e\""
+    },
+    "rak-wismesh-tap-v2.svg": {
+      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    },
+    "heltec_v4.svg": {
+      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
+    },
+    "rak4631.svg": {
+      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    },
+    "tbeam.svg": {
+      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
+    },
+    "heltec-mesh-solar.svg": {
+      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
+    },
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    },
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
+    },
+    "heltec-wsl-v3.svg": {
+      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
+    },
+    "tlora-v2-1-1_6.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "wio-tracker-wm1110.svg": {
+      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    },
+    "rak4631_case.svg": {
+      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
     },
     "thinknode_m3.svg": {
       "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
@@ -165,47 +174,38 @@
     "pico.svg": {
       "etag": "\"25eaff431def69b7bf838a2e312c1032\""
     },
-    "tlora-t3s3-epaper.svg": {
-      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
     },
-    "crowpanel_5_0.svg": {
-      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    "t-echo.svg": {
+      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
     },
-    "m5_c6l.svg": {
-      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
-    },
-    "t5s3_epaper.svg": {
-      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
-    },
-    "rak4631_case.svg": {
-      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
-    },
-    "heltec_wireless_tracker_v2.svg": {
-      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
-    },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
-    "heltec-mesh-node-t114-case.svg": {
-      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
-    },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
-    },
-    "rak-wismeshtap.svg": {
-      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
-    },
-    "crowpanel_2_4.svg": {
-      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
+    "crowpanel_2_8.svg": {
+      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
     },
     "seeed-sensecap-indicator.svg": {
       "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
     },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
+    "crowpanel_3_5.svg": {
+      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
     },
-    "muzi_r1_neo.svg": {
-      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
+    },
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "rak3401.svg": {
+      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
+    },
+    "crowpanel_2_4.svg": {
+      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
+    },
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    },
+    "techo_lite.svg": {
+      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
     }
   },
   "api_hash": "da281fe426e5989c17ce8933916f4c7367f90a5e15a1672f4b0b53f541c016be"

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -50,8 +50,8 @@ struct Connect: View {
 									VStack(alignment: .center) {
 										CircleText(text: node?.user?.shortName?.addingVariationSelectors ?? "?", color: Color(UIColor(hex: UInt32(node?.num ?? 0))), circleSize: 90)
 											.padding(.trailing, 5)
-										if node?.latestDeviceMetrics != nil {
-											BatteryCompact(batteryLevel: node?.latestDeviceMetrics?.batteryLevel ?? 0, font: .caption, iconFont: .callout, color: .accentColor)
+										if let batteryLevel = latestBatteryLevel(for: node) {
+											BatteryCompact(batteryLevel: batteryLevel, font: .caption, iconFont: .callout, color: .accentColor)
 												.padding(.trailing, 5)
 										}
 									}
@@ -425,6 +425,20 @@ struct Connect: View {
 		.onChange(of: accessoryManager.isConnecting) { _, _ in updateNymeaDiscovery() }
 	}
 
+	/// Fetch only the latest device metrics battery level without faulting all telemetries.
+	private func latestBatteryLevel(for node: NodeInfoEntity?) -> Int32? {
+		guard let nodeNum = node?.num else { return nil }
+		let metricsType: Int32 = 0
+		var descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType },
+			sortBy: [SortDescriptor(\TelemetryEntity.time, order: .reverse)]
+		)
+		descriptor.fetchLimit = 1
+		guard let result = try? context.fetch(descriptor).first else { return nil }
+		let level = result.batteryLevel ?? 0
+		return level > 0 ? level : nil
+	}
+
 	/// Starts nymea passive discovery only when the Connect view is foreground-visible
 	/// and the app has no primary transport in flight; otherwise stops it.
 	private func updateNymeaDiscovery() {
@@ -445,8 +459,14 @@ struct Connect: View {
 		liveActivityStarted = true
 		// 15 Minutes Local Stats Interval
 		let timerSeconds = 900
-		let localStats = node?.telemetries.filter { $0.metricsType == 4 }
-		let mostRecent = localStats?.last
+		let nodeNum = node?.num ?? 0
+		let metricsType: Int32 = 4
+		var statsDescriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType },
+			sortBy: [SortDescriptor(\TelemetryEntity.time, order: .reverse)]
+		)
+		statsDescriptor.fetchLimit = 1
+		let mostRecent = try? context.fetch(statsDescriptor).first
 		
 		let activityAttributes = MeshActivityAttributes(nodeNum: Int(node?.num ?? 0), name: node?.user?.longName?.addingVariationSelectors ?? "unknown", shortName: node?.user?.shortName ?? "?")
 		

--- a/Meshtastic/Views/Helpers/RXTXIndicatorView.swift
+++ b/Meshtastic/Views/Helpers/RXTXIndicatorView.swift
@@ -12,6 +12,9 @@ import OSLog
 struct RXTXIndicatorWidget: View {
 	@EnvironmentObject var accessoryManager: AccessoryManager
 	@State private var isPopoverOpen = false
+	@State private var localSent: Int = 0
+	@State private var localReceived: Int = 0
+	private let pollTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
 	let fontSize: CGFloat = 7.0
 	var body: some View {
@@ -42,12 +45,12 @@ struct RXTXIndicatorWidget: View {
 				HStack(spacing: 2.0) {
 					Image(systemName: "arrow.up")
 						.font(.system(size: fontSize))
-					LEDIndicator(flash: $accessoryManager.packetsSent, color: .green)
+					LEDIndicator(flash: $localSent, color: .green)
 				}.frame(maxHeight: fontSize)
 				HStack(spacing: 2.0) {
 					Image(systemName: "arrow.down")
 						.font(.system(size: fontSize))
-					LEDIndicator(flash: $accessoryManager.packetsReceived, color: .red)
+					LEDIndicator(flash: $localReceived, color: .red)
 				}.frame(maxHeight: fontSize)
 			}
 			.contentShape(Rectangle()) // Make sure the whole thing is tappable
@@ -66,23 +69,23 @@ struct RXTXIndicatorWidget: View {
 						VStack(alignment: .leading) {
 							HStack(spacing: 3.0) {
 								HStack(spacing: 2.0) {
-									LEDIndicator(flash: $accessoryManager.packetsSent, color: .green)
+									LEDIndicator(flash: $localSent, color: .green)
 										.frame(maxHeight: fontSize)
 									Image(systemName: "arrow.up")
 										.font(.system(size: fontSize))
 								}
-								Text("To Radio (TX): \(accessoryManager.packetsSent)")
+								Text("To Radio (TX): \(localSent)")
 									.font(.caption2)
 								Spacer()
 							}
 							HStack(spacing: 3.0) {
 								HStack(spacing: 2.0) {
-									LEDIndicator(flash: $accessoryManager.packetsReceived, color: .red)
+									LEDIndicator(flash: $localReceived, color: .red)
 										.frame(maxHeight: fontSize)
 									Image(systemName: "arrow.down")
 										.font(.system(size: fontSize))
 								}
-								Text("From Radio (RX): \(accessoryManager.packetsReceived)")
+								Text("From Radio (RX): \(localReceived)")
 									.font(.caption2)
 								Spacer()
 							}
@@ -93,6 +96,12 @@ struct RXTXIndicatorWidget: View {
 				.presentationCompactAdaptation(.popover)
 			}
 		}.buttonStyle(.borderless)
+		.onReceive(pollTimer) { _ in
+			let sent = accessoryManager.packetsSent
+			let received = accessoryManager.packetsReceived
+			if sent != localSent { localSent = sent }
+			if received != localReceived { localReceived = received }
+		}
 	}
 }
 

--- a/Meshtastic/Views/Messages/MessageText.swift
+++ b/Meshtastic/Views/Messages/MessageText.swift
@@ -1,7 +1,6 @@
 import MeshtasticProtobufs
 import OSLog
 import SwiftUI
-import DatadogSessionReplay
 #if !targetEnvironment(macCatalyst)
 import Translation
 #endif
@@ -21,31 +20,29 @@ struct MessageText: View {
 	@State private var isShowingTranslationPresentation = false
 	
 	var body: some View {
-		SessionReplayPrivacyView(textAndInputPrivacy: .maskAll) {
-			messageContent
-				.environment(\.openURL, OpenURLAction { url in
-					handleURL(url)
-				})
-				.sheet(item: $saveChannelLink) { link in
-					SaveChannelQRCode(
-						channelSetLink: link.data,
-						addChannels: link.add,
-						accessoryManager: accessoryManager
-					)
-					.presentationDetents([.large])
-					.presentationDragIndicator(.visible)
+		messageContent
+			.environment(\.openURL, OpenURLAction { url in
+				handleURL(url)
+			})
+			.sheet(item: $saveChannelLink) { link in
+				SaveChannelQRCode(
+					channelSetLink: link.data,
+					addChannels: link.add,
+					accessoryManager: accessoryManager
+				)
+				.presentationDetents([.large])
+				.presentationDragIndicator(.visible)
+			}
+			.confirmationDialog(
+				"Are you sure you want to delete this message?",
+				isPresented: $isShowingDeleteConfirmation,
+				titleVisibility: .visible
+			) {
+				Button("Delete Message", role: .destructive) {
+					deleteMessage()
 				}
-				.confirmationDialog(
-					"Are you sure you want to delete this message?",
-					isPresented: $isShowingDeleteConfirmation,
-					titleVisibility: .visible
-				) {
-					Button("Delete Message", role: .destructive) {
-						deleteMessage()
-					}
-					Button("Cancel", role: .cancel) {}
-				}
-		}
+				Button("Cancel", role: .cancel) {}
+			}
 	}
 	
 	private var sourceMessageText: String {

--- a/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import OSLog
-import DatadogSessionReplay
 
 struct TextMessageField: View {
 	static let maxbytes = 200
@@ -17,8 +16,7 @@ struct TextMessageField: View {
 	@State private var sendPositionWithMessage = false
 
 	var body: some View {
-		SessionReplayPrivacyView(textAndInputPrivacy: .maskAllInputs) {
-			VStack(spacing: 0) {
+		VStack(spacing: 0) {
 				HStack(alignment: .bottom) {
 					if replyMessageId != 0 || isFocused {
 						Button {
@@ -127,7 +125,6 @@ struct TextMessageField: View {
 						.padding(.vertical, 10)
 						.background(.bar)
 					}
-				}
 			}
 		}
 	}

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -284,23 +284,28 @@ fileprivate extension NodeFilterParameters {
 				let meanLat = poi.latitude * .pi / 180
 				let deltaLat = d / r * 180 / .pi
 				let deltaLon = d / (r * cos(meanLat)) * 180 / .pi
-				let minLat = poi.latitude - deltaLat
-				let maxLat = poi.latitude + deltaLat
-				let minLon = poi.longitude - deltaLon
-				let maxLon = poi.longitude + deltaLon
-				let hasNearbyPosition = (user.userNode?.positions ?? []).contains { pos in
-					guard pos.latest else { return false }
-					let lon = Double(pos.longitudeI) / 1e7
-					let lat = Double(pos.latitudeI) / 1e7
-					return lon >= minLon && lon <= maxLon && lat >= minLat && lat <= maxLat
+				let minLatI = Int32((poi.latitude - deltaLat) * 1e7)
+				let maxLatI = Int32((poi.latitude + deltaLat) * 1e7)
+				let minLonI = Int32((poi.longitude - deltaLon) * 1e7)
+				let maxLonI = Int32((poi.longitude + deltaLon) * 1e7)
+				if let nodeNum = user.userNode?.num, let ctx = user.modelContext {
+					let descriptor = FetchDescriptor<PositionEntity>(
+						predicate: #Predicate<PositionEntity> {
+							$0.nodePosition?.num == nodeNum && $0.latest == true
+							&& $0.latitudeI >= minLatI && $0.latitudeI <= maxLatI
+							&& $0.longitudeI >= minLonI && $0.longitudeI <= maxLonI
+						}
+					)
+					let count = (try? ctx.fetchCount(descriptor)) ?? 0
+					if count == 0 { return false }
+				} else {
+					return false
 				}
-				if !hasNearbyPosition { return false }
 			}
 		}
 		// Unmessagable filter
 		if user.unmessagable {
-			let hasMessages = !(user.receivedMessages ?? []).isEmpty || !(user.sentMessages ?? []).isEmpty
-			if !hasMessages { return false }
+			if user.lastMessage == nil { return false }
 		}
 		// Ignored
 		if user.userNode?.ignored == true { return false }

--- a/Meshtastic/Views/Settings/Discovery/RadarSweepView.swift
+++ b/Meshtastic/Views/Settings/Discovery/RadarSweepView.swift
@@ -24,7 +24,7 @@ struct RadarSweepView: View {
 
 	var body: some View {
 		if isActive {
-			TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { timeline in
+			TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
 				let elapsed = timeline.date.timeIntervalSince(startDate)
 				let rotation = (elapsed / rotationDuration).truncatingRemainder(dividingBy: 1.0) * 360.0
 

--- a/scripts/download_images.py
+++ b/scripts/download_images.py
@@ -174,7 +174,7 @@ def main():
             new_api_hash = hashlib.sha256(api_data_bytes).hexdigest()
             devices = json.loads(api_data_bytes.decode('utf-8'))
     except (urllib.error.URLError, urllib.error.HTTPError, socket.timeout) as e:
-        log_error(f"Could not fetch API data from {API_URL}: {e}")
+        log_warning(f"Could not fetch API data from {API_URL}: {e}. Building with cached images.")
         sys.exit(0) # Fail silently, XCode may be building offline without a network
     except json.JSONDecodeError:
         log_error("Failed to parse JSON from API response. The server may be down or the response is corrupt.")


### PR DESCRIPTION
## What changed

Broad performance pass across SwiftData queries, BLE scanning, location services, Watch sync, and UI rendering. Also removes DatadogSessionReplay which was causing background crashes.

### SwiftData query optimizations

**`UserEntityExtension.swift`** — Same pattern as #1773: replace relationship array traversal with targeted `FetchDescriptor` queries:
- `messageList`: FetchDescriptor with predicate instead of concatenating `sentMessages` + `receivedMessages` and filtering
- `mostRecentMessage`: `fetchLimit = 1` instead of loading all messages and taking `.last`
- `sensorMessageList`: FetchDescriptor instead of faulting `sentMessages` array
- `unreadMessages`: `fetchCount` instead of loading all messages and filtering by `!read`

**`MeshPackets.swift`** — Prevent faulting entire relationship arrays during packet processing:
- Use inverse relationship assignment (`telemetry.nodeTelemetry = node`) instead of `node.telemetries.append(telemetry)` — `.append()` faults the entire relationship array into memory
- Telemetry pruning uses targeted FetchDescriptor with `fetchLimit` instead of loading all telemetries, sorting, and deleting excess
- Added `recreateShared()` to periodically release accumulated `ModelContext` memory by creating a fresh `MeshPackets` actor instance

**`UpdateSwiftData.swift`** — Same inverse relationship pattern for positions:
- Position deduplication fetches only the most recent position via FetchDescriptor instead of loading the full positions array
- Pruning uses `fetchCount` + `fetchLimit` instead of a `while` loop over a mutable array
- Indentation fix for `fetchCurrentLatestPositionsRequest`

**`Connect.swift`** — Use FetchDescriptor for battery level and local stats instead of `node?.latestDeviceMetrics` and `node?.telemetries.filter`

**`UserList.swift`** — POI proximity filter uses `fetchCount` with a coordinate-range predicate instead of loading `user.userNode?.positions` array. Unmessagable filter uses `user.lastMessage` instead of faulting `receivedMessages`/`sentMessages`

**`AccessoryManager+Connect.swift`** — Calls `MeshPackets.recreateShared()` after DB retrieval completes on connection to release accumulated ModelContext memory

### Reduce unnecessary work

**`AccessoryManager.swift` + `RXTXIndicatorView.swift`** — `packetsSent`/`packetsReceived` changed from `@Published` to plain vars. `@Published` on high-frequency counters forced every `@EnvironmentObject` observer to re-render on every packet. `RXTXIndicatorWidget` now polls via a 0.25s timer, isolating re-renders to just the indicator widget.

**`LocationsHandler.swift`** — Default accuracy changed to `kCLLocationAccuracyHundredMeters` with `distanceFilter: 10m` to save battery. Automatically escalates to `kCLLocationAccuracyBest` with no distance filter during route recording via `didSet` on `isRecording`.

**`WatchSessionManager.swift`** — Throttles Watch updates to 60-second minimum interval with coalescing. Filters nodes to within 0.5 miles to reduce payload size. Uses targeted FetchDescriptor for latest position instead of faulting `nodeInfo.positions`.

**`BLETransport.swift`** — `CBCentralManagerScanOptionAllowDuplicatesKey` set to `false` to reduce duplicate BLE discovery callbacks.

**`RadarSweepView.swift`** — Reduce animation from 60fps to 30fps (radar sweep doesn't need 60fps).

### Remove DatadogSessionReplay

- Remove `SessionReplay` from `MeshtasticApp.swift` — was causing crashes when accessing SwiftUI view hierarchy while backgrounded
- Remove `SessionReplayPrivacyView` wrappers from `MessageText.swift` and `TextMessageField.swift`
- Remove `DatadogSessionReplay` import
- Reduce Datadog trace sample rate from 100% to 20%

### Other

- `download_images.py`: Graceful offline handling (`log_warning` instead of `log_error`)
- `image_manifest.json`: Regenerated with new device entries

## Why it changed

Memory profiling during the map tab memory investigation (#1772, #1773) revealed additional sources of unnecessary memory allocation and CPU work across the app. The SessionReplay removal fixes a known crash on backgrounding.

## How it was tested

- Manual testing on device with active mesh
- Verified message lists, battery display, connection flow, Watch sync, BLE scanning all function correctly
- Monitored memory usage across tab switches and extended use
- Verified route recording still uses high-accuracy GPS
- Confirmed no DatadogSessionReplay references remain

## Labels
skip-docs-check
