### PR TITLE
Fix blank navigation title when translation returns empty string

### DIFF
--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
@@ -1,4 +1,4 @@
-// MARK: DocTranslationService
+right // MARK: DocTranslationService
 //
 //  DocTranslationService.swift
 //  Meshtastic
@@ -256,7 +256,8 @@ actor DocTranslationService {
 		}
 
 		let task = Task<String, Never> {
-			if let translated = await self.translateUIText(source, targetLanguage: languageCode) {
+			if let translated = await self.translateUIText(source, targetLanguage: languageCode),
+			   !translated.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
 				return translated
 			}
 			return text


### PR DESCRIPTION
The Translation API sometimes returns an empty string for short phrases like "Help & Docs". This was being cached and used as the navigation title, resulting in a blank title bar.

Now guards against empty/whitespace-only translation results and falls back to the original English text.