### PR TITLE
Fix app icon badge persisting after reading messages

### DIFF
--- a/Meshtastic/AppState.swift
+++ b/Meshtastic/AppState.swift
@@ -1,4 +1,6 @@
 import Combine
+import OSLog
+import SwiftData
 import SwiftUI
 
 class AppState: ObservableObject {
@@ -24,5 +26,31 @@ class AppState: ObservableObject {
 					.setBadgeCount(badgeCounts.0 + badgeCounts.1)
 			})
 			.store(in: &cancellables)
+	}
+
+	/// Recalculate unread message counts from the database and update
+	/// the app icon badge. Call this when the app becomes active or
+	/// after any bulk read/delete operation to keep the badge in sync.
+	@MainActor
+	func refreshBadgeCount(context: ModelContext) {
+		let channelDescriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> { msg in
+				msg.toUser == nil && msg.isEmoji == false && msg.read == false
+			}
+		)
+		let dmDescriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> { msg in
+				msg.toUser != nil && msg.isEmoji == false && msg.read == false && msg.admin == false
+			}
+		)
+		let channelCount = (try? context.fetchCount(channelDescriptor)) ?? 0
+		let dmCount = (try? context.fetchCount(dmDescriptor)) ?? 0
+		if unreadChannelMessages != channelCount {
+			unreadChannelMessages = channelCount
+		}
+		if unreadDirectMessages != dmCount {
+			unreadDirectMessages = dmCount
+		}
+		Logger.data.debug("🔢 Badge refresh: \(channelCount) channel + \(dmCount) DM = \(channelCount + dmCount) total")
 	}
 }

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -228,6 +228,9 @@ struct MeshtasticAppleApp: App {
 			case .active:
 				Logger.services.info("🎬 [App] Scene is active")
 				accessoryManager.appDidBecomeActive()
+				if let context = persistenceController?.container.mainContext {
+					appState.refreshBadgeCount(context: context)
+				}
 			@unknown default:
 				Logger.services.error("🍎 [App] Apple must have changed something")
 			}


### PR DESCRIPTION
## What changed?

- Added `AppState.refreshBadgeCount(context:)` — recalculates unread channel and DM message counts directly from the database using `fetchCount` queries, then updates `unreadChannelMessages` and `unreadDirectMessages` (which triggers the existing Combine sink to call `setBadgeCount`).
- Call `refreshBadgeCount` in `MeshtasticApp.onChange(of: scenePhase)` when the scene becomes `.active`.

## Why did it change?

The app icon badge count was only decremented when `markMessagesAsRead()` ran inside `ChannelMessageList` or `UserMessageList`. Several scenarios caused the badge to go stale:

1. User reads messages but navigates away before all `onAppear` read-marks fire
2. App is backgrounded before the 250ms batched read sync completes
3. User opens the app from a notification but doesn't scroll to see all unread messages
4. `clearNotifications()` removes delivered notifications but never resets the badge

In all cases the `AppState` unread counts stayed stale and the badge persisted until force quit.

## How is this tested?

1. Receive messages while app is backgrounded → badge appears ✓
2. Open app, navigate to the conversation, read all messages → badge clears ✓
3. Background app, reopen → badge stays cleared ✓
4. Receive messages, open app to a different tab (not Messages) → badge persists correctly ✓
5. Read messages, background immediately → reopen, badge now clears on foreground ✓

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have tested the change to ensure that it works as intended.