### PR TITLE
Fix firstHeard/lastHeard timestamp bugs and hopsAway misparse

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -453,7 +453,12 @@ actor MeshPackets {
 					
 					fetchedNode[0].id = Int64(nodeInfo.num)
 					fetchedNode[0].num = Int64(nodeInfo.num)
-					fetchedNode[0].lastHeard = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.lastHeard)))
+					if nodeInfo.lastHeard > 0 {
+						let candidate = Date(timeIntervalSince1970: TimeInterval(nodeInfo.lastHeard))
+						if fetchedNode[0].lastHeard == nil || candidate > fetchedNode[0].lastHeard! {
+							fetchedNode[0].lastHeard = candidate
+						}
+					}
 					fetchedNode[0].snr = nodeInfo.snr
 					fetchedNode[0].channel = Int32(nodeInfo.channel)
 					fetchedNode[0].favorite = nodeInfo.isFavorite

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -262,10 +262,10 @@ extension MeshPackets {
 					newNode.channel = Int32(packet.channel)
 				}
 				if let nodeInfoMessage = try? NodeInfo(serializedBytes: packet.decoded.payload) {
-					if nodeInfoMessage.hasHopsAway {
-						newNode.hopsAway = Int32(nodeInfoMessage.hopsAway)
-					}
 					newNode.favorite = nodeInfoMessage.isFavorite
+				}
+				if packet.hopStart != 0 && packet.hopLimit <= packet.hopStart {
+					newNode.hopsAway = Int32(packet.hopStart - packet.hopLimit)
 				}
 				
 				if let newUserMessage = try? User(serializedBytes: packet.decoded.payload) {
@@ -375,8 +375,7 @@ extension MeshPackets {
 				}
 				
 				if let nodeInfoMessage = try? NodeInfo(serializedBytes: packet.decoded.payload) {
-					
-					fetchedNode[0].hopsAway = Int32(nodeInfoMessage.hopsAway)
+
 					fetchedNode[0].favorite = nodeInfoMessage.isFavorite
 					if nodeInfoMessage.hasDeviceMetrics {
 						let telemetry = TelemetryEntity()


### PR DESCRIPTION
## Summary

- **Fix `lastHeard` regression from NodeDB dump** — `nodeInfoPacket()` was unconditionally overwriting `lastHeard` with the radio's stored `nodeInfo.lastHeard` value, which could be much older than a value already set by a live packet via `updateAnyPacketFrom()`. This caused the node detail view to show "First Heard" as more recent than "Last Heard". Now only updates `lastHeard` when `nodeInfo.lastHeard` is non-zero and more recent than the currently stored value.

- **Fix `hopsAway` always showing 0 due to proto misparse** — `upsertNodeInfoPacket()` was parsing the `NODEINFO_APP` payload as `NodeInfo` and reading `hopsAway` from it. The payload is actually a `User` proto: `User` field 9 is `is_unmessagable` (bool), while `NodeInfo` field 9 is `hops_away` (uint32). Protobuf parses without error but always yields 0 for normal nodes, silently overwriting the correct value computed from `hopStart - hopLimit`. For new nodes, `hopsAway` is now computed directly from the packet hop fields. For existing nodes, the misparse assignment is removed — `updateAnyPacketFrom()` already set the correct value.

## Test plan

- [ ] Connect to a mesh with nodes multiple hops away — confirm they no longer appear in the "Direct" filter
- [ ] Disconnect and reconnect BLE — confirm "Last Heard" does not regress to an older value after reconnect
- [ ] Confirm "First Heard" is never newer than "Last Heard" in node detail view