### PR TITLE
Navigation performance, query optimizations, and UX improvements

### DIFF
--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -36,13 +36,7 @@ class Router: ObservableObject {
 		set {
 			selectedTab = newValue.selectedTab
 			messagesState = newValue.messages
-			if let num = newValue.nodeListSelectedNodeNum {
-				selectedNodeNum = num
-				lastNodeNum = num
-			} else {
-				selectedNodeNum = nil
-				lastNodeNum = nil
-			}
+			selectedNodeNum = newValue.nodeListSelectedNodeNum
 			mapState = newValue.map
 			if let setting = newValue.settings {
 				settingsPath = [setting]
@@ -51,9 +45,6 @@ class Router: ObservableObject {
 			}
 		}
 	}
-
-	/// Tracks the last node num navigated to for cross-tab deep links.
-	@Published var lastNodeNum: Int64?
 
 	/// The currently selected node in the NavigationSplitView detail pane.
 	@Published var selectedNodeNum: Int64?
@@ -174,10 +165,8 @@ class Router: ObservableObject {
 		selectedTab = .nodes
 		if let nodeId {
 			selectedNodeNum = nodeId
-			lastNodeNum = nodeId
 		} else {
 			selectedNodeNum = nil
-			lastNodeNum = nil
 		}
 	}
 
@@ -185,14 +174,12 @@ class Router: ObservableObject {
 		Logger.services.info("🛣 [App] Direct route to node detail \(nodeNum, privacy: .public)")
 		selectedTab = .nodes
 		selectedNodeNum = nodeNum
-		lastNodeNum = nodeNum
 	}
 
 	func popToRoot(tab: NavigationState.Tab) {
 		switch tab {
 		case .nodes:
 			selectedNodeNum = nil
-			lastNodeNum = nil
 		case .settings:
 			settingsPath = []
 		default:

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -13,13 +13,10 @@ class Router: ObservableObject {
 	var messagesState: MessagesNavigationState?
 
 	@Published
-	var nodeListSelectedNodeNum: Int64?
-
-	@Published
 	var mapState: MapNavigationState?
 
 	@Published
-	var settingsState: SettingsNavigationState?
+	var settingsPath: [SettingsNavigationState] = []
 
 	@Published
 	var discoveryShowHistory: Bool = false
@@ -28,22 +25,38 @@ class Router: ObservableObject {
 	/// Provided for backward compatibility (e.g. tests) and convenience.
 	var navigationState: NavigationState {
 		get {
-			NavigationState(
+			return NavigationState(
 				selectedTab: selectedTab,
 				messages: messagesState,
-				nodeListSelectedNodeNum: nodeListSelectedNodeNum,
+				nodeListSelectedNodeNum: selectedNodeNum,
 				map: mapState,
-				settings: settingsState
+				settings: settingsPath.last
 			)
 		}
 		set {
 			selectedTab = newValue.selectedTab
 			messagesState = newValue.messages
-			nodeListSelectedNodeNum = newValue.nodeListSelectedNodeNum
+			if let num = newValue.nodeListSelectedNodeNum {
+				selectedNodeNum = num
+				lastNodeNum = num
+			} else {
+				selectedNodeNum = nil
+				lastNodeNum = nil
+			}
 			mapState = newValue.map
-			settingsState = newValue.settings
+			if let setting = newValue.settings {
+				settingsPath = [setting]
+			} else {
+				settingsPath = []
+			}
 		}
 	}
+
+	/// Tracks the last node num navigated to for cross-tab deep links.
+	@Published var lastNodeNum: Int64?
+
+	/// The currently selected node in the NavigationSplitView detail pane.
+	@Published var selectedNodeNum: Int64?
 
 	// MARK: Node Object ID Cache
 
@@ -85,9 +98,13 @@ class Router: ObservableObject {
 	) {
 		self.selectedTab = navigationState.selectedTab
 		self.messagesState = navigationState.messages
-		self.nodeListSelectedNodeNum = navigationState.nodeListSelectedNodeNum
+		if let num = navigationState.nodeListSelectedNodeNum {
+			self.selectedNodeNum = num
+		}
 		self.mapState = navigationState.map
-		self.settingsState = navigationState.settings
+		if let setting = navigationState.settings {
+			self.settingsPath = [setting]
+		}
 
 		$selectedTab.sink { tab in
 			Logger.services.info("🛣 [App] Routed to \(tab.rawValue, privacy: .public)")
@@ -155,12 +172,32 @@ class Router: ObservableObject {
 			.flatMap(Int64.init)
 
 		selectedTab = .nodes
-		nodeListSelectedNodeNum = nodeId
+		if let nodeId {
+			selectedNodeNum = nodeId
+			lastNodeNum = nodeId
+		} else {
+			selectedNodeNum = nil
+			lastNodeNum = nil
+		}
 	}
+
 	func navigateToNodeDetail(nodeNum: Int64) {
 		Logger.services.info("🛣 [App] Direct route to node detail \(nodeNum, privacy: .public)")
 		selectedTab = .nodes
-		nodeListSelectedNodeNum = nodeNum
+		selectedNodeNum = nodeNum
+		lastNodeNum = nodeNum
+	}
+
+	func popToRoot(tab: NavigationState.Tab) {
+		switch tab {
+		case .nodes:
+			selectedNodeNum = nil
+			lastNodeNum = nil
+		case .settings:
+			settingsPath = []
+		default:
+			break
+		}
 	}
 
 	private func routeMap(_ components: URLComponents) {
@@ -193,7 +230,11 @@ class Router: ObservableObject {
 			.flatMap(SettingsNavigationState.init(rawValue:))
 
 		selectedTab = .settings
-		settingsState = settingFromPath
+		if let settingFromPath {
+			settingsPath = [settingFromPath]
+		} else {
+			settingsPath = []
+		}
 
 		if settingFromPath == .localMeshDiscovery && segments.count > 1 && segments[1] == "history" {
 			discoveryShowHistory = true

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -58,9 +58,7 @@ struct ContentView: View {
 				}
 
 				Tab("Nodes", systemImage: "flipphone", value: NavigationState.Tab.nodes) {
-					NodeList(
-						router: appState.router
-					)
+					NodeList()
 				}
 
 				Tab("Mesh Map", systemImage: "map", value: NavigationState.Tab.map) {
@@ -68,9 +66,7 @@ struct ContentView: View {
 				}
 
 				Tab("Settings", systemImage: "gear", value: NavigationState.Tab.settings) {
-					Settings(
-						router: appState.router
-					)
+					Settings()
 				}
 			}
 		} else {
@@ -94,10 +90,8 @@ struct ContentView: View {
 				}
 				.tag(NavigationState.Tab.connect)
 
-				NodeList(
-					router: appState.router
-				)
-				.tabItem {
+				NodeList()
+			.tabItem {
 					Label("Nodes", systemImage: "flipphone")
 				}
 				.tag(NavigationState.Tab.nodes)
@@ -108,12 +102,10 @@ struct ContentView: View {
 				}
 				.tag(NavigationState.Tab.map)
 
-				Settings(
-					router: appState.router
-				)
-				.tabItem {
-					Label("Settings", systemImage: "gear")
-				}
+				Settings()
+			.tabItem {
+				Label("Settings", systemImage: "gear")
+			}
 				.tag(NavigationState.Tab.settings)
 			}
 		}

--- a/Meshtastic/Views/Messages/ChannelMessageRow.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageRow.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct ChannelMessageRow: View {
 	@EnvironmentObject var appState: AppState
+	@Environment(\.modelContext) private var context
 	
 	// Core Data object observed for changes (like Tapbacks being received)
 	@Bindable var message: MessageEntity
@@ -25,16 +26,16 @@ struct ChannelMessageRow: View {
 	}
 	
 	init(message: MessageEntity,
-	     allMessages: [MessageEntity],
-	     previousMessage: MessageEntity?,
-	     preferredPeripheralNum: Int,
-	     channel: ChannelEntity,
-	     replyMessageId: Binding<Int64>,
-	     messageFieldFocused: FocusState<Bool>.Binding,
-	     messageToHighlight: Binding<Int64>,
-	     scrollView: ScrollViewProxy,
-	     onInteractionComplete: @escaping () -> Void,
-	     onTapback: @escaping (MessageEntity) -> Void) {
+		 allMessages: [MessageEntity],
+		 previousMessage: MessageEntity?,
+		 preferredPeripheralNum: Int,
+		 channel: ChannelEntity,
+		 replyMessageId: Binding<Int64>,
+		 messageFieldFocused: FocusState<Bool>.Binding,
+		 messageToHighlight: Binding<Int64>,
+		 scrollView: ScrollViewProxy,
+		 onInteractionComplete: @escaping () -> Void,
+		 onTapback: @escaping (MessageEntity) -> Void) {
 		// Initialize ObservedObject with the concrete instance
 		self.message = message
 		self.allMessages = allMessages
@@ -98,13 +99,11 @@ struct ChannelMessageRow: View {
 				if isCurrentUser { Spacer(minLength: 50) }
 				// Node Detail Tap
 				if !isCurrentUser {
-					CircleText(text: message.fromUser?.shortName ?? "?", color: Color(UIColor(hex: UInt32(message.fromUser?.num ?? 0))), circleSize: 50)
-						.onTapGesture(count: 2) {
-							if let nodeNum = message.fromUser?.num {
-								appState.router.navigateToNodeDetail(nodeNum: Int64(nodeNum))
-							}
-						}
-						.padding(.all, 5).offset(y: -7)
+					NavigationLink(value: Int64(message.fromUser?.num ?? 0)) {
+						CircleText(text: message.fromUser?.shortName ?? "?", color: Color(UIColor(hex: UInt32(message.fromUser?.num ?? 0))), circleSize: 50)
+					}
+					.buttonStyle(.plain)
+					.padding(.all, 5).offset(y: -7)
 				}
 				
 				VStack(alignment: isCurrentUser ? .trailing : .leading) {

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -86,16 +86,26 @@ struct Messages: View {
 				Text("Select a conversation type")
 			}
 		} detail: {
-			if let myInfo = node?.myInfo, let channelSelection {
-				ChannelMessageList(myInfo: myInfo, channel: channelSelection)
-					// The toolbar is now defined inside ChannelMessageList.swift
-			} else if let userSelection {
-				UserMessageList(user: userSelection)
-			} else if case .channels = router.messagesState {
-				Text("Select a channel")
-			} else if case .directMessages = router.messagesState {
-				Text("Select a conversation")
+			NavigationStack {
+				Group {
+					if let myInfo = node?.myInfo, let channelSelection {
+						ChannelMessageList(myInfo: myInfo, channel: channelSelection)
+					} else if let userSelection {
+						UserMessageList(user: userSelection)
+					} else if case .channels = router.messagesState {
+						Text("Select a channel")
+					} else if case .directMessages = router.messagesState {
+						Text("Select a conversation")
+					}
+				}
+				.navigationDestination(for: Int64.self) { nodeNum in
+					if let node = getNodeInfo(id: nodeNum, context: context) {
+						NodeDetail(node: node)
+					}
+				}
 			}
+		}.onAppear {
+			setupNavigationState()
 		}.onChange(of: router.messagesState) {
 			setupNavigationState()
 		}
@@ -103,7 +113,7 @@ struct Messages: View {
 
 	private func setupNavigationState() {
 		let nodeId = Int64(UserDefaults.preferredPeripheralNum)
-		if nodeId > 0 {
+		if nodeId > 0 && node == nil {
 			node = getNodeInfo(id: nodeId, context: context)
 		}
 

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -91,14 +91,56 @@ private struct FilteredUserList: View {
 		allUsers.filter { filters.matches(user: $0) }
 	}
 
+	// MARK: - Precomputed message info cache
+
+	/// Batch-fetch most recent messages and unread counts for all visible users in two queries
+	/// instead of 2N individual queries (one per row).
+	private var messageInfo: [Int64: (mostRecent: MessageEntity?, unreadCount: Int)] {
+		let userNums = Set(users.map(\.num))
+		guard !userNums.isEmpty else { return [:] }
+
+		// Fetch all non-emoji, non-admin messages for visible users in one query
+		let detectionSensorPortNum: Int32 = 10
+		var descriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.isEmoji == false && $0.admin == false && $0.portNum != detectionSensorPortNum
+			},
+			sortBy: [SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse)]
+		)
+		let allMessages = (try? context.fetch(descriptor)) ?? []
+
+		var result: [Int64: (mostRecent: MessageEntity?, unreadCount: Int)] = [:]
+		for num in userNums {
+			result[num] = (mostRecent: nil, unreadCount: 0)
+		}
+		for message in allMessages {
+			let fromNum = message.fromUser?.num
+			let toNum = message.toUser?.num
+			// Check if this message belongs to any of the visible users
+			for num in [fromNum, toNum].compactMap({ $0 }) where userNums.contains(num) {
+				var entry = result[num]!
+				if entry.mostRecent == nil {
+					entry.mostRecent = message
+				}
+				if !message.read {
+					entry.unreadCount += 1
+				}
+				result[num] = entry
+			}
+		}
+		return result
+	}
+
 	var body: some View {
 		let localeDateFormat = DateFormatter.dateFormat(fromTemplate: "yyMMdd", options: 0, locale: Locale.current)
 		let dateFormatString = (localeDateFormat ?? "MM/dd/YY")
+		let cachedInfo = messageInfo
 
 		List(users, selection: $userSelection) { user in
-			let mostRecent = user.mostRecentMessage
+			let info = cachedInfo[user.num]
+			let mostRecent = info?.mostRecent
 			let hasMessages = mostRecent != nil
-			let hasUnreadMessages = user.unreadMessages > 0
+			let hasUnreadMessages = (info?.unreadCount ?? 0) > 0
 			let lastMessageTime = Date(timeIntervalSince1970: TimeInterval(Int64((mostRecent?.messageTimestamp ?? 0 ))))
 			let lastMessageDay = Calendar.current.dateComponents([.day], from: lastMessageTime).day ?? 0
 			let currentDay = Calendar.current.dateComponents([.day], from: Date()).day ?? 0

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -24,12 +24,19 @@ struct UserMessageList: View {
 	@State private var tapbackTargetMessage: MessageEntity?
 	@State private var tapbackText = ""
 	@FocusState var tapbackFocused: Bool
-	private var allPrivateMessages: [MessageEntity] {
-		let sent = user.sentMessages ?? []
-		let received = user.receivedMessages ?? []
-		return (sent + received)
-			.filter { !$0.isEmoji }
-			.sorted { $0.messageTimestamp < $1.messageTimestamp }
+	@Query private var allPrivateMessages: [MessageEntity]
+
+	init(user: UserEntity) {
+		self.user = user
+		let userNum = user.num
+		let detectionSensorPortNum: Int32 = 10
+		_allPrivateMessages = Query(
+			filter: #Predicate<MessageEntity> {
+				($0.fromUser?.num == userNum || $0.toUser?.num == userNum)
+				&& $0.isEmoji == false && $0.admin == false && $0.portNum != detectionSensorPortNum
+			},
+			sort: \MessageEntity.messageTimestamp
+		)
 	}
 
 	func handleInteractionComplete() {

--- a/Meshtastic/Views/Messages/UserMessageRow.swift
+++ b/Meshtastic/Views/Messages/UserMessageRow.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct UserMessageRow: View {
 	
 	@EnvironmentObject var appState: AppState
+	@Environment(\.modelContext) private var context
 	@Bindable var message: MessageEntity
 	let allMessages: [MessageEntity]
 	let previousMessage: MessageEntity?
@@ -29,16 +30,16 @@ struct UserMessageRow: View {
 	}
 	
 	init(message: MessageEntity,
-	     allMessages: [MessageEntity],
-	     previousMessage: MessageEntity?,
-	     preferredPeripheralNum: Int,
-	     user: UserEntity,
-	     replyMessageId: Binding<Int64>,
-	     messageFieldFocused: FocusState<Bool>.Binding,
-	     messageToHighlight: Binding<Int64>,
-	     scrollView: ScrollViewProxy,
-	     onInteractionComplete: @escaping () -> Void,
-	     onTapback: @escaping (MessageEntity) -> Void) {
+		 allMessages: [MessageEntity],
+		 previousMessage: MessageEntity?,
+		 preferredPeripheralNum: Int,
+		 user: UserEntity,
+		 replyMessageId: Binding<Int64>,
+		 messageFieldFocused: FocusState<Bool>.Binding,
+		 messageToHighlight: Binding<Int64>,
+		 scrollView: ScrollViewProxy,
+		 onInteractionComplete: @escaping () -> Void,
+		 onTapback: @escaping (MessageEntity) -> Void) {
 		// Initialize ObservedObject with the concrete instance
 		self.message = message
 		self.allMessages = allMessages
@@ -105,13 +106,11 @@ struct UserMessageRow: View {
 				
 				// Node Detail Tap
 				if !isCurrentUser {
-					CircleText(text: message.fromUser?.shortName ?? "?", color: Color(UIColor(hex: UInt32(message.fromUser?.num ?? 0))), circleSize: 50)
-						.onTapGesture(count: 2) {
-							if let nodeNum = message.fromUser?.num {
-								appState.router.navigateToNodeDetail(nodeNum: Int64(nodeNum))
-							}
-						}
-						.padding(.all, 5).offset(y: -7)
+					NavigationLink(value: Int64(message.fromUser?.num ?? 0)) {
+						CircleText(text: message.fromUser?.shortName ?? "?", color: Color(UIColor(hex: UInt32(message.fromUser?.num ?? 0))), circleSize: 50)
+					}
+					.buttonStyle(.plain)
+					.padding(.all, 5).offset(y: -7)
 				}
 				
 				VStack(alignment: isCurrentUser ? .trailing : .leading) {

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/AnimatedNodePin.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/AnimatedNodePin.swift
@@ -66,15 +66,18 @@ struct PulsingCircle: View {
 
 	var body: some View {
 		Circle()
-			.fill(Color(nodeColor.lighter()).opacity(0.4))
-			.frame(width: 55, height: 55)
-			.scaleEffect(isPulsing ? 1.2 : 0.8)
+			.fill(Color(nodeColor.lighter()).opacity(0.3))
+			.frame(width: 50, height: 50)
+			.scaleEffect(isPulsing ? 1.1 : 0.9)
 			.animation(
-				.easeInOut(duration: 0.8).repeatForever(autoreverses: true).delay(calculatedDelay),
+				.easeInOut(duration: 1.2).repeatForever(autoreverses: true).delay(calculatedDelay),
 				value: isPulsing
 			)
 			.onAppear {
 				isPulsing = true
+			}
+			.onDisappear {
+				isPulsing = false
 			}
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -23,7 +23,47 @@ struct ReducedPrecisionMapCircleKey: Hashable {
 }
 
 struct MeshMapContent: MapContent {
-	
+
+	/// Lightweight snapshot of a position's node data, extracted once to avoid
+	/// repeated SwiftData relationship faults inside the MapContent builder.
+	struct PositionSnapshot: Identifiable {
+		let id: PersistentIdentifier
+		let coordinate: CLLocationCoordinate2D
+		let precisionBits: Int32
+		let nodeNum: Int64
+		let longName: String
+		let shortName: String?
+		let isOnline: Bool
+		let viaMqtt: Bool
+		let calculatedDelay: Double
+	}
+
+	/// Pre-extract all position data into value-type snapshots so the map builder
+	/// never faults SwiftData relationships during layout.
+	private var positionSnapshots: [PositionSnapshot] {
+		filteredPositions.compactMap { (position) -> PositionSnapshot? in
+			let coord: CLLocationCoordinate2D = if position.isPreciseLocation {
+				position.nodeCoordinate ?? LocationsHandler.DefaultLocation
+			} else {
+				position.fuzzedNodeCoordinate ?? LocationsHandler.DefaultLocation
+			}
+			let bits = position.precisionBits
+			guard 12...15 ~= bits || bits == 32 else { return nil }
+			let node = position.nodePosition
+			return PositionSnapshot(
+				id: position.persistentModelID,
+				coordinate: coord,
+				precisionBits: bits,
+				nodeNum: node?.num ?? 0,
+				longName: node?.user?.longName ?? "?",
+				shortName: node?.user?.shortName,
+				isOnline: node?.isOnline ?? false,
+				viaMqtt: node?.viaMqtt ?? true,
+				calculatedDelay: Double(abs(position.persistentModelID.hashValue) % 100) / 100.0 * 0.5
+			)
+		}
+	}
+
 	/// Parameters
 	@Binding var showUserLocation: Bool
 	@AppStorage("meshMapShowNodeHistory") private var showNodeHistory = false
@@ -53,34 +93,23 @@ struct MeshMapContent: MapContent {
 
 	@MapContentBuilder
 	var positionAnnotations: some MapContent {
-		ForEach(filteredPositions, id: \.id) { position in
-			let coordinateForNodePin: CLLocationCoordinate2D = if position.isPreciseLocation {
-				position.nodeCoordinate ?? LocationsHandler.DefaultLocation
-			} else {
-				position.fuzzedNodeCoordinate ?? LocationsHandler.DefaultLocation
-			}
-			if 12...15 ~= position.precisionBits || position.precisionBits == 32 {
-
-				let nodeColor = UIColor(hex: UInt32(position.nodePosition?.num ?? 0))
-				let positionName = position.nodePosition?.user?.longName ?? "?"
-
-				// Use a hash of the position ID to stagger animation delays for each node, preventing synchronized animations and improving visual distinction.
-				let calculatedDelay = Double(position.id.hashValue % 100) / 100.0 * 0.5
-
-				Annotation(positionName, coordinate: coordinateForNodePin) {
-					LazyVStack {
-						AnimatedNodePin(
-							nodeColor: nodeColor,
-							shortName: position.nodePosition?.user?.shortName,
-							hasDetectionSensorMetrics: false,
-							isOnline: position.nodePosition?.isOnline ?? false,
-							calculatedDelay: calculatedDelay
-						)
-					}
-					.highPriorityGesture(TapGesture().onEnded { _ in
-						selectedPosition = (selectedPosition == position ? nil : position)
-					})
+		let snapshots = positionSnapshots
+		ForEach(snapshots) { snap in
+			Annotation(snap.longName, coordinate: snap.coordinate) {
+				LazyVStack {
+					AnimatedNodePin(
+						nodeColor: UIColor(hex: UInt32(snap.nodeNum)),
+						shortName: snap.shortName,
+						hasDetectionSensorMetrics: false,
+						isOnline: snap.isOnline,
+						calculatedDelay: snap.calculatedDelay
+					)
 				}
+				.highPriorityGesture(TapGesture().onEnded { _ in
+					if let pos = filteredPositions.first(where: { $0.persistentModelID == snap.id }) {
+						selectedPosition = (selectedPosition == pos ? nil : pos)
+					}
+				})
 			}
 		}
 	}
@@ -177,11 +206,12 @@ struct MeshMapContent: MapContent {
 		// When filteredPositions is empty (tab off-screen), skip all expensive content
 		// to reduce memory from MapKit annotation/overlay view trees.
 		if !filteredPositions.isEmpty {
+			let snapshots = positionSnapshots
 			// Only compute LoRa node coordinates when the convex hull is actually displayed.
 			let loraCoords: [CLLocationCoordinate2D] = showConvexHull
-				? filteredPositions
-					.filter { !($0.nodePosition?.viaMqtt ?? true) }
-					.compactMap { $0.nodeCoordinate ?? LocationsHandler.DefaultLocation }
+				? snapshots
+					.filter { !$0.viaMqtt }
+					.map(\.coordinate)
 				: []
 			/// Convex Hull
 			if showConvexHull {

--- a/Meshtastic/Views/Nodes/Helpers/Map/PositionPopover.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/PositionPopover.swift
@@ -14,13 +14,10 @@ struct PositionPopover: View {
 	@Environment(\.modelContext) private var context
 	@EnvironmentObject var appState: AppState
 	private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
-	@Environment(\.dismiss) private var dismiss
 	@Environment(\.openURL) var openURL
 	var position: PositionEntity
-	var popover: Bool = true
 	let distanceFormatter = MKDistanceFormatter()
 	
-	@State private var detentSelection: PresentationDetent = .fraction(0.65)
 	@State private var navigateToCompass = false
 
 	var body: some View {
@@ -29,18 +26,7 @@ struct PositionPopover: View {
 		NavigationStack {
 			VStack {
 				HStack {
-					ZStack {
-					Button {
-						if let nodeNum = position.nodePosition?.num {
-							dismiss()
-							DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-								appState.router.navigateToNodeDetail(nodeNum: Int64(nodeNum))
-							}
-						}
-						} label: {
-							CircleText(text: position.nodePosition?.user?.shortName ?? "?", color: Color(nodeColor), circleSize: 65)
-						}
-				}
+					CircleText(text: position.nodePosition?.user?.shortName ?? "?", color: Color(nodeColor), circleSize: 65)
 					Text(position.nodePosition?.user?.longName ?? "Unknown")
 						.font(.largeTitle)
 				}
@@ -49,10 +35,7 @@ struct PositionPopover: View {
 					VStack(alignment: .leading) {
 						if position.isPreciseLocation {
 							Button {
-								detentSelection = .large
-								DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-									navigateToCompass = true
-								}
+								navigateToCompass = true
 							} label: {
 								Label {
 									Text("Open Compass")
@@ -245,25 +228,9 @@ struct PositionPopover: View {
 					}
 				}
 				.padding(.top)
-				if !popover {
-#if targetEnvironment(macCatalyst)
-					Spacer()
-					Button {
-						dismiss()
-					} label: {
-						Label("Close", systemImage: "xmark")
-					}
-					.buttonStyle(.bordered)
-					.buttonBorderShape(.capsule)
-					.controlSize(.large)
-					.padding(.bottom)
-#endif
-				}
 			}
-			.presentationDetents([.fraction(0.65), .large], selection: $detentSelection)
-			.presentationContentInteraction(.scrolls)
-			.presentationDragIndicator(.visible)
-			.presentationBackgroundInteraction(.enabled(upThrough: .large))
+			.frame(idealWidth: 350, maxHeight: .infinity)
+			.fixedSize(horizontal: false, vertical: true)
 			.navigationDestination(isPresented: $navigateToCompass) {
 				CompassView(
 					waypointLocation: position.nodeCoordinate ?? LocationsHandler.DefaultLocation,

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -25,6 +25,7 @@ struct NodeDetail: View {
 	@State private var showingRebootConfirm: Bool = false
 	@State private var dateFormatRelative: Bool = true
 	@Bindable	var node: NodeInfoEntity
+	var showMapLink: Bool = true
 	@State private var environmentSectionHeight: CGFloat = 0
 
 	/// The currently BLE-connected (or remotely administered) node, derived reactively
@@ -43,31 +44,35 @@ struct NodeDetail: View {
 	@State var showingCompassSheet = false
 	
 	var body: some View {
-		NavigationStack {
-			ScrollViewReader { scrollView in
-				Color.clear
-					.frame(height: 0) // Ensure it has no height
-					.id("topOfList")
-				List {
-					NodeInfoItem(node: node)
-					nodeSection
-					environmentSection
-					powerSection
-					logsSection
-					actionsSection
-					administrationSection
-				}
-				.sheet(isPresented: $showingCompassSheet) {
-					CompassView(waypointLocation: node.latestPosition?.nodeCoordinate ?? nil, waypointLongName: node.user?.longName ?? nil, waypointShortName: node.user?.shortName ?? nil, color: Color(UIColor(hex: UInt32(node.num))))
-						}
-				.onAppear {
-					scrollView.scrollTo("topOfList", anchor: .top)
-				}
-				.listStyle(.insetGrouped)
-				.navigationTitle(String(node.user?.longName?.addingVariationSelectors ?? "Unknown".localized))
-				.navigationBarTitleDisplayMode(.inline)
+		ScrollViewReader { scrollView in
+			Color.clear
+				.frame(height: 0) // Ensure it has no height
+				.id("topOfList")
+			nodeDetailList
+			.sheet(isPresented: $showingCompassSheet) {
+				CompassView(waypointLocation: node.latestPosition?.nodeCoordinate ?? nil, waypointLongName: node.user?.longName ?? nil, waypointShortName: node.user?.shortName ?? nil, color: Color(UIColor(hex: UInt32(node.num))))
+					}
+			.onAppear {
+				scrollView.scrollTo("topOfList", anchor: .top)
 			}
+			.contentMargins(.top, 0, for: .scrollContent)
+			.navigationTitle(String(node.user?.longName?.addingVariationSelectors ?? "Unknown".localized))
+			.navigationBarTitleDisplayMode(.inline)
 		}
+	}
+
+	@ViewBuilder
+	private var nodeDetailList: some View {
+		List {
+			NodeInfoItem(node: node)
+			nodeSection
+			environmentSection
+			powerSection
+			logsSection
+			actionsSection
+			administrationSection
+		}
+		.listStyle(.insetGrouped)
 	}
 
 	// MARK: - Node Section
@@ -409,17 +414,19 @@ struct NodeDetail: View {
 				}
 			}
 			.disabled(!node.hasDeviceMetrics)
-			NavigationLink {
-				NodeMapSwiftUI(node: node, showUserLocation: connectedNode?.num ?? 0 == node.num)
-			} label: {
-				Label {
-					Text("Node Map")
-				} icon: {
-					Image(systemName: "map")
-						.symbolRenderingMode(.multicolor)
+			if showMapLink {
+				NavigationLink {
+					NodeMapSwiftUI(node: node, showUserLocation: connectedNode?.num ?? 0 == node.num)
+				} label: {
+					Label {
+						Text("Node Map")
+					} icon: {
+						Image(systemName: "map")
+							.symbolRenderingMode(.multicolor)
+					}
 				}
+				.disabled(!node.hasPositions)
 			}
-			.disabled(!node.hasPositions)
 			NavigationLink {
 				PositionLog(node: node)
 			} label: {

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -151,8 +151,14 @@ struct MeshMap: View {
 					.ignoresSafeArea()
 				}
 				.sheet(item: $selectedPosition) { selection in
-					PositionPopover(position: selection, popover: false)
-						.padding()
+					if let nodeNum = selection.nodePosition?.num,
+					   let node = getNodeInfo(id: Int64(nodeNum), context: context) {
+						NavigationStack {
+							NodeDetail(node: node, showMapLink: false)
+						}
+						.presentationDetents([.large])
+						.presentationDragIndicator(.visible)
+					}
 				}
 				.sheet(item: $selectedWaypoint) { selection in
 					WaypointForm(waypoint: selection)
@@ -196,7 +202,7 @@ struct MeshMap: View {
 				}
 				.sheet(isPresented: $showLegend) {
 					MapLegend(isMeshMap: true)
-						.presentationDetents([.medium, .large])
+						.presentationDetents([.large])
 						.presentationContentInteraction(.scrolls)
 						.presentationDragIndicator(.visible)
 						.presentationBackgroundInteraction(.enabled(upThrough: .medium))

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -156,6 +156,28 @@ struct MeshMap: View {
 						NavigationStack {
 							NodeDetail(node: node, showMapLink: false)
 						}
+						#if targetEnvironment(macCatalyst)
+						.overlay(alignment: .topTrailing) {
+							Button {
+								selectedPosition = nil
+							} label: {
+								ZStack {
+									Circle()
+										.fill(Color(white: 0.19))
+									Image(systemName: "xmark")
+										.resizable()
+										.scaledToFit()
+										.font(.body.weight(.bold))
+										.scaleEffect(0.416)
+										.foregroundColor(Color(white: 0.62))
+								}
+								.frame(width: 36, height: 36)
+							}
+							.buttonStyle(.plain)
+							.padding(.top, 14)
+							.padding(.trailing, 14)
+						}
+						#endif
 						.presentationDetents([.large])
 						.presentationDragIndicator(.visible)
 					}

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -13,9 +13,8 @@ import Foundation
 struct NodeList: View {
 	@Environment(\.modelContext) private var context
 	@EnvironmentObject var accessoryManager: AccessoryManager
-	@StateObject var router: Router
+	@EnvironmentObject var router: Router
 	@AppStorage("nodeListDensity") private var nodeListDensity: NodeListDensity = .standard
-	@State private var selectedNode: NodeInfoEntity?
 	@State private var isPresentingTraceRouteSentAlert = false
 	@State private var isPresentingPositionSentAlert = false
 	@State private var isPresentingPositionFailedAlert = false
@@ -27,6 +26,8 @@ struct NodeList: View {
 	@State private var showingHelp = false
 	@SceneStorage("selectedDetailView") var selectedDetailView: String?
 
+	@State private var selectedNode: NodeInfoEntity?
+
 	var connectedNode: NodeInfoEntity? {
 		if let num = accessoryManager.activeDeviceNum {
 			return getNodeInfo(id: num, context: context)
@@ -34,24 +35,25 @@ struct NodeList: View {
 		return nil
 	}
 
+	@State private var columnVisibility: NavigationSplitViewVisibility = .all
+
 	var body: some View {
-		NavigationSplitView {
+		NavigationSplitView(columnVisibility: $columnVisibility) {
 			sidebarContent
 		} detail: {
-			detailContent
-		}
-		.onChange(of: router.navigationState.nodeListSelectedNodeNum) { _, newNum in
-			if let num = newNum {
-				self.selectedNode = getNodeInfo(id: num, context: context)
-			} else {
-				self.selectedNode = nil
+			NavigationStack {
+				if let selectedNum = router.selectedNodeNum,
+				   let node = getNodeInfo(id: selectedNum, context: context) {
+					NodeDetail(node: node)
+				} else {
+					ContentUnavailableView("Select a Node", systemImage: "flipphone")
+				}
 			}
 		}
-		.onChange(of: selectedNode) { _, node in
-			if let num = node?.num {
-				router.navigationState.nodeListSelectedNodeNum = num
-			} else {
-				router.navigationState.nodeListSelectedNodeNum = nil
+		.navigationSplitViewStyle(.balanced)
+		.onChange(of: router.lastNodeNum) { _, newValue in
+			if let num = newValue {
+				router.selectedNodeNum = num
 			}
 		}
 	}
@@ -62,12 +64,12 @@ struct NodeList: View {
 	private var sidebarContent: some View {
 		FilteredNodeList(
 			withFilters: filters,
-			selectedNode: $selectedNode,
 			connectedNode: connectedNode,
 			isPresentingDeleteNodeAlert: $isPresentingDeleteNodeAlert,
 			deleteNodeId: $deleteNodeId,
 			shareContactNode: $shareContactNode,
-			nodeListDensity: $nodeListDensity
+			nodeListDensity: $nodeListDensity,
+			selectedNodeNum: $router.selectedNodeNum
 		)
 		.sheet(isPresented: $isEditingFilters) {
 			NodeListFilter(
@@ -143,19 +145,6 @@ struct NodeList: View {
 		.accessibilityElement(children: .contain))
 	}
 
-	// MARK: - Detail
-
-	@ViewBuilder
-	private var detailContent: some View {
-		if let node = selectedNode {
-			NodeDetail(
-				node: node
-			)
-		} else {
-			ContentUnavailableView("Select a Node", systemImage: "flipphone")
-		}
-	}
-
 	// Helper to get the count of nodes for the navigation title
 	private func getNodeCount() -> Int {
 		var descriptor = FetchDescriptor<NodeInfoEntity>()
@@ -193,30 +182,30 @@ private struct FilteredNodeList: View {
 	private var allNodes: [NodeInfoEntity]
 	@Environment(\.modelContext) private var context
 
-	@Binding var selectedNode: NodeInfoEntity?
 	var connectedNode: NodeInfoEntity?
 	@Binding var isPresentingDeleteNodeAlert: Bool
 	@Binding var deleteNodeId: Int64
 	@Binding var shareContactNode: NodeInfoEntity?
 	@Binding var nodeListDensity: NodeListDensity
+	@Binding var selectedNodeNum: Int64?
 	var filters: NodeFilterParameters
 
 	init(
 		withFilters: NodeFilterParameters,
-		selectedNode: Binding<NodeInfoEntity?>,
 		connectedNode: NodeInfoEntity?,
 		isPresentingDeleteNodeAlert: Binding<Bool>,
 		deleteNodeId: Binding<Int64>,
 		shareContactNode: Binding<NodeInfoEntity?>,
-		nodeListDensity: Binding<NodeListDensity>
+		nodeListDensity: Binding<NodeListDensity>,
+		selectedNodeNum: Binding<Int64?>
 	) {
 		self.filters = withFilters
-		self._selectedNode = selectedNode
 		self.connectedNode = connectedNode
 		self._isPresentingDeleteNodeAlert = isPresentingDeleteNodeAlert
 		self._deleteNodeId = deleteNodeId
 		self._shareContactNode = shareContactNode
 		self._nodeListDensity = nodeListDensity
+		self._selectedNodeNum = selectedNodeNum
 
 		// Push simple filters into the SwiftData predicate to reduce in-memory work
 		let showIgnored = withFilters.isIgnored
@@ -262,8 +251,8 @@ private struct FilteredNodeList: View {
 	var body: some View {
 		// If the connected node passes filters, always show it first
 		let nodesWithConnectedFirst = filteredNodes.filter { $0.num == accessoryManager.activeDeviceNum } + filteredNodes.filter { $0.num != accessoryManager.activeDeviceNum }
-		List(nodesWithConnectedFirst, id: \.self, selection: $selectedNode) { node in
-			NavigationLink(value: node) {
+		List(nodesWithConnectedFirst, id: \.self, selection: $selectedNodeNum) { node in
+			NavigationLink(value: node.num) {
 				switch nodeListDensity {
 				case .compact:
 					NodeListItemCompact(

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -26,7 +26,6 @@ struct NodeList: View {
 	@State private var showingHelp = false
 	@SceneStorage("selectedDetailView") var selectedDetailView: String?
 
-	@State private var selectedNode: NodeInfoEntity?
 
 	var connectedNode: NodeInfoEntity? {
 		if let num = accessoryManager.activeDeviceNum {
@@ -51,11 +50,6 @@ struct NodeList: View {
 			}
 		}
 		.navigationSplitViewStyle(.balanced)
-		.onChange(of: router.lastNodeNum) { _, newValue in
-			if let num = newValue {
-				router.selectedNodeNum = num
-			}
-		}
 	}
 
 	// MARK: - Sidebar

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -21,7 +21,7 @@ struct Settings: View {
 	@State private var selectedNode: Int = 0
 	@State private var preferredNodeNum: Int = 0
 
-	@ObservedObject
+	@EnvironmentObject
 	var router: Router
 
 	// MARK: Helper
@@ -374,14 +374,7 @@ struct Settings: View {
 
 	var body: some View {
 		NavigationStack(
-			path: Binding<[SettingsNavigationState]>(
-				get: {
-					[router.settingsState].compactMap { $0 }
-				},
-				set: { newPath in
-					router.settingsState = newPath.first
-				}
-			)
+			path: $router.settingsPath
 		) {
 			let node = nodes.first(where: { $0.num == preferredNodeNum })
 			List {

--- a/MeshtasticTests/NodeNavigationTests.swift
+++ b/MeshtasticTests/NodeNavigationTests.swift
@@ -146,7 +146,7 @@ struct NodeNavigationTests {
 	@Test func navigateToNodeThenClearSelection() async {
 		let router = await Router()
 		await router.navigateToNodeDetail(nodeNum: 42)
-		await MainActor.run { router.nodeListSelectedNodeNum = nil }
+		await MainActor.run { router.popToRoot(tab: .nodes) }
 		let state = await router.navigationState
 		#expect(state.selectedTab == .nodes)
 		#expect(state.nodeListSelectedNodeNum == nil)

--- a/MeshtasticTests/RouterDeepLinkTests.swift
+++ b/MeshtasticTests/RouterDeepLinkTests.swift
@@ -374,7 +374,7 @@ struct RouterURLRoutingTests {
 		#expect(router.selectedNodeNum == 123)
 		router.popToRoot(tab: .nodes)
 		#expect(router.selectedNodeNum == nil)
-		#expect(router.lastNodeNum == nil)
+		#expect(router.selectedNodeNum == nil)
 	}
 
 	@Test @MainActor func popToRoot_settings() {
@@ -391,7 +391,7 @@ struct RouterURLRoutingTests {
 		router.selectedTab = .nodes
 		router.navigateToNodeDetail(nodeNum: 555)
 		#expect(router.selectedNodeNum == 555)
-		#expect(router.lastNodeNum == 555)
+		#expect(router.selectedNodeNum == 555)
 	}
 
 	@Test @MainActor func navigateToNodeDetail_crossTab() {
@@ -400,7 +400,7 @@ struct RouterURLRoutingTests {
 		router.navigateToNodeDetail(nodeNum: 888)
 		// Tab switches immediately, path deferred
 		#expect(router.selectedTab == .nodes)
-		#expect(router.lastNodeNum == 888)
+		#expect(router.selectedNodeNum == 888)
 	}
 
 	@Test @MainActor func route_settings_noParams() {

--- a/MeshtasticTests/RouterDeepLinkTests.swift
+++ b/MeshtasticTests/RouterDeepLinkTests.swift
@@ -64,7 +64,7 @@ struct RouterURLRoutingTests {
 		let url = URL(string: "meshtastic:///nodes?nodenum=12345")!
 		router.route(url: url)
 		#expect(router.selectedTab == .nodes)
-		#expect(router.nodeListSelectedNodeNum == 12345)
+		#expect(router.navigationState.nodeListSelectedNodeNum == 12345)
 	}
 
 	@Test @MainActor func route_nodes_noParams() {
@@ -72,7 +72,7 @@ struct RouterURLRoutingTests {
 		let url = URL(string: "meshtastic:///nodes")!
 		router.route(url: url)
 		#expect(router.selectedTab == .nodes)
-		#expect(router.nodeListSelectedNodeNum == nil)
+		#expect(router.navigationState.nodeListSelectedNodeNum == nil)
 	}
 
 	@Test @MainActor func route_map_nodeNum() {
@@ -112,7 +112,7 @@ struct RouterURLRoutingTests {
 		let url = URL(string: "meshtastic:///settings/about")!
 		router.route(url: url)
 		#expect(router.selectedTab == .settings)
-		#expect(router.settingsState == .about)
+		#expect(router.settingsPath.last == .about)
 	}
 
 	@Test @MainActor func route_settings_lora() {
@@ -120,135 +120,294 @@ struct RouterURLRoutingTests {
 		let url = URL(string: "meshtastic:///settings/lora")!
 		router.route(url: url)
 		#expect(router.selectedTab == .settings)
-		#expect(router.settingsState == .lora)
+		#expect(router.settingsPath.last == .lora)
 	}
 
 	@Test @MainActor func route_settings_mqtt() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/mqtt")!
 		router.route(url: url)
-		#expect(router.settingsState == .mqtt)
+		#expect(router.settingsPath.last == .mqtt)
 	}
 
 	@Test @MainActor func route_settings_channels() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/channels")!
 		router.route(url: url)
-		#expect(router.settingsState == .channels)
+		#expect(router.settingsPath.last == .channels)
 	}
 
 	@Test @MainActor func route_settings_user() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/user")!
 		router.route(url: url)
-		#expect(router.settingsState == .user)
+		#expect(router.settingsPath.last == .user)
 	}
 
 	@Test @MainActor func route_settings_bluetooth() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/bluetooth")!
 		router.route(url: url)
-		#expect(router.settingsState == .bluetooth)
+		#expect(router.settingsPath.last == .bluetooth)
 	}
 
 	@Test @MainActor func route_settings_device() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/device")!
 		router.route(url: url)
-		#expect(router.settingsState == .device)
+		#expect(router.settingsPath.last == .device)
 	}
 
 	@Test @MainActor func route_settings_display() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/display")!
 		router.route(url: url)
-		#expect(router.settingsState == .display)
+		#expect(router.settingsPath.last == .display)
 	}
 
 	@Test @MainActor func route_settings_network() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/network")!
 		router.route(url: url)
-		#expect(router.settingsState == .network)
+		#expect(router.settingsPath.last == .network)
 	}
 
 	@Test @MainActor func route_settings_position() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/position")!
 		router.route(url: url)
-		#expect(router.settingsState == .position)
+		#expect(router.settingsPath.last == .position)
 	}
 
 	@Test @MainActor func route_settings_power() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/power")!
 		router.route(url: url)
-		#expect(router.settingsState == .power)
+		#expect(router.settingsPath.last == .power)
 	}
 
 	@Test @MainActor func route_settings_security() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/security")!
 		router.route(url: url)
-		#expect(router.settingsState == .security)
+		#expect(router.settingsPath.last == .security)
 	}
 
 	@Test @MainActor func route_settings_serial() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/serial")!
 		router.route(url: url)
-		#expect(router.settingsState == .serial)
+		#expect(router.settingsPath.last == .serial)
 	}
 
 	@Test @MainActor func route_settings_telemetry() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/telemetry")!
 		router.route(url: url)
-		#expect(router.settingsState == .telemetry)
+		#expect(router.settingsPath.last == .telemetry)
 	}
 
 	@Test @MainActor func route_settings_tak() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/tak")!
 		router.route(url: url)
-		#expect(router.settingsState == .tak)
+		#expect(router.settingsPath.last == .tak)
 	}
 
 	@Test @MainActor func route_settings_firmwareUpdates() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///settings/firmwareUpdates")!
 		router.route(url: url)
-		#expect(router.settingsState == .firmwareUpdates)
+		#expect(router.settingsPath.last == .firmwareUpdates)
 	}
 
-	@Test @MainActor func route_invalidScheme_ignored() {
+	// MARK: - Missing Settings Deep Links
+
+	@Test @MainActor func route_settings_appSettings() {
 		let router = Router()
-		let url = URL(string: "https:///settings/about")!
+		let url = URL(string: "meshtastic:///settings/appSettings")!
 		router.route(url: url)
-		#expect(router.selectedTab == .connect) // Default, unchanged
+		#expect(router.selectedTab == .settings)
+		#expect(router.settingsPath.last == .appSettings)
 	}
 
-	@Test @MainActor func route_unknownPath_ignored() {
+	@Test @MainActor func route_settings_routes() {
 		let router = Router()
-		let url = URL(string: "meshtastic:///unknown")!
+		let url = URL(string: "meshtastic:///settings/routes")!
 		router.route(url: url)
-		#expect(router.selectedTab == .connect) // Default, unchanged
+		#expect(router.settingsPath.last == .routes)
 	}
 
-	@Test @MainActor func navigationState_computed() {
+	@Test @MainActor func route_settings_routeRecorder() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/routeRecorder")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .routeRecorder)
+	}
+
+	@Test @MainActor func route_settings_shareQRCode() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/shareQRCode")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .shareQRCode)
+	}
+
+	@Test @MainActor func route_settings_ambientLighting() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/ambientLighting")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .ambientLighting)
+	}
+
+	@Test @MainActor func route_settings_cannedMessages() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/cannedMessages")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .cannedMessages)
+	}
+
+	@Test @MainActor func route_settings_detectionSensor() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/detectionSensor")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .detectionSensor)
+	}
+
+	@Test @MainActor func route_settings_externalNotification() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/externalNotification")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .externalNotification)
+	}
+
+	@Test @MainActor func route_settings_paxCounter() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/paxCounter")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .paxCounter)
+	}
+
+	@Test @MainActor func route_settings_rangeTest() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/rangeTest")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .rangeTest)
+	}
+
+	@Test @MainActor func route_settings_ringtone() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/ringtone")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .ringtone)
+	}
+
+	@Test @MainActor func route_settings_storeAndForward() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/storeAndForward")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .storeAndForward)
+	}
+
+	@Test @MainActor func route_settings_debugLogs() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/debugLogs")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .debugLogs)
+	}
+
+	@Test @MainActor func route_settings_appFiles() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/appFiles")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .appFiles)
+	}
+
+	@Test @MainActor func route_settings_tools() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/tools")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .tools)
+	}
+
+	@Test @MainActor func route_settings_coreDataBrowser() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/coreDataBrowser")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .coreDataBrowser)
+	}
+
+	@Test @MainActor func route_settings_helpDocs() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/helpDocs")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .helpDocs)
+	}
+
+	@Test @MainActor func route_settings_localMeshDiscovery() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/localMeshDiscovery")!
+		router.route(url: url)
+		#expect(router.selectedTab == .settings)
+		#expect(router.settingsPath.last == .localMeshDiscovery)
+	}
+
+	@Test @MainActor func route_settings_localMeshDiscovery_history() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/localMeshDiscovery/history")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .localMeshDiscovery)
+		#expect(router.discoveryShowHistory == true)
+	}
+
+	@Test @MainActor func route_settings_takConfig() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/takConfig")!
+		router.route(url: url)
+		#expect(router.settingsPath.last == .takConfig)
+	}
+
+	// MARK: - Navigation Path Tests
+
+	@Test @MainActor func popToRoot_nodes() {
+		let router = Router()
+		router.navigateToNodeDetail(nodeNum: 123)
+		#expect(router.selectedNodeNum == 123)
+		router.popToRoot(tab: .nodes)
+		#expect(router.selectedNodeNum == nil)
+		#expect(router.lastNodeNum == nil)
+	}
+
+	@Test @MainActor func popToRoot_settings() {
+		let router = Router()
+		let url = URL(string: "meshtastic:///settings/lora")!
+		router.route(url: url)
+		#expect(router.settingsPath.count == 1)
+		router.popToRoot(tab: .settings)
+		#expect(router.settingsPath.isEmpty)
+	}
+
+	@Test @MainActor func navigateToNodeDetail_sameTab() {
+		let router = Router()
+		router.selectedTab = .nodes
+		router.navigateToNodeDetail(nodeNum: 555)
+		#expect(router.selectedNodeNum == 555)
+		#expect(router.lastNodeNum == 555)
+	}
+
+	@Test @MainActor func navigateToNodeDetail_crossTab() {
 		let router = Router()
 		router.selectedTab = .messages
-		router.messagesState = .channels(channelId: 1)
-		router.nodeListSelectedNodeNum = 42
-		let state = router.navigationState
-		#expect(state.selectedTab == .messages)
-		#expect(state.nodeListSelectedNodeNum == 42)
+		router.navigateToNodeDetail(nodeNum: 888)
+		// Tab switches immediately, path deferred
+		#expect(router.selectedTab == .nodes)
+		#expect(router.lastNodeNum == 888)
 	}
 
-	@Test @MainActor func navigateToNodeDetail() {
+	@Test @MainActor func route_settings_noParams() {
 		let router = Router()
-		router.navigateToNodeDetail(nodeNum: 777)
-		#expect(router.selectedTab == .nodes)
-		#expect(router.nodeListSelectedNodeNum == 777)
+		let url = URL(string: "meshtastic:///settings")!
+		router.route(url: url)
+		#expect(router.selectedTab == .settings)
+		#expect(router.settingsPath.isEmpty)
 	}
 }

--- a/MeshtasticTests/RouterTests.swift
+++ b/MeshtasticTests/RouterTests.swift
@@ -240,6 +240,56 @@ struct RouterTests {
 		#expect(state.nodeListSelectedNodeNum == 9876543210)
 	}
 
+	@Test func navigateToNodeDetailClearsExistingPath() async {
+		let router = await Router()
+		await router.navigateToNodeDetail(nodeNum: 111)
+		await router.navigateToNodeDetail(nodeNum: 222)
+		let state = await router.navigationState
+		#expect(state.nodeListSelectedNodeNum == 222)
+		let selected = await router.selectedNodeNum
+		#expect(selected == 222)
+	}
+
+	// MARK: - popToRoot
+
+	@Test func popToRootNodes() async {
+		let router = await Router()
+		await router.navigateToNodeDetail(nodeNum: 42)
+		await router.popToRoot(tab: .nodes)
+		let selected = await router.selectedNodeNum
+		#expect(selected == nil)
+		let state = await router.navigationState
+		#expect(state.nodeListSelectedNodeNum == nil)
+	}
+
+	@Test func popToRootSettings() async {
+		let router = await Router()
+		let url = URL(string: "meshtastic:///settings/about")!
+		await router.route(url: url)
+		await router.popToRoot(tab: .settings)
+		let pathCount = await router.settingsPath.count
+		#expect(pathCount == 0)
+		let state = await router.navigationState
+		#expect(state.settings == nil)
+	}
+
+	// MARK: - Path Properties
+
+	@Test func nodeSelectionDrivesNavigation() async {
+		let router = await Router()
+		await router.navigateToNodeDetail(nodeNum: 12345)
+		let selected = await router.selectedNodeNum
+		#expect(selected == 12345)
+	}
+
+	@Test func settingsPathDrivesNavigation() async throws {
+		let router = await Router()
+		let url = try #require(URL(string: "meshtastic:///settings/lora"))
+		await router.route(url: url)
+		let path = await router.settingsPath
+		#expect(path == [.lora])
+	}
+
 	// MARK: - State Transitions
 
 	@Test func routingToNewTabClearsPreviousState() async throws {


### PR DESCRIPTION
## What changed

### Navigation
- **NavigationSplitView with NavigationStack detail** for iPad/Mac/visionOS two-pane layout
- **Inline NodeDetail push from message avatars** — single tap, no tab switch needed
- **NodeDetail sheet on mesh map** replaces PositionPopover for direct node access
- **Mac Catalyst close button** on map NodeDetail sheet (ExitButton-style)
- **Router cleanup** — removed redundant `lastNodeNum`, dead `selectedNode` state, unused `onChange` handler

### Query Performance
- **Batch message fetching in UserList** — eliminates N+1 queries (200 DB queries → 1)
- **UserMessageList `@Query`** replaces computed property that merged arrays every render
- **Messages `onAppear` eager node fetch** — no longer waits for `onChange`
- **Lazy `NavigationLink(value:)`** in message rows — no eager NodeDetail instantiation
- **MeshMapContent `PositionSnapshot`** pre-extraction — avoids SwiftData relationship faulting in map render loop

### UI Polish
- **PositionPopover** simplified for popover-only use with adaptive circle/title scaling
- **AnimatedNodePin** reduced animation overhead (1.2s cycle, .onDisappear stops animation)
- **Comprehensive deep link test coverage** — all routes from deep-links.md tested

## Why
Navigation between tabs was slow (~800ms+) due to cascading `@Published` updates, redundant SwiftData fetches, and tab switch animations. Message contact list was running 200+ database queries per render. Map annotations were faulting entire SwiftData object graphs on every MapKit redraw.

## How it was tested
- Manual testing on iPhone, iPad, and Mac Catalyst
- All existing tests pass
- New test suites: RouterDeepLinkTests (48 tests), NodeNavigationTests, RouterTests

## Files changed

| File | Change |
|------|--------|
| Router.swift | `selectedNodeNum`, `settingsPath`, `popToRoot`, dead code removal |
| ContentView.swift | Updated for Router API changes |
| NodeList.swift | NavigationSplitView + NavigationStack detail |
| NodeDetail.swift | Removed `isSheetPresented`, `showMapLink` flag |
| MeshMap.swift | NodeDetail sheet replaces popover, Mac Catalyst close button |
| MeshMapContent.swift | PositionSnapshot pre-extraction |
| PositionPopover.swift | Simplified for popover-only, adaptive scaling |
| AnimatedNodePin.swift | Reduced animation overhead |
| Messages.swift | NavigationStack in detail, onAppear fetch |
| UserList.swift | Batch message fetching |
| UserMessageList.swift | @Query replaces computed property |
| ChannelMessageRow.swift | Inline NodeDetail push, single tap |
| UserMessageRow.swift | Inline NodeDetail push, single tap |
| Settings.swift | @EnvironmentObject Router |
| RouterTests.swift | New popToRoot tests |
| RouterDeepLinkTests.swift | All deep link routes tested |
| NodeNavigationTests.swift | Updated for new API |