### PR TITLE
Fix: display channel names without reformatting

### DIFF
--- a/Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift
@@ -9,6 +9,30 @@ import SwiftData
 import MeshtasticProtobufs
 
 extension ChannelEntity {
+	var displayName: String {
+		if let name, !name.isEmpty {
+			return name
+		}
+
+		if index == 0 && role == 1 {
+			return "Primary Channel"
+		}
+
+		return "Channel \(index)"
+	}
+
+	var shortDisplayName: String {
+		if let name, !name.isEmpty {
+			return name
+		}
+
+		if index == 0 {
+			return "Primary"
+		}
+
+		return "Channel \(index)"
+	}
+
 	@MainActor
 	var allPrivateMessages: [MessageEntity] {
 		let context = PersistenceController.shared.context

--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -65,18 +65,8 @@ struct ChannelList: View {
 			VStack(alignment: .leading) {
 				HStack {
 					ChannelLock(channel: channel)
-					if channel.name?.isEmpty ?? false {
-						if channel.role == 1 {
-							Text(String("PrimaryChannel").camelCaseToWords())
-								.font(.headline)
-						} else {
-							Text(String("Channel \(channel.index)").camelCaseToWords())
-								.font(.headline)
-						}
-					} else {
-						Text(String(channel.name ?? "Channel \(channel.index)").camelCaseToWords())
-							.font(.headline)
-					}
+					Text(channel.displayName)
+						.font(.headline)
 
 					Spacer()
 

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -216,7 +216,7 @@ struct ChannelMessageList: View {
 			ToolbarItem(placement: .principal) {
 				HStack {
 					CircleText(text: String(channel.index), color: .accentColor, circleSize: 44).fixedSize()
-					Text(String(channel.name ?? "Unknown").camelCaseToWords()).font(.headline)
+					Text(channel.displayName).font(.headline)
 				}
 			}
 			ToolbarItem(placement: .navigationBarTrailing) {

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -147,15 +147,7 @@ struct Channels: View {
 									VStack {
 										HStack {
 											ChannelLock(channel: channel)
-											if channel.name?.isEmpty ?? false {
-												if channel.role == 1 {
-													Text(String("PrimaryChannel").camelCaseToWords()).font(.headline)
-												} else {
-													Text(String("Channel \(channel.index)").camelCaseToWords()).font(.headline)
-												}
-											} else {
-												Text(String(channel.name ?? "Channel \(channel.index)").camelCaseToWords()).font(.headline)
-											}
+											Text(channel.displayName).font(.headline)
 										}
 									}
 								}

--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -85,14 +85,14 @@ struct ShareChannels: View {
 									Toggle("Channel 0 Included", isOn: $includeChannel0)
 										.toggleStyle(.switch)
 										.labelsHidden()
-									Text(((channel.name?.isEmpty ?? true ? "Primary" : channel.name) ?? "Primary").camelCaseToWords())
+									Text(channel.shortDisplayName)
 									ChannelLock(channel: channel)
 								} else if channel.index == 1 && channel.role > 0 {
 									Toggle("Channel 1 Included", isOn: $includeChannel1)
 										.toggleStyle(.switch)
 										.labelsHidden()
 										.disabled(channel.role == 1)
-											Text(((channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
+									Text(channel.shortDisplayName).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
 											.foregroundColor(.red)
@@ -105,7 +105,7 @@ struct ShareChannels: View {
 										.toggleStyle(.switch)
 										.labelsHidden()
 										.disabled(channel.role == 1)
-									Text(((channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
+									Text(channel.shortDisplayName).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
 											.foregroundColor(.red)
@@ -118,7 +118,7 @@ struct ShareChannels: View {
 										.toggleStyle(.switch)
 										.labelsHidden()
 										.disabled(channel.role == 1)
-									Text(((channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
+									Text(channel.shortDisplayName).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
 											.foregroundColor(.red)
@@ -131,7 +131,7 @@ struct ShareChannels: View {
 										.toggleStyle(.switch)
 										.labelsHidden()
 										.disabled(channel.role == 1)
-									Text(((channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
+									Text(channel.shortDisplayName).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
 											.foregroundColor(.red)
@@ -144,7 +144,7 @@ struct ShareChannels: View {
 										.toggleStyle(.switch)
 										.labelsHidden()
 										.disabled(channel.role == 1)
-									Text(((channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
+									Text(channel.shortDisplayName).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
 											.foregroundColor(.red)
@@ -157,7 +157,7 @@ struct ShareChannels: View {
 										.toggleStyle(.switch)
 										.labelsHidden()
 										.disabled(channel.role == 1)
-									Text(((channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
+									Text(channel.shortDisplayName).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
 											.foregroundColor(.red)
@@ -170,7 +170,7 @@ struct ShareChannels: View {
 										.toggleStyle(.switch)
 										.labelsHidden()
 										.disabled(channel.role == 1)
-									Text(((channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()).fixedSize()
+									Text(channel.shortDisplayName).fixedSize()
 									if channel.psk?.hexDescription.count ??  0 <  3 {
 										Image(systemName: "lock.slash.fill")
 											.foregroundColor(.red)

--- a/Meshtastic/Views/Settings/TAKServerConfig.swift
+++ b/Meshtastic/Views/Settings/TAKServerConfig.swift
@@ -425,15 +425,7 @@ struct TAKServerConfig: View {
 	// MARK: - Channel Label
 	@ViewBuilder
 	private func channelLabel(_ channel: ChannelEntity) -> some View {
-		if channel.name?.isEmpty ?? false {
-			if channel.role == 1 {
-				Text(String("PrimaryChannel").camelCaseToWords())
-			} else {
-				Text(String("Channel \(channel.index)").camelCaseToWords())
-			}
-		} else {
-			Text(String(channel.name ?? "Channel \(channel.index)").camelCaseToWords())
-		}
+		Text(channel.displayName)
 	}
 
 	// MARK: - Import Handlers


### PR DESCRIPTION
## Summary

- **Stop applying `camelCaseToWords()` to channel names** — Channel names like "LongFast" were being displayed as "Long Fast" throughout the UI (ChannelList, ChannelMessageList, Channels settings, ShareChannels, TAKServerConfig). This is misleading because the actual name — used for MQTT topic matching and over-the-air channel identification — is the unformatted version. Adds `displayName` and `shortDisplayName` computed properties to `ChannelEntity` that return the name as-is, falling back to "Primary Channel" or "Channel N" for unnamed channels.

## Future Improvement Suggestion

New users don't understand the modem preset (LongFast, LongSlow, etc.) linking with the channel name and think they can rename the public channel — the moment someone customizes a channel name or switches presets it kills their public broadcasts. It may be worth surfacing the modem preset as the primary concept in LoRa settings, with the raw channel name field moved to an advanced section within LoRa to prevent unintended changes. This would leave only the secondary channels as editable in the channel settings and would allow the display name of the public channel to be separated from the modem preset (i.e. it would always show as "Public").

## Test plan

- [ ] Open Messages → channel list — confirm "LongFast" appears instead of "Long Fast"
- [ ] Open Settings → Channels — confirm channel names are unformatted
- [ ] Open Share Channels sheet — confirm channel names are unformatted
- [ ] Confirm unnamed primary channel still shows "Primary Channel" / "Primary"
- [ ] Confirm unnamed secondary channels show "Channel 1", "Channel 2", etc.