### PR TITLE
Fix all Translation API availability guards to iOS 26

### DIFF
--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
@@ -170,7 +170,7 @@ actor DocTranslationService {
 
 	#if !targetEnvironment(macCatalyst)
 	/// Translate a page using a provided TranslationSession (from .translationTask modifier).
-	@available(iOS 17.4, *)
+	@available(iOS 26, *)
 	func translateWithSession(_ session: TranslationSession, page: DocPage) async -> String? {
 		guard let htmlData = try? Data(contentsOf: page.htmlURL),
 			  let htmlString = String(data: htmlData, encoding: .utf8) else {
@@ -284,7 +284,7 @@ actor DocTranslationService {
 
 	private func translateUIText(_ text: String, targetLanguage: String) async -> String? {
 		#if !targetEnvironment(macCatalyst)
-		if #available(iOS 17.4, *) {
+		if #available(iOS 26, *) {
 			if let viaTranslation = await translateWithTranslationFramework(text: text, targetLanguage: targetLanguage) {
 				return viaTranslation
 			}
@@ -312,7 +312,7 @@ actor DocTranslationService {
 		var translateSegment: ((String) async -> String?)?
 
 		#if !targetEnvironment(macCatalyst)
-		if #available(iOS 17.4, *) {
+		if #available(iOS 26, *) {
 			let source = Locale.Language(identifier: "en")
 			let target = Locale.Language(identifier: targetLanguage)
 			let availability = LanguageAvailability()
@@ -422,7 +422,7 @@ actor DocTranslationService {
 	#if !targetEnvironment(macCatalyst)
 	// MARK: - Translation Framework (iOS 26+)
 
-	@available(iOS 17.4, *)
+	@available(iOS 26, *)
 	private func translateWithTranslationFramework(text: String, targetLanguage: String) async -> String? {
 		do {
 			let source = Locale.Language(identifier: "en")


### PR DESCRIPTION
Previous fix (#1786) only changed a MARK comment — the actual `@available(iOS 17.4, *)` and `#available(iOS 17.4, *)` guards were not updated due to a merge issue. This fixes all 4 remaining occurrences.

```
Line 173: @available(iOS 17.4, *) → @available(iOS 26, *)
Line 287: #available(iOS 17.4, *) → #available(iOS 26, *)
Line 315: #available(iOS 17.4, *) → #available(iOS 26, *)
Line 425: @available(iOS 17.4, *) → @available(iOS 26, *)
```

Fixes Xcode Cloud builds 1918, 1919, 1920.