### PR TITLE
chore: document per-locale tone settings in glossary.json

### DIFF
--- a/scripts/glossary.json
+++ b/scripts/glossary.json
@@ -25,7 +25,7 @@
   ],
   "tone": {
     "default": "professional",
-    "_comment": "Tone settings recorded from each machine translation run. Community-contributed locales (da, he, pl, ru, se, sr, zh-Hans, zh-Hant-TW) predate the machine translation pipeline and have no tone setting.",
+    "_comment": "Tone settings recorded from each machine translation run. Community-contributed locales (da, he, pl, ru, se, sr) predate the machine translation pipeline and have no tone setting.",
     "de": "informal",
     "es": "professional",
     "fr": "professional",
@@ -33,7 +33,9 @@
     "ja": "professional",
     "ko": "professional",
     "pt-BR": "informal",
-    "zh-Hant": "professional"
+    "zh-Hans": "professional",
+    "zh-Hant": "professional",
+    "zh-Hant-TW": "professional"
   },
   "toneNotes": {
     "de": "du-form (informal) — appropriate for a technical consumer app (PR #1799)",
@@ -43,6 +45,8 @@
     "ja": "professional — default; no explicit tone specified in PR #1806",
     "ko": "professional — formal 합쇼체 register appropriate for an IT publication (PR #1812)",
     "pt-BR": "informal — você register matching the friendly Brazilian Meshtastic community voice at meshbrasil.com (PR #1808)",
-    "zh-Hant": "professional — default; no explicit tone specified in PR #1809"
+    "zh-Hans": "professional — default; no explicit tone specified in PR #1800. Appropriate for mainland Chinese consumer software audience.",
+    "zh-Hant": "professional — default; no explicit tone specified in PR #1809",
+    "zh-Hant-TW": "professional — explicitly stated in PR #1803: tone extracted from 745 pre-existing confirmed translations, consistent professional register"
   }
 }

--- a/scripts/glossary.json
+++ b/scripts/glossary.json
@@ -25,6 +25,24 @@
   ],
   "tone": {
     "default": "professional",
-    "ko": "professional"
+    "_comment": "Tone settings recorded from each machine translation run. Community-contributed locales (da, he, pl, ru, se, sr, zh-Hans, zh-Hant-TW) predate the machine translation pipeline and have no tone setting.",
+    "de": "informal",
+    "es": "professional",
+    "fr": "professional",
+    "it": "professional",
+    "ja": "professional",
+    "ko": "professional",
+    "pt-BR": "informal",
+    "zh-Hant": "professional"
+  },
+  "toneNotes": {
+    "de": "du-form (informal) — appropriate for a technical consumer app (PR #1799)",
+    "es": "professional — default; no explicit tone specified in PR #1805",
+    "fr": "professional — default; no explicit tone specified in PR #1807",
+    "it": "professional — default; no explicit tone specified in PR #1804",
+    "ja": "professional — default; no explicit tone specified in PR #1806",
+    "ko": "professional — formal 합쇼체 register appropriate for an IT publication (PR #1812)",
+    "pt-BR": "informal — você register matching the friendly Brazilian Meshtastic community voice at meshbrasil.com (PR #1808)",
+    "zh-Hant": "professional — default; no explicit tone specified in PR #1809"
   }
 }


### PR DESCRIPTION
## What changed
Audited all machine translation PRs and encoded the tone/register used for each locale into `scripts/glossary.json`.

## Per-locale tone settings

| Locale | Tone | Notes |
|---|---|---|
| `de` | informal | du-form — appropriate for a technical consumer app (PR #1799) |
| `es` | professional | Default — no explicit tone specified in PR #1805 |
| `fr` | professional | Default — no explicit tone specified in PR #1807 |
| `it` | professional | Default — no explicit tone specified in PR #1804 |
| `ja` | professional | Default — no explicit tone specified in PR #1806 |
| `ko` | professional | Formal 합쇼체 register appropriate for an IT publication (PR #1812) |
| `pt-BR` | informal | você register matching the Brazilian Meshtastic community voice (PR #1808) |
| `zh-Hans` | professional | Default — no explicit tone specified in PR #1800. Appropriate for mainland Chinese consumer software audience. |
| `zh-Hant` | professional | Default — no explicit tone specified in PR #1809 |
| `zh-Hant-TW` | professional | Explicitly stated in PR #1803: extracted from 745 pre-existing confirmed translations |

Community-contributed locales (`da`, `he`, `pl`, `ru`, `se`, `sr`) predate the machine translation pipeline and carry no tone setting.

## Why
Future retranslation runs (e.g. when new strings are added) can now read this file to apply the same tone that was originally chosen, ensuring consistency across updates.

## How it was tested
- JSON validates cleanly
- No app code changes — this is a developer tooling file only