### PR TITLE
Firmware: select region-aware artifacts with safe fallback

### DIFF
--- a/Meshtastic/Enums/LoraConfig/RegionCodes+FirmwareLocale.swift
+++ b/Meshtastic/Enums/LoraConfig/RegionCodes+FirmwareLocale.swift
@@ -1,0 +1,40 @@
+//
+//  RegionCodes+FirmwareLocale.swift
+//  Meshtastic
+//
+
+import Foundation
+
+extension RegionCodes {
+    static let latinScriptRegions: Set<RegionCodes> = [
+        .us, .eu433, .eu868, .anz, .anz433, .in, .nz865, .my433, .my919,
+        .sg923, .ph433, .ph868, .ph915, .kz433, .kz863, .np865, .br902,
+        .itu12M, .itu232M, .eu866, .eu874, .eu917, .euN868, .lora24
+    ]
+
+    var prefersLocalizedFontFirmware: Bool {
+        !Self.latinScriptRegions.contains(self) && self != .unset
+    }
+
+    var firmwareLocaleTagCandidates: [String] {
+        let primary = topic.uppercased()
+        var tags: [String] = []
+
+        func append(_ value: String?) {
+            guard let value, !value.isEmpty, !tags.contains(value) else { return }
+            tags.append(value)
+        }
+
+        append(primary)
+        append(primary.lowercased())
+        append(primary.replacingOccurrences(of: "_", with: "-"))
+        append(primary.lowercased().replacingOccurrences(of: "_", with: "-"))
+
+        if let firstSegment = primary.split(separator: "_").first.map(String.init) {
+            append(firstSegment)
+            append(firstSegment.lowercased())
+        }
+
+        return tags
+    }
+}

--- a/Meshtastic/Model/Firmware/FirmwareFile.swift
+++ b/Meshtastic/Model/Firmware/FirmwareFile.swift
@@ -69,6 +69,7 @@ extension FirmwareFile {
 class FirmwareFile: ObservableObject, Hashable, Equatable {
 	let localUrl: URL
 	let remoteUrl: URL?
+	let remoteUrlCandidates: [URL]
 	let versionId: String
 	let platformioTarget: String
 	let releaseType: ReleaseType
@@ -79,7 +80,12 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 	
 	let versionMajor, versionMinor, versionPatch: Int
 	
-	init(firmware: FirmwareReleaseEntity, hardware: DeviceHardwareEntity, type: FirmwareType? = nil) throws {
+	init(
+		firmware: FirmwareReleaseEntity,
+		hardware: DeviceHardwareEntity,
+		type: FirmwareType? = nil,
+		localeTags: [String] = []
+	) throws {
 		// Get the target and architecture from the given DeviceHardwareEntity
 		guard let target = hardware.platformioTarget else { throw FirmwareFileError.unknownTarget }
 		self.platformioTarget = target
@@ -117,12 +123,16 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 			throw FirmwareFileError.unknownArchitecture
 		}
 		self.firmwareType = type ?? defaultFileType
-		let fileNameVersion = versionId.hasPrefix("v") ? String(versionId.dropFirst()) : versionId
-		let fileName = "firmware-\(target)-\(fileNameVersion)\(firmwareType)"
-		self.localUrl = FirmwareFile.localFirmwareStorageURL.appendingPathComponent(fileName)
-		self.remoteUrl = FirmwareFile.remoteFirmwareURLPrefix
-			.appendingPathComponent("firmware-\(fileNameVersion)")
-			.appendingPathComponent(fileName)
+			let fileNameVersion = versionId.hasPrefix("v") ? String(versionId.dropFirst()) : versionId
+			let fileName = "firmware-\(target)-\(fileNameVersion)\(firmwareType)"
+			self.localUrl = FirmwareFile.localFirmwareStorageURL.appendingPathComponent(fileName)
+			self.remoteUrlCandidates = Self.makeRemoteURLCandidates(
+				target: target,
+				version: fileNameVersion,
+				firmwareType: firmwareType,
+				localeTags: localeTags
+			)
+			self.remoteUrl = self.remoteUrlCandidates.first
 		
 		if FileManager.default.fileExists(atPath: localUrl.path) {
 			self.status = .downloaded
@@ -239,33 +249,40 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 		self.remoteUrl = FirmwareFile.remoteFirmwareURLPrefix
 			.appendingPathComponent("firmware-\(fileNameVersion)")
 			.appendingPathComponent(fileName)
+		self.remoteUrlCandidates = [self.remoteUrl].compactMap { $0 }
 	}
 	
 	@MainActor
 	func download() async throws {
-		guard let remoteUrl else {
+		guard !remoteUrlCandidates.isEmpty else {
 			throw FirmwareFileError.unknownRemoteURL
 		}
-		do {
-			let (tempLocalUrl, response) = try await URLSession.shared.download(from: remoteUrl)
 
-			if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
-				throw URLError(.badServerResponse)
+		var lastError: Error?
+		for candidateRemoteUrl in remoteUrlCandidates {
+			do {
+				let (tempLocalUrl, response) = try await URLSession.shared.download(from: candidateRemoteUrl)
+
+				if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
+					throw URLError(.badServerResponse)
+				}
+
+				if FileManager.default.fileExists(atPath: localUrl.path) {
+					try FileManager.default.removeItem(at: localUrl)
+				}
+
+				try FileManager.default.moveItem(at: tempLocalUrl, to: localUrl)
+				self.status = .downloaded
+				return
+			} catch {
+				lastError = error
 			}
-
-			if FileManager.default.fileExists(atPath: localUrl.path) {
-				try FileManager.default.removeItem(at: localUrl)
-			}
-
-			try FileManager.default.moveItem(at: tempLocalUrl, to: localUrl)
-
-			self.status = .downloaded
-
-		} catch {
-			try? FileManager.default.removeItem(at: localUrl)
-			self.status = .error(error.localizedDescription)
-			throw error
 		}
+
+		try? FileManager.default.removeItem(at: localUrl)
+		let finalError = lastError ?? URLError(.badServerResponse)
+		self.status = .error(finalError.localizedDescription)
+		throw finalError
 	}
 	
 	static func validFilenameSuffixes(forArchitecture: Architecture) -> [FirmwareType] {
@@ -297,5 +314,26 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 		hasher.combine(releaseType)
 		hasher.combine(firmwareType)
 		hasher.combine(architecture)
+	}
+
+	private static func makeRemoteURLCandidates(
+		target: String,
+		version: String,
+		firmwareType: FirmwareType,
+		localeTags: [String]
+	) -> [URL] {
+		let directory = remoteFirmwareURLPrefix.appendingPathComponent("firmware-\(version)")
+		var fileNames: [String] = []
+		var seen = Set<String>()
+		func append(_ value: String) {
+			guard !seen.contains(value) else { return }
+			seen.insert(value)
+			fileNames.append(value)
+		}
+		for tag in localeTags where !tag.isEmpty {
+			append("firmware-\(target)-\(version)-\(tag)\(firmwareType.rawValue)")
+		}
+		append("firmware-\(target)-\(version)\(firmwareType.rawValue)")
+		return fileNames.map { directory.appendingPathComponent($0) }
 	}
 }

--- a/Meshtastic/Model/Firmware/FirmwareViewModel.swift
+++ b/Meshtastic/Model/Firmware/FirmwareViewModel.swift
@@ -38,9 +38,11 @@ extension FirmwareViewModel {
 class FirmwareViewModel: ObservableObject {
 	@Published var firmwareFiles: [FirmwareFile] = []
 	let hardware: DeviceHardwareEntity
+	let preferredRegion: RegionCodes
 
-	init(forHardware: DeviceHardwareEntity) {
+	init(forHardware: DeviceHardwareEntity, preferredRegion: RegionCodes = .unset) {
 		self.hardware = forHardware
+		self.preferredRegion = preferredRegion
 		Task {
 			refresh()
 		}
@@ -58,18 +60,28 @@ class FirmwareViewModel: ObservableObject {
 		let descriptor = FetchDescriptor<FirmwareReleaseEntity>()
 		do {
 			let firmwareReleases = try context.fetch(descriptor)
-			for release in firmwareReleases {
-				if let architecture = hardwareArchitecture {
-					for firmwareType in FirmwareFile.validFilenameSuffixes(forArchitecture: architecture) {
-						let firmwareFile = try FirmwareFile(firmware: release, hardware: hardware, type: firmwareType)
+				for release in firmwareReleases {
+					let localeTags = preferredRegion == .unset ? [] : preferredRegion.firmwareLocaleTagCandidates
+					if let architecture = hardwareArchitecture {
+						for firmwareType in FirmwareFile.validFilenameSuffixes(forArchitecture: architecture) {
+							let firmwareFile = try FirmwareFile(
+								firmware: release,
+								hardware: hardware,
+								type: firmwareType,
+								localeTags: localeTags
+							)
+							newFirmwareList[firmwareFile.localUrl.lastPathComponent] = firmwareFile
+						}
+					} else {
+						// Just the default
+						let firmwareFile = try FirmwareFile(
+							firmware: release,
+							hardware: hardware,
+							localeTags: localeTags
+						)
 						newFirmwareList[firmwareFile.localUrl.lastPathComponent] = firmwareFile
 					}
-				} else {
-					// Just the default
-					let firmwareFile = try FirmwareFile(firmware: release, hardware: hardware)
-					newFirmwareList[firmwareFile.localUrl.lastPathComponent] = firmwareFile
 				}
-			}
 		} catch {
 			Logger.services.error("Error fetching firmware releases: \(error)")
 		}

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -99,7 +99,8 @@ private struct FirmwareContentView: View {
 	init(node: NodeInfoEntity, hardware: DeviceHardwareEntity) {
 		self.node = node
 		self.hardware = hardware
-		_firmwareList = StateObject(wrappedValue: FirmwareViewModel(forHardware: hardware))
+		let region = RegionCodes(rawValue: Int(node.loRaConfig?.regionCode ?? -1)) ?? .unset
+		_firmwareList = StateObject(wrappedValue: FirmwareViewModel(forHardware: hardware, preferredRegion: region))
 	}
 	
 	var body: some View {
@@ -131,12 +132,31 @@ private struct FirmwareContentView: View {
 					Text("Architecture").font(.caption).foregroundColor(.secondary)
 					Text("\(hardware.architecture ?? "Unknown")")
 				}
-				VStack(alignment: .leading) {
-					Text("Current Firmware Version").font(.caption).foregroundColor(.secondary)
-					Text("\(node.metadata?.firmwareVersion ?? "Unknown")")
+					VStack(alignment: .leading) {
+						Text("Current Firmware Version").font(.caption).foregroundColor(.secondary)
+						Text("\(node.metadata?.firmwareVersion ?? "Unknown")")
+					}
+					VStack(alignment: .leading) {
+						Text("Intended LoRa Region").font(.caption).foregroundColor(.secondary)
+						Text(intendedRegionLabel)
+					}
+					if shouldShowRegionUnsetWarning {
+						Label("Set a LoRa region before installing firmware.", systemImage: "exclamationmark.triangle.fill")
+							.foregroundStyle(.orange)
+							.font(.caption)
+					} else if shouldShowLocaleVariantWarning {
+						Label("This region may require a locale-specific firmware file for correct on-device text rendering.", systemImage: "character.book.closed.fill")
+							.foregroundStyle(.orange)
+							.font(.caption)
+					}
+					if let suggestedFileNameHint {
+						VStack(alignment: .leading, spacing: 2) {
+							Text("Suggested file pattern").font(.caption).foregroundColor(.secondary)
+							Text(suggestedFileNameHint).font(.caption).textSelection(.enabled)
+						}
+					}
 				}
-			}
-			.listRowSeparator(.hidden)
+				.listRowSeparator(.hidden)
 
 			// SECTION 2: RELEASES
 			Section(header: releasesHeader, footer: lastUpdatedFooter) {
@@ -228,6 +248,40 @@ private struct FirmwareContentView: View {
 				}
 			}
 		}
+	}
+
+	var nodeRegion: RegionCodes? {
+		guard let code = Int(exactly: node.loRaConfig?.regionCode ?? -1) else { return nil }
+		return RegionCodes(rawValue: code)
+	}
+
+	var intendedRegionLabel: String {
+		guard let region = nodeRegion else {
+			return "Not available"
+		}
+		return "\(region.description) (\(region.topic))"
+	}
+
+	var shouldShowRegionUnsetWarning: Bool {
+		nodeRegion == nil || nodeRegion == .unset
+	}
+
+	var shouldShowLocaleVariantWarning: Bool {
+		guard let region = nodeRegion else { return false }
+		return region.prefersLocalizedFontFirmware
+	}
+
+	var suggestedFileNameHint: String? {
+		guard let platformioTarget = hardware.platformioTarget?.trimmingCharacters(in: .whitespacesAndNewlines),
+			  !platformioTarget.isEmpty else {
+			return nil
+		}
+
+		if let region = nodeRegion, region != .unset {
+			return "firmware-\(platformioTarget)-<version>[-\(region.topic)]"
+		}
+
+		return "firmware-\(platformioTarget)-<version>"
 	}
 	
 	var allowedTypes: [UTType] {


### PR DESCRIPTION
# What changed?
• Added region-aware firmware selection for downloads/install flow.
• FirmwareViewModel now accepts a preferredRegion (RegionCodes, default `.unset`) and generates locale tag candidates for firmware artifact lookup.
• FirmwareFile now builds multiple remote artifact candidates (region-specific first, generic last) and attempts download with fallback.
• Firmware UI (Views/Settings/Firmware/Firmware.swift) now:
   • derives intended region from node.loRaConfig?.regionCode
   • passes region into FirmwareViewModel
   • shows intended region and guidance/warnings for localized-font firmware cases.
• Added `RegionCodes+FirmwareLocale.swift` with:
   • latinScriptRegions allowlist
   • prefersLocalizedFontFirmware
   • firmwareLocaleTagCandidates

# Why did it change?
The app previously treated firmware artifacts as region-agnostic and effectively selected only generic firmware naming. That caused poor outcomes for users needing locale-specific firmware variants (for correct non-Latin on-device rendering).
This change makes installation behavior region-aware while preserving safety via generic fallback when region-specific artifacts are unavailable.

# How is this tested?
• Static verification in Xcode for changed files (XcodeRefreshCodeIssuesInFile): no new diagnostics in modified firmware/region files.
• Manual logic validation:
   • `.unset` region produces generic-only artifact selection.
   • set region produces region-tag candidate list and fallback behavior.
• Full project build attempted; blocked by local signing/provisioning/capability profile constraints unrelated to this change (CarPlay/Critical Alerts entitlements).

Screenshots/Videos (when applicable)
• Not attached in this PR.
• UI impact is limited to firmware screen informational rows and warnings.

