### PR TITLE
Replace all .navigationBarItems with .toolbar app-wide

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -348,18 +348,19 @@ struct Connect: View {
 			}
 			.background(Color(.systemGroupedBackground))
 			.navigationTitle("Connect")
-			.navigationBarItems(
-				leading: MeshtasticLogo(),
-				trailing: ZStack {
+			.toolbar {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo()
+				}
+				ToolbarItem(placement: .topBarTrailing) {
 					ConnectedDevice(
 						deviceConnected: accessoryManager.isConnected,
 						name: accessoryManager.activeConnection?.device.shortName ?? "?",
 						mqttProxyConnected: accessoryManager.mqttProxyConnected,
 						mqttTopic: accessoryManager.mqttManager.topic
-						
 					)
 				}
-			)
+			}
 			
 		}
 		// TODO: REMOVING VERSION STUFF?

--- a/Meshtastic/Views/Helpers/ConnectedDevice.swift
+++ b/Meshtastic/Views/Helpers/ConnectedDevice.swift
@@ -98,12 +98,14 @@ struct ConnectedDevice: View {
 	NavigationView {
 		Text("Connect screen")
 			.navigationTitle("Connect")
-			.navigationBarItems(
-				leading: MeshtasticLogo(),
-				trailing: ZStack {
+			.toolbar {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo()
+				}
+				ToolbarItem(placement: .topBarTrailing) {
 					ConnectedDevice(deviceConnected: true, name: "MEMO", mqttProxyConnected: false)
 						.environmentObject(AccessoryManager.shared)
 				}
-			)
+			}
 	}
 }

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -72,7 +72,11 @@ struct Messages: View {
 			.listStyle(.plain)
 			.navigationTitle("Messages")
 			.navigationBarTitleDisplayMode(.large)
-			.navigationBarItems(leading: MeshtasticLogo())
+			.toolbar {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo()
+				}
+			}
 		} content: {
 			switch router.messagesState {
 			case .channels(let channelId, let messageId):

--- a/Meshtastic/Views/Nodes/DetectionSensorLog.swift
+++ b/Meshtastic/Views/Nodes/DetectionSensorLog.swift
@@ -131,10 +131,11 @@ struct DetectionSensorLog: View {
 		}
 		.navigationTitle("Detection Sensor Log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 		.fileExporter(
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),

--- a/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
@@ -231,10 +231,11 @@ struct DeviceMetricsLog: View {
 		}
 		.navigationTitle("Device Metrics Log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 		.fileExporter(
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),

--- a/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
@@ -150,10 +150,11 @@ struct EnvironmentMetricsLog: View {
 
 		.navigationTitle("Environment Metrics Log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 		.fileExporter(
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),

--- a/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
@@ -77,12 +77,11 @@ struct NodeMapSwiftUI: View {
 			}
 		}
 		.navigationBarTitle(String((node.user?.shortName ?? "Unknown".localized) + (" \(node.positions.count) points")), displayMode: .inline)
-		.navigationBarItems(trailing:
-			ZStack {
-				ConnectedDevice(
-					deviceConnected: accessoryManager.isConnected,
-					name: accessoryManager.activeConnection?.device.shortName ?? "?")
-			})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 	}
 
 	private var configuredMap: some View {

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -264,20 +264,27 @@ struct MeshMap: View {
 					.padding(5)
 				}
 			}
-			.navigationBarItems(leading: MeshtasticLogo(), trailing: HStack {
-				if supportsMultipleWindows && showOpenWindowButton && !isMapWindowOpen {
-					Button {
-						if router.selectedTab == .map {
-							router.selectedTab = .nodes
+			.toolbar {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo()
+				}
+				ToolbarItem(placement: .topBarTrailing) {
+					HStack {
+						if supportsMultipleWindows && showOpenWindowButton && !isMapWindowOpen {
+							Button {
+								if router.selectedTab == .map {
+									router.selectedTab = .nodes
+								}
+								openWindow(id: "meshmap-window")
+								isMapWindowOpen = true
+							} label: {
+								Image(systemName: "macwindow.badge.plus")
+							}
 						}
-						openWindow(id: "meshmap-window")
-						isMapWindowOpen = true
-					} label: {
-						Image(systemName: "macwindow.badge.plus")
+						ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
 					}
 				}
-				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-			})
+			}
 			.toolbarBackground(.hidden, for: .navigationBar)
 		}
 		.onAppear {

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -129,14 +129,19 @@ struct NodeList: View {
 			ShareContactQRDialog(manuallyVerified: false, node: selectedNode.toProto())
 		}
 		.navigationSplitViewColumnWidth(min: 100, ideal: 300, max: .infinity)
-		.navigationBarItems(leading: MeshtasticLogo(), trailing: ZStack {
-			ConnectedDevice(
-				deviceConnected: accessoryManager.isConnected,
-				name: accessoryManager.activeConnection?.device.shortName ?? "?",
-				phoneOnly: true
-			)
+		.toolbar {
+			ToolbarItem(placement: .topBarLeading) {
+				MeshtasticLogo()
+			}
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(
+					deviceConnected: accessoryManager.isConnected,
+					name: accessoryManager.activeConnection?.device.shortName ?? "?",
+					phoneOnly: true
+				)
+				.accessibilityElement(children: .contain)
+			}
 		}
-		.accessibilityElement(children: .contain))
 	}
 
 	// Helper to get the count of nodes for the navigation title

--- a/Meshtastic/Views/Nodes/PaxCounterLog.swift
+++ b/Meshtastic/Views/Nodes/PaxCounterLog.swift
@@ -207,10 +207,11 @@ struct PaxCounterLog: View {
 		}
 		.navigationTitle("PAX Counter Log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 		.fileExporter(
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),

--- a/Meshtastic/Views/Nodes/PositionLog.swift
+++ b/Meshtastic/Views/Nodes/PositionLog.swift
@@ -169,12 +169,11 @@ struct PositionLog: View {
 			}
 		}
 		.navigationTitle("Position Log \(node.positions.count) Points")
-		.navigationBarItems(
-			trailing:
-				ZStack {
-					ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 	}
 }
 

--- a/Meshtastic/Views/Nodes/PowerMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/PowerMetricsLog.swift
@@ -272,10 +272,11 @@ struct PowerMetricsLog: View {
 		}
 		.navigationTitle("Power Metrics Log")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarItems(trailing:
-			ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 		.fileExporter(
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),

--- a/Meshtastic/Views/Nodes/TraceRouteLog.swift
+++ b/Meshtastic/Views/Nodes/TraceRouteLog.swift
@@ -216,10 +216,11 @@ struct TraceRouteLog: View {
 			}
 			.navigationTitle("Trace Route Log")
 		}
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 	}
 	@ViewBuilder func contents(animation: Animation? = nil) -> some View {
 		ForEach(0..<indexes, id: \.self) { idx in

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -247,10 +247,11 @@ struct AppSettings: View {
 			}
 		}
 		.navigationTitle("App Settings")
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 	}
 }
 

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -342,10 +342,11 @@ struct Channels: View {
 		.onAppear {
 			normalizeDuplicateChannelsIfNeeded()
 		}
-		.navigationBarItems(trailing:
-		ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 	}
 }
 

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -648,10 +648,12 @@ struct Settings: View {
 				}
 			}
 			.navigationTitle("Settings")
-			.navigationBarItems(
-				leading: MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
+			.toolbar {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
+					}
 				}
-			)
+			}
 		}
 	}
 	

--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -249,10 +249,11 @@ struct ShareChannels: View {
 			.padding(.bottom, 5)
 			.navigationTitle("Generate QR Code")
 			.navigationBarTitleDisplayMode(.inline)
-			.navigationBarItems(trailing:
-			ZStack {
-				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-			})
+			.toolbar {
+				ToolbarItem(placement: .topBarTrailing) {
+					ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+				}
+			}
 			.onAppear {
 				generateChannelSet()
 			}

--- a/Meshtastic/Views/Settings/UserConfig.swift
+++ b/Meshtastic/Views/Settings/UserConfig.swift
@@ -211,10 +211,11 @@ struct UserConfig: View {
 			}
 		}
 		.navigationTitle("User Config")
-		.navigationBarItems(trailing:
-								ZStack {
-			ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-		})
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
 		.onAppear {
 			self.shortName = node?.user?.shortName ?? ""
 			self.longName = node?.user?.longName ?? ""


### PR DESCRIPTION
## What changed?

Removed every remaining use of the deprecated `.navigationBarItems` modifier across the entire app (18 files), replacing with `.toolbar { ToolbarItem(placement:) }`.

This is the companion to #1831 which handled the 20 Config/ files. Together they eliminate all `.navigationBarItems` usage from the codebase.

### Files changed

**Settings:** AppSettings, Channels, ShareChannels, UserConfig, Settings
**Nodes:** NodeList, MeshMap, PositionLog, EnvironmentMetricsLog, DeviceMetricsLog, PowerMetricsLog, DetectionSensorLog, PaxCounterLog, TraceRouteLog, NodeMapSwiftUI
**Connect:** Connect
**Messages:** Messages
**Helpers:** ConnectedDevice (preview)

### Replacement patterns

| Old | New |
|---|---|
| `.navigationBarItems(leading: MeshtasticLogo())` | `.toolbar { ToolbarItem(placement: .topBarLeading) { MeshtasticLogo() } }` |
| `.navigationBarItems(trailing: ZStack { ConnectedDevice(...) })` | `.toolbar { ToolbarItem(placement: .topBarTrailing) { ConnectedDevice(...) } }` |
| `.navigationBarItems(leading:, trailing:)` | Two separate `ToolbarItem` entries |

Also removed unnecessary `ZStack` wrappers around single views.

## Why did it change?

`.navigationBarItems` has been deprecated since iOS 14. With our minimum target at iOS 17.5, there is no reason to keep using it.

## How is this tested?

- No behavioral changes — purely API modernization
- All files compile without errors
- Visual verification that navigation bars render identically