### PR TITLE
Firmware: select region-aware artifacts with safe fallback

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 		DD00003ASUPPORTLVL0000001 /* SupportLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */; };
 		DD00003C000SNAP00000001 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DD00003B000SNAP00000000 /* SnapshotTesting */; };
 		DD0000DEVLNKTST000000001 /* DeviceLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */; };
+		DD1827FB0000000000000002 /* RegionCodesFirmwareLocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1827FA0000000000000002 /* RegionCodesFirmwareLocaleTests.swift */; };
 		DD007BAE2AA4E91200F5FA12 /* MyInfoEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD007BAD2AA4E91200F5FA12 /* MyInfoEntityExtension.swift */; };
 		DD007BB02AA5981000F5FA12 /* NodeInfoEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD007BAF2AA5981000F5FA12 /* NodeInfoEntityExtension.swift */; };
 		DD09240001E7FAD600E70001 /* MapLegend.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD09240002E7FAD600E70001 /* MapLegend.swift */; };
@@ -432,6 +433,7 @@
 		DDB6ABE228B13FB500384BA1 /* PositionConfigEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABE128B13FB500384BA1 /* PositionConfigEnums.swift */; };
 		DDB6ABE428B13FFF00384BA1 /* DisplayEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABE328B13FFF00384BA1 /* DisplayEnums.swift */; };
 		DDB6ABE628B1406100384BA1 /* LoraConfigEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6ABE528B1406100384BA1 /* LoraConfigEnums.swift */; };
+		DD1827FB0000000000000001 /* RegionCodes+FirmwareLocale.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1827FA0000000000000001 /* RegionCodes+FirmwareLocale.swift */; };
 		DDB6CCFB2AAF805100945AF6 /* NodeMapSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB6CCFA2AAF805100945AF6 /* NodeMapSwiftUI.swift */; };
 		DDB75A0F2A05920E006ED576 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB75A0E2A05920E006ED576 /* FileManager.swift */; };
 		DDB75A112A059258006ED576 /* Url.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB75A102A059258006ED576 /* Url.swift */; };
@@ -908,6 +910,7 @@
 		DD000031FWEDTENUM0000000 /* FirmwareEditionEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareEditionEnum.swift; sourceTree = "<group>"; };
 		DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportLevel.swift; sourceTree = "<group>"; };
 		DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLinkTests.swift; sourceTree = "<group>"; };
+		DD1827FA0000000000000002 /* RegionCodesFirmwareLocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCodesFirmwareLocaleTests.swift; sourceTree = "<group>"; };
 		DD007BAD2AA4E91200F5FA12 /* MyInfoEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoEntityExtension.swift; sourceTree = "<group>"; };
 		DD007BAF2AA5981000F5FA12 /* NodeInfoEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeInfoEntityExtension.swift; sourceTree = "<group>"; };
 		DD04804A2E9295A5005F946C /* MeshtasticDataModelV 55.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 55.xcdatamodel"; sourceTree = "<group>"; };
@@ -1061,6 +1064,7 @@
 		DDB6ABE128B13FB500384BA1 /* PositionConfigEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionConfigEnums.swift; sourceTree = "<group>"; };
 		DDB6ABE328B13FFF00384BA1 /* DisplayEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayEnums.swift; sourceTree = "<group>"; };
 		DDB6ABE528B1406100384BA1 /* LoraConfigEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoraConfigEnums.swift; sourceTree = "<group>"; };
+		DD1827FA0000000000000001 /* RegionCodes+FirmwareLocale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RegionCodes+FirmwareLocale.swift"; sourceTree = "<group>"; };
 		DDB6CCFA2AAF805100945AF6 /* NodeMapSwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeMapSwiftUI.swift; sourceTree = "<group>"; };
 		DDB759E12A04B264006ED576 /* MeshtasticDataModelV12.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV12.xcdatamodel; sourceTree = "<group>"; };
 		DDB75A0E2A05920E006ED576 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
@@ -1643,6 +1647,7 @@
 				DD7E5740000000000000008A /* LockdownCoordinatorTests.swift */,
 				DD7E5740000000000000008B /* LockdownPassphraseStoreTests.swift */,
 				DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */,
+				DD1827FA0000000000000002 /* RegionCodesFirmwareLocaleTests.swift */,
 				DD000031STATMSGDISP00000 /* StatusMessageDisplayTests.swift */,
 			);
 			path = MeshtasticTests;
@@ -2034,6 +2039,7 @@
 				DD5D0A9B2931B9F200F7EA61 /* EthernetModes.swift */,
 				DD1BEF572E0A00030090CE24 /* FirmwareEditionEnum.swift */,
 				DDB6ABE528B1406100384BA1 /* LoraConfigEnums.swift */,
+				DD1827FA0000000000000001 /* RegionCodes+FirmwareLocale.swift */,
 				DD3CC6BF28E7A60700FA9159 /* MessagingEnums.swift */,
 				DDB6ABE128B13FB500384BA1 /* PositionConfigEnums.swift */,
 				DD268D8D2BCC90E2008073AE /* RouteEnums.swift */,
@@ -2707,6 +2713,7 @@
 				DD7E5750000000000000008A /* LockdownCoordinatorTests.swift in Sources */,
 				DD7E5750000000000000008B /* LockdownPassphraseStoreTests.swift in Sources */,
 				DD0000DEVLNKTST000000001 /* DeviceLinkTests.swift in Sources */,
+				DD1827FB0000000000000002 /* RegionCodesFirmwareLocaleTests.swift in Sources */,
 				DD000031STATMSGDISP00001 /* StatusMessageDisplayTests.swift in Sources */,
 				AA009MCT0000002000000001 /* MarkdownConverterTests.swift in Sources */,
 				AA0001012E2730EC00600001 /* ConnectViewTests.swift in Sources */,
@@ -3005,6 +3012,7 @@
 				DD3CC6C228EB9D4900FA9159 /* UpdateSwiftData.swift in Sources */,
 				DDE0F7C5295F77B700B8AAB3 /* AppSettingsEnums.swift in Sources */,
 				DDB6ABE628B1406100384BA1 /* LoraConfigEnums.swift in Sources */,
+				DD1827FB0000000000000001 /* RegionCodes+FirmwareLocale.swift in Sources */,
 				231A53782E69ADB900216B99 /* NodeFilterParameters.swift in Sources */,
 				2D8C25541553DE3B517A4347 /* EditNodeDisplayNameView.swift in Sources */,
 				232ED4C52E2C5EDD009DA392 /* TCPConnection.swift in Sources */,

--- a/Meshtastic/Enums/LoraConfigEnums.swift
+++ b/Meshtastic/Enums/LoraConfigEnums.swift
@@ -131,11 +131,11 @@ enum RegionCodes: Int, CaseIterable, Identifiable {
 		case .sg923:
 			"SG_923"
 		case .ph433:
-			"ph_433"
+			"PH_433"
 		case .ph868:
-			"ph_868"
+			"PH_868"
 		case .ph915:
-			"ph_915"
+			"PH_915"
 		case .kz433:
 			"KZ_433"
 		case .kz863:

--- a/Meshtastic/Enums/RegionCodes+FirmwareLocale.swift
+++ b/Meshtastic/Enums/RegionCodes+FirmwareLocale.swift
@@ -1,0 +1,52 @@
+//
+//  RegionCodes+FirmwareLocale.swift
+//  Meshtastic
+//
+//  Region-aware firmware artifact selection (PR #1827, @laconicman).
+//  Some regions imply a non-Latin display language, and firmware releases can
+//  ship locale-tagged variants with the right on-device fonts (e.g.
+//  firmware-tbeam-2.7.0-RU.bin). These helpers classify regions and produce
+//  candidate locale tags to try before falling back to the generic artifact.
+//
+import Foundation
+
+extension RegionCodes {
+	/// Regions whose default display language renders fine with the generic
+	/// (Latin-font) firmware. Everything else prefers a locale-tagged variant.
+	/// Keep exhaustive: RegionCodesFirmwareLocaleTests fails when a new region
+	/// is added without classifying it here or in the test's non-Latin list.
+	static let latinScriptRegions: Set<RegionCodes> = [
+		.us, .eu433, .eu868, .anz, .anz433, .in, .nz865, .my433, .my919,
+		.sg923, .ph433, .ph868, .ph915, .kz433, .kz863, .np865, .br902,
+		.eu866, .eu874, .eu917, .euN868, .lora24,
+		.itu12M, .itu22M, .itu32M, .itu170Cm, .itu270Cm, .itu370Cm, .itu2125Cm
+	]
+
+	var prefersLocalizedFontFirmware: Bool {
+		!Self.latinScriptRegions.contains(self) && self != .unset
+	}
+
+	/// Locale tags to try in firmware artifact filenames, most specific first.
+	/// Derived from `topic` (e.g. "UA_433" → UA_433, ua_433, UA-433, ua-433, UA, ua).
+	var firmwareLocaleTagCandidates: [String] {
+		let primary = topic.uppercased()
+		var tags: [String] = []
+
+		func append(_ value: String?) {
+			guard let value, !value.isEmpty, !tags.contains(value) else { return }
+			tags.append(value)
+		}
+
+		append(primary)
+		append(primary.lowercased())
+		append(primary.replacingOccurrences(of: "_", with: "-"))
+		append(primary.lowercased().replacingOccurrences(of: "_", with: "-"))
+
+		if let firstSegment = primary.split(separator: "_").first.map(String.init) {
+			append(firstSegment)
+			append(firstSegment.lowercased())
+		}
+
+		return tags
+	}
+}

--- a/Meshtastic/Model/Firmware/FirmwareFile.swift
+++ b/Meshtastic/Model/Firmware/FirmwareFile.swift
@@ -69,6 +69,10 @@ extension FirmwareFile {
 class FirmwareFile: ObservableObject, Hashable, Equatable {
 	let localUrl: URL
 	let remoteUrl: URL?
+	/// Remote artifact URLs to try in order: region/locale-tagged variants
+	/// first (when the node's LoRa region prefers localized-font firmware),
+	/// generic artifact last. `remoteUrl` is the first candidate.
+	let remoteUrlCandidates: [URL]
 	let versionId: String
 	let platformioTarget: String
 	let releaseType: ReleaseType
@@ -79,7 +83,7 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 	
 	let versionMajor, versionMinor, versionPatch: Int
 	
-	init(firmware: FirmwareReleaseEntity, hardware: DeviceHardwareEntity, type: FirmwareType? = nil) throws {
+	init(firmware: FirmwareReleaseEntity, hardware: DeviceHardwareEntity, type: FirmwareType? = nil, localeTags: [String] = []) throws {
 		// Get the target and architecture from the given DeviceHardwareEntity
 		guard let target = hardware.platformioTarget else { throw FirmwareFileError.unknownTarget }
 		self.platformioTarget = target
@@ -120,10 +124,14 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 		let fileNameVersion = versionId.hasPrefix("v") ? String(versionId.dropFirst()) : versionId
 		let fileName = "firmware-\(target)-\(fileNameVersion)\(firmwareType)"
 		self.localUrl = FirmwareFile.localFirmwareStorageURL.appendingPathComponent(fileName)
-		self.remoteUrl = FirmwareFile.remoteFirmwareURLPrefix
-			.appendingPathComponent("firmware-\(fileNameVersion)")
-			.appendingPathComponent(fileName)
-		
+		self.remoteUrlCandidates = Self.makeRemoteURLCandidates(
+			target: target,
+			version: fileNameVersion,
+			firmwareType: firmwareType,
+			localeTags: localeTags
+		)
+		self.remoteUrl = self.remoteUrlCandidates.first
+
 		if FileManager.default.fileExists(atPath: localUrl.path) {
 			self.status = .downloaded
 		} else {
@@ -239,33 +247,42 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 		self.remoteUrl = FirmwareFile.remoteFirmwareURLPrefix
 			.appendingPathComponent("firmware-\(fileNameVersion)")
 			.appendingPathComponent(fileName)
+		self.remoteUrlCandidates = [self.remoteUrl].compactMap { $0 }
 	}
 	
 	@MainActor
 	func download() async throws {
-		guard let remoteUrl else {
+		guard !remoteUrlCandidates.isEmpty else {
 			throw FirmwareFileError.unknownRemoteURL
 		}
-		do {
-			let (tempLocalUrl, response) = try await URLSession.shared.download(from: remoteUrl)
 
-			if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
-				throw URLError(.badServerResponse)
+		// Try each candidate in order (locale-tagged variants first, generic
+		// last); a release without a locale variant 404s and falls through.
+		var lastError: Error?
+		for candidateRemoteUrl in remoteUrlCandidates {
+			do {
+				let (tempLocalUrl, response) = try await URLSession.shared.download(from: candidateRemoteUrl)
+
+				if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
+					throw URLError(.badServerResponse)
+				}
+
+				if FileManager.default.fileExists(atPath: localUrl.path) {
+					try FileManager.default.removeItem(at: localUrl)
+				}
+
+				try FileManager.default.moveItem(at: tempLocalUrl, to: localUrl)
+				self.status = .downloaded
+				return
+			} catch {
+				lastError = error
 			}
-
-			if FileManager.default.fileExists(atPath: localUrl.path) {
-				try FileManager.default.removeItem(at: localUrl)
-			}
-
-			try FileManager.default.moveItem(at: tempLocalUrl, to: localUrl)
-
-			self.status = .downloaded
-
-		} catch {
-			try? FileManager.default.removeItem(at: localUrl)
-			self.status = .error(error.localizedDescription)
-			throw error
 		}
+
+		try? FileManager.default.removeItem(at: localUrl)
+		let finalError = lastError ?? URLError(.badServerResponse)
+		self.status = .error(finalError.localizedDescription)
+		throw finalError
 	}
 	
 	static func validFilenameSuffixes(forArchitecture: Architecture) -> [FirmwareType] {
@@ -297,5 +314,26 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 		hasher.combine(releaseType)
 		hasher.combine(firmwareType)
 		hasher.combine(architecture)
+	}
+
+	private static func makeRemoteURLCandidates(
+		target: String,
+		version: String,
+		firmwareType: FirmwareType,
+		localeTags: [String]
+	) -> [URL] {
+		let directory = remoteFirmwareURLPrefix.appendingPathComponent("firmware-\(version)")
+		var fileNames: [String] = []
+		var seen = Set<String>()
+		func append(_ value: String) {
+			guard !seen.contains(value) else { return }
+			seen.insert(value)
+			fileNames.append(value)
+		}
+		for tag in localeTags where !tag.isEmpty {
+			append("firmware-\(target)-\(version)-\(tag)\(firmwareType.rawValue)")
+		}
+		append("firmware-\(target)-\(version)\(firmwareType.rawValue)")
+		return fileNames.map { directory.appendingPathComponent($0) }
 	}
 }

--- a/Meshtastic/Model/Firmware/FirmwareFile.swift
+++ b/Meshtastic/Model/Firmware/FirmwareFile.swift
@@ -260,6 +260,7 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 		// last); a release without a locale variant 404s and falls through.
 		var lastError: Error?
 		for candidateRemoteUrl in remoteUrlCandidates {
+			try Task.checkCancellation()
 			do {
 				let (tempLocalUrl, response) = try await URLSession.shared.download(from: candidateRemoteUrl)
 
@@ -274,6 +275,8 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 				try FileManager.default.moveItem(at: tempLocalUrl, to: localUrl)
 				self.status = .downloaded
 				return
+			} catch let urlError as URLError where urlError.code == .cancelled {
+				throw urlError
 			} catch {
 				lastError = error
 			}

--- a/Meshtastic/Model/Firmware/FirmwareViewModel.swift
+++ b/Meshtastic/Model/Firmware/FirmwareViewModel.swift
@@ -63,7 +63,7 @@ class FirmwareViewModel: ObservableObject {
 		let descriptor = FetchDescriptor<FirmwareReleaseEntity>()
 		do {
 			let firmwareReleases = try context.fetch(descriptor)
-			let localeTags = preferredRegion == .unset ? [] : preferredRegion.firmwareLocaleTagCandidates
+			let localeTags = preferredRegion.prefersLocalizedFontFirmware ? preferredRegion.firmwareLocaleTagCandidates : []
 			for release in firmwareReleases {
 				if let architecture = hardwareArchitecture {
 					for firmwareType in FirmwareFile.validFilenameSuffixes(forArchitecture: architecture) {

--- a/Meshtastic/Model/Firmware/FirmwareViewModel.swift
+++ b/Meshtastic/Model/Firmware/FirmwareViewModel.swift
@@ -38,9 +38,14 @@ extension FirmwareViewModel {
 class FirmwareViewModel: ObservableObject {
 	@Published var firmwareFiles: [FirmwareFile] = []
 	let hardware: DeviceHardwareEntity
+	/// The connected node's LoRa region; non-Latin regions get locale-tagged
+	/// remote artifact candidates so the right on-device fonts ship. `.unset`
+	/// keeps the previous generic-only behavior.
+	let preferredRegion: RegionCodes
 
-	init(forHardware: DeviceHardwareEntity) {
+	init(forHardware: DeviceHardwareEntity, preferredRegion: RegionCodes = .unset) {
 		self.hardware = forHardware
+		self.preferredRegion = preferredRegion
 		Task {
 			refresh()
 		}
@@ -58,15 +63,16 @@ class FirmwareViewModel: ObservableObject {
 		let descriptor = FetchDescriptor<FirmwareReleaseEntity>()
 		do {
 			let firmwareReleases = try context.fetch(descriptor)
+			let localeTags = preferredRegion == .unset ? [] : preferredRegion.firmwareLocaleTagCandidates
 			for release in firmwareReleases {
 				if let architecture = hardwareArchitecture {
 					for firmwareType in FirmwareFile.validFilenameSuffixes(forArchitecture: architecture) {
-						let firmwareFile = try FirmwareFile(firmware: release, hardware: hardware, type: firmwareType)
+						let firmwareFile = try FirmwareFile(firmware: release, hardware: hardware, type: firmwareType, localeTags: localeTags)
 						newFirmwareList[firmwareFile.localUrl.lastPathComponent] = firmwareFile
 					}
 				} else {
 					// Just the default
-					let firmwareFile = try FirmwareFile(firmware: release, hardware: hardware)
+					let firmwareFile = try FirmwareFile(firmware: release, hardware: hardware, localeTags: localeTags)
 					newFirmwareList[firmwareFile.localUrl.lastPathComponent] = firmwareFile
 				}
 			}

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -78,7 +78,10 @@ private struct FirmwareContentView: View {
 	
 	let node: NodeInfoEntity
 	let hardware: DeviceHardwareEntity
-	
+	/// The node's LoRa region at the time this view was created; drives
+	/// region-aware artifact selection and the locale-variant guidance rows.
+	let nodeRegion: RegionCodes
+
 	// We can safely init the StateObject here because 'hardware' is passed in
 	@StateObject var firmwareList: FirmwareViewModel
 	@State private var firmwareSelection = FirmwareTab.stable
@@ -99,7 +102,9 @@ private struct FirmwareContentView: View {
 	init(node: NodeInfoEntity, hardware: DeviceHardwareEntity) {
 		self.node = node
 		self.hardware = hardware
-		_firmwareList = StateObject(wrappedValue: FirmwareViewModel(forHardware: hardware))
+		let region = node.loRaConfig.flatMap { RegionCodes(rawValue: Int($0.regionCode)) } ?? .unset
+		self.nodeRegion = region
+		_firmwareList = StateObject(wrappedValue: FirmwareViewModel(forHardware: hardware, preferredRegion: region))
 	}
 	
 	var body: some View {
@@ -134,6 +139,25 @@ private struct FirmwareContentView: View {
 				VStack(alignment: .leading) {
 					Text("Current Firmware Version").font(.caption).foregroundColor(.secondary)
 					Text("\(node.metadata?.firmwareVersion ?? "Unknown")")
+				}
+				VStack(alignment: .leading) {
+					Text("Intended LoRa Region").font(.caption).foregroundColor(.secondary)
+					Text(intendedRegionLabel)
+				}
+				if shouldShowRegionUnsetWarning {
+					Label("Set a LoRa region before installing firmware.", systemImage: "exclamationmark.triangle.fill")
+						.foregroundStyle(.orange)
+						.font(.caption)
+				} else if shouldShowLocaleVariantWarning {
+					Label("This region may require a locale-specific firmware file for correct on-device text rendering.", systemImage: "character.book.closed.fill")
+						.foregroundStyle(.orange)
+						.font(.caption)
+				}
+				if let suggestedFileNameHint {
+					VStack(alignment: .leading, spacing: 2) {
+						Text("Suggested file pattern").font(.caption).foregroundColor(.secondary)
+						Text(suggestedFileNameHint).font(.caption).textSelection(.enabled)
+					}
 				}
 			}
 			.listRowSeparator(.hidden)
@@ -230,6 +254,32 @@ private struct FirmwareContentView: View {
 		}
 	}
 	
+	var intendedRegionLabel: String {
+		"\(nodeRegion.description) (\(nodeRegion.topic))"
+	}
+
+	var shouldShowRegionUnsetWarning: Bool {
+		nodeRegion == .unset
+	}
+
+	var shouldShowLocaleVariantWarning: Bool {
+		nodeRegion.prefersLocalizedFontFirmware
+	}
+
+	/// Example artifact filename for this hardware, with the optional locale
+	/// tag shown for regions that ship localized-font variants. Selectable so
+	/// users hunting for a file on meshtastic.github.io can copy it.
+	var suggestedFileNameHint: String? {
+		guard let platformioTarget = hardware.platformioTarget?.trimmingCharacters(in: .whitespacesAndNewlines),
+			  !platformioTarget.isEmpty else {
+			return nil
+		}
+		if nodeRegion != .unset {
+			return "firmware-\(platformioTarget)-<version>[-\(nodeRegion.topic)]"
+		}
+		return "firmware-\(platformioTarget)-<version>"
+	}
+
 	var allowedTypes: [UTType] {
 		switch hardware.architecture.flatMap( {Architecture(rawValue: $0) }) {
 		case .esp32, .esp32C3, .esp32S3, .esp32C6:

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -274,7 +274,7 @@ private struct FirmwareContentView: View {
 			  !platformioTarget.isEmpty else {
 			return nil
 		}
-		if nodeRegion != .unset {
+		if nodeRegion.prefersLocalizedFontFirmware {
 			return "firmware-\(platformioTarget)-<version>[-\(nodeRegion.topic)]"
 		}
 		return "firmware-\(platformioTarget)-<version>"

--- a/MeshtasticTests/RegionCodesFirmwareLocaleTests.swift
+++ b/MeshtasticTests/RegionCodesFirmwareLocaleTests.swift
@@ -1,0 +1,97 @@
+//
+//  RegionCodesFirmwareLocaleTests.swift
+//  Meshtastic
+//
+//  Created by laconicman on 5/18/26.
+//
+
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("RegionCodes+FirmwareLocale")
+struct RegionCodesFirmwareLocaleTests {
+
+	// MARK: - prefersLocalizedFontFirmware
+
+	@Test("Latin regions do not prefer locale firmware")
+	func latinRegionsDoNotPreferLocale() {
+		let latinRegions: [RegionCodes] = [
+			.us, .eu433, .eu868, .anz, .in, .nz865,
+			.my433, .my919, .sg923, .ph433, .ph868, .ph915, .lora24,
+			.anz433, .kz433, .kz863, .np865, .br902,
+			.eu866, .eu874, .eu917, .euN868,
+			.itu12M, .itu22M, .itu32M, .itu170Cm, .itu270Cm, .itu370Cm, .itu2125Cm
+		]
+		for region in latinRegions {
+			#expect(!region.prefersLocalizedFontFirmware, "\(region) should be Latin")
+		}
+	}
+
+	@Test("Non-Latin regions prefer locale firmware")
+	func nonLatinRegionsPreferLocale() {
+		let nonLatinRegions: [RegionCodes] = [.ru, .ua433, .ua868, .cn, .jp, .kr, .tw, .th]
+		for region in nonLatinRegions {
+			#expect(region.prefersLocalizedFontFirmware, "\(region) should be non-Latin")
+		}
+	}
+
+	@Test("Unset region does not prefer locale firmware")
+	func unsetDoesNotPreferLocale() {
+		#expect(!RegionCodes.unset.prefersLocalizedFontFirmware)
+	}
+
+	// MARK: - firmwareLocaleTagCandidates
+
+	@Test("Simple region produces two candidates")
+	func simpleRegionCandidates() {
+		#expect(RegionCodes.ru.firmwareLocaleTagCandidates == ["RU", "ru"])
+	}
+
+	@Test("Compound region expands to six candidates")
+	func compoundRegionCandidates() {
+		#expect(RegionCodes.ua433.firmwareLocaleTagCandidates == ["UA_433", "ua_433", "UA-433", "ua-433", "UA", "ua"])
+	}
+
+	// MARK: - More general checks
+
+	@Test("All region topics are uppercase")
+	/// `topic` is always uppercase — the root invariant
+	func allTopicsAreUppercase() {
+		for region in RegionCodes.allCases {
+			#expect(region.topic == region.topic.uppercased(),
+					"\(region).topic '\(region.topic)' is not uppercase")
+		}
+	}
+
+	/// latinScriptRegions exhaustiveness — the "new region" trap
+	@Test("All non-unset regions are explicitly classified as Latin or non-Latin")
+	func allRegionsAreExplicitlyClassified() {
+		let knownNonLatin: Set<RegionCodes> = [.ru, .ua433, .ua868, .cn, .jp, .kr, .tw, .th]
+		let allNonUnset = Set(RegionCodes.allCases.filter { $0 != .unset })
+		#expect(RegionCodes.latinScriptRegions.union(knownNonLatin) == allNonUnset,
+				"A region is missing from latinScriptRegions or knownNonLatin")
+	}
+
+	/// The full stringly-typed chain — URL construction
+	@Test("Locale tag candidates are non-empty and well-formed for all set regions",
+		  arguments: RegionCodes.allCases.filter { $0 != .unset })
+	func localeTagCandidatesForRegion(region: RegionCodes) {
+		let tags = region.firmwareLocaleTagCandidates
+		#expect(!tags.isEmpty, "\(region) should produce at least one tag")
+		#expect(tags.first == region.topic.uppercased(),
+				"\(region) first tag should be uppercased topic")
+		#expect(tags.count == Set(tags).count,
+				"\(region) should have no duplicate tags")
+	}
+
+	// MARK: - Some specific tests
+
+	@Test("Philippines topic strings are uppercase and properly formatted with `_`")
+	func philippinesTopicIsUppercase() {
+		#expect(RegionCodes.ph433.topic == "PH_433")
+		#expect(RegionCodes.ph868.topic == "PH_868")
+		#expect(RegionCodes.ph915.topic == "PH_915")
+	}
+}


### PR DESCRIPTION
# What changed?
• Added region-aware firmware selection for downloads/install flow.
• FirmwareViewModel now accepts a preferredRegion (RegionCodes, default `.unset`) and generates locale tag candidates for firmware artifact lookup.
• FirmwareFile now builds multiple remote artifact candidates (region-specific first, generic last) and attempts download with fallback.
• Firmware UI (Views/Settings/Firmware/Firmware.swift) now:
   • derives intended region from node.loRaConfig?.regionCode
   • passes region into FirmwareViewModel
   • shows intended region and guidance/warnings for localized-font firmware cases.
• Added `RegionCodes+FirmwareLocale.swift` with:
   • latinScriptRegions allowlist
   • prefersLocalizedFontFirmware
   • firmwareLocaleTagCandidates

# Why did it change?
The app previously treated firmware artifacts as region-agnostic and effectively selected only generic firmware naming. That caused poor outcomes for users needing locale-specific firmware variants (for correct non-Latin on-device rendering).
This change makes installation behavior region-aware while preserving safety via generic fallback when region-specific artifacts are unavailable.

# How is this tested?
• Static verification in Xcode for changed files (XcodeRefreshCodeIssuesInFile): no new diagnostics in modified firmware/region files.
• Manual logic validation:
   • `.unset` region produces generic-only artifact selection.
   • set region produces region-tag candidate list and fallback behavior.
• Full project build attempted; blocked by local signing/provisioning/capability profile constraints unrelated to this change (CarPlay/Critical Alerts entitlements).

Screenshots/Videos (when applicable)
• Not attached in this PR.
• UI impact is limited to firmware screen informational rows and warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Firmware selection now uses the device’s intended LoRa region to prefer locale-specific firmware artifacts when needed.
  * The firmware screen now shows the intended LoRa region, provides warnings for unset/locale-specific requirements, and displays a suggested filename pattern.
* **Bug Fixes**
  * Firmware downloads now attempt multiple region/locale-matched artifact URLs before falling back, improving the chance of a successful match.
  * Standardized Philippines region labels to an uppercase format.
* **Tests**
  * Added coverage for region-to-locale firmware candidate generation, including ordering, deduplication, and topic formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->