### PR TITLE
Fix DocTranslationService.swift top-level expression error

### DIFF
--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
@@ -1,4 +1,4 @@
-right // MARK: DocTranslationService
+// MARK: DocTranslationService
 //
 //  DocTranslationService.swift
 //  Meshtastic


### PR DESCRIPTION
## Summary

- Line 1 of `Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift` was `right // MARK: DocTranslationService`. The stray `right` is parsed as a top-level expression with no declaration in scope, breaking the archive build.
- Xcode Cloud build 1924 (both Archive — iOS and Archive — macOS) failed with `Expressions are not allowed at the top level`. Removing the token restores the intended `// MARK:` comment.
- Local iOS Simulator builds tolerated the typo via parser error-recovery, which is why it slipped through to main on #1791 (5357fb65).

## Test plan

- [x] `swiftc -typecheck -sdk iPhoneOS26.0.sdk -target arm64-apple-ios17.0 Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift` — clean (was: `error: cannot find 'right' in scope`).
- [ ] Xcode Cloud re-runs Archive — iOS and Archive — macOS on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)