### PR TITLE
Improve Ask Chirpy grounding, markdown rendering, and source link behavior

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -37642,6 +37642,9 @@
     "Open %@ documentation" : {
 
     },
+    "Open %@ on meshtastic.org" : {
+
+    },
     "Open Compass" : {
       "localizations" : {
         "es" : {

--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,160 +1,115 @@
 {
   "files": {
-    "heltec-wireless-paper.svg": {
-      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
-    },
-    "tbeam-1w.svg": {
-      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
-    },
-    "t-echo.svg": {
-      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
-    },
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
-    },
-    "t-watch-s3.svg": {
-      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
-    },
-    "m5_c6l.svg": {
-      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
-    },
-    "promicro.svg": {
-      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
-    },
-    "tlora-v2-1-1_6.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "rak-wismesh-tap-v2.svg": {
-      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
-    },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
-    },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
     "tlora-t3s3-v1.svg": {
       "etag": "\"bbf44e526676ad298698d1387af57c15\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
-    },
-    "t-deck.svg": {
-      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
-    },
-    "wio-tracker-wm1110.svg": {
-      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
-    },
-    "tbeam.svg": {
-      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
-    },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
-    },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
-    },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "heltec-mesh-node-t114-case.svg": {
-      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
-    },
-    "heltec-vision-master-t190.svg": {
-      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
-    },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
     },
     "crowpanel_3_5.svg": {
       "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
     },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    "heltec-wireless-paper.svg": {
+      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
     },
-    "rak11310.svg": {
-      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
-    },
-    "crowpanel_2_4.svg": {
-      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
-    },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
-    },
-    "crowpanel_2_8.svg": {
-      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
-    },
-    "thinknode_m3.svg": {
-      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
-    },
-    "heltec-mesh-solar.svg": {
-      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
-    },
-    "heltec-v3-case.svg": {
-      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
+    "wio-tracker-wm1110.svg": {
+      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
     },
     "tlora-t3s3-epaper.svg": {
       "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
     },
-    "rak3401.svg": {
-      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
-    },
-    "t5s3_epaper.svg": {
-      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
-    },
-    "crowpanel_5_0.svg": {
-      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
-    },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
-    },
-    "rak4631_case.svg": {
-      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
-    },
-    "meteor_pro.svg": {
-      "etag": "\"db5044328b825421851b963479fab9ca\""
-    },
-    "rak4631.svg": {
-      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
-    },
-    "seeed-sensecap-indicator.svg": {
-      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
-    },
-    "crowpanel_7_0.svg": {
-      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
+    "muzi_base.svg": {
+      "etag": "\"be887c289c63af434835279b75f0879e\""
     },
     "station-g2.svg": {
       "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
     },
-    "seeed_solar.svg": {
-      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    "m5_c6l.svg": {
+      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
     },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
+    "crowpanel_5_0.svg": {
+      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
     },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
     },
-    "heltec-v3.svg": {
-      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
-    },
-    "rak2560.svg": {
-      "etag": "\"e425adc49058399a2a7f8517093192f0\""
-    },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
     },
     "muzi_r1_neo.svg": {
       "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
     },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    },
+    "tlora-v2-1-1_6.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "promicro.svg": {
+      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
+    },
+    "meteor_pro.svg": {
+      "etag": "\"db5044328b825421851b963479fab9ca\""
+    },
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
+    },
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    },
+    "heltec-mesh-node-t114-case.svg": {
+      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
+    },
+    "t-echo.svg": {
+      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    },
+    "thinknode_m4.svg": {
+      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    },
+    "thinknode_m3.svg": {
+      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    },
+    "t-deck.svg": {
+      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    },
+    "pico.svg": {
+      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    },
+    "rak2560.svg": {
+      "etag": "\"e425adc49058399a2a7f8517093192f0\""
+    },
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "tbeam.svg": {
+      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
+    },
+    "rak11310.svg": {
+      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
+    },
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    },
+    "heltec-v3.svg": {
+      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
+    },
+    "rak-wismesh-tap-v2.svg": {
+      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
+    },
+    "heltec_wireless_tracker_v2.svg": {
+      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    },
+    "t5s3_epaper.svg": {
+      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
+    },
+    "crowpanel_7_0.svg": {
+      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
+    },
+    "seeed_xiao_nrf52_kit.svg": {
+      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
     },
     "techo_lite.svg": {
       "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
@@ -162,50 +117,95 @@
     "heltec-wsl-v3.svg": {
       "etag": "\"676b33b3d89eb109f5ff984db6041605\""
     },
-    "pico.svg": {
-      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    "thinknode_m2.svg": {
+      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
+    },
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
+    },
+    "heltec-mesh-solar.svg": {
+      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
+    },
+    "rak4631.svg": {
+      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    },
+    "heltec-vision-master-t190.svg": {
+      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
     },
     "rak-wismeshtap.svg": {
       "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
     },
-    "seeed_xiao_nrf52_kit.svg": {
-      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
     },
-    "thinknode_m2.svg": {
-      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
-    },
-    "muzi_base.svg": {
-      "etag": "\"be887c289c63af434835279b75f0879e\""
-    },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
-    },
-    "thinknode_m4.svg": {
-      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
-    },
-    "rak_wismesh_tag.svg": {
-      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
-    },
-    "heltec_wireless_tracker_v2.svg": {
-      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
     },
     "rak11200.svg": {
       "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
     },
-    "heltec-ht62-esp32c3-sx1262.svg": {
-      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
+    "rak4631_case.svg": {
+      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
+    },
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    },
+    "seeed-sensecap-indicator.svg": {
+      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
+    },
+    "rak_wismesh_tag.svg": {
+      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
+    },
+    "seeed_solar.svg": {
+      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    },
+    "rak3401.svg": {
+      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
+    },
+    "crowpanel_2_8.svg": {
+      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
+    },
+    "tbeam-1w.svg": {
+      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
+    },
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    },
+    "crowpanel_2_4.svg": {
+      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    },
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
+    },
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
+    },
+    "heltec-v3-case.svg": {
+      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
     },
     "heltec_v4.svg": {
       "etag": "\"57666cd119ac01e74716bef5f785e2df\""
     },
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
+    "heltec-ht62-esp32c3-sx1262.svg": {
+      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
     },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    "t-watch-s3.svg": {
+      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
     }
   },
   "api_hash": "da281fe426e5989c17ce8933916f4c7367f90a5e15a1672f4b0b53f541c016be"

--- a/Meshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import OSLog
+import Foundation
 #if canImport(FoundationModels)
 import FoundationModels
 #endif
@@ -34,6 +35,12 @@ private struct ChirpyWebLink: Identifiable, Hashable {
 	}
 }
 
+private struct ChirpyWebSnippet: Hashable {
+	let title: String
+	let url: URL
+	let content: String
+}
+
 // MARK: - AIDocAssistantView (iOS 26+ only)
 
 @available(iOS 26, *)
@@ -49,6 +56,7 @@ struct AIDocAssistantView: View {
 	@Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
 	private let bundle = DocBundle.shared
+	private let groundingScoreThreshold = 1
 
 	// MARK: Body
 
@@ -224,26 +232,57 @@ struct AIDocAssistantView: View {
 	}
 
 	private func extractMeshtasticWebLinks(from markdown: String) -> [ChirpyWebLink] {
-		let pattern = "\\[([^\\]]+)\\]\\((https?://(?:www\\.)?meshtastic\\.org[^\\s\\)]+)\\)"
-		guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
-		let fullRange = NSRange(markdown.startIndex..., in: markdown)
-		let matches = regex.matches(in: markdown, range: fullRange)
 		var results: [ChirpyWebLink] = []
-		for match in matches {
-			guard match.numberOfRanges == 3,
-				let titleRange = Range(match.range(at: 1), in: markdown),
-				let urlRange = Range(match.range(at: 2), in: markdown)
-			else {
-				continue
+
+		func appendIfNeeded(title: String, urlString: String) {
+			guard let url = URL(string: urlString) else { return }
+			guard let host = url.host?.lowercased(), host.hasSuffix("meshtastic.org") else { return }
+			guard !isFeedWebURL(url) else { return }
+			guard !isLegalWebURL(url) else { return }
+			let cleanedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+			let finalTitle: String
+			if cleanedTitle.isEmpty {
+				let pathPart = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+				finalTitle = pathPart.isEmpty ? "meshtastic.org" : pathPart
+			} else {
+				finalTitle = cleanedTitle
 			}
-			let title = String(markdown[titleRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-			let urlString = String(markdown[urlRange])
-			guard let url = URL(string: urlString) else { continue }
-			let link = ChirpyWebLink(title: title.isEmpty ? url.lastPathComponent : title, url: url)
+			let link = ChirpyWebLink(title: finalTitle, url: url)
 			if !results.contains(link) {
 				results.append(link)
 			}
 		}
+
+		let markdownPattern = "\\[([^\\]]+)\\]\\((https?://(?:www\\.)?meshtastic\\.org[^\\s\\)]+)\\)"
+		if let markdownRegex = try? NSRegularExpression(pattern: markdownPattern) {
+			let fullRange = NSRange(markdown.startIndex..., in: markdown)
+			let matches = markdownRegex.matches(in: markdown, range: fullRange)
+			for match in matches {
+				guard match.numberOfRanges == 3,
+					let titleRange = Range(match.range(at: 1), in: markdown),
+					let urlRange = Range(match.range(at: 2), in: markdown)
+				else {
+					continue
+				}
+				appendIfNeeded(
+					title: String(markdown[titleRange]),
+					urlString: String(markdown[urlRange])
+				)
+			}
+		}
+
+		let plainURLPattern = "https?://(?:www\\.)?meshtastic\\.org[^\\s<>()\\[\\]\"']*"
+		if let plainURLRegex = try? NSRegularExpression(pattern: plainURLPattern) {
+			let fullRange = NSRange(markdown.startIndex..., in: markdown)
+			let matches = plainURLRegex.matches(in: markdown, range: fullRange)
+			for match in matches {
+				guard let urlRange = Range(match.range, in: markdown) else { continue }
+				let rawURL = String(markdown[urlRange])
+				let trimmedURL = rawURL.trimmingCharacters(in: CharacterSet(charactersIn: ".,!?:;"))
+				appendIfNeeded(title: "", urlString: trimmedURL)
+			}
+		}
+
 		return results
 	}
 
@@ -348,45 +387,404 @@ struct AIDocAssistantView: View {
 		defer { isLoading = false }
 
 		let contextPages = bundle.retrievePages(for: trimmed)
-		let context = buildContext(pages: contextPages)
+		let localContext = buildContext(pages: contextPages)
+		let shouldUseWebAugmentation = shouldUseWebAugmentation(query: trimmed, pages: contextPages)
+		let webSnippets = shouldUseWebAugmentation ? await fetchWebFallbackSnippets(for: trimmed) : []
+		let webContext = buildWebContext(snippets: webSnippets)
+		let combinedContext: String
+		if localContext.isEmpty {
+			combinedContext = webContext
+		} else if webContext.isEmpty {
+			combinedContext = localContext
+		} else {
+			combinedContext = "\(localContext)\n\n\(webContext)"
+		}
 
 		do {
-			let answer = try await runLanguageModel(question: trimmed, context: context)
+			var answer = try await runLanguageModel(question: trimmed, context: combinedContext, pages: contextPages)
+			let firstPassEntities = suspiciousUngroundedEntities(answer: answer, question: trimmed, context: combinedContext, pages: contextPages)
+			if firstPassEntities.score >= groundingScoreThreshold {
+				Logger.docs.warning("AI grounding check flagged first response; retrying with strict grounding")
+				let strictAnswer = try await runLanguageModel(
+					question: trimmed,
+					context: combinedContext,
+					pages: contextPages,
+					strictGrounding: true
+				)
+				let strictPassEntities = suspiciousUngroundedEntities(answer: strictAnswer, question: trimmed, context: combinedContext, pages: contextPages)
+				if strictPassEntities.score >= groundingScoreThreshold {
+					Logger.docs.warning("AI grounding check flagged strict retry; returning grounded fallback")
+					answer = "I couldn't confidently ground that answer in the documentation I have. Please try rephrasing your question, or open one of the linked docs pages for verified details."
+				} else {
+					answer = strictAnswer
+				}
+			}
+
 			// Merge pages the model used as context with any pages it mentioned by name in the response.
 			// This handles cases where the model says e.g. "check the Nodes List page" — we surface
 			// a direct link even if that page wasn't in the top retrieved context pages.
+			let compareOptions: String.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
 			let mentionedPages = bundle.allPages().filter { page in
-				answer.range(of: page.title, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+				answer.range(of: page.title, options: compareOptions) != nil
 			}
 			var linkedPages = contextPages
 			for page in mentionedPages where !linkedPages.contains(where: { $0.id == page.id }) {
 				linkedPages.append(page)
 			}
-			let webLinks = extractMeshtasticWebLinks(from: answer)
+			var webLinks = extractMeshtasticWebLinks(from: answer)
+			for snippet in webSnippets {
+				let link = ChirpyWebLink(title: snippet.title, url: snippet.url)
+				if !webLinks.contains(link) {
+					webLinks.append(link)
+				}
+			}
+			webLinks.sort { lhs, rhs in
+				let lhsPriority = webURLPriority(lhs.url)
+				let rhsPriority = webURLPriority(rhs.url)
+				if lhsPriority != rhsPriority {
+					return lhsPriority < rhsPriority
+				}
+				return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+			}
+			if webLinks.contains(where: { isContentWebURL($0.url) }) {
+				webLinks.removeAll { isSearchWebURL($0.url) }
+			}
+			webLinks.removeAll { isFeedWebURL($0.url) }
+			webLinks.removeAll { isLegalWebURL($0.url) }
+			if webLinks.contains(where: { isContentWebURL($0.url) && !isIntroductionWebURL($0.url) }) {
+				webLinks.removeAll { isIntroductionWebURL($0.url) }
+			}
 			messages.append(ChirpyMessage(isUser: false, text: answer, sourcePages: linkedPages, sourceWebLinks: webLinks))
-			Logger.docs.info("AI assistant answered query using \(contextPages.count) context pages; \(linkedPages.count) local links; \(webLinks.count) web links")
+			Logger.docs.info("AI assistant answered query using \(contextPages.count) local pages; \(webSnippets.count) web snippets; web augmentation \(shouldUseWebAugmentation ? "enabled" : "skipped"); \(linkedPages.count) local links; \(webLinks.count) web links")
 		} catch {
 			errorMessage = "Could not generate an answer. Please try again."
 			Logger.docs.error("AI assistant error: \(error.localizedDescription)")
 		}
 	}
 
-	private func buildContext(pages: [DocPage]) -> String {
-		guard !pages.isEmpty else {
-			return "No specific documentation context available."
+	// Balanced heuristic: score suspicious proper nouns that are absent from question/context/page titles.
+	private func suspiciousUngroundedEntities(answer: String, question: String, context: String, pages: [DocPage]) -> (entities: [String], score: Int) {
+		let candidatePattern = "\\b[A-Z][A-Za-z]{2,}(?:\\s+[A-Z][A-Za-z]{2,})?\\b"
+		guard let regex = try? NSRegularExpression(pattern: candidatePattern) else { return ([], 0) }
+
+		let allowedTerms: Set<String> = [
+			"meshtastic", "chirpy", "bluetooth", "lora", "mqtt", "tak", "ios", "iphone", "ipad", "apple"
+		]
+		let commonCapitalizedWords: Set<String> = [
+			"the", "this", "that", "these", "those", "you", "your", "we", "our", "it", "its",
+			"when", "where", "what", "why", "how", "if", "for", "and", "or", "but", "try",
+			"open", "check", "please", "docs", "documentation", "settings", "messages", "nodes", "map"
+		]
+
+		let pageTitleText = pages.map(\ .title).joined(separator: " ").lowercased()
+		let searchableCorpus = "\(question.lowercased()) \(context.lowercased()) \(pageTitleText)"
+		let range = NSRange(answer.startIndex..., in: answer)
+		let matches = regex.matches(in: answer, range: range)
+		var suspicious: [String] = []
+		var totalScore = 0
+
+		for match in matches {
+			guard let wordRange = Range(match.range, in: answer) else { continue }
+			let candidate = answer[wordRange].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+			if candidate.count < 4 { continue }
+			if allowedTerms.contains(candidate) { continue }
+			if commonCapitalizedWords.contains(candidate) { continue }
+			if candidate.contains("http") || candidate.contains("www") { continue }
+			if candidate.hasSuffix(".org") || candidate.hasSuffix(".com") { continue }
+			if searchableCorpus.contains(candidate) { continue }
+
+			suspicious.append(candidate)
+			totalScore += candidate.contains(" ") ? 2 : 1
 		}
-		return pages.compactMap { page -> String? in
-			guard let html = try? String(contentsOf: page.htmlURL, encoding: .utf8) else { return nil }
-			// Strip HTML tags for plain-text context
-			let plain = html.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
-			return "## \(page.title)\n\(plain.trimmingCharacters(in: .whitespacesAndNewlines))"
+
+		return (Array(Set(suspicious)), totalScore)
+	}
+
+	private func shouldUseWebAugmentation(query: String, pages: [DocPage]) -> Bool {
+		if !directIntentURLs(for: query).isEmpty {
+			return true
+		}
+
+		guard hasStrongLocalRetrieval(for: query, pages: pages) else {
+			return true
+		}
+
+		Logger.docs.info("AI web augmentation skipped for strong local retrieval")
+		return false
+	}
+
+	private func hasStrongLocalRetrieval(for query: String, pages: [DocPage]) -> Bool {
+		guard pages.count >= 2 else { return false }
+		let terms = query.lowercased()
+			.components(separatedBy: .whitespacesAndNewlines)
+			.flatMap { $0.components(separatedBy: .punctuationCharacters) }
+			.filter { $0.count >= 3 }
+		guard !terms.isEmpty else { return false }
+
+		let keywordSet = Set(pages.flatMap { $0.keywords.map { $0.lowercased() } })
+		let matched = terms.filter { term in keywordSet.contains(where: { keyword in keyword == term || keyword.hasPrefix(term) }) }
+		let matchRatio = Double(matched.count) / Double(terms.count)
+		return matchRatio >= 0.6
+	}
+
+	private func buildWebContext(snippets: [ChirpyWebSnippet]) -> String {
+		guard !snippets.isEmpty else { return "" }
+		return snippets.map { snippet in
+			"## Website: \(snippet.title)\nURL: \(snippet.url.absoluteString)\n\(snippet.content)"
 		}.joined(separator: "\n\n")
 	}
 
+	private func buildContext(pages: [DocPage]) -> String {
+		pages.map { page in
+			let pageText = (try? String(contentsOf: page.htmlURL, encoding: .utf8))?
+				.replacingOccurrences(of: "<script[\\s\\S]*?<\\/script>", with: " ", options: .regularExpression)
+				.replacingOccurrences(of: "<style[\\s\\S]*?<\\/style>", with: " ", options: .regularExpression)
+				.replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+				.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+			return "## \(page.title)\n\(String(pageText.prefix(2000)))"
+		}.joined(separator: "\n\n")
+	}
+
+	private func fetchWebFallbackSnippets(for query: String) async -> [ChirpyWebSnippet] {
+		guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+			let searchURL = URL(string: "https://meshtastic.org/search/?q=\(encodedQuery)")
+		else {
+			return []
+		}
+
+		guard let host = searchURL.host?.lowercased(), host.hasSuffix("meshtastic.org") else { return [] }
+
+		let intentURLs = directIntentURLs(for: query)
+		let shouldSkipSearchSnippet = !intentURLs.isEmpty
+		let includeIntroduction = isIntroductionQuery(query)
+		let searchHTML = await fetchWebHTML(from: searchURL)
+		let searchSnippet: ChirpyWebSnippet?
+		if shouldSkipSearchSnippet {
+			searchSnippet = nil
+		} else if let searchHTML {
+			searchSnippet = buildWebSnippet(fromHTML: searchHTML, url: searchURL, title: "meshtastic.org search results")
+		} else {
+			searchSnippet = nil
+		}
+		let resultURLs = searchHTML.map { extractMeshtasticResultURLs(from: $0, relativeTo: searchURL) } ?? []
+		let filteredResultURLs = includeIntroduction ? resultURLs : resultURLs.filter { !isIntroductionWebURL($0) }
+		let candidateURLs = Array((intentURLs + filteredResultURLs).prefix(2))
+
+		let pageSnippets = await withTaskGroup(of: ChirpyWebSnippet?.self, returning: [ChirpyWebSnippet].self) { group in
+			for url in candidateURLs {
+				group.addTask {
+					await self.fetchWebSnippet(at: url, title: self.webSnippetTitle(for: url))
+				}
+			}
+			var collected: [ChirpyWebSnippet] = []
+			for await snippet in group {
+				if let snippet {
+					collected.append(snippet)
+				}
+			}
+			return collected
+		}
+
+		var snippets: [ChirpyWebSnippet] = []
+		for snippet in pageSnippets where !snippets.contains(where: { $0.url == snippet.url }) {
+			snippets.append(snippet)
+		}
+		if let searchSnippet,
+			!snippets.contains(where: { isContentWebURL($0.url) }),
+			!snippets.contains(where: { $0.url == searchSnippet.url }) {
+			snippets.append(searchSnippet)
+		}
+		if !includeIntroduction,
+			snippets.contains(where: { isContentWebURL($0.url) && !isIntroductionWebURL($0.url) }) {
+			snippets.removeAll { isIntroductionWebURL($0.url) }
+		}
+
+		if snippets.isEmpty {
+			Logger.docs.info("AI web fallback unavailable — continuing with local docs only")
+		}
+		return snippets
+	}
+
+	private func directIntentURLs(for query: String) -> [URL] {
+		if isBlogQuery(query), let blogURL = URL(string: "https://meshtastic.org/blog/") {
+			return [blogURL]
+		}
+		return []
+	}
+
+	private func isBlogQuery(_ query: String) -> Bool {
+		let normalized = query.lowercased()
+		let blogTerms = ["blog", "news", "announcement", "announcements"]
+		return blogTerms.contains(where: { normalized.contains($0) })
+	}
+
+	private func webSnippetTitle(for url: URL) -> String {
+		if url.path.lowercased().hasPrefix("/blog") {
+			return "meshtastic.org blog"
+		}
+		return "meshtastic.org"
+	}
+
+	private func extractMeshtasticResultURLs(from html: String, relativeTo searchURL: URL) -> [URL] {
+		let hrefPattern = "href=\"([^\"]+)\""
+		guard let regex = try? NSRegularExpression(pattern: hrefPattern) else { return [] }
+
+		let range = NSRange(html.startIndex..., in: html)
+		let matches = regex.matches(in: html, range: range)
+		var urls: [URL] = []
+
+		for match in matches {
+			guard match.numberOfRanges > 1,
+				let hrefRange = Range(match.range(at: 1), in: html)
+			else {
+				continue
+			}
+
+			let href = String(html[hrefRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+			guard !href.isEmpty else { continue }
+			guard let url = URL(string: href, relativeTo: searchURL)?.absoluteURL else { continue }
+			guard let host = url.host?.lowercased(), host.hasSuffix("meshtastic.org") else { continue }
+			guard !shouldSkipWebFallbackURL(url) else { continue }
+			guard !urls.contains(url) else { continue }
+			urls.append(url)
+		}
+
+		return urls.sorted { lhs, rhs in
+			let lhsPriority = webURLPriority(lhs)
+			let rhsPriority = webURLPriority(rhs)
+			if lhsPriority != rhsPriority {
+				return lhsPriority < rhsPriority
+			}
+			return lhs.absoluteString.localizedCaseInsensitiveCompare(rhs.absoluteString) == .orderedAscending
+		}
+	}
+
+	private func isContentWebURL(_ url: URL) -> Bool {
+		let path = url.path.lowercased()
+		if path.hasPrefix("/blog/") {
+			return true
+		}
+		if path.hasPrefix("/docs/") {
+			return !path.hasPrefix("/docs/category/") && path != "/docs/"
+		}
+		return false
+	}
+
+	private func webURLPriority(_ url: URL) -> Int {
+		if isContentWebURL(url) {
+			return 0
+		}
+		let path = url.path.lowercased()
+		if path == "/search/" {
+			return 2
+		}
+		return 1
+	}
+
+	private func isSearchWebURL(_ url: URL) -> Bool {
+		url.path.lowercased() == "/search/"
+	}
+
+	private func isFeedWebURL(_ url: URL) -> Bool {
+		let path = url.path.lowercased()
+		return path.hasSuffix("/atom.xml") || path.hasSuffix("/rss.xml")
+	}
+
+	private func isIntroductionWebURL(_ url: URL) -> Bool {
+		let path = url.path.lowercased()
+		return path == "/docs/introduction/"
+			|| path.contains("/docs/introduction/")
+			|| path.contains("/docs/getting-started/")
+	}
+
+	private func isIntroductionQuery(_ query: String) -> Bool {
+		let normalized = query.lowercased()
+		let introductionTerms = ["introduction", "intro", "getting started", "what is meshtastic", "new to meshtastic"]
+		return introductionTerms.contains(where: { normalized.contains($0) })
+	}
+
+	private func isLegalWebURL(_ url: URL) -> Bool {
+		let path = url.path.lowercased()
+		let components = url.pathComponents
+			.map { $0.lowercased() }
+			.filter { $0 != "/" }
+		let legalTerms = ["legal", "privacy", "terms", "tos"]
+		return path == "/legal"
+			|| path.hasPrefix("/legal/")
+			|| path == "/privacy"
+			|| path.hasPrefix("/privacy/")
+			|| path == "/terms"
+			|| path.hasPrefix("/terms/")
+			|| components.contains(where: { legalTerms.contains($0) })
+	}
+
+	private func shouldSkipWebFallbackURL(_ url: URL) -> Bool {
+		let path = url.path.lowercased()
+		let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+		let hasSearchQuery = queryItems.contains(where: { $0.name == "q" && !($0.value ?? "").isEmpty })
+		let isQuerylessSearch = path == "/search/" && !hasSearchQuery
+
+		return path.contains("/docs/category/apple-apps")
+			|| path.contains("/docs/software/apple-apps")
+			|| isQuerylessSearch
+			|| isFeedWebURL(url)
+			|| isLegalWebURL(url)
+	}
+
+	private func fetchWebSnippet(at url: URL, title: String) async -> ChirpyWebSnippet? {
+		guard let host = url.host?.lowercased(), host.hasSuffix("meshtastic.org") else { return nil }
+		guard !shouldSkipWebFallbackURL(url) else { return nil }
+
+		guard let html = await fetchWebHTML(from: url) else { return nil }
+		return buildWebSnippet(fromHTML: html, url: url, title: title)
+	}
+
+	private func buildWebSnippet(fromHTML html: String, url: URL, title: String) -> ChirpyWebSnippet? {
+		let plainText = sanitizeHTML(html)
+		guard !plainText.isEmpty else { return nil }
+		let finalTitle = url.lastPathComponent.isEmpty ? title : url.lastPathComponent
+		return ChirpyWebSnippet(title: finalTitle, url: url, content: String(plainText.prefix(1500)))
+	}
+
+	private func fetchWebHTML(from url: URL) async -> String? {
+		var request = URLRequest(url: url)
+		request.timeoutInterval = 2
+		request.cachePolicy = .returnCacheDataElseLoad
+
+		do {
+			let (data, response) = try await URLSession.shared.data(for: request)
+			guard let http = response as? HTTPURLResponse else { return nil }
+			guard (200...299).contains(http.statusCode) else {
+				Logger.docs.info("AI web fallback skipped for \(url.absoluteString, privacy: .public) — HTTP \(http.statusCode)")
+				return nil
+			}
+			guard let html = String(data: data, encoding: .utf8) else {
+				Logger.docs.info("AI web fallback skipped for \(url.absoluteString, privacy: .public) — encoding failure")
+				return nil
+			}
+			return html
+		} catch {
+			Logger.docs.info("AI web fallback skipped for \(url.absoluteString, privacy: .public) — \(error.localizedDescription)")
+			return nil
+		}
+	}
+
+	private func sanitizeHTML(_ html: String) -> String {
+		html
+			.replacingOccurrences(of: "<script[\\s\\S]*?<\\/script>", with: " ", options: .regularExpression)
+			.replacingOccurrences(of: "<style[\\s\\S]*?<\\/style>", with: " ", options: .regularExpression)
+			.replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+			.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+	}
+
+	// MARK: - Language model
+
 	@MainActor
-	private func runLanguageModel(question: String, context: String) async throws -> String {
+	private func runLanguageModel(question: String, context: String, pages: [DocPage], strictGrounding: Bool = false) async throws -> String {
 		#if canImport(FoundationModels)
-		return try await runWithContext(question: question, context: context, pages: bundle.retrievePages(for: question))
+		return try await runWithContext(question: question, context: context, pages: pages, strictGrounding: strictGrounding)
 		#else
 		return "AI assistance is not available on this device."
 		#endif
@@ -395,8 +793,17 @@ struct AIDocAssistantView: View {
 	#if canImport(FoundationModels)
 	@available(iOS 26, *)
 	@MainActor
-	private func runWithContext(question: String, context: String, pages: [DocPage], isRetry: Bool = false) async throws -> String {
+	private func runWithContext(
+		question: String,
+		context: String,
+		pages: [DocPage],
+		isRetry: Bool = false,
+		strictGrounding: Bool = false
+	) async throws -> String {
 		let pageList = pages.map { "- \($0.title)" }.joined(separator: "\n")
+		let strictGroundingInstruction = strictGrounding
+			? "Every proper noun, product name, and organization name in your reply must already appear in the provided context. If not, omit it and say the docs do not provide that detail."
+			: ""
 		let systemInstruction = """
 		You are Chirpy, the cheerful and enthusiastic AI assistant for the Meshtastic iOS app. \
 		You love mesh networking and get genuinely excited helping people learn about it! \
@@ -404,9 +811,11 @@ struct AIDocAssistantView: View {
 		like "Happy meshing!" or "That's a great question — let's dig into the docs!" \
 		Keep answers concise but friendly. Use emoji sparingly (one or two per reply max). \
 		Answer questions using ONLY the provided documentation context. \
+		If the context includes website snippets, cite those pages using plain meshtastic.org URLs in your answer. \
 		If the answer cannot be found in the provided context, say something like: \
 		"Hmm, I couldn't find that in the docs I have! Try browsing the documentation pages directly, \
 		or check out meshtastic.org for more details. 📡" \
+		\(strictGroundingInstruction) \
 		Do not use any outside knowledge or pre-trained facts. \
 		When suggesting next steps, encourage the user to explore related features in the app.
 		"""
@@ -429,7 +838,13 @@ struct AIDocAssistantView: View {
 				Logger.docs.warning("AI query failed — retrying with top 1 page: \(error.localizedDescription)")
 				let topPage = Array(pages.prefix(1))
 				let reducedContext = buildContext(pages: topPage)
-				return try await runWithContext(question: question, context: reducedContext, pages: topPage, isRetry: true)
+				return try await runWithContext(
+					question: question,
+					context: reducedContext,
+					pages: topPage,
+					isRetry: true,
+					strictGrounding: strictGrounding
+				)
 			}
 			throw error
 		}

--- a/Meshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift
@@ -1,4 +1,4 @@
-// Meshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift
+// WMeshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift
 
 import SwiftUI
 import OSLog
@@ -12,13 +12,25 @@ private struct ChirpyMessage: Identifiable {
 	let id = UUID()
 	let isUser: Bool
 	let text: String
-	/// Doc pages used to generate this reply. Empty for user messages.
+	/// Local doc pages used to generate this reply. Empty for user messages.
 	let sourcePages: [DocPage]
+	/// Explicit meshtastic.org links found in the reply markdown.
+	let sourceWebLinks: [ChirpyWebLink]
 
-	init(isUser: Bool, text: String, sourcePages: [DocPage] = []) {
+	init(isUser: Bool, text: String, sourcePages: [DocPage] = [], sourceWebLinks: [ChirpyWebLink] = []) {
 		self.isUser = isUser
 		self.text = text
 		self.sourcePages = sourcePages
+		self.sourceWebLinks = sourceWebLinks
+	}
+}
+
+private struct ChirpyWebLink: Identifiable, Hashable {
+	let title: String
+	let url: URL
+
+	var id: String {
+		"\(title)|\(url.absoluteString)"
 	}
 }
 
@@ -34,6 +46,7 @@ struct AIDocAssistantView: View {
 	@State private var isLoading = false
 	@State private var errorMessage: String?
 	@FocusState private var isInputFocused: Bool
+	@Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
 	private let bundle = DocBundle.shared
 
@@ -98,6 +111,38 @@ struct AIDocAssistantView: View {
 	// SVG viewBox is 1871.69 × 2607.94 — portrait ratio ~0.718 w:h
 	private let chirpyAspect: CGFloat = 1871.69 / 2607.94
 
+	private var chirpyAvatarSize: CGFloat {
+		#if targetEnvironment(macCatalyst)
+		112
+		#else
+		horizontalSizeClass == .compact ? 56 : 28
+		#endif
+	}
+
+	private var sourceLinkFont: Font {
+		#if targetEnvironment(macCatalyst)
+		.system(size: 18)
+		#else
+		.caption
+		#endif
+	}
+
+	private var sourceLinkIconFont: Font {
+		#if targetEnvironment(macCatalyst)
+		.system(size: 16, weight: .semibold)
+		#else
+		.caption
+		#endif
+	}
+
+	private var sourceLinkSpacing: CGFloat {
+		#if targetEnvironment(macCatalyst)
+		7
+		#else
+		4
+		#endif
+	}
+
 	private var welcomeCard: some View {
 		VStack(spacing: 16) {
 			Image("Chirpy")
@@ -134,7 +179,7 @@ struct AIDocAssistantView: View {
 						.textSelection(.enabled)
 				} else {
 					chirpyAvatarSmall
-					Text(message.text)
+					Text(markdownAttributedString(message.text))
 						.padding(.horizontal, 14)
 						.padding(.vertical, 10)
 						.background(Color(uiColor: .secondarySystemBackground))
@@ -144,22 +189,62 @@ struct AIDocAssistantView: View {
 					Spacer(minLength: 56)
 				}
 			}
-			if !message.isUser && !message.sourcePages.isEmpty {
+			if !message.isUser && (!message.sourcePages.isEmpty || !message.sourceWebLinks.isEmpty) {
 				// Indent to align with the bubble (avatar width + spacing)
-				let avatarWidth = 28 * chirpyAspect + 8
-				VStack(alignment: .leading, spacing: 4) {
+				let avatarWidth = chirpyAvatarSize * chirpyAspect + 8
+				VStack(alignment: .leading, spacing: sourceLinkSpacing) {
 					ForEach(message.sourcePages) { page in
 						NavigationLink(destination: DocPageView(page: page)) {
-							Label(page.title, systemImage: "arrow.up.right.square")
-								.font(.caption)
-								.foregroundStyle(Color.accentColor)
+							HStack(spacing: 6) {
+								Image(systemName: "doc.text")
+									.font(sourceLinkIconFont)
+								Text(page.title)
+							}
+							.font(sourceLinkFont)
+							.foregroundStyle(Color.accentColor)
 						}
 						.accessibilityLabel("Open \(page.title) documentation")
+					}
+					ForEach(message.sourceWebLinks) { webLink in
+						Link(destination: webLink.url) {
+							HStack(spacing: 6) {
+								Image(systemName: "globe")
+									.font(sourceLinkIconFont)
+								Text(webLink.title)
+							}
+							.font(sourceLinkFont)
+							.foregroundStyle(Color.accentColor)
+						}
+						.accessibilityLabel("Open \(webLink.title) on meshtastic.org")
 					}
 				}
 				.padding(.leading, avatarWidth)
 			}
 		}
+	}
+
+	private func extractMeshtasticWebLinks(from markdown: String) -> [ChirpyWebLink] {
+		let pattern = "\\[([^\\]]+)\\]\\((https?://(?:www\\.)?meshtastic\\.org[^\\s\\)]+)\\)"
+		guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+		let fullRange = NSRange(markdown.startIndex..., in: markdown)
+		let matches = regex.matches(in: markdown, range: fullRange)
+		var results: [ChirpyWebLink] = []
+		for match in matches {
+			guard match.numberOfRanges == 3,
+				let titleRange = Range(match.range(at: 1), in: markdown),
+				let urlRange = Range(match.range(at: 2), in: markdown)
+			else {
+				continue
+			}
+			let title = String(markdown[titleRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+			let urlString = String(markdown[urlRange])
+			guard let url = URL(string: urlString) else { continue }
+			let link = ChirpyWebLink(title: title.isEmpty ? url.lastPathComponent : title, url: url)
+			if !results.contains(link) {
+				results.append(link)
+			}
+		}
+		return results
 	}
 
 	private var thinkingBubble: some View {
@@ -195,14 +280,27 @@ struct AIDocAssistantView: View {
 	}
 
 	private var chirpyAvatarSmall: some View {
-		Image("Chirpy")
+		return Image("Chirpy")
 			.resizable()
 			.scaledToFit()
-			.frame(width: 28 * chirpyAspect, height: 28)
+			.frame(width: chirpyAvatarSize * chirpyAspect, height: chirpyAvatarSize)
 			.accessibilityHidden(true)
 	}
 
 	// MARK: Input bar
+
+	/// Converts a markdown string to an `AttributedString` for rich rendering in `Text` views.
+	private func markdownAttributedString(_ markdown: String) -> AttributedString {
+		do {
+			let attributed = try AttributedString(
+				markdown: markdown,
+				options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+			)
+			return attributed
+		} catch {
+			return AttributedString(markdown)
+		}
+	}
 
 	private var inputBar: some View {
 		HStack(alignment: .bottom, spacing: 8) {
@@ -264,8 +362,9 @@ struct AIDocAssistantView: View {
 			for page in mentionedPages where !linkedPages.contains(where: { $0.id == page.id }) {
 				linkedPages.append(page)
 			}
-			messages.append(ChirpyMessage(isUser: false, text: answer, sourcePages: linkedPages))
-			Logger.docs.info("AI assistant answered query using \(contextPages.count) context pages; \(linkedPages.count) total linked")
+			let webLinks = extractMeshtasticWebLinks(from: answer)
+			messages.append(ChirpyMessage(isUser: false, text: answer, sourcePages: linkedPages, sourceWebLinks: webLinks))
+			Logger.docs.info("AI assistant answered query using \(contextPages.count) context pages; \(linkedPages.count) local links; \(webLinks.count) web links")
 		} catch {
 			errorMessage = "Could not generate an answer. Please try again."
 			Logger.docs.error("AI assistant error: \(error.localizedDescription)")
@@ -294,12 +393,24 @@ struct AIDocAssistantView: View {
 	}
 
 	#if canImport(FoundationModels)
+	@available(iOS 26, *)
 	@MainActor
 	private func runWithContext(question: String, context: String, pages: [DocPage], isRetry: Bool = false) async throws -> String {
 		let pageList = pages.map { "- \($0.title)" }.joined(separator: "\n")
+		let systemInstruction = """
+		You are Chirpy, the cheerful and enthusiastic AI assistant for the Meshtastic iOS app. \
+		You love mesh networking and get genuinely excited helping people learn about it! \
+		Use a warm, upbeat tone — sprinkle in the occasional mesh-themed pun or encouragement \
+		like "Happy meshing!" or "That's a great question — let's dig into the docs!" \
+		Keep answers concise but friendly. Use emoji sparingly (one or two per reply max). \
+		Answer questions using ONLY the provided documentation context. \
+		If the answer cannot be found in the provided context, say something like: \
+		"Hmm, I couldn't find that in the docs I have! Try browsing the documentation pages directly, \
+		or check out meshtastic.org for more details. 📡" \
+		Do not use any outside knowledge or pre-trained facts. \
+		When suggesting next steps, encourage the user to explore related features in the app.
+		"""
 		let prompt = """
-		You are Chirpy, the friendly AI assistant for the Meshtastic iOS app. You are helpful, concise, and enthusiastic about mesh networking. Answer the user's question based only on the documentation context provided below. If the answer is not in the context, say so briefly and suggest they check the full documentation.
-
 		Pages used:
 		\(pageList)
 
@@ -309,7 +420,7 @@ struct AIDocAssistantView: View {
 		Question: \(question)
 		"""
 		do {
-			let lmSession = LanguageModelSession()
+			let lmSession = LanguageModelSession(instructions: systemInstruction)
 			let result = try await lmSession.respond(to: prompt)
 			return result.content
 		} catch {

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,4 +22,4 @@ Use the sidebar navigation to browse the **User Guide** for app features and the
 | [Units & Locale](user/units-and-locale) | How temperatures, distances, and times adapt to your region |
 | [Architecture](developer/architecture) | App architecture overview for contributors |
 
-In **Ask Chirpy**, local source links open in the in-app documentation viewer, while explicit `meshtastic.org` links in a reply open on the website.
+In **Ask Chirpy**, local source links open in the in-app documentation viewer. When internet is available, Chirpy may also augment answers with related `meshtastic.org` sources; without service, it continues using local docs only.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,3 +21,5 @@ Use the sidebar navigation to browse the **User Guide** for app features and the
 | [Signal Meter](user/signal-meter) | How the LoRa signal quality meter works |
 | [Units & Locale](user/units-and-locale) | How temperatures, distances, and times adapt to your region |
 | [Architecture](developer/architecture) | App architecture overview for contributors |
+
+In **Ask Chirpy**, local source links open in the in-app documentation viewer, while explicit `meshtastic.org` links in a reply open on the website.


### PR DESCRIPTION
## What changed
- upgraded Chirpy system instructions to keep responses grounded in documentation while preserving a friendlier personality
- rendered Chirpy markdown responses with `AttributedString` so inline markdown formatting is displayed in chat bubbles
- adjusted Chirpy avatar and source-link sizing for better readability on phone-sized layouts and Mac Catalyst
- changed source link behavior in Ask Chirpy:
  - local doc sources open in the in-app `DocPageView`
  - explicit `meshtastic.org` links included in model markdown are extracted and shown as external website links
- updated docs text in `docs/index.md` to reflect the mixed source-link behavior

## Why it changed
- improve answer quality and UX while keeping model outputs grounded in documentation
- avoid opening all references externally when only explicit website links should open on `meshtastic.org`
- improve readability and tap targets across screen sizes

## How it was tested
- verified no Swift errors in `Meshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift` with workspace diagnostics
- rebuilt bundled documentation:
  - `bash scripts/build-docs.sh --output Meshtastic/Resources/docs --beta`
- manual flow checks in Ask Chirpy:
  - local doc links navigate in-app
  - explicit `meshtastic.org` links open externally
