### PR TITLE
Retry UI label translations after language pack installs

### DIFF
--- a/Meshtastic/Resources/DeviceHardware.json
+++ b/Meshtastic/Resources/DeviceHardware.json
@@ -1398,5 +1398,20 @@
     "images": [
       "mini-epaper-s3.svg"
     ]
+  },
+  {
+    "hwModel": 127,
+    "hwModelSlug": "HELTEC_MESH_NODE_T096",
+    "platformioTarget": "heltec-mesh-node-t096",
+    "architecture": "nrf52840",
+    "activelySupported": false,
+    "supportLevel": 1,
+    "displayName": "Heltec Mesh Node 096",
+    "tags": [
+      "Heltec"
+    ],
+    "images": [
+      "heltec-mesh-node-t096.svg"
+    ]
   }
 ]

--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,212 +1,212 @@
 {
   "files": {
-    "tlora-t3s3-v1.svg": {
-      "etag": "\"bbf44e526676ad298698d1387af57c15\""
-    },
-    "crowpanel_3_5.svg": {
-      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
-    },
-    "heltec-wireless-paper.svg": {
-      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
-    },
-    "wio-tracker-wm1110.svg": {
-      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
-    },
-    "tlora-t3s3-epaper.svg": {
-      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
-    },
     "muzi_base.svg": {
       "etag": "\"be887c289c63af434835279b75f0879e\""
-    },
-    "station-g2.svg": {
-      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
-    },
-    "m5_c6l.svg": {
-      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
-    },
-    "crowpanel_5_0.svg": {
-      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
-    },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
-    },
-    "muzi_r1_neo.svg": {
-      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
-    },
-    "tlora-v2-1-1_6.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "promicro.svg": {
-      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
-    },
-    "meteor_pro.svg": {
-      "etag": "\"db5044328b825421851b963479fab9ca\""
-    },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
-    },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
-    },
-    "heltec-mesh-node-t114-case.svg": {
-      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
-    },
-    "t-echo.svg": {
-      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
     },
     "thinknode_m4.svg": {
       "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
     },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
-    },
-    "thinknode_m3.svg": {
-      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
     },
     "t-deck.svg": {
       "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
     },
-    "pico.svg": {
-      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
-    },
-    "rak2560.svg": {
-      "etag": "\"e425adc49058399a2a7f8517093192f0\""
-    },
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
-    },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "tbeam.svg": {
-      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
-    },
-    "rak11310.svg": {
-      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
-    },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
-    },
-    "heltec-v3.svg": {
-      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
-    },
-    "rak-wismesh-tap-v2.svg": {
-      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
-    },
-    "heltec_wireless_tracker_v2.svg": {
-      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
     },
     "t5s3_epaper.svg": {
       "etag": "\"423640c486cc7c4480f194bc02481ea5\""
     },
-    "crowpanel_7_0.svg": {
-      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
-    },
-    "seeed_xiao_nrf52_kit.svg": {
-      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
-    },
-    "techo_lite.svg": {
-      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
-    },
-    "heltec-wsl-v3.svg": {
-      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
-    },
     "thinknode_m2.svg": {
       "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
     },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
-    },
-    "heltec-mesh-solar.svg": {
-      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
-    },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
-    },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
-    "rak4631.svg": {
-      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
-    },
-    "heltec-vision-master-t190.svg": {
-      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
-    },
-    "rak-wismeshtap.svg": {
-      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
-    },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
-    },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "rak11200.svg": {
-      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
-    },
-    "rak4631_case.svg": {
-      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
-    },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
-    },
-    "seeed-sensecap-indicator.svg": {
-      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
-    },
-    "rak_wismesh_tag.svg": {
-      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
-    },
-    "seeed_solar.svg": {
-      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
-    },
-    "rak3401.svg": {
-      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
-    },
-    "crowpanel_2_8.svg": {
-      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
-    },
-    "tbeam-1w.svg": {
-      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
-    },
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
     },
     "crowpanel_2_4.svg": {
       "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
     },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
     },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    "heltec-wireless-paper.svg": {
+      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
     },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
+    "heltec-vision-master-t190.svg": {
+      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
     },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
-    },
-    "heltec-v3-case.svg": {
-      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
     },
     "heltec_v4.svg": {
       "etag": "\"57666cd119ac01e74716bef5f785e2df\""
     },
-    "heltec-ht62-esp32c3-sx1262.svg": {
-      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
+    "pico.svg": {
+      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    },
+    "heltec-wsl-v3.svg": {
+      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
+    },
+    "rak_wismesh_tag.svg": {
+      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
+    },
+    "m5_c6l.svg": {
+      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
+    },
+    "heltec-v3.svg": {
+      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
+    },
+    "heltec-mesh-node-t114-case.svg": {
+      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
+    },
+    "thinknode_m3.svg": {
+      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    },
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
+    },
+    "tlora-v2-1-1_6.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "wio-tracker-wm1110.svg": {
+      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    },
+    "station-g2.svg": {
+      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "seeed_solar.svg": {
+      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    },
+    "seeed-sensecap-indicator.svg": {
+      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
+    },
+    "tbeam.svg": {
+      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
     },
     "t-watch-s3.svg": {
       "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
+    },
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    },
+    "rak-wismesh-tap-v2.svg": {
+      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
+    },
+    "meteor_pro.svg": {
+      "etag": "\"db5044328b825421851b963479fab9ca\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    },
+    "crowpanel_3_5.svg": {
+      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
+    },
+    "rak4631_case.svg": {
+      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
+    },
+    "crowpanel_5_0.svg": {
+      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    },
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "t-echo.svg": {
+      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    },
+    "techo_lite.svg": {
+      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
+    },
+    "tlora-t3s3-v1.svg": {
+      "etag": "\"bbf44e526676ad298698d1387af57c15\""
+    },
+    "rak3401.svg": {
+      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
+    },
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    },
+    "tbeam-1w.svg": {
+      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
+    },
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
+    },
+    "heltec-ht62-esp32c3-sx1262.svg": {
+      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
+    },
+    "seeed_xiao_nrf52_kit.svg": {
+      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
+    },
+    "crowpanel_2_8.svg": {
+      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
+    },
+    "promicro.svg": {
+      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
+    },
+    "muzi_r1_neo.svg": {
+      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
+    },
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
+    },
+    "rak11310.svg": {
+      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
+    },
+    "heltec_wireless_tracker_v2.svg": {
+      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    },
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    },
+    "rak11200.svg": {
+      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
+    },
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "heltec-mesh-solar.svg": {
+      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
+    },
+    "heltec-v3-case.svg": {
+      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
+    },
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
+    },
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "tlora-t3s3-epaper.svg": {
+      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    },
+    "rak4631.svg": {
+      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    },
+    "rak2560.svg": {
+      "etag": "\"e425adc49058399a2a7f8517093192f0\""
+    },
+    "rak-wismeshtap.svg": {
+      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
+    },
+    "crowpanel_7_0.svg": {
+      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
     }
   },
-  "api_hash": "da281fe426e5989c17ce8933916f4c7367f90a5e15a1672f4b0b53f541c016be"
+  "api_hash": "48bdd6bb8b53a802a113c420c5948d25bc9bf5fe9a63f623a3fd0b70680eff08"
 }

--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocBrowserView.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocBrowserView.swift
@@ -110,6 +110,14 @@ struct DocBrowserView: View {
 			translatedLabels = [:]
 			startLabelTranslations()
 		}
+		.onReceive(NotificationCenter.default.publisher(for: DocTranslationService.languageBecameAvailableNotification)) { _ in
+			// Language pack just finished downloading — clear stale failures and retry
+			Task {
+				await DocTranslationService.shared.clearUIStringCache()
+			}
+			translatedLabels = [:]
+			startLabelTranslations()
+		}
 	}
 
 	@ViewBuilder

--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocPageView.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocPageView.swift
@@ -148,6 +148,20 @@ struct DocPageView: View {
 			translatedTitle = nil
 			startTranslation()
 		}
+		.onReceive(NotificationCenter.default.publisher(for: DocTranslationService.languageBecameAvailableNotification)) { _ in
+			// Language pack just installed — retry title if it wasn't translated yet
+			if translatedTitle == nil {
+				let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
+				guard languageCode != "en" else { return }
+				Task {
+					await DocTranslationService.shared.clearUIStringCache()
+					let title = await DocTranslationService.shared.translatedUIString(page.title, targetLanguage: languageCode)
+					if !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, title != page.title {
+						await MainActor.run { translatedTitle = title }
+					}
+				}
+			}
+		}
 	}
 
 	// MARK: - Translation Loading

--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocTranslationService.swift
@@ -30,6 +30,10 @@ actor DocTranslationService {
 
 	static let shared = DocTranslationService()
 
+	/// Posted when a language transitions from `supported` to `installed`, signalling that
+	/// UI labels which previously failed translation should be retried.
+	static let languageBecameAvailableNotification = Notification.Name("DocTranslationServiceLanguageBecameAvailable")
+
 	/// Avoids spamming identical availability logs for each translated text segment.
 	private var lastAvailabilityStatusByLanguage: [String: String] = [:]
 	private var inFlightHTMLByCacheKey: [String: Task<String?, Never>] = [:]
@@ -40,6 +44,10 @@ actor DocTranslationService {
 
 	private init() {}
 
+	/// Clears cached UI string translations so they can be retried.
+	func clearUIStringCache() {
+		uiStringCache.removeAll()
+	}
 	// MARK: - Public API
 
 	/// Returns translated HTML string for the given page, or nil if English should be used.
@@ -321,8 +329,18 @@ actor DocTranslationService {
 			let statusDescription = String(describing: status)
 
 			if lastAvailabilityStatusByLanguage[targetLanguage] != statusDescription {
+				let previousStatus = lastAvailabilityStatusByLanguage[targetLanguage]
 				Logger.docs.info("DocTranslationService: Translation availability for \(targetLanguage, privacy: .public): \(statusDescription, privacy: .public)")
 				lastAvailabilityStatusByLanguage[targetLanguage] = statusDescription
+				if status == .supported {
+					Logger.docs.info("DocTranslationService: Language \(targetLanguage, privacy: .public) supported but not installed — download via Settings > General > Language & Region > Translation Languages")
+				}
+				// Language pack just finished downloading — notify views to retry UI labels
+				if status == .installed && previousStatus != nil {
+					Task { @MainActor in
+						NotificationCenter.default.post(name: DocTranslationService.languageBecameAvailableNotification, object: nil)
+					}
+				}
 			}
 
 			if status == .installed {
@@ -337,7 +355,7 @@ actor DocTranslationService {
 					}
 				}
 			} else if status == .supported {
-				Logger.docs.info("DocTranslationService: Language \(targetLanguage, privacy: .public) supported but not installed — download via Settings > General > Language & Region > Translation Languages")
+				// Already logged once via dedup block above
 			}
 		}
 		#endif
@@ -433,16 +451,22 @@ actor DocTranslationService {
 			let status = await availability.status(from: source, to: target)
 			let statusDescription = String(describing: status)
 			if lastAvailabilityStatusByLanguage[targetLanguage] != statusDescription {
+				let previousStatus = lastAvailabilityStatusByLanguage[targetLanguage]
 				Logger.docs.info("DocTranslationService: Translation availability for \(targetLanguage, privacy: .public): \(statusDescription, privacy: .public)")
 				lastAvailabilityStatusByLanguage[targetLanguage] = statusDescription
+				if status == .supported {
+					Logger.docs.info("DocTranslationService: Language \(targetLanguage, privacy: .public) supported but not installed — download via Settings > General > Language & Region > Translation Languages")
+				} else if status != .installed {
+					Logger.docs.info("DocTranslationService: Translation framework does not support \(targetLanguage, privacy: .public)")
+				}
+				if status == .installed && previousStatus != nil {
+					Task { @MainActor in
+						NotificationCenter.default.post(name: DocTranslationService.languageBecameAvailableNotification, object: nil)
+					}
+				}
 			}
 
 			guard status == .installed else {
-				if status == .supported {
-					Logger.docs.info("DocTranslationService: Language \(targetLanguage, privacy: .public) supported but not installed — download via Settings > General > Language & Region > Translation Languages")
-				} else {
-					Logger.docs.info("DocTranslationService: Translation framework does not support \(targetLanguage, privacy: .public)")
-				}
 				return nil
 			}
 


### PR DESCRIPTION
When a user first opens docs with a non-English language, the Translation framework reports the language as `supported` but not `installed`. iOS downloads the language pack in the background (~20s). During this window, all UI string translations (nav title, search prompt, section names, page titles) fail and fall back to English.

The page body translation succeeds later because it runs after the pack finishes downloading, but the UI labels never retry — leaving a mix of English labels and translated content.

### Fix
- `DocTranslationService` now detects when a language transitions from `supported` → `installed` and posts `languageBecameAvailableNotification`
- `DocBrowserView` observes the notification, clears stale UI string cache, and re-runs all label translations
- `DocPageView` observes the notification and retries the nav bar title translation if it wasn't translated yet
- Added `clearUIStringCache()` to allow flushing failed translation results