### PR TITLE
Add Brazilian Portuguese (pt-BR) localisation strings

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -50,6 +50,12 @@
             "value" : "\t%@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -107,6 +113,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : " %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@"
           }
         },
         "sr" : {
@@ -168,6 +180,12 @@
             "value" : " %@%%"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@%%"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -217,6 +235,12 @@
             "value" : "DFUにリセットを送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar Reboot para DFU"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -263,6 +287,12 @@
             "value" : "---"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você pode usar o aplicativo para controlar o seu dispositivo BLE, GPS, Wi-Fi e Bluetooth."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -306,6 +336,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : ": %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : ": %@"
           }
         },
@@ -362,6 +398,12 @@
             "value" : ": %d"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : ": %d"
+          }
+        },
         "sr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -409,6 +451,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Meshtasticから離れる - 接続されているBLEノードから離れる"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desconecte o Meshtastic"
           }
         },
         "zh-Hans" : {
@@ -459,6 +507,12 @@
             "value" : "Meshtasticの直接メッセージを送信する"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar uma mensagem direta do Meshtastic - enviar uma mensagem privada para um nó"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -507,6 +561,12 @@
             "value" : "Meshtasticグループメッセージを送信する - メッシュチャンネルにメッセージを送信する"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar um grupo de mensagem Meshtastic - enviar uma mensagem para um canal de rede mesh"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -547,6 +607,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Meshtasticノードをシャットダウンまたはリスタートします"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desligue meu nó Meshtastic ou reinicie meu nó Meshtastic"
           }
         },
         "zh-Hans" : {
@@ -599,6 +665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ボード用のPIN_GPS_ENを（再）定義してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(Re)defina PIN_GPS_EN para sua placa."
           }
         },
         "ru" : {
@@ -659,6 +731,12 @@
             "value" : "[%lld アイテム]"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "[%lld itens]"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -708,6 +786,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "%@"
           }
         },
@@ -773,6 +857,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%1$@ - %2$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "%1$@ - %2$@"
           }
         },
@@ -847,6 +937,12 @@
             "value" : "%1$@ - %2$@ - %3$@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ - %2$@ - %3$@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -918,6 +1014,12 @@
             "value" : "%1$@ - %2$@ 送信 %3$@ 受信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ - %2$@ Em direção a %3$@ de volta"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -982,6 +1084,12 @@
             "value" : "%@ - 応答なし"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ - Sem resposta"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1044,6 +1152,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ - 送信されませんでした"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ - Não Enviado"
           }
         },
         "ru" : {
@@ -1116,6 +1230,12 @@
             "value" : "%1$@ (%2$@)"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ (%2$@)"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1183,6 +1303,12 @@
             "value" : "%1$@ (%2$lld)"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ (%2$lld)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -1239,6 +1365,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ %@"
           }
         },
         "ru" : {
@@ -1312,6 +1444,12 @@
             "value" : "%1$@ %2$lld"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$d"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1375,6 +1513,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 離れた場所"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ distante"
           }
         },
         "ru" : {
@@ -1441,6 +1585,12 @@
             "value" : "%1$@ は最大 %2$@ バイトまで設定できます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ pode ser até %@ bytes de comprimento."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1505,6 +1655,12 @@
             "value" : "%@ チャンネル？"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Quais canais?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1561,6 +1717,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "PKC管理者から構成データがリクエストされましたが、リモートノードから返信がありません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ dados de configuração foram solicitados via PKC admin, mas não houve resposta retornada do nó remoto."
           }
         },
         "ru" : {
@@ -1627,6 +1789,12 @@
             "value" : "%@ dB"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ dB"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1687,6 +1855,12 @@
             "value" : "%@ のドキュメントページ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Documentação da página %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -1733,6 +1907,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "%@ の dwell 期間"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@ Duração de permanência"
           }
         },
         "zh-Hans" : {
@@ -1790,6 +1970,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%1$@, %2$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "%1$@, %2$@"
           }
         },
@@ -1860,6 +2046,12 @@
             "value" : "%1$@: %2$lld"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@: %2$lld bytes"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -1909,6 +2101,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%@%%"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "%@%%"
           }
         },
@@ -1976,6 +2174,12 @@
             "value" : "%@°F"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@°C"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2037,6 +2241,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%@mA"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "%@mA"
           }
         },
@@ -2104,6 +2314,12 @@
             "value" : "%@V"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@V"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2166,6 +2382,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%d"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O número de itens"
           }
         },
         "ru" : {
@@ -2334,6 +2556,30 @@
             }
           }
         },
+        "pt-BR" : {
+          "variations" : {
+            "plural" : {
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "muitas colheitas"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Um Hop"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%d saltos"
+                }
+              }
+            }
+          }
+        },
         "ru" : {
           "variations" : {
             "plural" : {
@@ -2452,6 +2698,12 @@
             "value" : "%lld"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2510,6 +2762,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "%lld 回信"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld repetido"
           }
         },
         "zh-Hans" : {
@@ -2648,6 +2906,30 @@
             }
           }
         },
+        "pt-BR" : {
+          "variations" : {
+            "plural" : {
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "muitos recursos"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%lld recurso"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%lld recursos"
+                }
+              }
+            }
+          }
+        },
         "ru" : {
           "variations" : {
             "plural" : {
@@ -2760,6 +3042,12 @@
             "value" : "%lld Mesh"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld Mesh"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -2798,6 +3086,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "%lld ノード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld nós"
           }
         },
         "zh-Hans" : {
@@ -2850,6 +3144,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lldホップ以下"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld ou menos saltos de distância"
           }
         },
         "ru" : {
@@ -2916,6 +3216,12 @@
             "value" : "計 %lld 件の読み取り値"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld Leitura Total"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2976,6 +3282,12 @@
             "value" : "%lld受信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld recebidos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -3022,6 +3334,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "%lld ロータリがキャンセルされました。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld relé cancelado"
           }
         },
         "zh-Hans" : {
@@ -3072,6 +3390,12 @@
             "value" : "%lld 回信されました"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld vezes retransmitido"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -3118,6 +3442,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "送信されたパケット数: %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld enviados"
           }
         },
         "zh-Hans" : {
@@ -3172,6 +3502,12 @@
             "value" : "計 %lld 件の検出イベント"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld Eventos de Detecção Totais"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3220,6 +3556,12 @@
             "value" : "%1$lld/%2$lld nodi online"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$lld/%2$lld nós online"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -3263,6 +3605,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%lld%%"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "%lld%%"
           }
         },
@@ -3322,6 +3670,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%llddb送信電力"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%llddB Potência de Transmissão"
           }
         },
         "ru" : {
@@ -3388,6 +3742,12 @@
             "value" : "%llddBm送信電力"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%llddBm Potencia de Transmissao"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3446,6 +3806,12 @@
             "value" : "%@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -3493,6 +3859,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ファイル選択器から**場所**まで完全に戻ってください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Volte até o final da tela de seleção de locais."
           }
         },
         "zh-Hans" : {
@@ -3543,6 +3915,12 @@
             "value" : "USBデバイスを選択し、**保存**を押してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha seu dispositivo USB e toque em **Salvar**."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -3589,6 +3967,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "USBにファームウェアを保存するボタンをタップしてください"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toque no botão **Salvar Firmware no USB** abaixo."
           }
         },
         "zh-Hans" : {
@@ -3639,6 +4023,12 @@
             "value" : "ダウンロードしたファームウェアのファイル名は、iOSのキャッシュを防ぐために`.uf2`で終わるランダムな文字列になります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O nome do arquivo será uma string aleatória terminando em `.uf2` para evitar a cache do iOS."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -3685,6 +4075,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "デバイスが更新した後すぐに切断されるため、ファイルを保存できないというエラーが表示されることがあります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você pode ver um erro dizendo que o arquivo não pode ser salvo. Isso é normal, pois o dispositivo desliga imediatamente após a atualização."
           }
         },
         "zh-Hans" : {
@@ -3737,6 +4133,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "< 1%"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1%"
           }
         },
         "ru" : {
@@ -3799,6 +4201,12 @@
             "value" : "設定された値: (%@) は最適化オプションの1つではありません。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "⚠️ O valor configurado: (%@) não é uma das opções otimizadas."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3848,6 +4256,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "1"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "1"
           }
         },
@@ -3902,6 +4316,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "1バイト"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 byte"
           }
         },
         "ru" : {
@@ -3968,6 +4388,12 @@
             "value" : "1ホップ先"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "1 hop longe"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4032,6 +4458,12 @@
             "value" : "7"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "7"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4088,6 +4520,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "12時間表示"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Relógio de 12 Horas"
           }
         },
         "ru" : {
@@ -4150,6 +4588,12 @@
             "value" : "15分 dwell time"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "15 minutos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -4199,6 +4643,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "25"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "25"
           }
         },
@@ -4262,6 +4712,12 @@
             "value" : "30分"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "30 minutos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -4308,6 +4764,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "45分"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "45 minutos"
           }
         },
         "zh-Hans" : {
@@ -4359,6 +4821,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "50"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "50"
           }
         },
@@ -4422,6 +4890,12 @@
             "value" : "60分"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "60 minutos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -4471,6 +4945,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "75"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "75"
           }
         },
@@ -4534,6 +5014,12 @@
             "value" : "90分"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "90 minutos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -4583,6 +5069,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "100"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "100"
           }
         },
@@ -4646,6 +5138,12 @@
             "value" : "120分"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "120 minutos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -4696,6 +5194,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "128 bit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "128 bits"
           }
         },
         "ru" : {
@@ -4756,6 +5260,12 @@
             "value" : "180"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "180"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -4803,6 +5313,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "180分"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "180 minutos"
           }
         },
         "zh-Hans" : {
@@ -4855,6 +5371,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "256 bit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "256 bits"
           }
         },
         "ru" : {
@@ -4917,6 +5439,12 @@
             "value" : "TAK サーバーのポート番号は 8089 です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "8089"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -4965,6 +5493,12 @@
             "value" : "0番目は、放送パケットを送信するプライマリチャネルです。2.7バージョン以降に、最初に有効化されたチャネルから位置データが放送されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Um índice de canal de 0 indica o canal primário onde os pacotes de transmissão são enviados. Os dados de localização são transmitidos pelo primeiro canal onde estão habilitados com a versão do firmware 2.7 em diante."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -5009,6 +5543,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "localhost接続にはデフォルトの自己署名証明書が含まれています。必要に応じてカスタム.p12をインポートしてください。クライアントCA(.pem)はTAKクライアントを接続する際に検証します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Um certificado self-signado padrão é incluído para conexões localhost. Importe um .p12 personalizado se necessário. O CA do cliente (.pem) valida a conexão de clientes TAK."
           }
         },
         "zh-Hans" : {
@@ -5059,6 +5599,12 @@
             "value" : "このノードの前の位置報告です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Um relatório anterior de posição para este nó"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -5103,6 +5649,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "前回の位置報告は、移動方向を示しています。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Um relatório anterior de posição mostrando a direção de viagem."
           }
         },
         "zh-Hans" : {
@@ -5153,6 +5705,12 @@
             "value" : "QRコードには、ラジオが通信するためのLoRa設定とチャンネルが含まれています。チャンネルを変更するには、チャンネルを変更する、または既存のチャンネルにチャンネルの追加を行うことができます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Um código QR contém a configuração LoRa e as faixas de frequência necessárias para que os radiotransmissores possam se comunicar. Use Substituir Faixas para substituir ou Adicionar Faixas para adicionar faixas existentes."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -5199,6 +5757,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "共有ポイント。マップを長押しして作成します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Um ponto de interesse compartilhado. Aperte e mantenha pressionado o mapa para criar um."
           }
         },
         "zh-Hans" : {
@@ -5251,6 +5815,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trace Route が送信されましたが、応答が受信されませんでした。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uma rota de rastreamento foi enviada, mas não houve resposta recebida."
           }
         },
         "ru" : {
@@ -5317,6 +5887,12 @@
             "value" : "概要"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sobre"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5379,6 +5955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Meshtasticについて"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sobre Meshtastic"
           }
         },
         "ru" : {
@@ -5445,6 +6027,12 @@
             "value" : "精度 %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Precisão %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5507,6 +6095,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "応答SNR: %@ dB"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "SNR: %@ dB"
           }
         },
         "ru" : {
@@ -5573,6 +6167,12 @@
             "value" : "応答時間: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo de resposta: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5635,6 +6235,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "他のノードで確認済み"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reconhecido por outro nó"
           }
         },
         "ru" : {
@@ -5701,6 +6307,12 @@
             "value" : "アクション"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ações"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5765,6 +6377,12 @@
             "value" : "アクティブ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5825,6 +6443,12 @@
             "value" : "現在の設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Preset Ativo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -5875,6 +6499,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アクティビティ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atividade"
           }
         },
         "ru" : {
@@ -5953,6 +6583,12 @@
             "value" : "ADC Override"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar/Desativar ADC"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6017,6 +6653,12 @@
             "value" : "CAを追加します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Adicione CA"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -6067,6 +6709,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネルを追加"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Adicionar Canal"
           }
         },
         "ru" : {
@@ -6133,6 +6781,12 @@
             "value" : "チャンネルを追加"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Adicionar Canais"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6189,6 +6843,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "連絡先を追加"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Adicionar Contato"
           }
         },
         "ru" : {
@@ -6307,6 +6967,12 @@
             "value" : "お気に入りに追加"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Adicionar aos favoritos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6367,6 +7033,12 @@
             "value" : "さらにサポートはこちらをご覧ください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mais Ajuda"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -6417,6 +7089,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "住所"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Endereço"
           }
         },
         "ru" : {
@@ -6475,6 +7153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理者キー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chaves de administrador"
           }
         },
         "ru" : {
@@ -6541,6 +7225,12 @@
             "value" : "管理"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Administração"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6603,6 +7293,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理機能が有効"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Administração ativada"
           }
         },
         "ru" : {
@@ -6669,6 +7365,12 @@
             "value" : "上級"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Avancado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6731,6 +7433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高度なデバイスGPS"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "GPS avançado"
           }
         },
         "ru" : {
@@ -6797,6 +7505,12 @@
             "value" : "高度な位置フラグ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Flags de posição avançada"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6853,6 +7567,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "上級ユーザーのみです。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Usuário Avançado Apenas."
           }
         },
         "zh-Hans" : {
@@ -6991,6 +7711,30 @@
             }
           }
         },
+        "pt-BR" : {
+          "variations" : {
+            "plural" : {
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Depois de %lld dias"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Depois de um dia"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "Depois de %lld dias"
+                }
+              }
+            }
+          }
+        },
         "ru" : {
           "variations" : {
             "plural" : {
@@ -7121,6 +7865,12 @@
             "value" : "Po zapisaniu wartości konfiguracji węzeł zostanie zrestartowany."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Depois de salvar os valores de configuração, o nó reiniciará."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7203,6 +7953,12 @@
             "value" : "Czas nadawania"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo de uso"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7273,6 +8029,12 @@
             "value" : "アラート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7335,6 +8097,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ベル受信時にGPIOブザーでアラート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta o zumbido do GPIO ao receber um sino"
           }
         },
         "ru" : {
@@ -7401,6 +8169,12 @@
             "value" : "メッセージ受信時にGPIOブザーでアラート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta o zumbido do GPIO ao receber uma mensagem"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7463,6 +8237,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ベル受信時にGPIO振動モーターでアラート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta o GPIO vibra o motor ao receber um sino"
           }
         },
         "ru" : {
@@ -7529,6 +8309,12 @@
             "value" : "メッセージ受信時にGPIO振動モーターでアラート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta o GPIO vibra o motor ao receber uma mensagem"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7591,6 +8377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ベル受信時にアラート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta ao receber um sino"
           }
         },
         "ru" : {
@@ -7657,6 +8449,12 @@
             "value" : "メッセージ受信時にアラート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta ao receber uma mensagem"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7719,6 +8517,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全て"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tudo"
           }
         },
         "ru" : {
@@ -7785,6 +8589,12 @@
             "value" : "位置要求を許可"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Permite Solicitações de Posicionamento"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7845,6 +8655,12 @@
             "value" : "アルファ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alpha"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -7895,6 +8711,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高度"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alt"
           }
         },
         "ru" : {
@@ -7961,6 +8783,12 @@
             "value" : "高度"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Altitude"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8023,6 +8851,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高度 %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Altitude %@"
           }
         },
         "ru" : {
@@ -8089,6 +8923,12 @@
             "value" : "高度ジオイド分離"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Separação Geoidal da Altitude"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8153,6 +8993,12 @@
             "value" : "高度は平均海面レベル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Altitude é o nível do mar médio"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8215,6 +9061,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "常に北を指す"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sempre apontar para o norte"
           }
         },
         "ru" : {
@@ -8285,6 +9137,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "環境照明"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Iluminação Ambiental"
           }
         },
         "ru" : {
@@ -8363,6 +9221,12 @@
             "value" : "環境照明設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Iluminação Ambiental"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8433,6 +9297,12 @@
             "value" : "手頃な価格の低電力無線機で動作する、オープンソース、オフグリッド、分散型メッシュネットワーク。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uma rede de rede de mesh aberta, off-grid, descentralizada e descentralizada que funciona em rádios de baixa potência e acessíveis."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8493,6 +9363,12 @@
             "value" : "LoRaノードのメッシュ上の位置を囲む輪郭"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uma borda que envolve todas as posições dos nós LoRa no mapeamento."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -8539,6 +9415,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "分析中..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Analizando..."
           }
         },
         "zh-Hans" : {
@@ -8591,6 +9473,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "見逃したメッセージは再配信されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagens perdidas serão entregues novamente."
           }
         },
         "ru" : {
@@ -8657,6 +9545,12 @@
             "value" : "App データ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dados do aplicativo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8721,6 +9615,12 @@
             "value" : "アプリファイル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arquivos do Aplicativo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8779,6 +9679,12 @@
             "value" : "アプリアイコン"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Icone do Aplicativo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8835,6 +9741,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "アプリ通知"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notificações do Aplicativo"
           }
         },
         "ru" : {
@@ -8901,6 +9813,12 @@
             "value" : "アプリ設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações do Aplicativo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8963,6 +9881,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Appleアプリ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aplicativos da Apple"
           }
         },
         "ru" : {
@@ -9029,6 +9953,12 @@
             "value" : "正確な位置"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Localização aproximada"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9089,6 +10019,12 @@
             "value" : "デバイスアーキテクチャ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arquitetura"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -9139,6 +10075,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このメッセージを削除してもよろしいですか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você está certo de querer excluir essa mensagem?"
           }
         },
         "ru" : {
@@ -9203,6 +10145,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ノードを工場出荷時設定にリセットしてもよろしいですか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você está certo de querer reiniciar o nó?"
           }
         },
         "ru" : {
@@ -9281,6 +10229,12 @@
             "value" : "Jesteś pewny?"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você está certo?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9341,6 +10295,12 @@
             "value" : "Domanda Chirpy"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pergunte ao Chirpy"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -9389,6 +10349,12 @@
             "value" : "チリピィAIアシスタントに質問してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pergunte ao assistente de IA Chirpy"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -9435,6 +10401,12 @@
             "value" : "Chirpy に聞いてください..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pergunte ao Chirpy..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -9479,6 +10451,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Meshtasticについて何か質問がありますか？\nドキュメントを検索し、わかりやすく答えます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pergunte-me qualquer coisa sobre Meshtastic. Vou procurar no manual e responder de forma simples."
           }
         },
         "zh-Hans" : {
@@ -9529,6 +10507,12 @@
             "value" : "TAKサーバーのメイン通信チャネルを自動的に修正する"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Auto-Corrigir Canal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -9573,6 +10557,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "自動接続"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conecte-se automaticamente"
           }
         },
         "ru" : {
@@ -9639,6 +10629,12 @@
             "value" : "指定した間隔に基づいて、カルーセルのように画面の次のページに自動的に切り替わります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Automatically alterna para a próxima página na tela como um carrossel, com base no intervalo especificado."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9703,6 +10699,12 @@
             "value" : "利用可能なモデムプリセット、デフォルトは Long Fast です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Preset de modem disponíveis, padrão é Long Fast."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9761,6 +10763,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "利用可能なWi-Fiネットワーク"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Redes Disponiveis"
           }
         },
         "zh-Hans" : {
@@ -9825,6 +10833,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dostępne radia"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Radios Disponiveis"
           }
         },
         "ru" : {
@@ -9893,6 +10907,12 @@
             "value" : "平均チャンネル利用率"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Utilização Média de Canal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -9937,6 +10957,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "バックアップ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Backup"
           }
         },
         "ru" : {
@@ -9995,6 +11021,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "プライベートキーをiCloudキーチェーンにバックアップします。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salve seu chave privada no seu iCloud Keychain."
           }
         },
         "ru" : {
@@ -10061,6 +11093,12 @@
             "value" : "帯域幅"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bandeira"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10123,6 +11161,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "バー系列"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Séries de Bar"
           }
         },
         "ru" : {
@@ -10199,6 +11243,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Battery"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bateria"
           }
         },
         "ru" : {
@@ -10284,6 +11334,12 @@
             "value" : "Poziom naładowania baterii"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nível de bateria"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10367,6 +11423,12 @@
             "value" : "Poziom naładowania baterii %"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nível de bateria %"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10444,6 +11506,12 @@
             "value" : "Poziom naładowania baterii %d"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nível de bateria %d"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10508,6 +11576,12 @@
             "value" : "ノードが報告したバッテリーレベル、電圧、チャネル利用率、および空間の時間"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nível de bateria, tensão, utilização de canal e tempo de operação relatados pelo nó"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -10558,6 +11632,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ボーレート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Baud rate"
           }
         },
         "ru" : {
@@ -10620,6 +11700,12 @@
             "value" : "更新を開始します"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Começar Atualização"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -10668,6 +11754,12 @@
             "value" : "バイナリファイル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arquivo binário"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -10714,6 +11806,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "バイナリデータ (%lldバイト)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dados Binários (%lld bytes)"
           }
         },
         "zh-Hans" : {
@@ -10766,6 +11864,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "BLE"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bluetooth"
           }
         },
         "ru" : {
@@ -10832,6 +11936,12 @@
             "value" : "Bluetoothデバイス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dispositivo BLE"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -10876,6 +11986,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "BLE OTA アップデート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizando OTA via BLE"
           }
         },
         "zh-Hans" : {
@@ -10940,6 +12056,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pin BLE musi mieć długość 6 cyfr."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O pino BLE deve ter 6 dígitos."
           }
         },
         "ru" : {
@@ -11021,6 +12143,12 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bluetooth"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "Bluetooth"
           }
         },
@@ -11106,6 +12234,12 @@
             "value" : "Konfiguracja Bluetooth"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações de Bluetooth"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11172,6 +12306,12 @@
             "value" : "Bluetooth接続を構成してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conectividade Bluetooth"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11230,6 +12370,12 @@
             "value" : "Bold Heading"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Título em negrito"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11286,6 +12432,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "画面に**タイトル**を強調表示します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Destaques do produto**"
           }
         },
         "ru" : {
@@ -11348,6 +12500,12 @@
             "value" : "Mesh to CoT Converterは、Meshの位置、ノード、ウェイポイント、メッセージを TAK/CoT形式にブリッジします。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Converte posições, nós, roteiros e mensagens do Mesh para o formato TAK/CoT"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -11392,6 +12550,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "送信デバイス指標"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Métricas do Dispositivo de Transmissão"
           }
         },
         "ru" : {
@@ -11450,6 +12614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ボタンGPIO"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Botão GPIO"
           }
         },
         "ru" : {
@@ -11516,6 +12686,12 @@
             "value" : "完成品無線機を購入"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Comprar Radios Completos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11578,6 +12754,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ブザーGPIO"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Botão GPIO"
           }
         },
         "ru" : {
@@ -11644,6 +12826,12 @@
             "value" : "この機能を有効にすることで、お客様のデバイスのリアルタイム地理位置が暗号化されずにMQTTプロトコル経由で送信されることを承知し、明示的に同意することを認めます。この位置データは、ライブマップ報告、デバイス追跡、関連テレメトリー機能などの目的で使用される場合があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ao habilitar essa funcionalidade, você concorda e expressamente autoriza a transmissão da localização geográfica em tempo real do seu dispositivo via protocolo MQTT sem criptografia. Esses dados de localização podem ser usados para fins como relatórios de mapas ao vivo, rastreamento de dispositivos e funções de telemetria relacionadas."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11701,6 +12889,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用バイト"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bytes utilizados"
           }
         },
         "ru" : {
@@ -11767,6 +12961,12 @@
             "value" : "コールサイン"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Identificador de chamada"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11829,6 +13029,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "コールサインは空にできません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O identificador de chamada não pode estar vazio"
           }
         },
         "ru" : {
@@ -11905,6 +13111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Anuluj"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cancelar"
           }
         },
         "ru" : {
@@ -11989,6 +13201,12 @@
             "value" : "Gotowe wiadomości"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagens em lata"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12071,6 +13289,12 @@
             "value" : "Konfiguracja gotowych wiadomości"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações de Mensagens Presas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12141,6 +13365,12 @@
             "value" : "カルーセル間隔"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Intervalo de Carousel"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12201,6 +13431,12 @@
             "value" : "カープレイメッセージング"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagem no CarPlay"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -12251,6 +13487,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "カテゴリ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Categorias"
           }
         },
         "ru" : {
@@ -12317,6 +13559,12 @@
             "value" : "カテゴリ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Categorias"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12375,6 +13623,12 @@
             "value" : "チャ Util"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Utilizador"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -12425,6 +13679,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ch1 現在"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ch1 corrente"
           }
         },
         "ru" : {
@@ -12491,6 +13751,12 @@
             "value" : "Ch1 電圧"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Volta Ch1"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12553,6 +13819,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ch2 現在"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ch2 Corrente"
           }
         },
         "ru" : {
@@ -12619,6 +13891,12 @@
             "value" : "Ch2 電圧"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tensão Ch2"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12683,6 +13961,12 @@
             "value" : "Ch3 現在"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ch3 Corrente"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12745,6 +14029,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ch3 電圧"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tensão de Ch3"
           }
         },
         "ru" : {
@@ -12823,6 +14113,12 @@
             "value" : "Kanał"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12893,6 +14189,12 @@
             "value" : "チャンネル0を含む"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 0 Incluído"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12955,6 +14257,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル1"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 1"
           }
         },
         "ru" : {
@@ -13021,6 +14329,12 @@
             "value" : "チャンネル1を含む"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 1 Incluído"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13083,6 +14397,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル2"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 2"
           }
         },
         "ru" : {
@@ -13149,6 +14469,12 @@
             "value" : "チャンネル2を含む"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 2 Incluído"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13211,6 +14537,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル 3"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 3"
           }
         },
         "ru" : {
@@ -13277,6 +14609,12 @@
             "value" : "チャンネル 3を含む"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 3 incluído"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13339,6 +14677,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル 4を含む"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 4 Incluído"
           }
         },
         "ru" : {
@@ -13405,6 +14749,12 @@
             "value" : "チャンネル 5を含む"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 5 Incluído"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13467,6 +14817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル 6を含む"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 6 Incluído"
           }
         },
         "ru" : {
@@ -13533,6 +14889,12 @@
             "value" : "チャンネル 7を含む"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal 7 Incluído"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13589,6 +14951,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル詳細"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal"
           }
         },
         "ru" : {
@@ -13651,6 +15019,12 @@
             "value" : "チャンネルが正常に修正されました！"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal corrigido!"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -13697,6 +15071,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "チャンネルインデックス"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Índice de Canais"
           }
         },
         "zh-Hans" : {
@@ -13749,6 +15129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル名"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome do Canal"
           }
         },
         "ru" : {
@@ -13815,6 +15201,12 @@
             "value" : "チャンネル番号は0から7の間である必要があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O número de canal deve estar entre 0 e 7."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13879,6 +15271,12 @@
             "value" : "チャンネル役割"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Papel de Canal"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13939,6 +15337,12 @@
             "value" : "チャンネルセキュリティ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Segurança de Canal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -13989,6 +15393,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル URL"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "URL do Canal"
           }
         },
         "ru" : {
@@ -14067,6 +15477,12 @@
             "value" : "Wykorzystanie kanału"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Utilização de Canal"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14135,6 +15551,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル使用率 %@%%"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Utilização do Canal %@%%"
           }
         },
         "ru" : {
@@ -14213,6 +15635,12 @@
             "value" : "Kanały"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canais"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14277,6 +15705,12 @@
             "value" : "チャンネルヘルプ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajuda de Canais"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14337,6 +15771,12 @@
             "value" : "メッセージ交換が多い設定は %@ です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Presets dominados por mensagens: %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -14387,6 +15827,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "充電中"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alterar"
           }
         },
         "ru" : {
@@ -14449,6 +15895,12 @@
             "value" : "Chirpy が答えをロードしています。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chirpy está carregando uma resposta"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -14493,6 +15945,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "適切なデバイスの役割を選択する"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolher o Papel Certo do Dispositivo"
           }
         },
         "zh-Hans" : {
@@ -14545,6 +16003,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "クリア"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Limpo"
           }
         },
         "ru" : {
@@ -14623,6 +16087,12 @@
             "value" : "Wyczyść dane aplikacji"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Limpar Dados do Aplicativo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14693,6 +16163,12 @@
             "value" : "ログクリア"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Registro limpo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14743,6 +16219,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "古いノードをクリア"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Limpar nós velhos"
           }
         },
         "ru" : {
@@ -14803,6 +16285,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "クリア翻訳"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Limpar Tradução"
           }
         },
         "zh-Hans" : {
@@ -14905,6 +16393,12 @@
             "value" : "クライアントCA証明書"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Certificado CA do Cliente"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -14949,6 +16443,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "クライアント構成"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração do Cliente"
           }
         },
         "zh-Hans" : {
@@ -15001,6 +16501,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "クライアント履歴"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Histórico de Clientes"
           }
         },
         "ru" : {
@@ -15067,6 +16573,12 @@
             "value" : "クライアント履歴リクエストを送信しました"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pedido de Histórico do Cliente Enviado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15131,6 +16643,12 @@
             "value" : "クライアントオプション"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções do cliente"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15193,6 +16711,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "時計回りロータリーイベント"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Evento Rotativo Ciclíco"
           }
         },
         "ru" : {
@@ -15271,6 +16795,12 @@
             "value" : "Zamknij"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fechar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15341,6 +16871,12 @@
             "value" : "符号化率"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Taxa de codificação"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15403,6 +16939,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "色"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cor"
           }
         },
         "ru" : {
@@ -15469,6 +17011,12 @@
             "value" : "通信中"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Comunicando"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15527,6 +17075,12 @@
             "value" : "コンパス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compass"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15581,6 +17135,12 @@
             "value" : "メッシュディスカバリースキャンを完了して結果を確認してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Complete a Local Mesh Discovery scan to see results here."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -15625,6 +17185,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "デバイスの完全設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração Completa do Dispositivo"
           }
         },
         "zh-Hans" : {
@@ -15677,6 +17243,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Config"
           }
         },
         "ru" : {
@@ -15737,6 +17309,12 @@
             "value" : "設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -15787,6 +17365,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ の設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração para: %@"
           }
         },
         "ru" : {
@@ -15853,6 +17437,12 @@
             "value" : "設定プリセット"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Presets de Configuração"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15915,6 +17505,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定する"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurar"
           }
         },
         "ru" : {
@@ -15981,6 +17577,12 @@
             "value" : "確認"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Confirmar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16037,6 +17639,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "接続"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conectar"
           }
         },
         "ru" : {
@@ -16103,6 +17711,12 @@
             "value" : "ノードに接続"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conecte-se a um nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16165,6 +17779,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "プロキシ経由でMQTTに接続"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conecte-se ao MQTT via Proxy"
           }
         },
         "ru" : {
@@ -16231,6 +17851,12 @@
             "value" : "新しい無線機に接続しますか？"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conecte-se ao novo rádio?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16291,6 +17917,12 @@
             "value" : "ローカルWi-Fiネットワーク上のノードに接続してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conecte-se aos nós na sua rede Wi-Fi local."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -16337,6 +17969,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Bluetooth Low Energyを使用して、Meshtasticノードに接続して、最高のメッセージング体験を実現してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conecte-se ao seu nó Meshtastic via Bluetooth Low Energy para a melhor experiência de mensagens."
           }
         },
         "zh-Hans" : {
@@ -16387,6 +18025,12 @@
             "value" : "デバイスを安定した電源に接続してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conecte seu dispositivo a uma fonte de alimentação estável."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -16433,6 +18077,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "mPWRD-OSデバイスをBluetoothを介してWi-Fiネットワークに接続してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conecte seu dispositivo mPWRD-OS a uma rede Wi-Fi via Bluetooth."
           }
         },
         "zh-Hans" : {
@@ -16497,6 +18147,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Podłączony"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conectado"
           }
         },
         "ru" : {
@@ -16565,6 +18221,12 @@
             "value" : "接続されたファームウェア: **%@**"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Firmware conectado: **%@**"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -16615,6 +18277,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接続済みノード %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nodo conectado %@"
           }
         },
         "ru" : {
@@ -16679,6 +18347,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接続済み無線機"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Radio conectado"
           }
         },
         "ru" : {
@@ -16757,6 +18431,12 @@
             "value" : "Łączenie . ."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conectando . . ."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16827,6 +18507,12 @@
             "value" : "新しい無線機に接続すると、電話上の全てのアプリデータがクリアされます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conectando a uma nova rádio apaga todos os dados da aplicação no telefone."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16891,6 +18577,12 @@
             "value" : "接続試行%1$lld/%2$lld"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tentativa de conexão %1$d de %2$d"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -16935,6 +18627,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "接続名"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome da Conexão"
           }
         },
         "ru" : {
@@ -17001,6 +18699,12 @@
             "value" : "MQTT経由での暗号化されていないノードデータの共有に同意"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Consentir a partilha de dados de nó não criptografados via MQTT"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17057,6 +18761,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "連絡先URL"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "URL de contato"
           }
         },
         "ru" : {
@@ -17119,6 +18829,12 @@
             "value" : "連絡先"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Contatos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -17163,6 +18879,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "続きです"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continue"
           }
         },
         "zh-Hans" : {
@@ -17211,6 +18933,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "連続位置更新"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizações de Localização Contínuas"
           }
         },
         "zh-Hans" : {
@@ -17263,6 +18991,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Control タイプ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tipo de Controle"
           }
         },
         "ru" : {
@@ -17329,6 +19063,12 @@
             "value" : "デバイス上の点滅LEDを制御します。ほとんどのデバイスでは最大4つのLEDのうち1つを制御し、充電器とGPS LEDは制御できません。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Controla a luz piscante no dispositivo. Para a maioria dos dispositivos, isso controlará um dos até 4 LEDs, os LEDs do carregador e GPS não são controláveis."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17391,6 +19131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "凸包"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Convolução de Hull"
           }
         },
         "ru" : {
@@ -17457,6 +19203,12 @@
             "value" : "座標"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Coordenada"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17521,6 +19273,12 @@
             "value" : "座標 %@, %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Coordenada %@, %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17583,6 +19341,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "座標:"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Coordenadas:"
           }
         },
         "ru" : {
@@ -17661,6 +19425,12 @@
             "value" : "Kopiuj"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Copie"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17731,6 +19501,12 @@
             "value" : "ノードが見つかりません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não foi possível encontrar o nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17795,6 +19571,12 @@
             "value" : "反時計回りの回転イベント"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Evento Rotativo Contra Relógio"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17855,6 +19637,12 @@
             "value" : "ノード コンタクト NFC タグ を作成"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Crie um NFC Contact Node"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -17905,6 +19693,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ウェイポイントを作成"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Criar ponto de referência"
           }
         },
         "ru" : {
@@ -17965,6 +19759,12 @@
             "value" : "作成者:"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Criado por:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -18015,6 +19815,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "作成日時: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Criado em %@"
           }
         },
         "ru" : {
@@ -18073,6 +19879,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "重要なアラート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alertas Críticas"
           }
         },
         "ru" : {
@@ -18139,6 +19951,12 @@
             "value" : "現在"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atual"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18199,6 +20017,12 @@
             "value" : "現在のファームウェアバージョン"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Versão Atual do Firmware"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -18249,6 +20073,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "現在: %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atual: %lld"
           }
         },
         "ru" : {
@@ -18311,6 +20141,12 @@
             "value" : "記録されたルートパスの表示線"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uma linha tracejada mostrando um caminho de rota gravado."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -18359,6 +20195,12 @@
             "value" : "データブラウザ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Navegador de Dados"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -18405,6 +20247,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メインデータベースブラウザ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Navegador de Banco de Dados"
           }
         },
         "zh-Hans" : {
@@ -18457,6 +20305,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日付"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Data"
           }
         },
         "ru" : {
@@ -18523,6 +20377,12 @@
             "value" : "デバッグ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desenvolvimento"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18587,6 +20447,12 @@
             "value" : "デバッグログ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Registros de depuração"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18649,6 +20515,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバッグログ%@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Registros de depuração%@"
           }
         },
         "ru" : {
@@ -18727,6 +20599,12 @@
             "value" : "Domyślny"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Padrão"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18793,6 +20671,12 @@
             "value" : "デフォルトキーが必要です"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chave padrão necessária para descoberta de rede local"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -18857,6 +20741,12 @@
             "value" : "Usuń"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apague"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18915,6 +20805,12 @@
             "value" : "すべて削除"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apague tudo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -18959,6 +20855,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全ての設定、キー、BLEボンドを削除しますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta todas as configurações, chaves e ligações BLE?"
           }
         },
         "ru" : {
@@ -19017,6 +20919,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全ての設定を削除しますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta todas as configurações?"
           }
         },
         "ru" : {
@@ -19089,6 +20997,12 @@
             "value" : "Usunąć wszystkie metryki urządzenia?"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta todos os métricas do dispositivo?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19145,6 +21059,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全ての環境メトリクスを削除しますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta todos os métricas ambientais?"
           }
         },
         "ru" : {
@@ -19209,6 +21129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全てのPAXデータを削除しますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta todos os dados de passageiros?"
           }
         },
         "ru" : {
@@ -19339,6 +21265,12 @@
             "value" : "メッセージを削除"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta Mensagem"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19401,6 +21333,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "メッセージを削除"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apague Mensagens"
           }
         },
         "ru" : {
@@ -19467,6 +21405,12 @@
             "value" : "ノードを削除"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta Nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19531,6 +21475,12 @@
             "value" : "ノードを削除しますか？"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta o nó?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19587,6 +21537,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "電力メトリクスを削除しますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Deleta os metadados de energia?"
           }
         },
         "ru" : {
@@ -19653,6 +21609,12 @@
             "value" : "説明"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Descrição"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19717,6 +21679,12 @@
             "value" : "説明は100バイト未満である必要があります"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Descrição deve ser menor que 100 bytes"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19775,6 +21743,12 @@
             "value" : "デスクトップ推奨"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recomendado para Desktop"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -19823,6 +21797,12 @@
             "value" : "詳細"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detalhes"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -19867,6 +21847,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "詳細..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detalhes..."
           }
         },
         "ru" : {
@@ -19933,6 +21919,12 @@
             "value" : "検出"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detecção"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19995,6 +21987,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "検出イベント"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Evento de detecção"
           }
         },
         "ru" : {
@@ -20074,6 +22072,12 @@
             "value" : "Detection Sensor"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sensor de Detecção"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20150,6 +22154,12 @@
             "value" : "検出センサー設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração do Sensor de Detecção"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20214,6 +22224,12 @@
             "value" : "ノードから報告されるセンサーイベント、例えば動きやドアが開閉のアラートなど"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eventos de sensores de detecção relatados pelo nó, como movimento ou alertas de abertura/fechamento de portas."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -20264,6 +22280,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "検出センサーログ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Registro do Sensor de Detecção"
           }
         },
         "ru" : {
@@ -20330,6 +22352,12 @@
             "value" : "検出センサーメッセージはテキストメッセージとして受信されます。通知を有効にすると、受信した各検出メッセージの通知と対応する未読メッセージバッジが表示されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "As mensagens de detecção do sensor são recebidas como mensagens de texto. Se você habilitar as notificações, receberá uma notificação para cada mensagem de detecção recebida e um ícone de mensagem não lida correspondente."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20392,6 +22420,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開発者"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desenvolvedores"
           }
         },
         "ru" : {
@@ -20468,6 +22502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Urządzenie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dispositivo"
           }
         },
         "ru" : {
@@ -20552,6 +22592,12 @@
             "value" : "Konfiguracja urządzenia"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração do Dispositivo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20622,6 +22668,12 @@
             "value" : "デバイス設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração do Dispositivo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20686,6 +22738,12 @@
             "value" : "デバイス設定ドキュメント"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Documentos de Configuração do Dispositivo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -20730,6 +22788,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "デバイスが接続されました"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dispositivo conectado"
           }
         },
         "zh-Hans" : {
@@ -20782,6 +22846,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイス GPS"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dispositivo GPS"
           }
         },
         "ru" : {
@@ -20848,6 +22918,12 @@
             "value" : "デバイスはメッシュ管理者によって管理されており、ユーザーはデバイス設定にアクセスできません。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O dispositivo é gerenciado por um administrador de rede, o usuário não pode acessar nenhuma das configurações do dispositivo."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20910,6 +22986,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイスメトリクス"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Métricas do dispositivo"
           }
         },
         "ru" : {
@@ -20976,6 +23058,12 @@
             "value" : "デバイスメトリクスログ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Relatório de Metricas do Dispositivo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21034,6 +23122,12 @@
             "value" : "デバイスオプション"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções do Dispositivo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21090,6 +23184,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイス役割"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Função do Dispositivo"
           }
         },
         "ru" : {
@@ -21152,6 +23252,12 @@
             "value" : "デバイスの役割は '%@' です。最適動作のために TAK または TAK トラッカーに設定することをお勧めします。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A função do dispositivo é '%@'. Considere definir como TAK ou TAK Tracker para operação otimizada."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -21196,6 +23302,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "デバイスロール"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Papéis do Dispositivo"
           }
         },
         "zh-Hans" : {
@@ -21248,6 +23360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイス画面"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tela do dispositivo"
           }
         },
         "ru" : {
@@ -21310,6 +23428,12 @@
             "value" : "DFU ファームウェアアップデート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualização de Firmware DFU"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -21360,6 +23484,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "精度希釈（DOP）、デフォルトでPDOPを使用"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diluição da precisão (DOP) PDOP utilizado por padrão"
           }
         },
         "ru" : {
@@ -21420,6 +23550,12 @@
             "value" : "ダイレクト"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Direto"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21476,6 +23612,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダイレクトメッセージキー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "chave de mensagem direta"
           }
         },
         "ru" : {
@@ -21554,6 +23696,12 @@
             "value" : "Bezpośrednie Wiadomości"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagens diretas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21620,6 +23768,12 @@
             "value" : "直接メッセージは、公開鍵インフラストラクチャを使用して暗号化されます。バージョン2.5またはそれ以上のファームウェアが必要です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Os mensagens diretas usam a infraestrutura de assinatura pública para criptografia. Requer versão do firmware 2.5 ou superior."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -21670,6 +23824,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダイレクトメッセージはチャンネルの共有キーを使用しています。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "As mensagens diretas estão usando a chave compartilhada para o canal."
           }
         },
         "ru" : {
@@ -21730,6 +23890,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Direct Messages ヘルプ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajuda com Mensagens Diretas"
           }
         },
         "zh-Hans" : {
@@ -21794,6 +23960,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wyłączony"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desativado"
           }
         },
         "ru" : {
@@ -21878,6 +24050,12 @@
             "value" : "Rozłącz"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desconectar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21942,6 +24120,12 @@
             "value" : "ノードを切断"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desconectar Nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21992,6 +24176,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "現在接続中のノードを切断します"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desconecte o nó conectado atualmente"
           }
         },
         "ru" : {
@@ -22052,6 +24242,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "発見マップ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapa de Descobrimento"
           }
         },
         "zh-Hans" : {
@@ -22116,6 +24312,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zamknij"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cancelar"
           }
         },
         "ru" : {
@@ -22200,6 +24402,12 @@
             "value" : "Wyświetlacz (Ekran Urządzenia)"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exibir"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22282,6 +24490,12 @@
             "value" : "Konfiguracja Wyświetlacza"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações de exibição"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22352,6 +24566,12 @@
             "value" : "華氏表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exibir Fahrenheit"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22414,6 +24634,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "表示モード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modo de exibição"
           }
         },
         "ru" : {
@@ -22538,6 +24764,12 @@
             "value" : "表示単位"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Unidades de exibição"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22602,6 +24834,12 @@
             "value" : "距離"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Distância"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22662,6 +24900,12 @@
             "value" : "距離と方位"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Distância & Ângulo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -22708,6 +24952,12 @@
             "value" : "距離と方位"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Distância e Ângulo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -22752,6 +25002,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "距離フィルター"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filtros de Distância"
           }
         },
         "ru" : {
@@ -22810,6 +25066,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "距離測定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Medidas de Distância"
           }
         },
         "ru" : {
@@ -22872,6 +25134,12 @@
             "value" : "アップデート中にアプリを閉じることはありません。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não feche o aplicativo durante a atualização."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -22922,6 +25190,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ドキュメント"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Documentação"
           }
         },
         "ru" : {
@@ -22982,6 +25256,12 @@
             "value" : "ドキュメント翻訳"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Traduções de Documentação"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -23030,6 +25310,12 @@
             "value" : "ドキュメントが読み込めませんでした"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Documentação indisponível"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -23074,6 +25360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完了"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Feito"
           }
         },
         "ru" : {
@@ -23140,6 +25432,12 @@
             "value" : "ダブルタップをボタンとして使用"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Double-tap como botão"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23204,6 +25502,12 @@
             "value" : "ダウンリンク有効"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Baixa ativada"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23264,6 +25568,12 @@
             "value" : "ダウンロード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Baixe"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -23308,6 +25618,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "TAKサーバーデータパッケージをダウンロードしてください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Baixe o pacote de dados do servidor TAK"
           }
         },
         "zh-Hans" : {
@@ -23358,6 +25674,12 @@
             "value" : "ダウンロード済みの firmware"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Firmware baixado"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -23402,6 +25724,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "マップにピンを配置"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Drope Pin no Maps"
           }
         },
         "ru" : {
@@ -23464,6 +25792,12 @@
             "value" : "dwell time"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo de permanência"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -23510,6 +25844,12 @@
             "value" : "設定ごとに滞在時間"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo de permanência por preset"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -23554,6 +25894,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "各ノードには、4バイト以内の短い名前（色付きの円の中に表示）と、それに続く長い名前が表示されます。ノード番号に基づいて円の色が異なります。短い名前は絵文字またはイニシャルにすることができます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cada nó tem um nome curto (até 4 bytes) exibido no círculo colorido, e um nome longo exibido ao lado dele. O colorido do círculo é baseado no número do nó. O nome curto pode ser um emoji ou inicial."
           }
         },
         "zh-Hans" : {
@@ -23612,6 +25958,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エコー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eco"
           }
         },
         "ru" : {
@@ -23684,6 +26036,12 @@
             "value" : "ウェイポイント編集"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Editar ponto de caminho"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23746,6 +26104,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "標高ゲイン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ganho de elevação"
           }
         },
         "ru" : {
@@ -23812,6 +26176,12 @@
             "value" : "絵文字"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Emoji"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23876,6 +26246,12 @@
             "value" : "空"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vazio"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23936,6 +26312,12 @@
             "value" : "バックグラウンドアクティビティを有効にする"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar Atualizações de Localização em Fundo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -23980,6 +26362,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メッシュネットワークにブロードキャストデバイスのメトリクスを有効にします。無効にすると、メトリクスは接続されたクライアントのみに送信されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar a transmissão de métricas do dispositivo para a rede de mesh. Quando desativado, as métricas são enviadas apenas para os clientes conectados."
           }
         },
         "ru" : {
@@ -24038,6 +26426,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ローカルネットワーク上でUDP経由のパケットブロードキャストを有効にします。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ative a transmissão de pacotes via UDP no rede local."
           }
         },
         "ru" : {
@@ -24104,6 +26498,12 @@
             "value" : "通知を有効にする"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar Notificações"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24162,6 +26562,12 @@
             "value" : "TAKサーバーを有効にする"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar o Servidor TAK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -24212,6 +26618,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このデバイスをStore and Forwardサーバーとして有効にします。PSRAMを搭載したESP32デバイスが必要です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ative este dispositivo como servidor de armazenamento e encaminhamento. Requer um dispositivo ESP32 com PSRAM."
           }
         },
         "ru" : {
@@ -24290,6 +26702,12 @@
             "value" : "Włączony"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24360,6 +26778,12 @@
             "value" : "ネイティブI2Sオーディオ出力を持つデバイスで、ブザーのようにスピーカー経由でRTTTLを使用できるようにします。例えば、T-Watch S3やT-Deckにはこの機能があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Permite que dispositivos com saída de áudio I2S nativa usem RTTTL como um zumbido no alto-falante. Exemplos como T-Watch S3 e T-Deck possuem essa capacidade."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24416,6 +26840,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メッシュマップであなたのスマートフォンの青い位置点を表示します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativa a seta de localização azul para o seu telefone no mapa do mesh."
           }
         },
         "ru" : {
@@ -24482,6 +26912,12 @@
             "value" : "検出センサーモジュールを有効にします。センサーを持つノードと、検出センサーテキストメッセージを受信したり、検出センサーログやチャートを表示したいノードの両方で有効にする必要があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativa o módulo do sensor de detecção, ele precisa ser ativado tanto no nó com o sensor quanto em qualquer nó que você deseja receber mensagens de texto de detecção de sensores ou visualizar o log e o gráfico do sensor de detecção."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24544,6 +26980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Store and Forwardモジュールを有効にします。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativa o módulo de armazenamento e transmissão."
           }
         },
         "ru" : {
@@ -24610,6 +27052,12 @@
             "value" : "Ethernetを有効にすると、アプリへのBluetooth接続が無効になります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar Ethernet desativa a conexão Bluetooth com o aplicativo."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24674,6 +27122,12 @@
             "value" : "Wi-Fiを有効にすると、アプリのBluetooth接続が停止します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar o WiFi desativa a conexão Bluetooth com o aplicativo."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24736,6 +27190,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エンコーダープレスイベント"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pressione o botão de encerramento"
           }
         },
         "ru" : {
@@ -24814,6 +27274,12 @@
             "value" : "Zaszyfrowany"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Encriptado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24880,6 +27346,12 @@
             "value" : "暗号化"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Encriptacao"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -24930,6 +27402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暗号化有効"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A criptografia está ativada"
           }
         },
         "ru" : {
@@ -24992,6 +27470,12 @@
             "value" : "デバイスを充電してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Certifique-se de que seu dispositivo esteja carregado."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -25038,6 +27522,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ホスト名[:ポート]を入力"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Digite o endereço IP ou o nome de host[:port]"
           }
         },
         "ru" : {
@@ -25098,6 +27588,12 @@
             "value" : "P12パスワードを入力してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Digite a senha P12"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -25146,6 +27642,12 @@
             "value" : "Wi-Fiパスワードを入力してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Digite sua senha Wi-Fi"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -25190,6 +27692,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "PKCS#12ファイルのパスワードを入力してください"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Digite a senha para o arquivo PKCS#12"
           }
         },
         "zh-Hans" : {
@@ -25240,6 +27748,12 @@
             "value" : "選択したテキストのURLを入力してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Digite a URL para o texto selecionado"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -25286,6 +27800,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "エントリ (%lld)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Entidades (%lld)"
           }
         },
         "zh-Hans" : {
@@ -25338,6 +27858,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "環境"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você pode usar o aplicativo para controlar dispositivos IoT, como lâmpadas inteligentes, termostatos e sensores de movimento."
           }
         },
         "ru" : {
@@ -25398,6 +27924,12 @@
             "value" : "環境指標が有効です"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Medidas Ambientais Ativas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25454,6 +27986,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "環境メトリクスログ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Relatório de Metricas Ambientais"
           }
         },
         "ru" : {
@@ -25514,6 +28052,12 @@
             "value" : "環境センサーオプション"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções de Sensores Ambientais"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25570,6 +28114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全てのアプリデータを消去しますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apagar todos os dados do aplicativo?"
           }
         },
         "ru" : {
@@ -25636,6 +28186,12 @@
             "value" : "全てのデバイスおよびアプリデータを消去しますか？"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apagar todos os dados do dispositivo e da aplicação?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25700,6 +28256,12 @@
             "value" : "エラー: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erro: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25758,6 +28320,12 @@
             "value" : "ESP32 BLE アップデートツール"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizador BLE ESP32"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -25802,6 +28370,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ESP32 OTA更新には、%@または後のファームウェアが必要です。Web Flasherを使用してデバイスのファームウェアを更新してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizar o firmware OTA do ESP32 requer o firmware %@ ou superior. Atualize o firmware do seu dispositivo usando o Web Flasher primeiro."
           }
         },
         "zh-Hans" : {
@@ -25850,6 +28424,12 @@
             "value" : "ESP32のアップデート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualização do ESP32"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -25894,6 +28474,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ESP32 WiFi アップデートツール"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizador WiFi ESP32"
           }
         },
         "zh-Hans" : {
@@ -25946,6 +28532,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "イーサネットオプション"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções de Ethernet"
           }
         },
         "ru" : {
@@ -26006,6 +28598,12 @@
             "value" : "位置交換"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Troque Posições"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26064,6 +28662,12 @@
             "value" : "ユーザー情報を交換"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Troque as informações do usuário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26114,6 +28718,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有効期限"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Validade"
           }
         },
         "ru" : {
@@ -26180,6 +28790,12 @@
             "value" : "期限切れ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Válido até"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26242,6 +28858,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有効期限"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Validade"
           }
         },
         "ru" : {
@@ -26308,6 +28930,12 @@
             "value" : "有効期限: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Validade: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26370,6 +28998,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エクスポート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exportar"
           }
         },
         "ru" : {
@@ -26446,6 +29080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zewnętrzne Powiadomienie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notificação externa"
           }
         },
         "ru" : {
@@ -26530,6 +29170,12 @@
             "value" : "Konfiguracja Zewnętrznego Powiadomienia"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Notificação Externa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26600,6 +29246,12 @@
             "value" : "Factory リセット"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar fábrica"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26656,6 +29308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "工場出荷時リセットによりデバイスとアプリのデータが削除されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O reset de fábrica apaga os dados do dispositivo e do aplicativo."
           }
         },
         "ru" : {
@@ -26716,6 +29374,12 @@
             "value" : "ユーザー情報を交換できませんでした。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Falhou ao trocar informações do usuário."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26772,6 +29436,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "交換用の有効な位置の取得に失敗しました"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Falhou ao obter uma posição válida para troca"
           }
         },
         "ru" : {
@@ -26838,6 +29508,12 @@
             "value" : "交換用の有効な位置の取得に失敗しました。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Falhou ao obter uma posição válida para troca."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26898,6 +29574,12 @@
             "value" : "False"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Falso"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -26950,6 +29632,12 @@
             "value" : "お気に入り"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meu favorito"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27000,6 +29688,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "I nodi preferiti e ignorati vengono sempre conservati. Gli altri nodi vengono eliminati dal database dell'app in base alla programmazione impostata dall'utente. (I nodi con chiavi PKC vengono sempre conservati per almeno 7 giorni). Questa funzione elimina solo i nodi dall'app che non sono memorizzati nel database del nodo del dispositivo."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Os nós favoritos e ignorados sempre serão mantidos. Outros nós são limpos do banco de dados do aplicativo no horário definido pelo usuário. (Os nós com chaves PKC são sempre mantidos por pelo menos 7 dias.) Esta função apenas limpa os nós do aplicativo que não estão armazenados no banco de dados do nó do dispositivo."
           }
         },
         "ru" : {
@@ -27058,6 +29752,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "お気に入り"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Favoritos"
           }
         },
         "ru" : {
@@ -27124,6 +29824,12 @@
             "value" : "お気に入りと最近のメッセージがあるノードは、連絡先リストの上部に表示されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Os favoritos e os nós com mensagens recentes aparecem no topo da lista de contatos."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27180,6 +29886,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "特定のノードの最新位置を取得"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Obter a posição mais recente de um determinado nó"
           }
         },
         "ru" : {
@@ -27246,6 +29958,12 @@
             "value" : "15分"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Quinze minutos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27310,6 +30028,12 @@
             "value" : "ファイルストレージ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Armazenamento de Arquivos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27361,6 +30085,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ファイルが存在するが、アクティブなファイルはありません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arquivos Disponíveis"
           }
         },
         "ru" : {
@@ -27419,6 +30149,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "あなたの携帯電話の近くにノードリストとメッシュマップをフィルタリングします。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Filtre a lista de nós e o mapa de rede com base na proximidade com seu telefone."
           }
         },
         "ru" : {
@@ -27485,6 +30221,12 @@
             "value" : "連絡先を検索"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Encontre um contato"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27549,6 +30291,12 @@
             "value" : "ノードを検索"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Encontre um nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27607,6 +30355,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "デバイスを探す"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Encontre o Dispositivo"
           }
         },
         "zh-Hans" : {
@@ -27671,6 +30425,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Finish"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Concluir"
           }
         },
         "ru" : {
@@ -27738,6 +30498,12 @@
             "value" : "完了"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Concluir"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27796,6 +30562,12 @@
             "value" : "ファームウェアファイル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arquivo de Firmware"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -27842,6 +30614,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ファームウェアリリース"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Versões de Firmware"
           }
         },
         "zh-Hans" : {
@@ -27892,6 +30670,12 @@
             "value" : "ファームウェアアップデートドキュメントへのリンク"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Documentação de Atualização de Firmware"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -27938,6 +30722,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ファームウェアアップデートが必要です"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualização de firmware necessária"
           }
         },
         "zh-Hans" : {
@@ -27990,6 +30780,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ファームウェア更新"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizações de Firmware"
           }
         },
         "ru" : {
@@ -28068,6 +30864,12 @@
             "value" : "Wersja Oprogramowania"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Versão do Firmware"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28138,6 +30940,12 @@
             "value" : "初回受信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Primeiro ouvido"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28202,6 +31010,12 @@
             "value" : "5分"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cinco minutos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28262,6 +31076,12 @@
             "value" : "チャンネルを修正します"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Corrigir Canal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -28308,6 +31128,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "プライマリチャネルを修正しますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Corrigir Canal Principal?"
           }
         },
         "zh-Hans" : {
@@ -28372,6 +31198,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stały PIN"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pin fixado"
           }
         },
         "ru" : {
@@ -28444,6 +31276,12 @@
             "value" : "固定位置"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Posicao Fixa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28506,6 +31344,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "画面反転"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trocar a tela"
           }
         },
         "ru" : {
@@ -28572,6 +31416,12 @@
             "value" : "画面を垂直に反転"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rotar a tela verticalmente"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28634,6 +31484,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "マップレポート以外のすべてのMqtt機能については、Mqtt経由でブリッジしたい各チャンネルのアップリンクとダウンリンクも設定する必要があります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Para todas as funcionalidades do MQTT, exceto o relatório de mapa, também é necessário definir uplink e downlink para cada canal que você deseja conectar via MQTT."
           }
         },
         "ru" : {
@@ -28700,6 +31556,12 @@
             "value" : "すべての人に"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Para todos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28764,6 +31626,12 @@
             "value" : "自分に"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Para mim"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28824,6 +31692,12 @@
             "value" : "セキュリティのため、iOSは外部USBデバイスに直接書き込むことができません。ファイルを手動で保存してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Por motivos de segurança, o iOS não pode escrever diretamente em dispositivos USB externos. Você deve salvar o arquivo manualmente."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -28862,6 +31736,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Foxhunt sul tuo orologio"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Caça ao Fox em seu relógio"
           }
         },
         "zh-Hans" : {
@@ -28914,6 +31794,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "周波数"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Frequência"
           }
         },
         "ru" : {
@@ -28980,6 +31866,12 @@
             "value" : "周波数オーバーライド"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar/desativar frequência"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29042,6 +31934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "周波数スロット"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Faixa de Frequência"
           }
         },
         "ru" : {
@@ -29108,6 +32006,12 @@
             "value" : "フレンドリー名"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome amigável"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29172,6 +32076,12 @@
             "value" : "メッシュに送信されるメッセージのフォーマットに使用されるフレンドリ名。例：「Motion」という名前は「Motion detected」というメッセージになります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome amigável usado para formatar mensagem enviada ao mesh. Exemplo: um nome \"Movimento\" resultaria em uma mensagem \"Movimento detectado\""
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29230,6 +32140,12 @@
             "value" : "%lldのラジオからの受信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Da Radio (RX): %lld"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29284,6 +32200,12 @@
             "value" : "最遠いノード距離"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Distância Mais Longa"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -29330,6 +32252,12 @@
             "value" : "TAK クライアントをこのサーバーに接続するためのデータパッケージ (.zip) を生成します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gerar um pacote de dados (.zip) para configurar clientes TAK para se conectarem a este servidor."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -29374,6 +32302,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "現在使用中のプライベートキーを置き換える新しいプライベートキーを生成します。パブリックキーはプライベートキーから自動的に再生成されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gerar uma nova chave privada para substituir a atual em uso. A chave pública será regenerada automaticamente a partir da sua chave privada."
           }
         },
         "ru" : {
@@ -29452,6 +32386,12 @@
             "value" : "Generuj Kod QR"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gerar QR Code"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29518,6 +32458,12 @@
             "value" : "ローカルAIの推奨事項が作成中です..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gerando recomendação de IA local..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -29568,6 +32514,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "カスタム防水ソーラー・検出センサールーターノード、アルミニウムデスクトップノード、頑丈なハンドセットを入手できます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Obtenha roteadores de nós solares e de detecção personalizados à prova d'água, nós de desktop de alumínio e telefones robustos."
           }
         },
         "ru" : {
@@ -29686,6 +32638,12 @@
             "value" : "始めましょう"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Comece agora"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29742,6 +32700,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GitHubリポジトリ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Repositório do GitHub"
           }
         },
         "ru" : {
@@ -29808,6 +32772,12 @@
             "value" : "GPIO"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pinos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29870,6 +32840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GPIO出力時間"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Duração de Saída do GPIO"
           }
         },
         "ru" : {
@@ -29936,6 +32912,12 @@
             "value" : "ロータリーエンコーダーAポート用GPIOピン。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pino GPIO para o portão de encoder rotativo A"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29998,6 +32980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ロータリーエンコーダーBポート用GPIOピン。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pino GPIO para o porta B do encoder rotativo."
           }
         },
         "ru" : {
@@ -30064,6 +33052,12 @@
             "value" : "ロータリーエンコーダープレスポート用GPIOピン。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pino GPIO para encoder rotativo. Pressa o porto."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30126,6 +33120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GPIO ピン to monitor"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pino GPIO para monitorar"
           }
         },
         "ru" : {
@@ -30192,6 +33192,12 @@
             "value" : "GPS有効化GPIO"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "GPS para GPIO"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30250,6 +33256,12 @@
             "value" : "ノードから報告されたGPS位置データ（緯度、経度、高度）。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Os dados de posição GPS relatados pelo nó, incluindo latitude, longitude e altitude."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -30300,6 +33312,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GPS受信GPIO"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "GPS Recebe GPIO"
           }
         },
         "ru" : {
@@ -30366,6 +33384,12 @@
             "value" : "GPS送信GPIO"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Transmit GPS GPIO"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30426,6 +33450,12 @@
             "value" : "グレーは成功の表示、オレンジは再試行可能なエラー、赤は再試行しても成功しない永続的な失敗です"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cinza indica entrega bem-sucedida. Laranja indica erro retryável. Vermelho indica falha permanente que não será bem-sucedida em um novo tentativa."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -30476,6 +33506,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "グループメッセージ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagem de Grupo"
           }
         },
         "ru" : {
@@ -30542,6 +33578,12 @@
             "value" : "突風 %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ventos %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30598,6 +33640,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ハードリセット"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar duro"
           }
         },
         "ru" : {
@@ -30664,6 +33712,12 @@
             "value" : "ハードウェア"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hardware"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30726,6 +33780,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "方位"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Título"
           }
         },
         "ru" : {
@@ -30792,6 +33852,12 @@
             "value" : "方位: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Título: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30852,6 +33918,12 @@
             "value" : "ヘルプ＆ドキュメント"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajuda e Documentação"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -30896,6 +33968,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ヘルプ＆ドキュメント"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajuda e Documentação"
           }
         },
         "zh-Hans" : {
@@ -30944,6 +34022,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "こんにちは、私はチッパーです。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Oi, eu sou o Chirpy!"
           }
         },
         "zh-Hans" : {
@@ -30996,6 +34080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アラートを非表示"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esconder alertas"
           }
         },
         "ru" : {
@@ -31062,6 +34152,12 @@
             "value" : "アラートを非表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esconder alertas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31122,6 +34218,12 @@
             "value" : "地図のラベルを隠す"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esconder a legenda"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -31168,6 +34270,12 @@
             "value" : "地図のレジェンドを隠す"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esconder a legenda do mapa"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -31212,6 +34320,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "地図のラベルを隠す"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Oculta a legenda do mapa."
           }
         },
         "zh-Hans" : {
@@ -31264,6 +34378,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alto"
           }
         },
         "ru" : {
@@ -31330,6 +34450,12 @@
             "value" : "履歴返信最大数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Histórico Voltar Max"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31394,6 +34520,12 @@
             "value" : "履歴返信時間枠"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Janela de Histórico"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31450,6 +34582,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ホップ距離"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hops Away"
           }
         },
         "ru" : {
@@ -31516,6 +34654,12 @@
             "value" : "ホップ距離 %d"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hops Away %d"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31578,6 +34722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ホップ距離: %d"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hops Away: %d"
           }
         },
         "ru" : {
@@ -31644,6 +34794,12 @@
             "value" : "時間"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Horário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31706,6 +34862,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "時間あたりデューティサイクル"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ciclo de Trabalho Horário"
           }
         },
         "ru" : {
@@ -31772,6 +34934,12 @@
             "value" : "ユーザーボタンが押されたり、メッセージが受信された後、画面が点灯し続ける時間。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Quanto tempo o display permanece ligado após a pressão do botão do usuário ou a recepção de mensagens."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31834,6 +35002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイスメトリクスがメッシュ経由で送信される頻度。デフォルトは30分です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qual a frequência com que os metadados do dispositivo são enviados pelo rede. O valor padrão é de 30 minutos."
           }
         },
         "ru" : {
@@ -31900,6 +35074,12 @@
             "value" : "環境メトリクスがメッシュ経由で送信される頻度。デフォルトは30分です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qual a frequência com que os metadados ambientais são enviados pelo rede. O padrão é 30 minutos."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31962,6 +35142,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "電力メトリクスがメッシュ経由で送信される頻度。デフォルトは30分です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qual a frequência com que os metadados de energia são enviados pelo rede. Por padrão, 30 minutos."
           }
         },
         "ru" : {
@@ -32028,6 +35214,12 @@
             "value" : "GPS位置を取得する頻度。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qual a frequência ideal para tentar obter uma posição GPS?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32090,6 +35282,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "検出の有無に関係なく、検出センサーの状態をメッシュに送信する頻度。デフォルトは「なし」です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qual a frequência de envio do estado do sensor de detecção para a rede Mesh, independentemente da detecção? Por padrão, nunca."
           }
         },
         "ru" : {
@@ -32168,6 +35366,12 @@
             "value" : "How often we can send a message to the mesh when people are detected."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Com que frequência podemos enviar um mensagem para a rede quando as pessoas são detectadas."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32234,6 +35438,12 @@
             "value" : "アップデート方法"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Como Atualizar"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -32277,6 +35487,12 @@
           }
         },
         "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "https://"
+          }
+        },
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "https://"
@@ -32332,6 +35548,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "湿度"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Umidade"
           }
         },
         "ru" : {
@@ -32398,6 +35620,12 @@
             "value" : "上記を読み理解しました。MQTT経由でのノードデータの暗号化されない送信に自発的に同意します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eu li e entendi o acima. Eu concordo voluntariamente com a transmissão não criptografada dos dados do meu nó via MQTT."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32456,6 +35684,12 @@
             "value" : "私は自分のことを知っている"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eu sei o que estou fazendo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -32506,6 +35740,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "IAQ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qualidade do ar"
           }
         },
         "ru" : {
@@ -32572,6 +35812,12 @@
             "value" : "IAQ "
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qualidade do ar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32634,6 +35880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "IAQ %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qualidade do ar %lld"
           }
         },
         "ru" : {
@@ -32700,6 +35952,12 @@
             "value" : "アイコン"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ícone"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32756,6 +36014,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "アイコン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ícones"
           }
         },
         "ru" : {
@@ -32818,6 +36082,12 @@
             "value" : "ID"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ID"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -32864,6 +36134,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "アイデンティティ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Identidade"
           }
         },
         "zh-Hans" : {
@@ -32914,6 +36190,12 @@
             "value" : "アイドル / 睡眠"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Idle / Dormindo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -32960,6 +36242,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "接続されている場合は、以下のボタンを押してDFUモードにリセットしてください。そうでない場合は、デバイスのリセットボタンを2回速く押してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se conectado, use o botão abaixo para reiniciar em DFU. Caso contrário, pressione o botão de reinício do seu dispositivo duas vezes rapidamente."
           }
         },
         "zh-Hans" : {
@@ -33012,6 +36300,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "DOPが設定されている場合、PDOPの代わりにHDOP / VDOP値を使用します"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se DOP estiver definido, use os valores HDOP / VDOP em vez de PDOP"
           }
         },
         "ru" : {
@@ -33078,6 +36372,12 @@
             "value" : "有効にすると、「出力」ピンがアクティブハイになり、無効にするとアクティブローになります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se ativado, o pino 'output' será puxado alto, desativado significa baixo."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33140,6 +36440,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定すると、送信したパケットがデバイスにエコーバックされます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se definido, quaisquer pacotes enviados serão refletidos de volta ao seu dispositivo."
           }
         },
         "ru" : {
@@ -33206,6 +36512,12 @@
             "value" : "デフォルトの地域トピックが混雑している場合は、よりローカルなトピックを選択できます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se o tópico de região padrão estiver muito ocupado, você pode escolher um tópico mais local."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33264,6 +36576,12 @@
             "value" : "デバイスにOTA_1パーティションに適切なアップデートドライバーがロードされている場合、BLEアップデートプロセスを試すことができます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se o seu dispositivo tiver o atualizador adequado carregado na parte OTA_1, você pode tentar usar o processo de atualização BLE."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -33308,6 +36626,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "デバイスがOTA_1パーティションに適切なアップデターがロードされている場合、WiFi更新プロセスを試すことができます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se seu dispositivo tiver o atualizador adequado carregado na parte OTA_1, você pode tentar usar o processo de atualização WiFi."
           }
         },
         "zh-Hans" : {
@@ -33360,6 +36684,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MQTTを無視"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ignorar MQTT"
           }
         },
         "ru" : {
@@ -33426,6 +36756,12 @@
             "value" : "ノードを無視"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ignorar Node"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33490,6 +36826,12 @@
             "value" : "無視"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ignorado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33548,6 +36890,12 @@
             "value" : "インポート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Importar"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -33592,6 +36940,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : ".pemファイルをインポートします"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Importar .pem"
           }
         },
         "zh-Hans" : {
@@ -33640,6 +36994,12 @@
             "value" : "カスタム.p12をインポート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Importar Chave Personal .p12"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -33684,6 +37044,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "エラー: インポート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erro de Importação"
           }
         },
         "zh-Hans" : {
@@ -33736,6 +37102,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ルートインポート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Importar Rota"
           }
         },
         "ru" : {
@@ -33798,6 +37170,12 @@
             "value" : "重要なメモ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notas Importantes"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -33842,6 +37220,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "設定、キー、BLE絆も消去されます"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Além de Config, Chaves e ligações BLE serão apagadas"
           }
         },
         "ru" : {
@@ -33920,6 +37304,12 @@
             "value" : "Dołącz"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Incluir"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33984,6 +37374,12 @@
             "value" : "受信メッセージ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagens entrantes"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34042,6 +37438,12 @@
             "value" : "未完了"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Incompleto"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34096,6 +37498,12 @@
             "value" : "Indica una precisione GPS ridotta. Il nodo si trova in una certa area ombreggiata."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Indica precisão reduzida do GPS. O nó está em algum lugar dentro da área sombreada."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -34146,6 +37554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "室内空気質（IAQ）"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qualidade do Ar Interior (IAQ)"
           }
         },
         "ru" : {
@@ -34208,6 +37622,12 @@
             "value" : "インフラストラクチャノード数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Infraestrutura"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -34258,6 +37678,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "入力"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Entradas"
           }
         },
         "ru" : {
@@ -34320,6 +37746,12 @@
             "value" : "暗号化されていない位置情報用のチャンネルです。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não criptografado com localização"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -34366,6 +37798,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "MQTTで不安全で、正確な位置データがインターネットにアップロードされています"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Inseguro com MQTT"
           }
         },
         "zh-Hans" : {
@@ -34416,6 +37854,12 @@
             "value" : "リンクをテキストに挿入"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Insira"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -34462,6 +37906,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "リンクを挿入"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Insira Link"
           }
         },
         "zh-Hans" : {
@@ -34512,6 +37962,12 @@
             "value" : "インストール"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Instalar"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -34556,6 +38012,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "無効なファイル内容です。ファイル形式を確認してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conteúdo de arquivo inválido. Por favor, verifique o formato do arquivo."
           }
         },
         "ru" : {
@@ -34616,6 +38078,12 @@
             "value" : "IPアドレス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Endereço IP"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -34662,6 +38130,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Wi-Fiネットワークに接続"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conectar"
           }
         },
         "zh-Hans" : {
@@ -34714,6 +38188,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "JSON有効"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "JSON habilitado"
           }
         },
         "ru" : {
@@ -34780,6 +38260,12 @@
             "value" : "JSONモードは、Home Assistantとのローカル統合のための限定的で暗号化されていないMQTT出力です"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modo JSON é uma saída MQTT limitada e não criptografada para integração local com o Home Assistant"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34844,6 +38330,12 @@
             "value" : "最新に移動"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vá para o presente"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -34904,6 +38396,12 @@
             "value" : "デバイスはスマートフォンに近づけてください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mantenha o dispositivo próximo ao seu telefone."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -34950,6 +38448,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メッシュマップを更新し、他のアプリを使用している間も位置をメッシュに送信します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mantém o mapa da rede atualizado e envia sua posição para a rede mesmo enquanto usa outros aplicativos."
           }
         },
         "zh-Hans" : {
@@ -35002,6 +38506,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "キー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "chave"
           }
         },
         "ru" : {
@@ -35060,6 +38570,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "キーバックアップ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Backup de Chave"
           }
         },
         "ru" : {
@@ -35126,6 +38642,12 @@
             "value" : "キーマッピング"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapeamento de Chaves"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35188,6 +38710,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "キーサイズ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tamanho da Chave"
           }
         },
         "ru" : {
@@ -35254,6 +38782,12 @@
             "value" : "最終受信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Última vez ouvida"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35312,6 +38846,12 @@
             "value" : "最後に聞いた時刻"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Última vez ouvida"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -35358,6 +38898,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "最後に接続されたデバイス:"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Último dispositivo visto:"
           }
         },
         "ru" : {
@@ -35412,6 +38958,12 @@
             "value" : "最後に確認したデバイス: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Último dispositivo visto: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35464,6 +39016,12 @@
             "value" : "最終更新者:"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Última atualização por:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -35508,6 +39066,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "最終更新: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Última Atualização: %@"
           }
         },
         "zh-Hans" : {
@@ -35558,6 +39122,12 @@
             "value" : "最終更新日: 不明"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Última atualização: Nunca"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -35604,6 +39174,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "後で"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mais tarde"
           }
         },
         "zh-Hans" : {
@@ -35656,6 +39232,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "緯度"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Latitude"
           }
         },
         "ru" : {
@@ -35716,6 +39298,12 @@
             "value" : "緯度（度単位、例: 37.7749）"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Latitude em graus (ex.: 37.7749)"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -35772,6 +39360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "緯度は-90度から90度の間である必要があります"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A latitude deve estar entre -90 e 90 graus"
           }
         },
         "ru" : {
@@ -35840,6 +39434,12 @@
             "value" : "最も混雑が少ない: **%1$@** (%2$@ 利用率)"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Menos congestionado: **%1$@** (%2$@ util)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -35890,6 +39490,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LEDハートビート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Batimento cardíaco LED"
           }
         },
         "ru" : {
@@ -35954,6 +39560,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LED状態"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Estado da LED"
           }
         },
         "ru" : {
@@ -36032,6 +39644,12 @@
             "value" : "Level"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nível"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36102,6 +39720,12 @@
             "value" : "ライセンスオペレーター"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Operador Licenciado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36164,6 +39788,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "特にテレメトリと位置情報のすべての定期ブロードキャスト間隔を制限します。ホップを増やす必要がある場合は、中央のノードではなく端のノードで行ってください。デューティサイクルが制限されている場合、ゲートウェイノードがすべての作業を行うため、MQTTは推奨されません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Limite as intervalos de transmissão periódica, especialmente para telemetria e posição. Se você precisar aumentar as hops, faça isso nos nós de borda, não nos de meio. MQTT não é recomendado quando o ciclo de trabalho está restrito porque o nó de gateway está fazendo todo o trabalho."
           }
         },
         "ru" : {
@@ -36230,6 +39860,12 @@
             "value" : "線系列"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Séries de Linhas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36290,6 +39926,12 @@
             "value" : "古いメッセージをロード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregar Mensagens Antigas"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -36338,6 +39980,12 @@
             "value" : "データベースをAPIから読み込み中です"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregando"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -36384,6 +40032,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ハードウェア情報を読み込み中..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregando informações de hardware..."
           }
         },
         "zh-Hans" : {
@@ -36436,6 +40090,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Loading ログs. . ."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregando Logs. . ."
           }
         },
         "ru" : {
@@ -36496,6 +40156,12 @@
             "value" : "TAK コンフィグをノードからロードしています。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregando configurações TAK do nó."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -36542,6 +40208,12 @@
             "value" : "読み込み中..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregando..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -36582,6 +40254,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ローカルメッシュディスカバリー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Descobrindo Rede Local"
           }
         },
         "zh-Hans" : {
@@ -36632,6 +40310,12 @@
             "value" : "メインチャネルはデフォルトのキーを使用する必要があります。スキャン前にメインチャネルキーをデフォルトに戻してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A descoberta de rede local exige que a canal principal use a chave padrão. Por favor, redefina a chave principal padrão antes de escanear."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -36678,6 +40362,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ローカルネットワークアクセスのオプション"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Acesso à Rede Local"
           }
         },
         "ru" : {
@@ -36744,6 +40434,12 @@
             "value" : "場所："
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Localização:"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36808,6 +40504,12 @@
             "value" : "ロック済み"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fechado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -36866,6 +40568,12 @@
             "value" : "ログアイコン"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ícones de Log"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -36916,6 +40624,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ログレベル"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Níveis de Log"
           }
         },
         "ru" : {
@@ -36994,6 +40708,12 @@
             "value" : "Rejestracja"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Registro"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37064,6 +40784,12 @@
             "value" : "ログ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Registros"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37128,6 +40854,12 @@
             "value" : "長い名前"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome Longo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37188,6 +40920,12 @@
             "value" : "長押しアクション"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ações de Long Press"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -37238,6 +40976,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "長押しで連絡先をお気に入りに追加、ミュート、または会話を削除できます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Long press para marcar como favorito ou silenciar o contato ou excluir uma conversa."
           }
         },
         "ru" : {
@@ -37304,6 +41048,12 @@
             "value" : "経度"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Longitude"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37362,6 +41112,12 @@
             "value" : "経度（度単位、例: -122.4194）"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Longitude em graus (ex.: -122.4194)"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37418,6 +41174,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "経度は-180度から180度の間である必要があります"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A longitude deve estar entre -180 e 180 graus"
           }
         },
         "ru" : {
@@ -37493,6 +41255,12 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "LoRa"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "LoRa"
           }
         },
@@ -37578,6 +41346,12 @@
             "value" : "Konfiguracja LoRa"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações LoRa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37640,6 +41414,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "LoRa設定変更"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações de LoRa:"
           }
         },
         "ru" : {
@@ -37706,6 +41486,12 @@
             "value" : "低"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "BAIXO"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37762,6 +41548,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "バッテリーが低い"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bateria baixa"
           }
         },
         "ru" : {
@@ -37840,6 +41632,12 @@
             "value" : "Manage Channels"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gerenciar Canais"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37905,6 +41703,12 @@
             "value" : "カスタムマップオーバーレイを管理"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gerenciar camadas de mapa personalizadas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -37962,6 +41766,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "地図データの管理"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gerenciar dados de mapa"
           }
         },
         "ru" : {
@@ -38028,6 +41838,12 @@
             "value" : "管理されたデバイス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dispositivo Gerenciado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38084,6 +41900,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "マニュアル"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Manual"
           }
         },
         "ru" : {
@@ -38144,6 +41966,12 @@
             "value" : "マニュアル接続文字列"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "String de conexão manual"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38202,6 +42030,12 @@
             "value" : "マニュアル接続"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conectividade Manual"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38256,6 +42090,12 @@
             "value" : "探索セッションの地図"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapa"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -38300,6 +42140,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "地図データ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dados de Mapa"
           }
         },
         "ru" : {
@@ -38362,6 +42208,12 @@
             "value" : "地図のラベル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Legenda do Mapa"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -38412,6 +42264,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "マップオプション"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções de Mapa"
           }
         },
         "ru" : {
@@ -38484,6 +42342,12 @@
             "value" : "Nakładki map"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapas de Sobreposição"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38554,6 +42418,12 @@
             "value" : "マップレポート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Relatório de Mapa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38618,6 +42488,12 @@
             "value" : "メッシュアクティビティ更新"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualização da atividade Mesh"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38676,6 +42552,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メッシュの凸包"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Coeficiente de cobertura do mesh"
           }
         },
         "zh-Hans" : {
@@ -38740,6 +42622,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Aktywność na Żywo"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atividade em Tempo Real Mesh"
           }
         },
         "ru" : {
@@ -38824,6 +42712,12 @@
             "value" : "Mapa Sieci"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapa Mesh"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38888,6 +42782,12 @@
             "value" : "メッシュマップ位置"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapa de Localização Mesh"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -38948,6 +42848,12 @@
             "value" : "メッシュからコットに変換器"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conversor de Mesh para CoT"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -38992,6 +42898,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メッシュティック"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meshtastic"
           }
         },
         "ru" : {
@@ -39054,6 +42966,12 @@
             "value" : "メッシュティック -> TAKが機能し、TAK -> メッシュティックがブロックされます"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meshtastic -> TAK funciona, TAK -> Meshtastic bloqueado"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -39102,6 +43020,12 @@
             "value" : "メッシュティックは個人情報を収集しません。使用状況やクラッシュデータは匿名で収集し、アプリの改善に役立てています。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meshtastic não coleta nenhuma informação pessoal. Nós coletamos anonimamente dados de uso e falhas para melhorar o aplicativo."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -39146,6 +43070,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Meshtasticノード %@ があなたとチャンネルを共有しました"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O nó Meshtastic %@ compartilha canais com você"
           }
         },
         "ru" : {
@@ -39204,6 +43134,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Meshtasticは、あなたのスマートフォンの位置情報を利用して、いくつかの機能を有効にします。設定からいつでも位置情報の許可を更新できます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Meshtastic usa a localização do seu telefone para habilitar várias funcionalidades. Você pode atualizar as permissões de localização a qualquer momento nas configurações."
           }
         },
         "ru" : {
@@ -39328,6 +43264,12 @@
             "value" : "メッセージ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagem"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39390,6 +43332,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "メッセージ内容が200バイトを超えています。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O conteúdo da mensagem excede 200 bytes."
           }
         },
         "ru" : {
@@ -39468,6 +43416,12 @@
             "value" : "Szczegóły wiadomości"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detalhes da Mensagem"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39534,6 +43488,12 @@
             "value" : "メッセージ通知"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notificações de Mensagens"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -39579,6 +43539,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "メッセージサイズ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tamanho da Mensagem"
           }
         },
         "ru" : {
@@ -39641,6 +43607,12 @@
             "value" : "メッセージステータス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Status de Mensagem"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -39687,6 +43659,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メッセージは最終受信者に送られましたが、確認されていません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A mensagem foi enviada, mas não confirmada pelo destinatário final."
           }
         },
         "zh-Hans" : {
@@ -39751,6 +43729,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wiadomości"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagens"
           }
         },
         "ru" : {
@@ -39823,6 +43807,12 @@
             "value" : "メッセージs separate with |"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagens separadas com |"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -39879,6 +43869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "メッセージング"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagem"
           }
         },
         "ru" : {
@@ -39941,6 +43937,12 @@
             "value" : "メタデータ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Metadados"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -39991,6 +43993,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最小距離"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Distância mínima"
           }
         },
         "ru" : {
@@ -40053,6 +44061,12 @@
             "value" : "最低必要なバージョン: **%@**"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Minimo requisitado: %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -40103,6 +44117,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "検出ブロードキャスト間の最小時間。デフォルトは45秒です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo mínimo entre transmissões de detecção. Por padrão, 45 segundos."
           }
         },
         "ru" : {
@@ -40181,6 +44201,12 @@
             "value" : "Tryb"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40247,6 +44273,12 @@
             "value" : "モデムプリセット一覧"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Preset de Modem"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -40309,6 +44341,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Konfiguracja modułu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração do módulo"
           }
         },
         "ru" : {
@@ -40377,6 +44415,12 @@
             "value" : "**%1$@**で最もユニークなノードが発見されました (%2$lldノード)"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mais nós descobertos no **%1$@** (%2$lld nós)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -40426,6 +44470,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "MQTT"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "MQTT"
           }
         },
@@ -40503,6 +44553,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Klient Proxy MQTT"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Proxy de Cliente MQTT"
           }
         },
         "ru" : {
@@ -40587,6 +44643,12 @@
             "value" : "Konfiguracja MQTT"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração MQTT"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40651,6 +44713,12 @@
             "value" : "mTLS"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TLS de segurança mútua"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -40713,6 +44781,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Multiplier"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Multiplicador"
           }
         },
         "ru" : {
@@ -40785,6 +44859,12 @@
             "value" : "単一の絵文字である必要があります"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "😊"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40847,6 +44927,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "名前"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome"
           }
         },
         "ru" : {
@@ -40913,6 +44999,12 @@
             "value" : "名前は30バイト未満である必要があります"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O nome deve ser menor que 30 bytes"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40977,6 +45069,12 @@
             "value" : "ノードに移動"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Navegue até o nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -41035,6 +45133,12 @@
             "value" : "近くのデバイス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dispositivos próximos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -41085,6 +45189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "近くのトピック"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tópicos próximos"
           }
         },
         "ru" : {
@@ -41161,6 +45271,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sieć"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Redes"
           }
         },
         "ru" : {
@@ -41245,6 +45361,12 @@
             "value" : "Konfiguracja sieci"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Rede"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -41309,6 +45431,12 @@
             "value" : "ネットワーク位置"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Localização da rede"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -41355,6 +45483,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Wi-Fiネットワーク名を入力してください"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome da rede Wi-Fi"
           }
         },
         "zh-Hans" : {
@@ -41407,6 +45541,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ネットワーク状態 オレンジ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Status da rede laranja"
           }
         },
         "ru" : {
@@ -41473,6 +45613,12 @@
             "value" : "ネットワーク状態 レッド"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Status da rede vermelho"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -41529,6 +45675,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "新しいノード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Novos Nodos"
           }
         },
         "ru" : {
@@ -41591,6 +45743,12 @@
             "value" : "新規スキャン開始"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nova Busca"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -41637,6 +45795,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "なし"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum"
           }
         },
         "zh-Hans" : {
@@ -41689,6 +45853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接続されたノードがありません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum nó conectado"
           }
         },
         "ru" : {
@@ -41748,6 +45918,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "データなし"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma informação disponível"
           }
         },
         "ru" : {
@@ -41826,6 +46002,12 @@
             "value" : "Brak podłączonych urządzeń"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum dispositivo conectado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -41892,6 +46074,12 @@
             "value" : "接続されていません。最初に発見されたデバイスを使用します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum dispositivo conectado. Usará o primeiro dispositivo descoberto."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -41942,6 +46130,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイスメトリクスがありません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma métrica do dispositivo"
           }
         },
         "ru" : {
@@ -42004,6 +46198,12 @@
             "value" : "まだ発見セッションを完了していません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma sessão de descoberta concluída"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -42054,6 +46254,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "環境メトリクスがありません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma métrica ambiental"
           }
         },
         "ru" : {
@@ -42112,6 +46318,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ファイルがアップロードされていません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum arquivo carregado"
           }
         },
         "ru" : {
@@ -42174,6 +46386,12 @@
             "value" : "このデバイスのファームウェアはダウンロードされていません。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum firmware foi baixado para este dispositivo."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -42222,6 +46440,12 @@
             "value" : "ローカル統計データがまだ収集されていません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não há dados coletados de LocalStats"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -42267,6 +46491,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "マップデータファイルがアップロードされていません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma file de dados de mapa carregada"
           }
         },
         "ru" : {
@@ -42331,6 +46561,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PAXカウンターログがありません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum registro de contagem de PAX"
           }
         },
         "ru" : {
@@ -42403,6 +46639,12 @@
             "value" : "位置情報がありません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma posição"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -42467,6 +46709,12 @@
             "value" : "電力メトリクスがありません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sem métricas de energia"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -42527,6 +46775,12 @@
             "value" : "まだ設定データがありません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma dados de preset disponíveis"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -42575,6 +46829,12 @@
             "value" : "このリストには%@のレコードが見つかりません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma recordação encontrada para %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -42613,6 +46873,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Nessun client SSH trovato. Apri l'App Store per installarne uno."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum cliente SSH encontrado. Vamos abrir a App Store para que você possa instalar um."
           }
         },
         "zh-Hans" : {
@@ -42665,6 +46931,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ノード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Node"
           }
         },
         "ru" : {
@@ -42737,6 +47009,12 @@
             "value" : "ノードコアデータバックアップ %1$@/%2$@ - %3$@ - %4$@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Backup do Core Data Node %1$@/%2$@ - %3$@ - %4$@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -42797,6 +47075,12 @@
             "value" : "ノードは過去2時間以内に耳にした。地図上で脈打つリングで表示されています。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O nó ouviu nos últimos 2 horas. Mostrado com um anel pulsante no mapa."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -42847,6 +47131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Node 履歴"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Histórico de nós"
           }
         },
         "ru" : {
@@ -42907,6 +47197,12 @@
             "value" : "ノードレイアウト"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração da Rede"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -42953,6 +47249,12 @@
             "value" : "ノードリスト密度"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Densidade da Lista de Nodos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -42997,6 +47299,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ノードリストのヘルプ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajuda com Lista de Nodos"
           }
         },
         "zh-Hans" : {
@@ -43049,6 +47357,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Node マップ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapa de Nodos"
           }
         },
         "ru" : {
@@ -43111,6 +47425,12 @@
             "value" : "接続されたノードの名前: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome do nó conectado: %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -43157,6 +47477,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "最近聞いたことがありません。地図にはパルスリングが表示されていません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O nó não foi ouvido recentemente. Mostrado sem o anel pulsante no mapa."
           }
         },
         "zh-Hans" : {
@@ -43209,6 +47535,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ノード番号"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Número do nó"
           }
         },
         "ru" : {
@@ -43269,6 +47601,12 @@
             "value" : "ノードステータス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Estado do nó"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -43309,6 +47647,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "検出センサーモジュールがアクティブなノード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nodo com módulo de sensor de detecção ativo."
           }
         },
         "zh-Hans" : {
@@ -43367,6 +47711,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ノード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nodos"
           }
         },
         "ru" : {
@@ -43429,6 +47779,12 @@
             "value" : "発見されたノード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nodes Descobridos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -43475,6 +47831,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "北欧DFUアップデート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualização DFU Nordica"
           }
         },
         "zh-Hans" : {
@@ -43527,6 +47889,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有効なルートファイルではありません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não é um arquivo de rota válido"
           }
         },
         "ru" : {
@@ -43589,6 +47957,12 @@
             "value" : "もうすぐです"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não agora"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -43637,6 +48011,12 @@
             "value" : "暗号化されていません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não criptografado de forma segura"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -43683,6 +48063,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "更新中は一時的にデバイスを切断します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este aviso informa que o dispositivo será desconectado temporariamente durante a atualização."
           }
         },
         "zh-Hans" : {
@@ -43735,6 +48121,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "メモ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notas"
           }
         },
         "ru" : {
@@ -43795,6 +48187,12 @@
             "value" : "チャンネルおよび直接メッセージの通知"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notificações para canais e mensagens diretas."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -43853,6 +48251,12 @@
             "value" : "接続デバイスのバッテリーが低いことを通知する通知"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notificações de alertas de bateria baixa para o dispositivo conectado."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -43909,6 +48313,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "新しく発見されたノードに関する通知"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notificações para novos nós descobertos."
           }
         },
         "ru" : {
@@ -43975,6 +48385,12 @@
             "value" : "ホップ数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Número de saltos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44037,6 +48453,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "レコード数"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Número de registros"
           }
         },
         "ru" : {
@@ -44103,6 +48525,12 @@
             "value" : "衛星数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Quantidade de satélites"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44163,6 +48591,12 @@
             "value" : "オフラインノード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nodo Offline"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -44207,6 +48641,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "OK"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ok"
           }
         },
         "ru" : {
@@ -44270,6 +48710,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "OK"
           }
         },
@@ -44337,6 +48783,12 @@
             "value" : "MQTT OK"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ok para MQTT"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44401,6 +48853,12 @@
             "value" : "OLEDタイプ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tipo de OLED"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44463,6 +48921,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ライセンス取得者のオンボーディングにはファームウェア2.0.20以上が必要です。必ずお住まいの地域の規制を参照し、疑問がある場合は地域のアマチュア周波数コーディネーターにお問い合わせください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Para operadores licenciados, o firmware 2.0.20 ou superior é necessário. Certifique-se de consultar suas regulamentações locais e entre em contato com os coordenadores de frequência amadoras locais com quaisquer dúvidas."
           }
         },
         "ru" : {
@@ -44539,6 +49003,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jedna Godzina"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uma hora"
           }
         },
         "ru" : {
@@ -44623,6 +49093,12 @@
             "value" : "Jedna Minuta"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uma Minute"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44693,6 +49169,12 @@
             "value" : "オンライン"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Online"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -44753,6 +49235,12 @@
             "value" : "オンラインノード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nodo Online"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -44797,6 +49285,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "%@のドキュメントを開く"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Acesse o guia de %@"
           }
         },
         "zh-Hans" : {
@@ -44845,6 +49339,12 @@
             "value" : "meshtastic.orgを開いてください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abra %@ no meshtastic.org"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -44889,6 +49389,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "コンパスを開く"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abrir Compasso"
           }
         },
         "ru" : {
@@ -44943,6 +49449,12 @@
             "value" : "ローカルファイルを開く"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abrir Arquivo Local..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -44993,6 +49505,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定を開く"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Acesse Configurações"
           }
         },
         "ru" : {
@@ -45053,6 +49571,12 @@
             "value" : "SSHクライアントを開く"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abrir o cliente SSH"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -45093,6 +49617,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Web Flasherを開く"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Abrir o aplicativo Web Flasher"
           }
         },
         "zh-Hans" : {
@@ -45141,6 +49671,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "%@のドキュメントを開きます"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Acesse a documentação do %@"
           }
         },
         "zh-Hans" : {
@@ -45193,6 +49729,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "位置メッセージを組み立てる際に含めるオプションフィールド。含めるフィールドが多いほどメッセージが大きくなり、通信時間が長くなってパケット損失のリスクが高くなります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Campos opcionais para incluir quando montar mensagens de posição. Quanto mais campos forem incluídos, maior será a mensagem - resultando em maior tempo de arremesso e maior risco de perda de pacotes"
           }
         },
         "ru" : {
@@ -45257,6 +49799,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "オプション GPIO"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "GPIO opcional"
           }
         },
         "ru" : {
@@ -45335,6 +49883,12 @@
             "value" : "Opcje"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -45401,6 +49955,12 @@
             "value" : "チャンネル設定を自分で修正して、この画面に戻してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Corrija as configurações do canal principal manualmente e volte para a tela atual."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -45451,6 +50011,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OSログエントリ詳細"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detalhes do Log do Sistema Operacional"
           }
         },
         "ru" : {
@@ -45517,6 +50083,12 @@
             "value" : "その他のデータソース"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Outras fontes de dados"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -45577,6 +50149,12 @@
             "value" : "他のネットワーク"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Outro Rede"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -45623,6 +50201,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "隠れたネットワーク…"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Outros Redes..."
           }
         },
         "zh-Hans" : {
@@ -45675,6 +50259,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "シリアル経由でライブデバッグログを出力し、Bluetooth経由で位置情報を削除したデバイスログを表示・エクスポート。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Exibe logs de depuração ao vivo via serial, visualiza logs de dispositivo redactados de posição via Bluetooth."
           }
         },
         "ru" : {
@@ -45741,6 +50331,12 @@
             "value" : "出力ピンブザーGPIO"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Saída do buzzer GPIO"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -45803,6 +50399,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "出力ピンGPIO"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Saída do pino GPIO"
           }
         },
         "ru" : {
@@ -45869,6 +50471,12 @@
             "value" : "出力ピン振動GPIO"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Saída do pino vibra GPIO"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -45933,6 +50541,12 @@
             "value" : "自動OLEDスクリーン検出をオーバーライド。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desative a detecção automática da tela OLED."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -45991,6 +50605,12 @@
             "value" : "デフォルトの画面レイアウトをオーバーライドします。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ativar layout de tela padrão."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -46047,6 +50667,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "パケット数"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Contagem de pacotes"
           }
         },
         "ru" : {
@@ -46125,6 +50751,12 @@
             "value" : "Tryb parowania"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modo de Conexão"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -46189,6 +50821,12 @@
             "value" : "分散翻訳に参加してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Participe nas Traduções Distribuídas"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -46251,6 +50889,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hasło"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Senha"
           }
         },
         "ru" : {
@@ -46332,6 +50976,12 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pause"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "Pause"
           }
         },
@@ -46417,6 +51067,12 @@
             "value" : "PAX Counter"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Contador de Pax"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -46493,6 +51149,12 @@
             "value" : "PAXカウンター設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações do Contador PAX"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -46561,6 +51223,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PAXカウンターログ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Registro de Contagem de Pax"
           }
         },
         "ru" : {
@@ -46633,6 +51301,12 @@
             "value" : "PAXカウンターログ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "paxcounter.log"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -46693,6 +51367,12 @@
             "value" : "各プリセットの結果"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Resultados por Preset"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -46743,6 +51423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接続しているノードの工場出荷時リセットを実行"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Realize um reset de fábrica no nó ao qual você está conectado"
           }
         },
         "ru" : {
@@ -46821,6 +51507,12 @@
             "value" : "GPS telefonu"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "GPS do telefone"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -46883,6 +51575,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "携帯電話の位置"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Localização do Telefone"
           }
         },
         "ru" : {
@@ -46949,6 +51647,12 @@
             "value" : "ピン %lld"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pino %lld"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -47011,6 +51715,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ピンA"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pino A"
           }
         },
         "ru" : {
@@ -47077,6 +51787,12 @@
             "value" : "ピンB"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pino B"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -47141,6 +51857,12 @@
             "value" : "PKIベースのノード管理、ファームウェアバージョン2.5+が必要"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Administração de nós baseada em PKI, requer versão do firmware 2.5+"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -47201,6 +51923,12 @@
             "value" : "デバイスをDFUモードに設定し、USB経由で接続してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Coloque seu dispositivo em modo DFU e conecte-o via USB."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -47247,6 +51975,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "プラットフォームIO"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Plataforma IO"
           }
         },
         "zh-Hans" : {
@@ -47299,6 +52033,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "マップレポートは暗号化されていないため、あなたのデータが第三者によって永続的に保存・表示される可能性があることをご承知ください。Meshtasticは、このようなデータの保存、表示、開示について一切の責任を負いません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Por favor, esteja ciente de que, porque o relatório de mapa não é criptografado, seus dados podem ser armazenados e exibidos permanentemente por terceiros. Meshtastic não se responsabiliza por qualquer armazenamento, exibição ou divulgação desses dados."
           }
         },
         "ru" : {
@@ -47361,6 +52101,12 @@
             "value" : "この情報が正しいことを確認してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Por favor, certifique-se de que isso está correto antes de prosseguir."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -47411,6 +52157,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定を構成するには無線機に接続してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Por favor, conecte-se a uma rádio para configurar as configurações."
           }
         },
         "ru" : {
@@ -47473,6 +52225,12 @@
             "value" : "このプロセスを完了するまで画面を離さないでください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Por favor, não saia desta tela até que o processo seja concluído."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -47519,6 +52277,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "デバイスを再接続してファームウェア情報をロードしてください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Por favor, reconecte-se ao seu dispositivo para carregar as informações do firmware."
           }
         },
         "zh-Hans" : {
@@ -47571,6 +52335,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "興味地点"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pontos de Interesse"
           }
         },
         "ru" : {
@@ -47629,6 +52399,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ポート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Port"
           }
         },
         "zh-Hans" : {
@@ -47693,6 +52469,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pozycja"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Posicao"
           }
         },
         "ru" : {
@@ -47771,6 +52553,12 @@
             "value" : "Konfiguracja pozycji"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Posicionamento"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -47839,6 +52627,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "位置交換に失敗しました"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Troca de posição falhou"
           }
         },
         "ru" : {
@@ -47963,6 +52757,12 @@
             "value" : "位置フラグ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Flags de posição"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48023,6 +52823,12 @@
             "value" : "ノードの位置履歴"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Histórico de posição"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -48069,6 +52875,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "位置履歴ポイント"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ponto de Histórico de Posicionamento"
           }
         },
         "zh-Hans" : {
@@ -48121,6 +52933,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "位置ログ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Registro de Posicionamento"
           }
         },
         "ru" : {
@@ -48251,6 +53069,12 @@
             "value" : "位置パケット"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Posicao Pacote"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48309,6 +53133,12 @@
             "value" : "位置精度"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Precisão de posição"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -48355,6 +53185,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "GPS精密度低下を示す円形アイコン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Circulo de Precisão de Localização Reduzida"
           }
         },
         "zh-Hans" : {
@@ -48407,6 +53243,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "位置送信済み"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Posicao enviada"
           }
         },
         "ru" : {
@@ -48469,6 +53311,12 @@
             "value" : "位置情報：方向"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Posicao com Direcao"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -48513,6 +53361,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "位置"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Posições"
           }
         },
         "zh-Hans" : {
@@ -48565,6 +53419,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "位置情報有効"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Posições Ativas"
           }
         },
         "ru" : {
@@ -48629,6 +53489,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "位置情報はデバイスのGPSによって提供されます。無効または存在しないを選択した場合は、固定位置を設定できます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "As posições serão fornecidas pelo GPS do seu dispositivo, se você selecionar desativado ou não presente, você pode definir uma posição fixa."
           }
         },
         "ru" : {
@@ -48705,6 +53571,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Power"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Energia"
           }
         },
         "ru" : {
@@ -48789,6 +53661,12 @@
             "value" : "Power Config"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações de Energia"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48859,6 +53737,12 @@
             "value" : "電力メトリクスログ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Relatório de Medidas de Potência"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48921,6 +53805,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "電源オフ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desligar"
           }
         },
         "ru" : {
@@ -48999,6 +53889,12 @@
             "value" : "Power Saving"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Economia de energia"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49069,6 +53965,12 @@
             "value" : "電源画面"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tela de Poder"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49127,6 +54029,12 @@
             "value" : "パワーセンサーオプション"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções do Sensor de Potência"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49183,6 +54091,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "電源供給中"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Powered"
           }
         },
         "ru" : {
@@ -49249,6 +54163,12 @@
             "value" : "精密位置"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Localização Precisa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49313,6 +54233,12 @@
             "value" : "プリセット"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49373,6 +54299,12 @@
             "value" : "スキャンされたプリセット数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Presets Scaneados"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -49423,6 +54355,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "プレスピン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Press Pin"
           }
         },
         "ru" : {
@@ -49487,6 +54425,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "気圧"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pressao"
           }
         },
         "ru" : {
@@ -49565,6 +54509,12 @@
             "value" : "Podstawowy"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Principal"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49635,6 +54585,12 @@
             "value" : "プライマリ管理キー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chave Administrativa Primária"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49695,6 +54651,12 @@
             "value" : "メインチャンネル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Canal Principal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -49745,6 +54707,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "プライマリGPIO"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ponto de entrada principal"
           }
         },
         "ru" : {
@@ -49811,6 +54779,12 @@
             "value" : "秘密キー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chave Privada"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49867,6 +54841,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ファイル処理中..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Processando arquivo..."
           }
         },
         "ru" : {
@@ -49933,6 +54913,12 @@
             "value" : "プロジェクト情報"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Informações do projeto"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -49993,6 +54979,12 @@
             "value" : "属性 (%lld)"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Propriedades (%lld)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -50037,6 +55029,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "匿名使用統計とクラッシュレポートを提供してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Forneça estatísticas de uso anônimas e relatórios de falhas."
           }
         },
         "ru" : {
@@ -50097,6 +55095,12 @@
             "value" : "確認を提供してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Forneça confirmação"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -50155,6 +55159,12 @@
             "value" : "プロビジョニング失敗です"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provisão Falhou"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -50205,6 +55215,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "公開キー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "chave pública"
           }
         },
         "ru" : {
@@ -50271,6 +55287,12 @@
             "value" : "公開鍵暗号化"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Encriptacao de Chaves Publicas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -50333,6 +55355,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "公開キー不一致"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diferença de Chave Pública"
           }
         },
         "ru" : {
@@ -50399,6 +55427,12 @@
             "value" : "パスワード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Senha"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -50459,6 +55493,12 @@
             "value" : "質問入力"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Digite sua pergunta"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -50509,6 +55549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "放射線"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Radiação"
           }
         },
         "ru" : {
@@ -50585,6 +55631,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Konfiguracja radia"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de rádio"
           }
         },
         "ru" : {
@@ -50669,6 +55721,12 @@
             "value" : "Test zasięgu"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Teste de intervalo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -50751,6 +55809,12 @@
             "value" : "Konfiguracja testu zasięgu"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Teste de Alcance"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -50815,6 +55879,12 @@
             "value" : "ラジオから範囲テスト設定が受け取れませんでした。デバイスを再接続してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A configuração de teste de intervalo não foi recebida pelo rádio. Tente reconectar ao dispositivo."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -50859,6 +55929,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "範囲テストには、暗号化されたプライベートチャネルが必要です。このノードの主要なチャネルは、デフォルトまたは空のキーを使用しています。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O teste de faixa requer um canal privado criptografado. O canal principal deste nó está usando uma chave padrão ou vazia."
           }
         },
         "zh-Hans" : {
@@ -50909,6 +55985,12 @@
             "value" : "分析の再実行"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recomeçar Análise"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -50957,6 +56039,12 @@
             "value" : "車載ディスプレイからMeshtasticチャンネルと直接メッセージを読み取って返すことができます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Leia e responda aos canais e mensagens de Meshtastic diretamente no display do seu carro usando CarPlay."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -51003,6 +56091,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "読み書きモード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modo de Leitura Única"
           }
         },
         "zh-Hans" : {
@@ -51069,6 +56163,12 @@
             "value" : "Uruchom ponownie"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -51133,6 +56233,12 @@
             "value" : "リセット＆アップデート開始"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar e iniciar atualização"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -51195,6 +56301,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uruchomić ponownie węzeł?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar o nó?"
           }
         },
         "ru" : {
@@ -51267,6 +56379,12 @@
             "value" : "再ブロードキャストモード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modo de Reprodutor"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -51331,6 +56449,12 @@
             "value" : "受信データ（RXD）GPIOピン"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Receber dados (rxd) Pin GPIO"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -51391,6 +56515,12 @@
             "value" : "バックグラウンドでも、受信されたメッセージや重要なアラートを受け取ることができます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Receba notificações para mensagens chegando e alertas críticos, mesmo quando o aplicativo estiver em segundo plano."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -51435,6 +56565,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "受信確認: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recebido ACK: %@"
           }
         },
         "ru" : {
@@ -51487,6 +56623,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "受信者確認: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recepção de confirmação: %@"
           }
         },
         "ru" : {
@@ -51543,6 +56685,12 @@
             "value" : "おすすめ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recomendação"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -51591,6 +56739,12 @@
             "value" : "推奨セキュリティバージョン: **%@**"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Versão segura recomendada: **%@**"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -51635,6 +56789,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メッシュを通ってメッセージがこのノードに到達するまでのホップを示す記録されたトラースルートパスを表示します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tráfego de registro mostrando os saltos que uma mensagem fez através do rede para chegar a este nó."
           }
         },
         "zh-Hans" : {
@@ -51687,6 +56847,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ルート記録中"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gravação da rota"
           }
         },
         "ru" : {
@@ -51753,6 +56919,12 @@
             "value" : "デバイスメタデータを更新"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizar metadados do dispositivo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -51809,6 +56981,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "プライベートキーを再生成"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gerar Chave Privada"
           }
         },
         "ru" : {
@@ -51875,6 +57053,12 @@
             "value" : "地域"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Região"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -51933,6 +57117,12 @@
             "value" : "最後に聞いた時刻"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Última Onda de Sinal Relativa"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -51983,6 +57173,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "%d %@が送信しました。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Relatado por %d %@"
           }
         },
         "ru" : {
@@ -52043,6 +57239,12 @@
             "value" : "リリースノート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notas de lançamento"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -52101,6 +57303,12 @@
             "value" : "デバッグ用証明書を再ロード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recarregar Certificados Embalados"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -52151,6 +57359,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ のリモート管理"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Administração remota para: %@"
           }
         },
         "ru" : {
@@ -52217,6 +57431,12 @@
             "value" : "リモートレガシー管理: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Administrador de Legado Remoto: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -52279,6 +57499,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "リモートPKI管理: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Administrador Remoto PKI: %@"
           }
         },
         "ru" : {
@@ -52345,6 +57571,12 @@
             "value" : "削除"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Remova"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -52403,6 +57635,12 @@
             "value" : "お気に入りから削除"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Remova do favoritos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -52459,6 +57697,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無視リストから削除"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Remova do ignorado"
           }
         },
         "ru" : {
@@ -52523,6 +57767,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネル置換"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Substitua Canais"
           }
         },
         "ru" : {
@@ -52601,6 +57851,12 @@
             "value" : "Odpowiedz"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Responda"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -52671,6 +57927,12 @@
             "value" : "レガシー管理者要求: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Requisitar Administrador Legado: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -52735,6 +57997,12 @@
             "value" : "PKI管理者要求: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Solicitar Administrador PKI: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -52795,6 +58063,12 @@
             "value" : "必須"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Obrigatório"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -52839,6 +58113,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "あなたのスマートフォンから正確なGPSロックが必要です"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Precisa de um fixo GPS preciso do seu telefone"
           }
         },
         "zh-Hans" : {
@@ -52891,6 +58171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイスに加速度計が必要です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "É necessário que o acelerômetro esteja ativado no seu dispositivo."
           }
         },
         "ru" : {
@@ -52957,6 +58243,12 @@
             "value" : "アプリ設定をリセット"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar Configurações do Aplicativo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -53021,6 +58313,12 @@
             "value" : "NodeDBをリセット"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar o NodeDB"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -53079,6 +58377,12 @@
             "value" : "デフォルトに戻す"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Voltar ao padrão"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -53129,6 +58433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "再起動"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar"
           }
         },
         "ru" : {
@@ -53189,6 +58499,12 @@
             "value" : "サーバーを再起動します"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar Servidor"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -53233,6 +58549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接続しているノードを再起動"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reiniciar no nó que você está conectado"
           }
         },
         "ru" : {
@@ -53291,6 +58613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "復元"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Restaurar"
           }
         },
         "ru" : {
@@ -53367,6 +58695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resume"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Resumo"
           }
         },
         "ru" : {
@@ -53491,6 +58825,12 @@
             "value" : "ノードを取得しています"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Retrievendo nós"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -53541,6 +58881,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Ricerca dei nodi %lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Retirando nós %lld"
           }
         },
         "ru" : {
@@ -53601,6 +58947,12 @@
             "value" : "リトライ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recarregar"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -53645,6 +58997,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "リトライ更新"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tentar Atualizar"
           }
         },
         "zh-Hans" : {
@@ -53693,6 +59051,12 @@
             "value" : "試行中 (%d)"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tentando novamente (tentativa %@)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -53737,6 +59101,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "試行中 (%lld)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tentando novamente (tentativa %lld)"
           }
         },
         "ru" : {
@@ -53803,6 +59173,12 @@
             "value" : "アプリをレビュー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Revise o aplicativo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -53861,6 +59237,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "無線健康"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Saúde RF"
           }
         },
         "zh-Hans" : {
@@ -53925,6 +59307,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dzwonek"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Som"
           }
         },
         "ru" : {
@@ -54009,6 +59397,12 @@
             "value" : "Ringtone Config"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Som"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54077,6 +59471,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "着信音転送言語"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Transferência de Som"
           }
         },
         "ru" : {
@@ -54161,6 +59561,12 @@
             "value" : "Ringtone Transfer Language(RTTTL) Ringtone String used by supported buzzers in external notifications."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tradutor de sons de notificação externa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54231,6 +59637,12 @@
             "value" : "役割"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Papel"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54293,6 +59705,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "役割"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Papéis"
           }
         },
         "ru" : {
@@ -54359,6 +59777,12 @@
             "value" : "ルートトピック"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tópico Raiz"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54421,6 +59845,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ロータリー1"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rotativo 1"
           }
         },
         "ru" : {
@@ -54487,6 +59917,12 @@
             "value" : "ルート（復路）: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Voltar para: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54547,6 +59983,12 @@
             "value" : "ルート終点"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pontos de rota"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -54593,6 +60035,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ルートライン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Linha de rota"
           }
         },
         "zh-Hans" : {
@@ -54645,6 +60093,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ルートライン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Linhas de rotas"
           }
         },
         "ru" : {
@@ -54703,6 +60157,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ルートリスト"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lista de rotas"
           }
         },
         "ru" : {
@@ -54769,6 +60229,12 @@
             "value" : "ルートレコーダー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gravador de rotas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54833,6 +60299,12 @@
             "value" : "ルート記録を一時停止"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gravação de rota pausada"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -54893,6 +60365,12 @@
             "value" : "ルート開始"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Começo da rota"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -54943,6 +60421,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ルート: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rota: %@"
           }
         },
         "ru" : {
@@ -55009,6 +60493,12 @@
             "value" : "ルート"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rotas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55073,6 +60563,12 @@
             "value" : "RSSI %@ dBm"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "RSSI %@ dBm"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55133,6 +60629,12 @@
             "value" : "RSSI %d dBm"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "RSSI %d dBm"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -55182,6 +60684,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "RSSI %ddB"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "RSSI %ddB"
           }
         },
@@ -55245,6 +60753,12 @@
             "value" : "RSSI %lld dBm"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "RSSI %lld dBm"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -55295,6 +60809,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "RX ブーストゲイン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ganho de RX aumentado"
           }
         },
         "ru" : {
@@ -55361,6 +60881,12 @@
             "value" : "衛星"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Satélites"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55425,6 +60951,12 @@
             "value" : "衛星推定数 %lld"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Estimativa de Sats %lld"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55487,6 +61019,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "視野内衛星数: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Satélites visíveis: %@"
           }
         },
         "ru" : {
@@ -55565,6 +61103,12 @@
             "value" : "Zapisz"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salvar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55635,6 +61179,12 @@
             "value" : "チャンネル設定を保存"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salve Configurações de Canal"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55693,6 +61243,12 @@
             "value" : "ファームウェアをUSBに保存"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salve o Firmware no USB"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -55727,6 +61283,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "TAKアイデンティティ設定を保存"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salvar Configurações de Identidade TAK"
           }
         },
         "zh-Hans" : {
@@ -55779,6 +61341,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ユーザー設定を %@ に保存しますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salvar Configurações do Usuário para %@?"
           }
         },
         "ru" : {
@@ -55845,6 +61413,12 @@
             "value" : "レンジテストメッセージの詳細をCSVで保存します。現在、Webサーバーを持つESP32デバイスでのみ利用可能です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salva um CSV com os detalhes do teste de mensagem, atualmente disponível apenas em dispositivos ESP32 com um servidor web."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -55905,6 +61479,12 @@
             "value" : "保存中..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Salvando..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -55951,6 +61531,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "スキャン進捗"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Progresso da Busca"
           }
         },
         "zh-Hans" : {
@@ -56001,6 +61587,12 @@
             "value" : "発見セッションの概要を表示するビューのタイトル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Resumo da descoberta"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -56045,6 +61637,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このQRコードをスキャンして、%@ を別のデバイスに追加してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escaneie esse código QR para adicionar %@ a outro dispositivo."
           }
         },
         "ru" : {
@@ -56107,6 +61705,12 @@
             "value" : "スキャン中..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Scanando..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -56157,6 +61761,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "画面オン時間"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O display está ligado para"
           }
         },
         "ru" : {
@@ -56223,6 +61833,12 @@
             "value" : "検索"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pesquisar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -56283,6 +61899,12 @@
             "value" : "検索ドキュメント"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pesquisar documentos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -56333,6 +61955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "秒"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Segunda"
           }
         },
         "ru" : {
@@ -56411,6 +62039,12 @@
             "value" : "Wtórny"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Segundária"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -56481,6 +62115,12 @@
             "value" : "副管理者キー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chave de Administrador Secundário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -56541,6 +62181,12 @@
             "value" : "TAKサーバー構成セクションのフッターに表示するテキストです。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Conectividade mTLS segura no port 8089. Ambos os certificados do servidor e do cliente são necessários. O índice de canal do TAK seleciona o índice de canal onde os mensagens do TAK serão enviadas."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -56587,6 +62233,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "暗号化済み"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seguramente Encriptado"
           }
         },
         "zh-Hans" : {
@@ -56639,6 +62291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "セキュリティ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Segurança"
           }
         },
         "ru" : {
@@ -56701,6 +62359,12 @@
             "value" : "セキュリティアドバイザリー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta de Segurança"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -56751,6 +62415,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "セキュリティ設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Segurança"
           }
         },
         "ru" : {
@@ -56817,6 +62487,12 @@
             "value" : "セキュリティ設定にはファームウェアバージョン2.5以上が必要です"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "As configurações de segurança exigem uma versão do firmware 2.5+"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -56877,6 +62553,12 @@
             "value" : "セキュリティアップデート推奨"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualização de Segurança Recomendada"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -56927,6 +62609,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "チャンネルを選択"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha uma faixa"
           }
         },
         "ru" : {
@@ -56993,6 +62681,12 @@
             "value" : "会話を選択"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha uma conversa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57057,6 +62751,12 @@
             "value" : "会話タイプを選択"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha um tipo de conversa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57115,6 +62815,12 @@
             "value" : "ノードを選択してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha um nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57171,6 +62877,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ドロップダウンからノードを選択して、接続済みまたはリモートデバイスを管理してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha um nó na lista de seleção para gerenciar dispositivos conectados ou remotos."
           }
         },
         "ru" : {
@@ -57237,6 +62949,12 @@
             "value" : "トレースルートを選択"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha uma rota de rastreamento"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57293,6 +63011,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "絵文字を選択してください"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha um emoji"
           }
         },
         "ru" : {
@@ -57353,6 +63077,12 @@
             "value" : "チャンネル選択"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha a Canal"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57411,6 +63141,12 @@
             "value" : "マップファイルを選択してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escolha o arquivo de mapa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57467,6 +63203,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "重要なパケットを受信すると、OS通知センターのミュートスイッチとDo Not Disturb設定を無視します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se selecionar pacotes enviados como críticos, o interruptor de silêncio e as configurações de Não Perturbar no centro de notificações do sistema operacional serão ignorados."
           }
         },
         "ru" : {
@@ -57533,6 +63275,12 @@
             "value" : "送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57595,6 +63343,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "${messageContent} をチャンネル ${channelNumber} に送信"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Envie ${messageContent} para ${channelNumber}"
           }
         },
         "ru" : {
@@ -57661,6 +63415,12 @@
             "value" : "${messageContent} をノード ${nodeNumber} に送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Envie o conteúdo do mensagem para o número do nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57723,6 +63483,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "直接メッセージを送信"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar uma mensagem direta"
           }
         },
         "ru" : {
@@ -57789,6 +63555,12 @@
             "value" : "グループメッセージを送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar uma mensagem de grupo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57851,6 +63623,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "サーバーの存在を通知するためのハートビートを送信します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Envie um pulso para anunciar a presença do servidor."
           }
         },
         "ru" : {
@@ -57917,6 +63695,12 @@
             "value" : "特定のMeshtasticチャンネルにメッセージを送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar uma mensagem para um determinado canal Meshtastic"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57979,6 +63763,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "特定のMeshtasticノードにメッセージを送信してください"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar uma mensagem para um determinado nó Meshtastic"
           }
         },
         "ru" : {
@@ -58045,6 +63835,12 @@
             "value" : "ユーザーボタンが3回クリックされたときにプライマリチャンネルで位置を送信します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar uma posição no canal principal quando o botão do usuário for triple clicado."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -58107,6 +63903,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接続しているノードにシャットダウン信号を送信"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Envie um desligamento ao nó que você está conectado"
           }
         },
         "ru" : {
@@ -58173,6 +63975,12 @@
             "value" : "ウェイポイントを送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar um ponto de referência"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -58233,6 +64041,12 @@
             "value" : "SiriとCarPlayを使ってMeshtasticのメッセージを送受信できます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Envie e receba mensagens Meshtastic de forma sem fio usando Siri e CarPlay."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -58283,6 +64097,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アラートメッセージ付きASCIIベルを送信。ベルでの外部通知のトリガーに便利です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Envia um sinal de campainha ASCII com mensagem de alerta. Útil para acionar notificações externas no campainha."
           }
         },
         "ru" : {
@@ -58349,6 +64169,12 @@
             "value" : "ベル送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar Alarme"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -58407,6 +64233,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "メッセージを送信したり、直接メッセージを送信したりします。メッセージを長押しすると、コピー、返信、リプライ、タップバック、送信詳細などのアクションができます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Envie transmissões de canal e mensagens diretas. Aperte com força qualquer mensagem para ações como copiar, responder, tocar de volta e detalhes de entrega."
           }
         },
         "zh-Hans" : {
@@ -58473,6 +64305,12 @@
             "value" : "Send Heartbeat"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar batimento cardíaco"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -58537,6 +64375,12 @@
             "value" : "通知を送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviar Notificações"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -58595,6 +64439,12 @@
             "value" : "クエスチョンを送信します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Envie sua pergunta para Chirpy"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -58645,6 +64495,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "センサー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sensor"
           }
         },
         "ru" : {
@@ -58705,6 +64561,12 @@
             "value" : "ノードが報告する温度、湿度、気圧などのセンサーデータ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dados do sensor como temperatura, umidade e pressão barométrica relatados pelo nó."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -58755,6 +64617,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "センサーオプション"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções de sensor"
           }
         },
         "ru" : {
@@ -58817,6 +64685,12 @@
             "value" : "センサーパケット数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pacotes de Sensores"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -58863,6 +64737,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "センサー主導: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dominado por dados de sensores: %@"
           }
         },
         "zh-Hans" : {
@@ -58928,6 +64808,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wysłano pakiet pozycji z GPS urządzenia Apple do węzła: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enviou um pacote de posição do dispositivo Apple GPS para o nó: %@@"
           }
         },
         "ru" : {
@@ -59000,6 +64886,12 @@
             "value" : "シーケンス番号"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Número de sequência"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -59062,6 +64954,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "シーケンス: %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sequencia: %@"
           }
         },
         "ru" : {
@@ -59138,6 +65036,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Seryjny"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Serial"
           }
         },
         "ru" : {
@@ -59222,6 +65126,12 @@
             "value" : "Konfiguracja seryjna"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração Serial"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -59292,6 +65202,12 @@
             "value" : "シリアルコンソール"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Console Serial"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -59354,6 +65270,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stream API経由のシリアルコンソール。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Console Serial via API de Streaming"
           }
         },
         "ru" : {
@@ -59420,6 +65342,12 @@
             "value" : "系列"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Séries"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -59482,6 +65410,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "サーバー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Servidor"
           }
         },
         "ru" : {
@@ -59548,6 +65482,12 @@
             "value" : "サーバーアドレス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Endereço do Servidor"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -59606,6 +65546,12 @@
             "value" : "サーバー証明書"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Certificado do Servidor"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -59656,6 +65602,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "サーバーオプション"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opção de Servidor"
           }
         },
         "ru" : {
@@ -59716,6 +65668,12 @@
             "value" : "サーバーステータス"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Status do Servidor"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -59756,6 +65714,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "セッション詳細"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detalhes da Sessão de Descobrimento"
           }
         },
         "zh-Hans" : {
@@ -59806,6 +65770,12 @@
             "value" : "過去の発見セッション一覧"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Histórico de Descobrimentos"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -59852,6 +65822,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "セッション概要"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Resumo da Sessão"
           }
         },
         "zh-Hans" : {
@@ -59904,6 +65880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurar"
           }
         },
         "ru" : {
@@ -59964,6 +65946,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "チャンネル名を設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Defina o nome da canal"
           }
         },
         "zh-Hans" : {
@@ -60028,6 +66016,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ustaw region LoRa"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurar Região LoRa"
           }
         },
         "ru" : {
@@ -60100,6 +66094,12 @@
             "value" : "RXDとTXDのGPIOピンを設定します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurar os pines GPIO para RXD e TXD."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -60156,6 +66156,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "現在の位置に設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurado para a localização atual"
           }
         },
         "ru" : {
@@ -60218,6 +66224,12 @@
             "value" : "Wi-Fi設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurar Wi-Fi"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -60268,6 +66280,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大ホップ数を設定します。デフォルトは3です。ホップ数を増やすと輻輳も増加するため、慎重に使用してください。0ホップのブロードキャストメッセージはACKを受信しません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Define o número máximo de saltos, padrão é 3. Aumentar os saltos também aumenta a congestionamento e deve ser usado com cuidado. Mensagens de broadcast com 0 saltos não receberão ACKs."
           }
         },
         "ru" : {
@@ -60328,6 +66346,12 @@
             "value" : "画面の時計表示を12時間形式に設定します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Define o formato do relógio da tela para 12 horas."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -60384,6 +66408,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações"
           }
         },
         "ru" : {
@@ -60462,6 +66492,12 @@
             "value" : "Ustawienia"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -60528,6 +66564,12 @@
             "value" : "チャンネルを共有する方法について説明します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compartilhar Canais"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -60572,6 +66614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "連絡先QRを共有"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compartilhar QR de Contato"
           }
         },
         "ru" : {
@@ -60630,6 +66678,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "位置を共有"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compartilhar Localização"
           }
         },
         "ru" : {
@@ -60708,6 +66762,12 @@
             "value" : "Udostępnij kod QR kanałów"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compartilhar código QR"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -60778,6 +66838,12 @@
             "value" : "QRコードとリンクを共有"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compartilhar QR Code e Link"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -60838,6 +66904,12 @@
             "value" : "TAK友達にQRコードを送信"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compartilhar com Amigos TAK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -60882,6 +66954,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "リアルタイムで自分の位置を共有し、組み込みのGPS機能を使用してグループを連携してください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Compartilhe sua localização em tempo real e mantenha sua equipe coordenada com recursos de GPS integrados."
           }
         },
         "ru" : {
@@ -60948,6 +67026,12 @@
             "value" : "共有キー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chave Compartilhada"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61012,6 +67096,12 @@
             "value" : "短い名前"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome curto"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61070,6 +67160,12 @@
             "value" : "ブランド名 & 製品名"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome curto & Nome longo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -61114,6 +67210,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "工場リセットを実行する前に確認ダイアログを表示します"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostre uma caixa de confirmação antes de realizar o reset de fábrica"
           }
         },
         "ru" : {
@@ -61180,6 +67282,12 @@
             "value" : "アラート表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostre alertas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61244,6 +67352,12 @@
             "value" : "アラート表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar alertas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61304,6 +67418,12 @@
             "value" : "地図のラベルを表示します"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar lenda"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -61348,6 +67468,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "地図のレジェンドを表示"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostre a lenda do mapa"
           }
         },
         "zh-Hans" : {
@@ -61460,6 +67586,12 @@
             "value" : "デバイス画面に表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar na tela do dispositivo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61524,6 +67656,12 @@
             "value" : "メッシュマップに表示。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostre no mapa de rede."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -61584,6 +67722,12 @@
             "value" : "元のメッセージを表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar Original"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -61632,6 +67776,12 @@
             "value" : "翻訳を表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar Tradução"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -61678,6 +67828,12 @@
             "value" : "GPS位置に基づいてノードの方向と距離を表示します。デバイスの両方が位置を共有する必要があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra a direção e a distância para um nó com base nas posições GPS. Requer que ambos os dispositivos compartilhem a localização."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -61722,6 +67878,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "地図のラベルを表示します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostra a legenda do mapa."
           }
         },
         "zh-Hans" : {
@@ -61774,6 +67936,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "シャットダウン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desligar"
           }
         },
         "ru" : {
@@ -61836,6 +68004,12 @@
             "value" : "ノードをリセットまたは終了します"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desligar / Reiniciar Nó"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -61886,6 +68060,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ノードをシャットダウンしますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desligar o nó?"
           }
         },
         "ru" : {
@@ -61950,6 +68130,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ノードをシャットダウンしますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desligar o nó?"
           }
         },
         "ru" : {
@@ -62022,6 +68208,12 @@
             "value" : "Shutdown on Power Loss"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desligamento em Perda de Energia"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -62086,6 +68278,12 @@
             "value" : "SSHでデフォルトのユーザー名とパスワードを変更してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Faça login via SSH para alterar o usuário e a senha padrão."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -62130,6 +68328,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "信号（直接のみ）"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sinal (Direto somente)"
           }
         },
         "zh-Hans" : {
@@ -62182,6 +68386,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "信号 %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sinal %@"
           }
         },
         "ru" : {
@@ -62242,6 +68452,12 @@
             "value" : "信号強度計"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Medidor de Força de Sinal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -62286,6 +68502,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "信号: 悪い"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O sinal: ruim"
           }
         },
         "zh-Hans" : {
@@ -62334,6 +68556,12 @@
             "value" : "信号: 良好"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O sinal: Bom"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -62380,6 +68608,12 @@
             "value" : "信号: 良好"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sinal: Bom"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -62424,6 +68658,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "信号: 非常に悪い"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O sinal: muito ruim"
           }
         },
         "zh-Hans" : {
@@ -62474,6 +68714,12 @@
             "value" : "SiriとCarPlayでMeshtasticを使用する方法"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Siri e CarPlay"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -62520,6 +68766,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Siri、ショートカット、カープレイの紹介"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Siri, Shortcuts e CarPlay"
           }
         },
         "zh-Hans" : {
@@ -62572,6 +68824,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "スマート位置"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Posicao Inteligente"
           }
         },
         "ru" : {
@@ -62635,6 +68893,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "SNR"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "SNR"
           }
         },
@@ -62702,6 +68966,12 @@
             "value" : "SNR %@ dB"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "SNR %@ dB"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -62766,6 +69036,12 @@
             "value" : "SNR %@dB"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "SNR %@dB"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -62824,6 +69100,12 @@
             "value" : "現在のモデムプリセットの制限を超えているSNRです。強い信頼性の高い信号です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "SNR está acima do limite para o preset do modem atual. Sinal forte e confiável."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -62868,6 +69150,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "SNRはモデム設定の制限を下回っています。この信号レベルでは通信が期待できません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O SNR está muito abaixo do limite pré-definido do modem. A comunicação é improvável nesse nível de sinal."
           }
         },
         "zh-Hans" : {
@@ -62916,6 +69204,12 @@
             "value" : "SNRはモデム設定の制限を下回っています。接続は不定期になる可能性があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "SNR está ligeiramente abaixo do limite pré-definido do modem. A conexão pode ser intermitente."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -62960,6 +69254,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "SNRはモデム設定の制限を下回っています。パケット損失や不確実な配信が予想されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "SNR está muito abaixo do limite pré-definido do modem. Espere perda de pacotes e entrega insegura."
           }
         },
         "zh-Hans" : {
@@ -63012,6 +69312,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "土壌水分"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Umidade do Solo"
           }
         },
         "ru" : {
@@ -63078,6 +69384,12 @@
             "value" : "土壌温度"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Temperatura do Solo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -63140,6 +69452,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "速度"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Velocidade"
           }
         },
         "ru" : {
@@ -63206,6 +69524,12 @@
             "value" : "速度 %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Velocidade %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -63270,6 +69594,12 @@
             "value" : "速度: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Velocidade: %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -63326,6 +69656,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アプリ開発をスポンサー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desenvolvimento de Aplicativos Patrocinados"
           }
         },
         "ru" : {
@@ -63392,6 +69728,12 @@
             "value" : "拡散係数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fator de Espalhamento"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -63451,6 +69793,12 @@
           }
         },
         "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ssh %1$@@%2$@"
+          }
+        },
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ssh %1$@@%2$@"
@@ -63520,6 +69868,12 @@
             "value" : "SSID"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "SSID"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -63586,6 +69940,12 @@
             "value" : "最新の安定したファームウェア"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Último firmware estável"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -63648,6 +70008,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Começar"
           }
         },
         "ru" : {
@@ -63716,6 +70082,12 @@
             "value" : "スキャン開始"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Começar Busca"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -63764,6 +70136,12 @@
             "value" : "状態"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Estado"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -63808,6 +70186,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ステータス"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Status"
           }
         },
         "zh-Hans" : {
@@ -63858,6 +70242,12 @@
             "value" : "ステップ1: デバイスを接続"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Passo 1: Conectar Dispositivo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -63906,6 +70296,12 @@
             "value" : "ステップ2: ファイルを保存"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Passo 2: Salvar o Arquivo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -63952,6 +70348,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "スキャン停止"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Parar a busca"
           }
         },
         "zh-Hans" : {
@@ -64004,6 +70406,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "蓄積転送"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Armazenamento e Envio"
           }
         },
         "ru" : {
@@ -64070,6 +70478,12 @@
             "value" : "蓄積転送設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Armazenamento e Envio"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -64132,6 +70546,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "蓄積転送サーバーには、PSRAM搭載のESP32デバイスまたはLinux Nativeが必要です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Os servidores de armazenamento e forwarding exigem um dispositivo ESP32 com PSRAM ou Linux Native."
           }
         },
         "ru" : {
@@ -64204,6 +70624,12 @@
             "value" : "購読済み"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Assinado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -64266,6 +70692,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "成功的に%1$@を%2$lldのオーバーレイとともにアップロードしました"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sucesso na upload '%1$@' com %2$lld sobreposições"
           }
         },
         "ru" : {
@@ -64332,6 +70764,12 @@
             "value" : "サポート済み"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Suportado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -64394,6 +70832,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "サポートされているI2C接続センサーは自動的に検出されます。センサーはBMP280、BME280、BME680、MCP9808、INA219、INA260、LPS22、およびSHTC3です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Os sensores conectados via I2C suportados serão detectados automaticamente, os sensores são BMP280, BME280, BME680, MCP9808, INA219, INA260, LPS22 e SHTC3."
           }
         },
         "ru" : {
@@ -64504,6 +70948,12 @@
             "value" : "リストが空です"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lista vazia"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -64553,6 +71003,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "TAK"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "TAK"
           }
         },
@@ -64616,6 +71072,12 @@
             "value" : "公共チャンネルでは TAK を使用できません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TAK nao pode ser usado em canal publico"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -64662,6 +71124,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "TAKチャンネルインデックス"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Índice de Canal TAK"
           }
         },
         "zh-Hans" : {
@@ -64712,6 +71180,12 @@
             "value" : "TAK 設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração do TAK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -64760,6 +71234,12 @@
             "value" : "TAKアイデンティティ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações de Identidade TAK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -64804,6 +71284,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "TAKサーバー"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Servidor TAK"
           }
         },
         "zh-Hans" : {
@@ -64856,6 +71342,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MeshtasticチャンネルURLを取得し、チャンネル設定を保存します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Recebe uma URL de canal Meshtastic e salva as configurações do canal."
           }
         },
         "ru" : {
@@ -64916,6 +71408,12 @@
             "value" : "Meshtastic連絡先URLを取得し、ノードデータベースに保存します"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toma uma URL de contato Meshtastic e salva-a no banco de dados dos nós"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -64972,6 +71470,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "絵文字を入力するにはタップしてください"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "To enter an emoji, tap here"
           }
         },
         "ru" : {
@@ -65044,6 +71548,12 @@
             "value" : "Odpowiedź na stuknięcie"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toque de volta"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -65110,6 +71620,12 @@
             "value" : "チーム"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Equipe"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -65172,6 +71688,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Telemetria (czujniki)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Telemetria"
           }
         },
         "ru" : {
@@ -65256,6 +71778,12 @@
             "value" : "Konfiguracja telemetrii"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração de Telemetria"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -65324,6 +71852,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "温度"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Temperatura"
           }
         },
         "ru" : {
@@ -65402,6 +71936,12 @@
             "value" : "Dziesięć Minut"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "10 minutos"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -65472,6 +72012,12 @@
             "value" : "第三管理者キー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chave Administrativa Terciária"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -65532,6 +72078,12 @@
             "value" : "メッセージ数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mensagens enviadas"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -65576,6 +72128,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Web Flasher は、このデバイス、USB、またはBLE 経由で更新をサポートしていません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O **Web Flasher** não suporta atualizações neste dispositivo ou via USB ou BLE."
           }
         },
         "zh-Hans" : {
@@ -65628,6 +72186,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "パケットが完了したと見なすまでの待機時間。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O tempo de espera antes de considerarmos seu pacote como concluído."
           }
         },
         "ru" : {
@@ -65690,6 +72254,12 @@
             "value" : "チャンネルは128ビットまたは256ビットAESキーで暗号化されています。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O canal é criptografado com uma chave AES de 128 ou 256 bits."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -65736,6 +72306,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "チャネルは暗号化されていませんが、正確な位置データに使用されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O canal não é criptografado de forma segura e é usado para dados de localização precisos."
           }
         },
         "zh-Hans" : {
@@ -65786,6 +72362,12 @@
             "value" : "チャンネルは暗号化されていません。正確な位置データがMQTTを介してインターネットにアップロードされています。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A canal nao esta criptografada de forma segura e dados de localizacao precisa estao sendo uplinkados para a internet via MQTT."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -65832,6 +72414,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "キーが使用されていないか、または1バイトの既知のキーを使用しているが、正確な位置データには使用されていない。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A canal não usa uma chave ou uma chave conhecida de 1 byte, mas não é usada para dados de localização precisos."
           }
         },
         "zh-Hans" : {
@@ -65884,6 +72472,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "画面上の円の外側にあるコンパスの方位は常に北を指します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A direção do compasso na tela fora do círculo sempre apontará para o norte."
           }
         },
         "ru" : {
@@ -65944,6 +72538,12 @@
             "value" : "すべての利用可能なノードデータを表示します。データがないフィールドは自動的に隠されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A visualização completa exibe todos os dados disponíveis dos nós. Campos sem dados são ocultados automaticamente."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -65994,6 +72594,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "現在の露点は %@ です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O ponto de orvalho está em %@ agora."
           }
         },
         "ru" : {
@@ -66056,6 +72662,12 @@
             "value" : "ドキュメントブーケが読み込めませんでした。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O pacote de documentação não pôde ser carregado."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -66106,6 +72718,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最小距離条件が満たされた場合の位置更新送信の最短間隔"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O tempo mais rápido que as atualizações de posição serão enviadas se a distância mínima for satisfeita"
           }
         },
         "ru" : {
@@ -66166,6 +72784,12 @@
             "value" : "完了レイアウトのグラデーションバーは、赤（信号なし）からオレンジ、黄色、緑（良好な信号）までの全体的な信号品質を示しています。SNRとRSSIは、モデム設定と比較して計算されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A barra de gradiente no layout Completo mostra a qualidade geral do sinal de vermelho (sem sinal) a laranja, amarelo e verde (bom sinal). Ela combina SNR e RSSI em relação ao seu preset de modem."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -66216,6 +72840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイスのBLE名を設定するため、MACアドレスの末尾4桁が短縮名に追加されます。短縮名は最大4バイトまでです。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Os 4 últimos caracteres do endereço MAC do dispositivo serão adicionados ao nome curto para definir o nome BLE do dispositivo. O nome curto pode ter até 4 bytes de comprimento."
           }
         },
         "ru" : {
@@ -66282,6 +72912,12 @@
             "value" : "ノードが位置をブロードキャストしない最大間隔"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O intervalo máximo que pode passar sem um nó transmitir uma posição"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -66342,6 +72978,12 @@
             "value" : "MeshtasticのAppleアプリは、%@またはそれ以上のファームウェアが必要です。古いファームウェアバージョンはサポートされなくなり、互換性問題や機能欠如が発生する可能性があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O aplicativo Meshtastic da Apple requer a versão %@ de firmware ou superior. Versões mais antigas de firmware não são mais suportadas e podem ter problemas de compatibilidade ou recursos ausentes."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -66392,6 +73034,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "スマート位置ブロードキャストで考慮される最小距離変化（メートル）。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A mudança mínima de distância em metros para ser considerada para uma transmissão de posição inteligente."
           }
         },
         "ru" : {
@@ -66454,6 +73102,12 @@
             "value" : "このノードの最新の公開鍵は、以前記録された鍵と一致していません。対面または電話で公開鍵を比較して、誰とメッセージを送っているか確認してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O maior chave pública deste nó não corresponde à chave previamente registrada. Verifique quem você está enviando uma mensagem para comparando as chaves públicas pessoalmente ou por telefone."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -66502,6 +73156,12 @@
             "value" : "最近、ノードが聞こえており、オンラインとみなされています。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O nó foi ouvido recentemente e é considerado online."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -66546,6 +73206,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "最近、ノードは音を聞かれていないため、眠っているか、範囲外にある可能性があります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O nó não foi ouvido recentemente e pode estar dormindo ou fora de alcance."
           }
         },
         "zh-Hans" : {
@@ -66594,6 +73260,12 @@
             "value" : "あなたとこのノードの間を中継する中間ノードの数です。ホップがない場合は、直接通信です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O número de nós intermediários que transmitem mensagens entre você e este nó. Sem saltos significa comunicação direta."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -66638,6 +73310,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "番号付きの円は、ノードが使用しているチャネルを示しています。プライマリチャネル0以外の二次チャネルで表示されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O círculo numerado indica qual canal o nó está usando. Só é mostrado quando o nó está no canal secundário (não no canal primário 0)."
           }
         },
         "zh-Hans" : {
@@ -66688,6 +73366,12 @@
             "value" : "メインチャンネルはブロードキャストトラフィックを処理します。メッセージグループごとに別々のチャネルを追加し、それぞれ独自の鍵で保護します。[詳細はこちら](https://meshtastic.org/docs/configuration/tips/)"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O canal principal trata do tráfego de transmissão. Adicione canais secundários para grupos de mensagens separados, cada um protegido por sua própria chave. [Aprenda mais](https://meshtastic.org/docs/configuration/tips/)"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -66734,6 +73418,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "プライマリチャンネルはデフォルトのキーを使用する必要があります。発見スキャンを実行するには。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O canal principal deve usar a chave padrão para realizar uma busca de descoberta."
           }
         },
         "zh-Hans" : {
@@ -66786,6 +73476,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このノードに管理メッセージを送信する権限を持つプライマリ公開キー。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O principal chave pública autorizada para enviar mensagens de administrador para este nó."
           }
         },
         "ru" : {
@@ -66846,6 +73542,12 @@
             "value" : "ESP32デバイスの推奨アップデート方法は、デスクトップコンピュータ（Chromeベースのブラウザ）で**Web Flasher**を使用することです。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A maneira recomendada de atualizar dispositivos ESP32 é usando o **Web Flasher** em um computador de mesa (navegador baseado em Chrome)."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -66896,6 +73598,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無線機を使用する地域。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A região onde você usará seus radiotransmissores."
           }
         },
         "ru" : {
@@ -66962,6 +73670,12 @@
             "value" : "MQTTに使用するルートトピック。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O tópico raiz para MQTT."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -67024,6 +73738,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このノードに管理メッセージを送信する権限を持つセカンダリ公開キー。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A chave pública secundária autorizada para enviar mensagens administrativas para este nó."
           }
         },
         "ru" : {
@@ -67090,6 +73810,12 @@
             "value" : "LEDの状態（オン/オフ）"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O estado da luz LED (ligada/desligada)"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -67152,6 +73878,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このノードに管理メッセージを送信する権限を持つ三次公開キー。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A chave pública terciária autorizada para enviar mensagens administrativas para este nó."
           }
         },
         "ru" : {
@@ -67218,6 +73950,12 @@
             "value" : "チャンネル設定のURL"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O URL para as configurações do canal"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -67274,6 +74012,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "追加するノードのURL"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O URL para o nó de adição"
           }
         },
         "ru" : {
@@ -67334,6 +74078,12 @@
             "value" : "このノードに対するPKC管理者のデバイスメタデータリクエストに対する返信はありません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma resposta foi recebida para uma solicitação de metadados do dispositivo via PKC admin para este nó."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -67390,6 +74140,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "この連絡先の公開鍵に問題があります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tem um problema com a chave pública deste contato."
           }
         },
         "ru" : {
@@ -67450,6 +74206,12 @@
             "value" : "この設定は、デバイスの役割が TAK または TAK トラッカーの場合のみ適用されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esses ajustes só se aplicam quando o papel do dispositivo é TAK ou TAK Tracker."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -67496,6 +74258,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "これらの設定は %@ を %@ します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esses ajustes vão %@"
           }
         },
         "ru" : {
@@ -67552,6 +74320,12 @@
             "value" : "TAK位置報告に含まれる値は、CyanとTeam Memberをファームウェアが使用できるようにデフォルトに設定することもできます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esses valores são incluídos nos relatórios de posição TAK. Deixe qualquer configuração em Defaults para que o firmware use Cyan e Team Member."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -67596,6 +74370,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "考えています..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pensando..."
           }
         },
         "zh-Hans" : {
@@ -67660,6 +74440,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trzydzieści Minut"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trinta minutos"
           }
         },
         "ru" : {
@@ -67732,6 +74518,12 @@
             "value" : "この会話は削除されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta conversa será apagada."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -67794,6 +74586,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "これには時間がかかる場合があります。応答は送信先ノードのトレースルートログに表示されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Isso pode levar um tempo, a resposta aparecerá no log de rota de rastreamento para o nó que foi enviado."
           }
         },
         "ru" : {
@@ -67860,6 +74658,12 @@
             "value" : "このデバイスは選択した間隔でレンジテストメッセージを送信します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este dispositivo enviará mensagens de teste de alcance no intervalo selecionado."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -67922,6 +74726,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このメッセージは配信されなかった可能性があります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Essa mensagem provavelmente não foi entregue."
           }
         },
         "ru" : {
@@ -67988,6 +74798,12 @@
             "value" : "このノードは設定可能なモジュールをサポートしていません。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este nó não suporta nenhum módulo configurável."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -68048,6 +74864,12 @@
             "value" : "このツールは、あなたのローカルエリアで、異なる周波数設定の近くのMeshtasticラジオを探します。設定を自動的に切り替えて、各設定で数分間リスニングし、ラジオの数を数え、空域の混雑度に基づいて、最適な設定を表示します。サポートされているデバイスでは、ローカルデバイスAIがスキャン結果を分析し、最適な設定を推奨します。インターネット接続は必要ありません。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este ferramenta escaneia sua área local para encontrar radiodifusores Meshtastic próximos em diferentes configurações de frequência. Ela alterna automaticamente entre as configurações, ouve por alguns minutos em cada uma e, em seguida, mostra a configuração que funciona melhor para sua localização com base no número de radiodifusores encontrados e na ocupação das ondas de rádio. Em dispositivos suportados, a inteligência artificial local do dispositivo analisará seus resultados de escaneamento e recomendará a configuração ideal sem necessidade de conexão com a internet."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -68094,6 +74916,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "この変更により、プライマリチャネルは以下のようになります。\n• 名前: TAK\n• 暗号化: 新規の256ビットAES鍵\n• LoRa設定: ショート・ファスト ( TAK に推奨)\n\n TAK サーバーが正常に動作するためには、この設定が必要です。既存のチャネル共有リンクは無効になります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Isso mudará seu canal principal para: • Nome: TAK • Senha: Novo chave AES de 256 bits • Preset LoRa: Curto Rápido (recomendado para TAK) Isso é necessário para que o servidor TAK funcione corretamente. Qualquer link de compartilhamento de canal existente se tornará inválido."
           }
         },
         "zh-Hans" : {
@@ -68146,6 +74974,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "これにより固定位置が無効になり、現在設定されている位置が削除されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Isso desativa a posição fixa e remove a posição atual."
           }
         },
         "ru" : {
@@ -68204,6 +75038,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "これにより、お使いの携帯電話から現在位置を送信し、固定位置を有効にします。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Isso enviará a sua posição atual do telefone e permitirá a posição fixa."
           }
         },
         "ru" : {
@@ -68270,6 +75110,12 @@
             "value" : "時刻"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -68330,6 +75176,12 @@
             "value" : "残りの時間"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo restante"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -68380,6 +75232,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "タイムスタンプ"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo de marcação"
           }
         },
         "ru" : {
@@ -68446,6 +75304,12 @@
             "value" : "タイムゾーン"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fuso Horário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -68508,6 +75372,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイス画面とログの日付用タイムゾーン。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fuso horário para datas na tela do dispositivo e no log."
           }
         },
         "ru" : {
@@ -68584,6 +75454,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limit czasu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo de espera excedido"
           }
         },
         "ru" : {
@@ -68668,6 +75544,12 @@
             "value" : "Znacznik czasu"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Data e hora"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -68732,6 +75614,12 @@
             "value" : "タイミングとオーバーライド"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo e Sobreposições"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -68790,6 +75678,12 @@
             "value" : "TLS証明書"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Certificados TLS"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -68840,6 +75734,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TLS有効"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TLS ativado"
           }
         },
         "ru" : {
@@ -68900,6 +75800,12 @@
             "value" : "公開Meshtastic MQTTサーバーにはTLSが必要です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TLS é necessário para o servidor público de MQTT Meshtastic."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -68950,6 +75856,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "CCPAやGDPRなどのプライバシー法に準拠するため、正確な位置データの共有は避けています。代わりに、あなたのプライバシーを保護するために匿名化または近似（不正確）の位置情報を使用します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Para cumprir com as leis de privacidade como a CCPA e a GDPR, evitamos compartilhar dados de localização exatos. Em vez disso, usamos informações de localização anônimas ou aproximadas (imprecisas) para proteger sua privacidade."
           }
         },
         "ru" : {
@@ -69008,6 +75920,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "送信機（TX）に%lld"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Para a Radio (TX): %lld"
           }
         },
         "ru" : {
@@ -69070,6 +75988,12 @@
             "value" : "地図のレジェンドをタップして切り替えます"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toggle the legend of the map"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -69114,6 +76038,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ツール"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ferramentas"
           }
         },
         "zh-Hans" : {
@@ -69166,6 +76096,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "合計"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Total"
           }
         },
         "ru" : {
@@ -69228,6 +76164,12 @@
             "value" : "発見セッションの合計滞在時間"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo de permanência total"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -69278,6 +76220,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "総PAX"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Total passageiros"
           }
         },
         "ru" : {
@@ -69346,6 +76294,12 @@
             "value" : "合計ユニークなノード数"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Total de nós únicos encontrados durante a busca"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -69396,6 +76350,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "トレースルート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tráfego de Roteamento"
           }
         },
         "ru" : {
@@ -69454,6 +76414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "トレースルート（%@秒）"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trace Route (em %@s)"
           }
         },
         "ru" : {
@@ -69520,6 +76486,12 @@
             "value" : "トレースルートログ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Log de Roteamento de Tráfego"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -69582,6 +76554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "トレースルート送信済み"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trace Route enviado"
           }
         },
         "ru" : {
@@ -69648,6 +76626,12 @@
             "value" : "%@ にトレースルートを送信しました"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trace route enviado para %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -69710,6 +76694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ へのトレースルートは送信されませんでした。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O trajeto de rastreamento para %@ não foi enviado."
           }
         },
         "ru" : {
@@ -69776,6 +76766,12 @@
             "value" : "トレースルートの送信レートが制限されました。トレースルートは30秒ごとに最大1回送信できます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O Trace Route foi rateado. Você pode enviar um Trace Route uma vez a cada trinta segundos."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -69834,6 +76830,12 @@
             "value" : "トラッキングルートを表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trace rotas"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -69872,6 +76874,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "位置を追跡および共有"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tracar e Compartilhar Localizações"
           }
         },
         "ru" : {
@@ -69930,6 +76938,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "トラフィック"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tráfego"
           }
         },
         "ru" : {
@@ -69992,6 +77006,12 @@
             "value" : "翻訳"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Traduzir"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -70040,6 +77060,12 @@
             "value" : "翻訳中..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Traduzindo..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -70084,6 +77110,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "翻訳中です..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tradução em andamento..."
           }
         },
         "zh-Hans" : {
@@ -70136,6 +77168,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "送信データ（TXD）GPIOピン"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Transmitir dados (txd) Pin GPIO"
           }
         },
         "ru" : {
@@ -70202,6 +77240,12 @@
             "value" : "送信有効"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Transmitido"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -70264,6 +77308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "サポートされている加速度計でのダブルタップをユーザーボタン押下として扱います。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trate o duplo toque nos acelerômetros suportados como um botão de pressão do usuário."
           }
         },
         "ru" : {
@@ -70330,6 +77380,12 @@
             "value" : "トリガータイプ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tipo de gatilho"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -70394,6 +77450,12 @@
             "value" : "トリプルクリック アドホックPing"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tripla Clique Ping Ad Hoc"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -70454,6 +77516,12 @@
             "value" : "true"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sim"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -70504,6 +77572,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "再試行"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tente novamente"
           }
         },
         "ru" : {
@@ -70582,6 +77656,12 @@
             "value" : "Dwie Godziny"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dois horas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -70648,6 +77728,12 @@
             "value" : "オブジェクトの種類"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tipo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -70698,6 +77784,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "UDPブロードキャスト"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Transmissão UDP"
           }
         },
         "ru" : {
@@ -70760,6 +77852,12 @@
             "value" : "UF2ファイル"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "UF2"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -70806,6 +77904,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "UF2 ファームウェアアップデート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualização de Firmware UF2"
           }
         },
         "zh-Hans" : {
@@ -70858,6 +77962,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "お気に入りを解除"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desfavoritar"
           }
         },
         "ru" : {
@@ -70918,6 +78028,12 @@
             "value" : "利用できません"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não disponível"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -70968,6 +78084,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "デバイス画面に表示される単位"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Unidades exibidas na tela do dispositivo"
           }
         },
         "ru" : {
@@ -71044,6 +78166,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nieznany"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desconhecido"
           }
         },
         "ru" : {
@@ -71128,6 +78256,12 @@
             "value" : "Nieznany wiek"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Idade desconhecida"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -71192,6 +78326,12 @@
             "value" : "メッセージ不可"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Impossível enviar mensagem"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -71248,6 +78388,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "監視なし"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desmonitrado"
           }
         },
         "ru" : {
@@ -71326,6 +78472,12 @@
             "value" : "Nieustawiony"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Desconhecido"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -71396,6 +78548,12 @@
             "value" : "サポート対象外"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Não suportado"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -71458,6 +78616,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上下 1"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Para cima, para baixo, 1"
           }
         },
         "ru" : {
@@ -71524,6 +78688,12 @@
             "value" : "更新間隔"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Intervalo de Atualização"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -71582,6 +78752,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Nordic DFU ファームウェアをフラッシュする際の警告です。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta de Atualização"
           }
         },
         "zh-Hans" : {
@@ -71646,6 +78822,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zaktualizuj firmware"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualize seu firmware"
           }
         },
         "ru" : {
@@ -71718,6 +78900,12 @@
             "value" : "ノード統計データを更新しました。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Os dados estatísticos do nó foram atualizados."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -71782,6 +78970,12 @@
             "value" : "更新日時: %@"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizado em %@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -71842,6 +79036,12 @@
             "value" : "現在更新中..."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualizando agora..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -71892,6 +79092,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アップリンク有効"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uplink ativado"
           }
         },
         "ru" : {
@@ -71952,6 +79158,12 @@
             "value" : "アップロードエラー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Erro de upload"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72008,6 +79220,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "カスタムマップオーバーレイを表示するためにGeoJSONファイルをアップロードしてください。ファイルはローカルに保存され、最大10MBまでです。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregue arquivos GeoJSON para exibir sobreposições de mapa personalizadas. Os arquivos são armazenados localmente e podem ter até 10 MB."
           }
         },
         "ru" : {
@@ -72069,6 +79287,12 @@
             "value" : "マップデータをアップロード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregar Dados de Mapa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72126,6 +79350,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "オーバーレイを有効にするにはマップデータをアップロード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregue dados de mapa para habilitar os overlays"
           }
         },
         "ru" : {
@@ -72186,6 +79416,12 @@
             "value" : "マップオーバーレイをアップロード"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Carregar Sobreposições de Mapa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72244,6 +79480,12 @@
             "value" : "デバイスに翻訳されたドキュメントをアップロードして、コミュニティの翻訳を改善してください。翻訳されたドキュメントは匿名で共有されるため、他のユーザーはデバイスのモデルを必要とせずに即座に翻訳を取得できます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Submeter documentos traduzidos no dispositivo para ajudar a melhorar as traduções para a comunidade. Os documentos traduzidos são compartilhados anonimamente, para que outros usuários obtenham traduções instantâneas sem precisar de modelos no dispositivo."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -72288,6 +79530,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アップロード成功"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Upload bem-sucedido"
           }
         },
         "ru" : {
@@ -72346,6 +79594,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "マップオーバーレイをアップロード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapas de Sobreposição Baixados"
           }
         },
         "ru" : {
@@ -72412,6 +79666,12 @@
             "value" : "稼働時間"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tempo de vida útil"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72476,6 +79736,12 @@
             "value" : "使用方法とクラッシュデータ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Uso e Dados de Falha"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72536,6 +79802,12 @@
             "value" : "プライマリチャネル用の256ビット暗号鍵を使用してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Utilize uma chave de criptografia de 256 bits"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -72586,6 +79858,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "オン/オフ出力ではなく、PWM出力（RAKブザーなど）をチューンに使用してください。これにより、出力、出力時間、アクティブ設定は無視され、代わりにデバイス設定のブザーGPIOオプションが使用されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Use uma saída PWM (como o Buzzer RAK) para músicas em vez de uma saída ligada/desligada. Isso ignorará a saída, a duração da saída e as configurações ativas e usará a opção GPIO do buzzer da configuração do dispositivo em vez disso."
           }
         },
         "ru" : {
@@ -72652,6 +79930,12 @@
             "value" : "I2Sをブザーとして使用"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Use I2S como Buzzer"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72708,6 +79992,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自分の位置を使用"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Use my Location"
           }
         },
         "ru" : {
@@ -72774,6 +80064,12 @@
             "value" : "プリセットを使用"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Use Preset"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72838,6 +80134,12 @@
             "value" : "PWMブザーを使用"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Use o Buzzer PWM"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -72888,6 +80190,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Utilizza il GPS del tuo telefono per inviare le posizioni al tuo nodo invece di utilizzare un GPS hardware sul tuo nodo."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Use o GPS do seu telefone para enviar localização para seu nó em vez de usar um GPS de hardware no seu nó."
           }
         },
         "ru" : {
@@ -72954,6 +80262,12 @@
             "value" : "リモート デバイスとの共有キーを作成するために使用されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Usado para criar uma chave compartilhada com um dispositivo remoto."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73010,6 +80324,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "監視されていないまたはインフラストラクチャノードを識別するために使用され、応答しないノードにはメッセージング機能が利用できないようにします。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Usado para identificar nós não monitorados ou de infraestrutura para que a mensagem não seja disponível para nós que nunca responderão."
           }
         },
         "ru" : {
@@ -73088,6 +80408,12 @@
             "value" : "Użytkownik"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Usuário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73158,6 +80484,12 @@
             "value" : "ユーザー設定"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configurações do usuário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73220,6 +80552,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ユーザー詳細"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Detalhes do Usuário"
           }
         },
         "ru" : {
@@ -73286,6 +80624,12 @@
             "value" : "ユーザーID"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ID do Usuário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73344,6 +80688,12 @@
             "value" : "ユーザー情報交換に失敗しました"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Troca de Informações do Usuário Falhou"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73394,6 +80744,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ユーザー情報送信"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Informação do usuário enviada"
           }
         },
         "ru" : {
@@ -73448,6 +80804,12 @@
             "value" : "ユーザープライバシー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Privacidade do Usuário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73499,6 +80861,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ユーザーがアップロード"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arquivo Submetido"
           }
         },
         "ru" : {
@@ -73577,6 +80945,12 @@
             "value" : "Nazwa użytkownika"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nome de usuário"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73647,6 +81021,12 @@
             "value" : "プルアップ抵抗を使用"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Utiliza resistor pull-up"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73709,6 +81089,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "スマートフォンのネットワーク接続を利用してMQTTに接続します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Utiliza a conexão de rede do seu telefone para conectar-se ao MQTT."
           }
         },
         "ru" : {
@@ -73775,6 +81161,12 @@
             "value" : "車両方位"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Direção do veículo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73839,6 +81231,12 @@
             "value" : "車両速度"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Velocidade do veículo"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73895,6 +81293,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "このノードの最新の公開鍵は、以前記録された鍵と一致しません。工場リセットや意図的な操作による鍵変更の場合、ノードを削除して鍵交換を再開することができますが、これはより深刻なセキュリティ問題を示す可能性もあります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verifique quem você está enviando mensagens para comparando as chaves públicas pessoalmente ou por telefone. A chave pública mais recente deste nó não corresponde à chave anteriormente registrada. Você pode excluir o nó e permitir que ele troque as chaves novamente se a mudança de chave foi devido a um resgate de fábrica ou outra ação intencional, mas isso também pode indicar um problema de segurança mais sério."
           }
         },
         "ru" : {
@@ -73957,6 +81361,12 @@
             "value" : "正しいファームウェアを選択してください"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verifique se você selecionou o firmware correto."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -74013,6 +81423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "バージョン: %@ (%@)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Versão: %1$@ (%2$@)"
           }
         },
         "ru" : {
@@ -74079,6 +81495,12 @@
             "value" : "LoRa経由"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Por meio de LoRa"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74143,6 +81565,12 @@
             "value" : "MQTT経由"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Por meio de MQTT"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74203,6 +81631,12 @@
             "value" : "発見セッションの詳細を表示"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ver Resumo Completo"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -74249,6 +81683,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "発見セッションの概要を表示"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Resumo da Sessão de Descobrimento"
           }
         },
         "zh-Hans" : {
@@ -74313,6 +81753,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Napięcie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tensão"
           }
         },
         "ru" : {
@@ -74382,6 +81828,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Volts %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "Volts %@"
           }
         },
@@ -74461,6 +81913,12 @@
             "value" : "Czekam. . ."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esperando"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74531,6 +81989,12 @@
             "value" : "承認待ち. . ."
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esperando ser reconhecido..."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74595,6 +82059,12 @@
             "value" : "タップまたはモーションで画面を起動"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toque ou movimento para acionar a tela de despertar"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74655,6 +82125,12 @@
             "value" : "警告"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alerta"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -74703,6 +82179,12 @@
             "value" : "ウェイポイント"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ponto de referência"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -74747,6 +82229,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ウェイポイントの送信に失敗"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O ponto de referência falhou ao enviar"
           }
         },
         "ru" : {
@@ -74813,6 +82301,12 @@
             "value" : "ウェイポイントオプション"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções de ponto de referência"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74871,6 +82365,12 @@
             "value" : "経路点"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pontos de referência"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -74927,6 +82427,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "気象条件"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Condições do Tempo"
           }
         },
         "ru" : {
@@ -74989,6 +82495,12 @@
             "value" : "%@のドキュメントを表示するウェブビュー"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Visualização da documentação %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -75039,6 +82551,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ウェブサイト"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Site"
           }
         },
         "ru" : {
@@ -75105,6 +82623,12 @@
             "value" : "重量"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Peso"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -75165,6 +82689,12 @@
             "value" : "メッシュティックへようこそ"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bem-vindo ao Meshtastic"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -75211,6 +82741,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "このツールは、どのデバイスが近くにあるかを探します。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O que isso faz?"
           }
         },
         "zh-Hans" : {
@@ -75263,6 +82799,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Meshtasticとは？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O que é Meshtastic?"
           }
         },
         "ru" : {
@@ -75327,6 +82869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ライセンス操作者モードの機能：\n* ノード名をコールサインに設定\n* 10分ごとにノード情報をブロードキャスト\n* 周波数、デューティサイクル、送信電力をオーバーライド\n* 暗号化を無効化"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Qual modo de operador licenciado faz: \n* Define o nome do nó como seu sinal de chamada\n* Transmite informações do nó a cada 10 minutos\n* Desativa a frequência, o ciclo de trabalho e a potência de transmissão\n* Desativa a criptografia"
           }
         },
         "ru" : {
@@ -75399,6 +82947,12 @@
             "value" : "PAXカウンターモジュールを有効にすると、WiFiとBluetoothを使用して通過する人数をカウントします。PAXカウンターを動作させるには、WiFiとBluetoothの両方を無効にする必要があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Quando ativado, o módulo PAX Counter conta o número de pessoas passando usando WiFi e Bluetooth. Ambos o WiFi e o Bluetooth devem estar desativados para o PAX Counter funcionar."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -75469,6 +83023,12 @@
             "value" : "GPIOモードで使用する際、この期間出力をオンに保ちます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Quando estiver em modo GPIO, mantenha a saída ligada por esse tempo."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -75533,6 +83093,12 @@
             "value" : "GPIOピンでINPUT_PULLUPモードを使用するかどうか。ボードがピンでプルアップ抵抗を使用している場合のみ適用されます"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Se o circuito usar resistores de pull-up no pino, pode usar o modo INPUT_PULLUP."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -75591,6 +83157,12 @@
             "value" : "Wi-Fi Provisioning"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provisão de Wi-Fi"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -75635,6 +83207,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Wi-Fi設定"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Configuração do Wi-Fi"
           }
         },
         "zh-Hans" : {
@@ -75687,6 +83265,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "WiFi"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wi-Fi"
           }
         },
         "ru" : {
@@ -75759,6 +83343,12 @@
             "value" : "WiFiオプション"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Opções de WiFi"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -75815,6 +83405,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Wi-Fi OTA アップデート"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Atualização OTA do WiFi"
           }
         },
         "zh-Hans" : {
@@ -75879,6 +83475,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Will sleep everything as much as possible, for the tracker and sensor role this will also include the lora radio. Don't use this setting if you want to use your device with the phone apps or are using a device without a user button."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vai dormir tudo o que for possível, para o papel do rastreador e sensor, isso também incluirá a rádio LoRa. Não use esta configuração se você quiser usar seu dispositivo com as aplicativos do telefone ou estiver usando um dispositivo sem botão de usuário."
           }
         },
         "ru" : {
@@ -75951,6 +83553,12 @@
             "value" : "風"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vento"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -76011,6 +83619,12 @@
             "value" : "NFCタグに連絡先を保存"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Escreva Contato no NFC Tag"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -76061,6 +83675,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "x"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "X"
           }
         },
         "ru" : {
@@ -76130,6 +83750,12 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "X: %1$@, Y: %2$d"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "X: %1$@, Y: %2$d"
           }
         },
@@ -76204,6 +83830,12 @@
             "value" : "X: %1$@, Y: %2$f"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "X: %1$@, Y: %2$f"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -76275,6 +83907,12 @@
             "value" : "X: %1$@, Y: %2$lld"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "X: %1$@, Y: %2$d"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -76340,6 +83978,12 @@
             "value" : "y"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "y"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -76400,6 +84044,12 @@
             "value" : "このノードを管理しています"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sim, eu controlo este nó"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -76456,6 +84106,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "昨日"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ontem"
           }
         },
         "ru" : {
@@ -76518,6 +84174,12 @@
             "value" : "デバイスの新しいファームウェアをフラッシュする前に注意してください。このプロセスにはリスクがあります。不成功の場合、更新が失敗し、場合によってはブートローダーを再フラッシュする必要があります。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você está prestes a instalar um novo firmware no seu dispositivo. Este processo carrega riscos. Atualizações não bem-sucedidas podem falhar e, em alguns casos, exigir a reinicialização do bootloader."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -76566,6 +84228,12 @@
             "value" : "この問題を自分で修正するには、プライマリチャネルを変更してください。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Você pode corrigir isso mesmo alterando seu canal primário:"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -76608,6 +84276,12 @@
             "value" : "Il tuo canale è stato configurato per TAK. Per condividere il codice QR: vai su Impostazioni > Condividi codice QR"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu canal foi configurado para TAK. Para compartilhar o código QR: vá para Configurações > Compartilhar Código QR"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -76648,6 +84322,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Il tuo dispositivo connesso sta eseguendo un firmware più vecchio di **%@**, che contiene vulnerabilità di sicurezza note. È fortemente raccomandato aggiornare il tuo firmware per proteggere il tuo dispositivo e la rete mesh."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu dispositivo conectado está rodando firmware mais antigo que **%@**, que contém vulnerabilidades de segurança conhecidas. Atualizar seu firmware é fortemente recomendado para proteger seu dispositivo e rede de mapeamento."
           }
         },
         "zh-Hans" : {
@@ -76700,6 +84380,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "現在の位置が固定位置として設定され、位置間隔でメッシュネットワーク上にブロードキャストされます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sua localização atual será definida como uma posição fixa e transmitida pelo rede em intervalos de posição."
           }
         },
         "ru" : {
@@ -76760,6 +84446,12 @@
             "value" : "mPWRD-OSデバイスはWi-Fiネットワークに接続されました。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu dispositivo mPWRD-OS se juntou à rede Wi-Fi."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -76810,6 +84502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MQTTサーバーはTLSをサポートする必要があります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu servidor MQTT deve suportar TLS."
           }
         },
         "ru" : {
@@ -76876,6 +84574,12 @@
             "value" : "ノードは設定されたMQTTサーバーに定期的に暗号化されていないマップレポートパケットを送信します。これにはID、短縮名と長い名前、おおよその位置、ハードウェアモデル、役割、ファームウェアバージョン、LoRa地域、モデムプリセット、プライマリチャンネル名が含まれます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu nó enviará periodicamente um pacote de relatório de mapa não criptografado para o servidor MQTT configurado, incluindo ID, nome curto e longo, localização aproximada, modelo de hardware, papel, versão do firmware, região LoRa, pré-configuração do modem e nome do canal primário."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -76940,6 +84644,12 @@
             "value" : "ノードの動作周波数は、地域、モデムプリセット、およびこのフィールドに基づいて計算されます。0の場合、スロットはプライマリチャンネル名に基づいて自動的に計算されます。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A frequência de operação do seu nó é calculada com base na região, no preset do modem e neste campo. Quando 0, a faixa é calculada automaticamente com base no nome do canal primário."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -77000,6 +84710,12 @@
             "value" : "パスワードはBluetoothでデバイスに直接送信され、保存されません。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sua senha é enviada diretamente para o dispositivo via Bluetooth e nunca é armazenada."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -77050,6 +84766,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "位置情報が位置の返信要求と共に送信されました。位置が返信されると通知を受け取ります。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sua posição foi enviada com uma solicitação de resposta com sua posição. Você receberá uma notificação quando uma posição for retornada."
           }
         },
         "ru" : {
@@ -77112,6 +84834,12 @@
             "value" : "プライマリチャネルはデフォルト設定を使用しており、名前やデフォルト暗号鍵が設定されていません。TAKサーバーはリクエストモードで実行されています。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu canal principal está usando as configurações padrão (sem nome ou chave de criptografia padrão). O servidor TAK está em modo de leitura única."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "needs_review",
@@ -77156,6 +84884,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "あなたの公開鍵は、あなたの秘密鍵から生成され、メッシュ上の他のノードに送信され、あなたと共有秘密鍵を計算できるようにします。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu chave pública é gerada a partir da sua chave privada e enviada para outros nós na rede para que eles possam calcular uma chave secreta compartilhada com você."
           }
         },
         "ru" : {
@@ -77214,6 +84948,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "お住まいの地域はデューティサイクルが%lld%%です。デューティサイクル制限がある場合、MQTTの使用は推奨されません。追加のトラフィックによってLoRaメッシュがすぐに圧迫されます。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu região tem um ciclo de trabalho de %lld%%\nMQTT não é recomendado quando você está com o ciclo de trabalho restrito, o tráfego extra rapidamente sobrecarregará sua rede LoRa."
           }
         },
         "ru" : {
@@ -77280,6 +85020,12 @@
             "value" : "お住まいの地域は時間あたり%lld%%のデューティサイクル制限があります。無線機が時間制限に達すると、パケットの送信を停止します。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sua região tem um ciclo de serviço de %lld% horas, seu rádio irá parar de enviar pacotes quando atingir o limite de serviço por hora."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -77344,6 +85090,12 @@
             "value" : "ルートファイルには緯度と経度の列とヘッダーの両方が必要です。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu arquivo de rota deve conter ambas as colunas de Latitude e Longitude e os cabeçalhos."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -77402,6 +85154,12 @@
             "value" : "ユーザー情報へのリクエストが送信されました。"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Seu usuário foi enviado com uma solicitação de resposta com suas informações de usuário."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -77454,6 +85212,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "ZIPファイル"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arquivo ZIP"
           }
         },
         "zh-Hans" : {

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -2388,6 +2388,7 @@
                 it,
                 ja,
                 pl,
+                "pt-BR",
                 ru,
                 se,
                 sr,

--- a/scripts/glossary.json
+++ b/scripts/glossary.json
@@ -24,7 +24,7 @@
     "SiriKit"
   ],
   "tone": {
-    "default": "formal",
-    "fr": "formal"
+    "default": "informal",
+    "pt-BR": "informal"
   }
 }


### PR DESCRIPTION
## What changed
- Added pt-BR to the Xcode project localisations (`project.pbxproj`)
- Machine-translated all 1,302 Brazilian Portuguese strings in `Localizable.xcstrings` using [local-localizer](https://github.com/JoshuaSullivan/local-localizer) (Apple on-device Intelligence — no API keys, no network)

## Tone
Informal register, matching the friendly community voice used by the Brazilian Meshtastic community at [meshbrasil.com](https://www.meshbrasil.com) — direct, welcoming, uses 'você'.

## Status
- 1,282 strings marked `needs_review` — a native Brazilian Portuguese speaker should review before merging
- 11 strings skipped by the model (flagged as unsafe content or exceeded context window) — need manual translation
- Coverage: **99.2%**

## How to review in Xcode
Open `Localizable.xcstrings`, filter by locale **pt-BR** and state **Needs Review**, and confirm or edit each string.