### PR TITLE
Fix BLE pin stripping all zeros instead of only leading zeros

### DIFF
--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -46,19 +46,16 @@ struct BluetoothConfig: View {
 						TextField("Fixed Pin", text: $fixedPin)
 							.foregroundColor(.gray)
 							.onChange(of: fixedPin) {
-								// Don't let the first character be 0 because it will get stripped when saving a UInt32
-								if fixedPin.first == "0" {
-									fixedPin = fixedPin.replacing("0", with: "")
-								}
+								// Only allow numeric characters
+								let filtered = fixedPin.filter(\.isNumber)
+								// Strip leading zeros since the protobuf value is a UInt32
+								let trimmed = String(filtered.drop(while: { $0 == "0" }))
 								// Require that pin is no more than 6 numbers and no less than 6 numbers
-								if fixedPin.utf8.count == pinLength {
-									shortPin = false
-								} else if fixedPin.utf8.count > pinLength {
-									shortPin = false
-									fixedPin = String(fixedPin.prefix(pinLength))
-								} else if fixedPin.utf8.count < pinLength {
-									shortPin = true
+								let clamped = String(trimmed.prefix(pinLength))
+								if fixedPin != clamped {
+									fixedPin = clamped
 								}
+								shortPin = clamped.count < pinLength
 							}
 							.foregroundColor(.gray)
 					}


### PR DESCRIPTION
Fixes #1152

## What changed?

Replaced `.replacing("0", with: "")` in the BLE fixed pin `onChange` handler with `.drop(while: { $0 == "0" })` to only strip leading zeros.

## Why did it change?

The previous code removed **every** zero from the pin input. Typing `100200` resulted in `12`. Since the protobuf value is a `UInt32`, only leading zeros are invalid — interior zeros like in `100200` or `300400` are perfectly valid 6-digit pins.

## How is this tested?

- Type `100200` → stays `100200` ✓ (was `12`)
- Type `0123456` → becomes `123456` (leading zero stripped) ✓  
- Type `000100` → becomes `100` (leading zeros stripped, shows short pin warning) ✓
- Type `1234567` → clamped to `123456` ✓
- Type `abcd` → filtered to empty ✓