### PR TITLE
Fix DocTranslationService.swift top-level expression error

### DIFF
--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
@@ -1,4 +1,4 @@
-right // MARK: DocTranslationService
+// MARK: DocTranslationService
 //
 //  DocTranslationService.swift
 //  Meshtastic


### PR DESCRIPTION
Line 1 of the file was `right // MARK: DocTranslationService` — the stray `right` is a top-level identifier with no declaration in scope, which Swift parses as an illegal top-level expression. Xcode Cloud build 1924 (Archive — iOS and Archive — macOS) both failed with:

    error: Expressions are not allowed at the top level
      right // MARK: DocTranslationService
      ^

Local iOS Simulator builds tolerated it (parser error-recovery), which is why the typo slipped through to main. Removing the stray token restores the intended `// MARK:` comment and lets the file type-check on all targets. Verified via:

    swiftc -typecheck -sdk iPhoneOS26.0.sdk -target arm64-apple-ios17.0 \
        Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift

The token was introduced in #1791 (5357fb65) as part of an unrelated nav-title fix.
