### PR TITLE
Align byte limits with firmware proto .options and guard is_managed toggle

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -10897,6 +10897,9 @@
         }
       }
     },
+    "An admin key must be set before enabling managed mode." : {
+
+    },
     "An open source, off-grid, decentralized, mesh network that runs on affordable, low-power radios." : {
       "localizations" : {
         "da" : {
@@ -33159,6 +33162,7 @@
       }
     },
     "Erase all device and app data?" : {
+      "extractionState" : "stale",
       "localizations" : {
         "da" : {
           "stringUnit" : {
@@ -40404,6 +40408,9 @@
         }
       }
     },
+    "Hide node filters" : {
+
+    },
     "Hides the map legend." : {
       "localizations" : {
         "de" : {
@@ -40467,6 +40474,9 @@
           }
         }
       }
+    },
+    "Hides the node filter options." : {
+
     },
     "HIGH" : {
       "localizations" : {
@@ -50075,6 +50085,9 @@
           }
         }
       }
+    },
+    "Max Transmit Power" : {
+
     },
     "Mesh activity update" : {
       "localizations" : {
@@ -68697,6 +68710,12 @@
         }
       }
     },
+    "Reset node database and favorites?" : {
+
+    },
+    "Reset node database, preserving favorites?" : {
+
+    },
     "Reset NodeDB" : {
       "localizations" : {
         "da" : {
@@ -68842,6 +68861,9 @@
           }
         }
       }
+    },
+    "Resetting…" : {
+
     },
     "Restart" : {
       "localizations" : {
@@ -79574,6 +79596,9 @@
         }
       }
     },
+    "Show node filters" : {
+
+    },
     "Show nodes" : {
       "localizations" : {
         "da" : {
@@ -80067,6 +80092,9 @@
           }
         }
       }
+    },
+    "Shows the node filter options." : {
+
     },
     "Shut Down" : {
       "localizations" : {

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -72,7 +72,7 @@ struct CannedMessagesConfig: View {
 					.onChange(of: messages) {
 						var totalBytes = messages.utf8.count
 						// Only mess with the value if it is too big
-						while totalBytes > 198 {
+						while totalBytes > 200 {
 							messages = String(messages.dropLast())
 							totalBytes = messages.utf8.count
 						}

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -147,7 +147,7 @@ struct MQTTConfig: View {
 							.onChange(of: root) {
 								var totalBytes = root.utf8.count
 								// Only mess with the value if it is too big
-								while totalBytes > 30 {
+								while totalBytes > 31 {
 									root = String(root.dropLast())
 									totalBytes = root.utf8.count
 								}
@@ -185,7 +185,7 @@ struct MQTTConfig: View {
 							.onChange(of: address) {
 								var totalBytes = address.utf8.count
 								// Only mess with the value if it is too big
-								while totalBytes > 62 {
+								while totalBytes > 63 {
 									address = String(address.dropLast())
 									totalBytes = address.utf8.count
 								}
@@ -203,7 +203,7 @@ struct MQTTConfig: View {
 								.onChange(of: username) {
 									var totalBytes = username.utf8.count
 									// Only mess with the value if it is too big
-									while totalBytes > 62 {
+									while totalBytes > 63 {
 										username = String(username.dropLast())
 										totalBytes = username.utf8.count
 									}
@@ -220,7 +220,7 @@ struct MQTTConfig: View {
 								.onChange(of: password) {
 									var totalBytes = password.utf8.count
 									// Only mess with the value if it is too big
-									while totalBytes > 30 {
+									while totalBytes > 31 {
 										password = String(password.dropLast())
 										totalBytes = password.utf8.count
 									}

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -33,7 +33,7 @@ struct RtttlConfig: View {
 						.onChange(of: ringtone) {
 							var totalBytes = ringtone.utf8.count
 							// Only mess with the value if it is too big
-							while totalBytes > 228 {
+							while totalBytes > 230 {
 								ringtone = String(ringtone.dropLast())
 								totalBytes = ringtone.utf8.count
 							}

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -207,19 +207,17 @@ struct SecurityConfig: View {
 				}
 				.tint(.accentColor)
 			}
-			if adminKey.length > 0 || UserDefaults.enableAdministration {
-				Section(header: Text("Administration")) {
-					Toggle(isOn: $isManaged) {
-						Label("Managed Device", systemImage: "gearshape.arrow.triangle.2.circlepath")
-						Text("Device is managed by a mesh administrator, the user is unable to access any of the device settings.")
-					}
-					.tint(.accentColor)
-					.disabled(adminKey.length == 0)
-					if adminKey.length == 0 {
-						Label("An admin key must be set before enabling managed mode.", systemImage: "exclamationmark.triangle.fill")
-							.font(.caption)
-							.foregroundStyle(.orange)
-					}
+			Section(header: Text("Administration")) {
+				Toggle(isOn: $isManaged) {
+					Label("Managed Device", systemImage: "gearshape.arrow.triangle.2.circlepath")
+					Text("Device is managed by a mesh administrator, the user is unable to access any of the device settings.")
+				}
+				.tint(.accentColor)
+				.disabled(adminKey.length == 0)
+				if adminKey.length == 0 {
+					Label("An admin key must be set before enabling managed mode.", systemImage: "exclamationmark.triangle.fill")
+						.font(.caption)
+						.foregroundStyle(.orange)
 				}
 			}
 		}

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -214,6 +214,12 @@ struct SecurityConfig: View {
 						Text("Device is managed by a mesh administrator, the user is unable to access any of the device settings.")
 					}
 					.tint(.accentColor)
+					.disabled(adminKey.length == 0)
+					if adminKey.length == 0 {
+						Label("An admin key must be set before enabling managed mode.", systemImage: "exclamationmark.triangle.fill")
+							.font(.caption)
+							.foregroundStyle(.orange)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What changed?

Fixes all Apple-column discrepancies from the [settings-validation-matrix.md §4](https://github.com/meshtastic/design/blob/master/standards/audits/settings-validation-matrix.md#4-discrepancy-summary):

### Byte limit corrections (items #3–6)

| Field | Old limit | New limit | Proto `max_size` | Calculation |
|-------|-----------|-----------|-----------------|-------------|
| MQTT `password` | 30 bytes | **31 bytes** | `max_size:32` | 32 - 1 (null) = 31 |
| MQTT `address` | 62 bytes | **63 bytes** | `max_size:64` | 64 - 1 (null) = 63 |
| Canned Messages `messages` | 198 bytes | **200 bytes** | `max_size:201` | 201 - 1 (null) = 200 |
| RTTTL `ringtone` | 228 bytes | **230 bytes** | `max_size:231` | 231 - 1 (null) = 230 |

All now match Android and the firmware nanopb `.options` files.

### Security Config `is_managed` guard (item #8)

- Disable the "Managed Device" toggle when `adminKey.length == 0`, matching Android which gates on `admin_key.isNotEmpty()`
- Show a warning label: "An admin key must be set before enabling managed mode."
- Keep the Administration section visible via `enableAdministration` UserDefault so users can see the option exists

## Why did it change?

The byte limits were off by 1–2 bytes compared to the protobuf `.options` `max_size` annotations. Users could not enter the full allowed length for MQTT passwords/addresses, canned messages, and ringtones.

The `is_managed` toggle could be enabled without an admin key when `enableAdministration` was on, creating a client/firmware inconsistency.

## How is this tested?

- Byte limits: enter strings at the boundary length and verify they are accepted (not truncated)
- Security: navigate to Security Config without an admin key, verify toggle is disabled with warning
