### PR TITLE
Fix data blending when switching between devices

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -610,7 +610,9 @@ struct ManualConnectionMenu: View {
 						if accessoryManager.allowDisconnect {
 							try await accessoryManager.disconnect()
 						}
+						await MeshPackets.shared.flushDebouncedSaves()
 						await PersistenceController.shared.clearDatabase(includeRoutes: false)
+						MeshPackets.recreateShared()
 						clearNotifications()
 						try await selectedTransport?.transport.manuallyConnect(toDevice: device)
 						
@@ -691,7 +693,12 @@ struct DeviceConnectRow: View {
 						if accessoryManager.allowDisconnect {
 							try await accessoryManager.disconnect()
 						}
+						// Flush any pending saves from the old device before clearing
+						await MeshPackets.shared.flushDebouncedSaves()
 						await PersistenceController.shared.clearDatabase(includeRoutes: false)
+						// Recreate MeshPackets with a fresh ModelContext so the new
+						// connection doesn't see stale cached objects from the old device
+						MeshPackets.recreateShared()
 						clearNotifications()
 						
 						try await accessoryManager.connect(to: device)

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -611,7 +611,7 @@ struct ManualConnectionMenu: View {
 							try await accessoryManager.disconnect()
 						}
 						await MeshPackets.shared.flushDebouncedSaves()
-						await PersistenceController.shared.clearDatabase(includeRoutes: false)
+						await MeshPackets.shared.clearDatabase(includeRoutes: false)
 						MeshPackets.recreateShared()
 						clearNotifications()
 						try await selectedTransport?.transport.manuallyConnect(toDevice: device)
@@ -693,11 +693,11 @@ struct DeviceConnectRow: View {
 						if accessoryManager.allowDisconnect {
 							try await accessoryManager.disconnect()
 						}
-						// Flush any pending saves from the old device before clearing
+						// Flush pending saves, clear database via the MeshPackets actor
+						// (not the main context) to avoid destroying model instances that
+						// views still reference, then recreate with a fresh ModelContext.
 						await MeshPackets.shared.flushDebouncedSaves()
-						await PersistenceController.shared.clearDatabase(includeRoutes: false)
-						// Recreate MeshPackets with a fresh ModelContext so the new
-						// connection doesn't see stale cached objects from the old device
+						await MeshPackets.shared.clearDatabase(includeRoutes: false)
 						MeshPackets.recreateShared()
 						clearNotifications()
 						

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -216,7 +216,9 @@ struct AppSettings: View {
 										Logger.services.error("🗄 Error Deleting Meshtastic.sqlite file \(error, privacy: .public)")
 									}
 								}
+								await MeshPackets.shared.flushDebouncedSaves()
 								await PersistenceController.shared.clearDatabase(includeRoutes: true)
+								MeshPackets.recreateShared()
 								clearNotifications()
 							}
 						}

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -217,7 +217,7 @@ struct AppSettings: View {
 									}
 								}
 								await MeshPackets.shared.flushDebouncedSaves()
-								await PersistenceController.shared.clearDatabase(includeRoutes: true)
+								await MeshPackets.shared.clearDatabase(includeRoutes: true)
 								MeshPackets.recreateShared()
 								clearNotifications()
 							}

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -175,7 +175,9 @@ struct DeviceConfig: View {
 										try await accessoryManager.sendNodeDBReset(fromUser: node!.user!, toUser: node!.user!)
 										try await Task.sleep(for: .seconds(1))
 										try await accessoryManager.disconnect()
+										await MeshPackets.shared.flushDebouncedSaves()
 										await PersistenceController.shared.clearDatabase(includeRoutes: false)
+										MeshPackets.recreateShared()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("NodeDB Reset Failed")
@@ -200,7 +202,9 @@ struct DeviceConfig: View {
 										try await accessoryManager.sendFactoryReset(fromUser: node!.user!, toUser: node!.user!)
 										try await Task.sleep(for: .seconds(1))
 										try await accessoryManager.disconnect()
+										await MeshPackets.shared.flushDebouncedSaves()
 										await PersistenceController.shared.clearDatabase(includeRoutes: false)
+										MeshPackets.recreateShared()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("Factory Reset Failed")
@@ -213,7 +217,9 @@ struct DeviceConfig: View {
 										try await accessoryManager.sendFactoryReset(fromUser: node!.user!, toUser: node!.user!, resetDevice: true)
 										try? await Task.sleep(for: .seconds(1))
 										try await accessoryManager.disconnect()
+										await MeshPackets.shared.flushDebouncedSaves()
 										await PersistenceController.shared.clearDatabase(includeRoutes: false)
+										MeshPackets.recreateShared()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("Factory Reset Failed")

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -176,7 +176,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .seconds(1))
 										try await accessoryManager.disconnect()
 										await MeshPackets.shared.flushDebouncedSaves()
-										await PersistenceController.shared.clearDatabase(includeRoutes: false)
+										await MeshPackets.shared.clearDatabase(includeRoutes: false)
 										MeshPackets.recreateShared()
 										clearNotifications()
 									} catch {
@@ -203,7 +203,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .seconds(1))
 										try await accessoryManager.disconnect()
 										await MeshPackets.shared.flushDebouncedSaves()
-										await PersistenceController.shared.clearDatabase(includeRoutes: false)
+										await MeshPackets.shared.clearDatabase(includeRoutes: false)
 										MeshPackets.recreateShared()
 										clearNotifications()
 									} catch {
@@ -218,7 +218,7 @@ struct DeviceConfig: View {
 										try? await Task.sleep(for: .seconds(1))
 										try await accessoryManager.disconnect()
 										await MeshPackets.shared.flushDebouncedSaves()
-										await PersistenceController.shared.clearDatabase(includeRoutes: false)
+										await MeshPackets.shared.clearDatabase(includeRoutes: false)
 										MeshPackets.recreateShared()
 										clearNotifications()
 									} catch {


### PR DESCRIPTION
## What changed

Added `MeshPackets.shared.flushDebouncedSaves()` + `MeshPackets.recreateShared()` **before** connecting to a new device, immediately after `clearDatabase()`, at all 5 call sites.

### Files changed

- **`Connect.swift`** — BLE device switch + manual connection switch
- **`DeviceConfig.swift`** — NodeDB reset, factory reset, factory reset with BLE bonds
- **`AppSettings.swift`** — full app data clear

## Why it changed

When switching devices, `clearDatabase()` runs on the **main `ModelContext`** (`PersistenceController.shared.context`), but `MeshPackets.shared` has its **own separate `ModelContext`** (created by `@ModelActor`). After clearing the database, the old `MeshPackets` actor still held stale cached objects from Device A in its context.

When Device B's DB retrieval began writing through the same stale `MeshPackets` instance, SwiftData could merge or confuse entities from both devices, blending node data from Device A into Device B's database.

`recreateShared()` was previously only called **after** DB retrieval completed (Step 7 of the connection sequence) — by which point Device B data had already been processed through a context contaminated with Device A's cached state.

### Sequence before fix:
```
1. disconnect()
2. clearDatabase() — deletes on main context
3. connect(to: deviceB) — DB retrieval uses MeshPackets.shared
4. MeshPackets.shared still has old ModelContext with Device A cached objects
5. New Device B data written through stale context → data blended
6. recreateShared() — too late, damage done
```

### Sequence after fix:
```
1. disconnect()
2. flushDebouncedSaves() — save any pending Device A data
3. clearDatabase() — deletes on main context
4. recreateShared() — fresh ModelContext, no stale cache
5. connect(to: deviceB) — DB retrieval uses clean MeshPackets
6. recreateShared() again at Step 7 — releases retrieval memory (existing behavior)
```

## How it was tested

- Connected to Device A, verified node data loaded
- Switched to Device B, verified database was cleanly populated with only Device B data
- No blended/duplicate nodes from Device A

## Labels
skip-docs-check
