### PR TITLE
Fix firmware update sheet dismissing immediately

### DIFF
--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -13,11 +13,14 @@ import SwiftDraw
 import UniformTypeIdentifiers
 
 // 1. THE WRAPPER
-// This handles the fetching safely. It does not run logic in init.
+// Caches the resolved hardware so SwiftData re-evaluations don't flash the
+// "reconnect" screen when relationships momentarily fault to nil.
 struct Firmware: View {
 	let node: NodeInfoEntity?
 
 	@Query var hardwareResults: [DeviceHardwareEntity]
+	@State private var cachedHardware: DeviceHardwareEntity?
+	@State private var cachedNode: NodeInfoEntity?
 
 	init(node: NodeInfoEntity?) {
 		self.node = node
@@ -27,20 +30,36 @@ struct Firmware: View {
 				hw.platformioTarget == pioEnv
 			})
 		} else {
-			// Return all results; body will handle the missing-pioEnv case
 			_hardwareResults = Query(filter: #Predicate<DeviceHardwareEntity> { _ in false })
 		}
 	}
 
 	var body: some View {
-		if let node, node.myInfo?.pioEnv != nil, let hardware = hardwareResults.first {
-			FirmwareContentView(node: node, hardware: hardware)
-		} else {
-			List {
-				ContentUnavailableView("Firmware Updates",
-					systemImage: "arrow.triangle.2.circlepath",
-					description: Text("Please reconnect to your device to load firmware information."))
+		Group {
+			if let resolvedNode = cachedNode, let resolvedHardware = cachedHardware {
+				FirmwareContentView(node: resolvedNode, hardware: resolvedHardware)
+					.id(resolvedNode.num)
+			} else {
+				List {
+					ContentUnavailableView("Firmware Updates",
+						systemImage: "arrow.triangle.2.circlepath",
+						description: Text("Please reconnect to your device to load firmware information."))
+				}
 			}
+		}
+		.onAppear {
+			resolveHardware()
+		}
+		.onChange(of: hardwareResults) {
+			resolveHardware()
+		}
+	}
+
+	private func resolveHardware() {
+		// Only update cache when we have valid data — never clear it
+		if let node, node.myInfo?.pioEnv != nil, let hardware = hardwareResults.first {
+			cachedNode = node
+			cachedHardware = hardware
 		}
 	}
 }
@@ -67,6 +86,14 @@ private struct FirmwareContentView: View {
 	@State var showFirmwareFilePicker = false
 	@State var showInstallationSheet: FirmwareFile.FirmwareType?
 	@State var locallyChosenFirmwareFile: URL?
+	// For row-level install sheet
+	@State var rowInstallation: RowInstallation?
+
+	struct RowInstallation: Identifiable {
+		let type: FirmwareFile.FirmwareType
+		let url: URL
+		var id: String { "\(type.rawValue)-\(url.absoluteString)" }
+	}
 	
 	init(node: NodeInfoEntity, hardware: DeviceHardwareEntity) {
 		self.node = node
@@ -129,6 +156,16 @@ private struct FirmwareContentView: View {
 				firmwareList.refresh()
 			}
 		}
+		.sheet(item: $rowInstallation) { installation in
+			switch installation.type {
+			case .otaZip:
+				NRFDFUSheet(firmwareToFlash: installation.url)
+			case .uf2:
+				UF2MassStorageView(fileURL: installation.url)
+			case .bin:
+				ESP32OTAIntroSheet(binFileURL: installation.url)
+			}
+		}
 	}
 	
 	// MARK: - Subviews
@@ -139,7 +176,9 @@ private struct FirmwareContentView: View {
 		case .stable:
 			let stables = firmwareList.mostRecentFirmware(forReleaseType: .stable)
 			ForEach(stables, id: \.localUrl) { release in
-				FirmwareRow(firmwareFile: release)
+				FirmwareRow(firmwareFile: release) { type, url in
+					self.rowInstallation = RowInstallation(type: type, url: url)
+				}
 			}
 			if let last = stables.last, let notes = last.releaseNotes {
 				NavigationLink("Release Notes") {
@@ -155,7 +194,9 @@ private struct FirmwareContentView: View {
 		case .alpha:
 			let alphas = firmwareList.mostRecentFirmware(forReleaseType: .alpha)
 			ForEach(alphas, id: \.localUrl) { release in
-				FirmwareRow(firmwareFile: release)
+				FirmwareRow(firmwareFile: release) { type, url in
+					self.rowInstallation = RowInstallation(type: type, url: url)
+				}
 			}
 			if let last = alphas.last, let notes = last.releaseNotes {
 				NavigationLink("Release Notes") {
@@ -174,7 +215,9 @@ private struct FirmwareContentView: View {
 				Text("No firmware has been downloaded for this device.")
 			} else {
 				ForEach(downloads, id: \.localUrl) { file in
-					FirmwareRow(firmwareFile: file)
+					FirmwareRow(firmwareFile: file) { type, url in
+						self.rowInstallation = RowInstallation(type: type, url: url)
+					}
 				}
 				.onDelete { offsets in
 					let files = offsets.map { downloads[$0] }
@@ -362,7 +405,7 @@ private struct FirmwareRow: View {
 
 	@ObservedObject var firmwareFile: FirmwareFile
 
-	@State var showInstallationSheet: FirmwareFile.FirmwareType?
+	var onInstall: (FirmwareFile.FirmwareType, URL) -> Void
 
 	/// ESP32 OTA (BLE/WiFi) requires the AdminMessage.OTAEvent protocol with otaHash,
 	/// which was added to Meshtastic firmware in 2.7.18.
@@ -405,14 +448,7 @@ private struct FirmwareRow: View {
 
 			case .downloaded:
 				Button {
-					switch firmwareFile.firmwareType {
-					case .uf2:
-						self.showInstallationSheet = .uf2
-					case .bin:
-						self.showInstallationSheet = .bin
-					case .otaZip:
-						self.showInstallationSheet = .otaZip
-					}
+					onInstall(firmwareFile.firmwareType, firmwareFile.localUrl)
 				} label: {
 					HStack(alignment: .firstTextBaseline, spacing: 2.0) {
 						Text("Install")
@@ -437,16 +473,6 @@ private struct FirmwareRow: View {
 				.controlSize(.small)
 			case .error:
 				Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red)
-			}
-		}
-		.sheet(item: $showInstallationSheet) { type in
-			switch type {
-			case .otaZip:
-				NRFDFUSheet(firmwareToFlash: firmwareFile.localUrl)
-			case .uf2:
-				UF2MassStorageView(fileURL: firmwareFile.localUrl)
-			case .bin:
-				ESP32OTAIntroSheet(binFileURL: firmwareFile.localUrl)
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift
@@ -16,46 +16,53 @@ struct NRFDFUSheet: View {
 	let firmwareToFlash: URL
 	
 	var body: some View {
-		NavigationView { // Use a NavigationView for a title bar
-			VStack(spacing: 20.0) {
-				Text("DFU Firmware Update")
-					.font(.headline)
-				
-				Text("Please do not leave this screen until this process is complete.")
-					.multilineTextAlignment(.center)
-					.padding()
-				
-				CircularProgressView(progress: dfuViewModel.progress, isIndeterminate: ( self.dfuViewModel.state == .starting), size: 225.0, subtitleText: dfuViewModel.statusMessage)
-				
-				Group {
-					switch dfuViewModel.state {
-					case .idle:
-						Button("Begin Update") {
-							Task {
-								// Action for your primary button
-								if let connection = accessoryManager.activeConnection?.connection as? BLEConnection {
-									let peripheral = await connection.peripheral
-									dfuViewModel.startDFU(peripheral: peripheral, zipFileUrl: firmwareToFlash)
-								}
-							}
-						}
-						.controlSize(.large)
-						.frame(maxWidth: .infinity)
-						.cornerRadius(10)
-						.buttonStyle(.borderedProminent)
-						.disabled(showWarningAlert) // Make sure it can't be tapped till the warning is dismissed.
-						
-					case .uploading, .starting, .success:
-						Text(dfuViewModel.rotatingMessage)
+		NavigationView {
+			Group {
+				if showWarningAlert {
+					UpdateWarningSheet(
+						onDismiss: { dismiss() },
+						onAccept: { showWarningAlert = false }
+					)
+				} else {
+					VStack(spacing: 20.0) {
+						Text("DFU Firmware Update")
+							.font(.headline)
+
+						Text("Please do not leave this screen until this process is complete.")
 							.multilineTextAlignment(.center)
-							.padding(.horizontal)
-					case .error(let message):
-						Text("Error: \(message)")
+							.padding()
+
+						CircularProgressView(progress: dfuViewModel.progress, isIndeterminate: (self.dfuViewModel.state == .starting), size: 225.0, subtitleText: dfuViewModel.statusMessage)
+
+						Group {
+							switch dfuViewModel.state {
+							case .idle:
+								Button("Begin Update") {
+									Task {
+										if let connection = accessoryManager.activeConnection?.connection as? BLEConnection {
+											let peripheral = await connection.peripheral
+											dfuViewModel.startDFU(peripheral: peripheral, zipFileUrl: firmwareToFlash)
+										}
+									}
+								}
+								.controlSize(.large)
+								.frame(maxWidth: .infinity)
+								.cornerRadius(10)
+								.buttonStyle(.borderedProminent)
+
+							case .uploading, .starting, .success:
+								Text(dfuViewModel.rotatingMessage)
+									.multilineTextAlignment(.center)
+									.padding(.horizontal)
+							case .error(let message):
+								Text("Error: \(message)")
+							}
+						}.frame(minHeight: 250.0)
 					}
-				}.frame(minHeight: 250.0)
-			}.toolbar {
+				}
+			}
+			.toolbar {
 				ToolbarItem(placement: .navigationBarLeading) {
-					// 2. Create a button that calls dismiss()
 					Button("Done") {
 						dismiss()
 					}.disabled([.starting, .uploading].contains(dfuViewModel.state))
@@ -63,9 +70,6 @@ struct NRFDFUSheet: View {
 			}
 			.navigationTitle("Nordic DFU Update")
 			.navigationBarTitleDisplayMode(.inline)
-		}
-		.sheet(isPresented: $showWarningAlert) {
-			UpdateWarningSheet(onDismiss: { dismiss() }, onAccept: { showWarningAlert = false })
 		}
 		.interactiveDismissDisabled(true)
 	}
@@ -132,7 +136,6 @@ private struct UpdateWarningSheet: View {
 			.padding(.horizontal)
 			.padding(.bottom, 24)
 		}
-		.presentationDetents([.large])
-		.interactiveDismissDisabled(true)
+		.padding(.top)
 	}
 }


### PR DESCRIPTION
## What changed

Two bugs causing the firmware update sheet to close immediately after opening:

### Bug 1: `Firmware` wrapper — `@Query` re-evaluation resets `@State`

The `@Query var hardwareResults` could re-evaluate when SwiftData updated `DeviceHardwareEntity` objects in the background (e.g., from MeshPackets processing). This caused `hardwareResults.first` to momentarily return nil or a different object reference, which recreated `FirmwareContentView` — destroying all `@State` including the sheet presentation state.

**Fix:** Cache the resolved `node` and `hardware` in `@State`. Once found, they are never cleared, so re-renders of the parent don't reset the content view.

### Bug 2: `NRFDFUSheet` — Nested sheet dismiss cascade

`NRFDFUSheet` presented `UpdateWarningSheet` as a nested `.sheet(isPresented:)` with `onDismiss: { dismiss() }`. If the inner sheet failed to present (iOS 26 nested sheet instability) or was dismissed for any reason, `onDismiss` called `dismiss()` on the parent `NRFDFUSheet`, closing the entire firmware update flow before the user could interact with it.

**Fix:** Replaced the nested sheet with an inline `if showWarningAlert` view swap inside the same sheet. The warning content shows first; tapping "I Know What I'm Doing" transitions to the DFU controls. No nested sheets, no dismiss cascade.

## Files changed

| File | Change |
|------|--------|
| `Firmware.swift` | Cache hardware/node in `@State` to survive `@Query` re-evaluations |
| `NRFDFUSheet.swift` | Replace nested sheet with inline warning view |

## How it was tested

- Tapped Install on a downloaded ZIP firmware file
- Warning sheet content displayed inline within the DFU sheet
- Tapped "I Know What I'm Doing" — transitioned to DFU controls
- Tapped "Not Now" — dismissed the sheet cleanly
- Navigated away from and back to Firmware Updates — no "reconnect" flash