### PR TITLE
Fix: center map on user location at 100km on open

### DIFF
--- a/Meshtastic/Enums/AppSettingsEnums.swift
+++ b/Meshtastic/Enums/AppSettingsEnums.swift
@@ -56,6 +56,7 @@ enum MeshMapDistances: Double, CaseIterable, Identifiable {
 	case tenMiles = 16093.4
 	case twentyFiveMiles = 40233.6
 	case fiftyMiles = 80467.2
+	case oneHundredKilometers = 100000
 	case oneHundredMiles = 160934
 	case twoHundredMiles = 321869
 	case fiveHundredMiles = 804672

--- a/Meshtastic/Extensions/UserDefaults.swift
+++ b/Meshtastic/Extensions/UserDefaults.swift
@@ -107,7 +107,7 @@ extension UserDefaults {
 	@UserDefault(.mapLayer, defaultValue: .standard)
 	static var mapLayer: MapLayer
 
-	@UserDefault(.meshMapDistance, defaultValue: 800000)
+	@UserDefault(.meshMapDistance, defaultValue: 100_000)
 	static var meshMapDistance: Double
 
 	@UserDefault(.enableMapWaypoints, defaultValue: true)

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
@@ -22,7 +22,7 @@ struct MapSettingsForm: View {
 	@Binding var traffic: Bool
 	@Binding var pointsOfInterest: Bool
 	@Binding var mapLayer: MapLayer
-	@AppStorage("meshMapDistance") private var meshMapDistance: Double = 800000
+	@AppStorage("meshMapDistance") private var meshMapDistance: Double = 100_000
 	@Binding var meshMap: Bool
 	@Binding var enabledOverlayConfigs: Set<UUID>
 

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -38,7 +38,7 @@ struct MeshMap: View {
 	@Namespace var mapScope
 	@AppStorage("meshMapDistance") private var meshMapDistance: Double = 100_000
 	@State var mapStyle: MapStyle = MapStyle.standard(elevation: .flat, emphasis: MapStyle.StandardEmphasis.muted, pointsOfInterest: .excludingAll, showsTraffic: false)
-	@State var position = MapCameraPosition.automatic
+	@State var position = MapCameraPosition.userLocation(followsHeading: false, fallback: .automatic)
 	@State private var distance = 100_000.0
 	@State private var hasSetInitialCamera = false
 	@State private var editingSettings = false
@@ -349,13 +349,22 @@ struct MeshMap: View {
 
 	private func setInitialMapCameraIfNeeded() {
 		guard !hasSetInitialCamera else { return }
-		guard let userLocation = LocationsHandler.currentLocation else { return }
 
-		let initialDistance = initialMapDistance(centeredAt: userLocation)
+		let center: CLLocationCoordinate2D
+		if let userLocation = LocationsHandler.currentLocation {
+			center = userLocation
+		} else if let firstPosition = filteredPositions.first(where: { 12...15 ~= $0.precisionBits || $0.precisionBits == 32 }),
+				  let nodeCoord = firstPosition.isPreciseLocation ? firstPosition.nodeCoordinate : firstPosition.fuzzedNodeCoordinate {
+			center = nodeCoord
+		} else {
+			return
+		}
+
+		let initialDistance = initialMapDistance(centeredAt: center)
 		distance = initialDistance
 		position = .camera(
 			MapCamera(
-				centerCoordinate: userLocation,
+				centerCoordinate: center,
 				distance: initialDistance,
 				heading: 0,
 				pitch: 0

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -13,11 +13,14 @@ import OSLog
 import MapKit
 
 struct MeshMap: View {
+	private let defaultMeshMapDistance: Double = 100_000
+	private let maximumInitialMeshMapDistance: Double = 1_000_000
 
 	@Environment(\.modelContext) private var context
 	@Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
 	@Environment(\.openWindow) private var openWindow
 	@EnvironmentObject var accessoryManager: AccessoryManager
+	@ObservedObject private var locationsHandler = LocationsHandler.shared
 
 	@ObservedObject
 	var router: Router
@@ -33,10 +36,11 @@ struct MeshMap: View {
 	@State private var enabledOverlayConfigs: Set<UUID> = []
 	// Map Configuration
 	@Namespace var mapScope
-	@AppStorage("meshMapDistance") private var meshMapDistance: Double = 800000
+	@AppStorage("meshMapDistance") private var meshMapDistance: Double = 100_000
 	@State var mapStyle: MapStyle = MapStyle.standard(elevation: .flat, emphasis: MapStyle.StandardEmphasis.muted, pointsOfInterest: .excludingAll, showsTraffic: false)
 	@State var position = MapCameraPosition.automatic
-	@State private var distance = 10000.0
+	@State private var distance = 100_000.0
+	@State private var hasSetInitialCamera = false
 	@State private var editingSettings = false
 	@State private var editingFilters = false
 	@State var selectedPosition: PositionEntity?
@@ -276,6 +280,8 @@ struct MeshMap: View {
 			// Initialize enabled overlay configs with all active files
 			let activeFiles = GeoJSONOverlayManager.shared.getUploadedFilesWithState().filter { $0.isActive }
 			enabledOverlayConfigs = Set(activeFiles.map { $0.id })
+			migrateLegacyMapDistanceDefaultIfNeeded()
+			setInitialMapCameraIfNeeded()
 
 			switch selectedMapLayer {
 			case .standard:
@@ -296,10 +302,17 @@ struct MeshMap: View {
 			if newTab == .map {
 				refreshMapWindowOpenState()
 				UIApplication.shared.isIdleTimerDisabled = true
+				setInitialMapCameraIfNeeded()
 			} else {
 				UIApplication.shared.isIdleTimerDisabled = false
 				GeoJSONOverlayManager.shared.clearCache()
 			}
+		}
+		.onChange(of: filteredPositions.count) {
+			setInitialMapCameraIfNeeded()
+		}
+		.onChange(of: locationsHandler.locationsArray.count) {
+			setInitialMapCameraIfNeeded()
 		}
 		.onReceive(NotificationCenter.default.publisher(for: Foundation.Notification.Name.mapDataFileDeleted)) { notification in
 			if let deletedFileId = notification.object as? UUID {
@@ -332,5 +345,46 @@ struct MeshMap: View {
 				)
 			)
 		})
+	}
+
+	private func setInitialMapCameraIfNeeded() {
+		guard !hasSetInitialCamera else { return }
+		guard let userLocation = LocationsHandler.currentLocation else { return }
+
+		let initialDistance = initialMapDistance(centeredAt: userLocation)
+		distance = initialDistance
+		position = .camera(
+			MapCamera(
+				centerCoordinate: userLocation,
+				distance: initialDistance,
+				heading: 0,
+				pitch: 0
+			)
+		)
+		hasSetInitialCamera = true
+	}
+
+	private func initialMapDistance(centeredAt userLocation: CLLocationCoordinate2D) -> Double {
+		let nodeDistances = filteredPositions.compactMap { position -> CLLocationDistance? in
+			guard 12...15 ~= position.precisionBits || position.precisionBits == 32 else { return nil }
+			let coordinate = position.isPreciseLocation ? position.nodeCoordinate : position.fuzzedNodeCoordinate
+			return coordinate?.distance(from: userLocation)
+		}
+
+		guard let nearestNodeDistance = nodeDistances.min() else {
+			return defaultMeshMapDistance
+		}
+
+		if nearestNodeDistance <= defaultMeshMapDistance {
+			return defaultMeshMapDistance
+		}
+
+		return min(nearestNodeDistance * 1.25, maximumInitialMeshMapDistance)
+	}
+
+	private func migrateLegacyMapDistanceDefaultIfNeeded() {
+		if meshMapDistance == 800_000 {
+			meshMapDistance = defaultMeshMapDistance
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Map no longer zooms out to fit all annotations on open** — The map was initialized with `MapCameraPosition.automatic`, which causes MapKit to expand the view to include all visible nodes — showing the whole country on a spread-out mesh. The initial position is now `userLocation`, which centers on the user without fitting annotations. On appear, the camera is explicitly set to 100km centered on the user's location. If the nearest node is farther than 100km, the camera scales out just enough to include it (capped at 1,000km). If user location isn't available yet, the map centers on the nearest known node instead. Existing users with the old 800km default stored in UserDefaults are migrated automatically on first launch.

## Test plan

- [ ] Open map with a spread-out mesh — confirm it no longer zooms to fit all nodes
- [ ] Fresh install — confirm map opens centered on user at ~100km
- [ ] Nearest node farther than 100km — confirm camera scales out to include it, not all nodes
- [ ] No location permission granted — confirm map centers on nearest node instead of fitting all
- [ ] Existing install with 800km stored in UserDefaults — confirm migrates to 100km on first open
- [ ] Switch away from map tab and back — confirm camera does not reset on return