### PR TITLE
Add Apple TAK v2 protocol spec and docs

### DIFF
--- a/specs/010-tak-v2-protocol/checklists/protocol.md
+++ b/specs/010-tak-v2-protocol/checklists/protocol.md
@@ -1,0 +1,103 @@
+# Protocol Integration Checklist: TAK v2 Protocol Integration (Apple)
+
+**Purpose**: Validate Apple-side TAK v2 requirements quality, completeness, and clarity across all spec dimensions — three wire formats, NWListener lifecycle, SwiftUI surface, platform constraints, and cross-platform interoperability with Android.
+**Created**: 2026-05-14
+**Feature**: `specs/010-tak-v2-protocol/spec.md`
+**Focus**: Full-breadth requirements quality | back-spec review gate | cross-platform parity coverage
+**Depth**: Standard
+**Audience**: Reviewer (cross-platform; Android maintainer in the loop)
+
+---
+
+## Constitution Compliance (Apple)
+
+- [x] CHK001 — All TAK logic resides in `Meshtastic/Helpers/TAK/`, `AccessoryManager+TAK.swift`, and `Views/Settings/TAKServerConfig.swift` — no scattered TAK code outside these locations? [Consistency, Spec §Source-Set Impact]
+- [x] CHK002 — Zero-lint-tolerance verified — `xcodebuild test` commands documented in `plan.md` § Constitution Check? [Consistency, Spec §Design Standards]
+- [x] CHK003 — SwiftUI-only surface confirmed for the TAK config screen — no UIKit storyboards / AppKit imports? [Consistency, Spec §Architecture]
+- [x] CHK004 — Privacy assessment confirms CoT payload content is never logged at non-debug levels (debug-only `Logger.tak.debug` logs are gated)? [Clarity, Spec §Privacy Assessment]
+- [x] CHK005 — Design Standards review scoped to all TAK-surface views (`TAKServerConfig`, `TAKModuleConfig`, `TAKIdentitySection`, "Route Received" notification body)? [Completeness, Spec §Design Standards]
+- [x] CHK006 — Verification commands documented for the full Apple TAK scope (test files + scheme) not just generic `xcodebuild build`? [Completeness, Spec §Plan Constitution Check]
+
+## Requirement Completeness — Wire Protocol (V2 + V1 ATAK_PLUGIN + V1 ATAK_FORWARDER)
+
+- [x] CHK007 — Apple's THREE wire formats explicitly enumerated (V2 port 78, V1 ATAK_PLUGIN port 72, V1 ATAK_FORWARDER port 257)? [Clarity, Spec §Summary, wire-protocol.md]
+- [x] CHK008 — Wire byte budget (225 bytes after Meshtastic framing within 237-byte LoRa MTU) specified with the same arithmetic as Android? [Clarity, Spec §FR-001 NFR-001]
+- [x] CHK009 — zstd dictionary selection (aircraft vs non-aircraft) documented as SDK-internal (vs. Android documenting the selection in app code)? [Completeness, research.md §R1]
+- [x] CHK010 — `flags = 0xFF` (uncompressed TAK_TRACKER) handling documented for the receive path? [Coverage, wire-protocol.md §Flags Byte Encoding]
+- [x] CHK011 — Apple's V1 ATAK_FORWARDER format (zlib + LT codes) documented in wire-protocol.md with the Apple-only interop caveat? [Gap, research.md §R6, wire-protocol.md]
+- [x] CHK012 — V2 send "what happens when compression fails" specified — Apple throws `AccessoryError.ioFailed` from `sendCoTToMeshV2`; bridge logs and aborts? [Clarity, Spec §FR-004]
+- [x] CHK013 — Port numbers (72, 78, 257) referenced via `PortNum.atakPlugin / atakPluginV2 / atakForwarder` enum constants throughout the implementation? [Clarity, wire-protocol.md §Port Assignments]
+- [x] CHK014 — Behavior when V2 packet arrives on a v2-incapable firmware specified — Apple receives on all portnums regardless? [Coverage, Spec §FR-005]
+
+## Requirement Completeness — Type Mapping
+
+- [x] CHK015 — V2 CoT type coverage delegated to the SDK (vs. Android enumerating in app code) and Apple does not duplicate the type list? [Completeness, data-model.md §Enum Mappings]
+- [x] CHK016 — Behavior for unknown CoT types on V2 documented — SDK parser throws; bridge logs and aborts (no fallback to V1)? [Clarity, Spec §Edge Cases]
+- [x] CHK017 — V1 ATAK_FORWARDER classifier (`GenericCoTHandler.classifySendMethod`) outputs documented (`.takPacketPLI`, `.takPacketChat`, `.exiDirect`, `.exiFountain`)? [Completeness, data-model.md §V1 ATAK_FORWARDER Classification]
+- [x] CHK018 — Bidirectional CoT preservation (source XML → V2 → wire → V2 → CoT XML → TAK client) maintains shape geometry via `sourceEventXml` preference? [Coverage, Spec §FR-011, research.md §R12]
+
+## Requirement Completeness — Server Lifecycle (NWListener)
+
+- [x] CHK019 — Failure modes beyond "port in use" documented — cert load failure, NWListener .failed state, TLS setup failure surface in `TAKServerManager.lastError`? [Coverage, Spec §Edge Cases]
+- [x] CHK020 — Maximum concurrent client count specified — not bounded in `TAKServerManager` (practical limit set by `NWListener` defaults; document in tasks.md as a future hardening)? [Gap, tasks.md T100]
+- [x] CHK021 — Graceful shutdown documented — `stop()` cancels keepalive tasks, closes connections via `NWConnection.cancel()`, removes from `connectedClients`? [Coverage, data-model.md §State Machines]
+- [x] CHK022 — 10-second keepalive interval traceable to ATAK's 15-second `RX_STALE_SECONDS` with margin? [Clarity, Spec §FR-007, wire-protocol.md §Keepalive]
+- [x] CHK023 — Behavior during iOS interruptions (incoming phone call, screen lock, app backgrounding) documented as bounded by BLE-peripheral background mode? [Gap, Spec §NFR-002, research.md]
+- [x] CHK024 — Offline queue FIFO eviction at enqueue time (oldest evicted when 50-cap is hit) documented? [Clarity, Spec §FR-014, data-model.md §Offline Queue Entry]
+- [x] CHK025 — Multiple-client-reconnect behavior — each client's `onClientConnected` triggers `drainOfflineQueue` independently; documented? [Coverage, data-model.md]
+
+## Requirement Clarity — Legacy Fallback (Apple-only V1 ATAK_FORWARDER)
+
+- [x] CHK026 — V1 ATAK_FORWARDER's Apple-to-Apple-only nature explicitly stated? Android peers act as opaque relays? [Clarity, Spec §Summary, wire-protocol.md §Interop Caveat]
+- [x] CHK027 — `.exiDirect` vs `.exiFountain` decision rule documented — single fragment if zlib output fits one MTU; else LT-coded? [Completeness, data-model.md §V1 ATAK_FORWARDER Classification, contracts/wire-protocol.md]
+- [x] CHK028 — Fountain receive timeout behavior documented — receiver waits for enough LT fragments to decode; drops silently on timeout? [Coverage, Spec §Edge Cases]
+- [x] CHK029 — Why Apple keeps ATAK_FORWARDER while Android dropped it — documented with rationale in research.md §R6? [Completeness, research.md]
+
+## Requirement Clarity — V1 ATAK_PLUGIN Interop with Android
+
+- [x] CHK030 — Apple ↔ Android PLI / GeoChat interop on port 72 explicitly asserted in both `spec.md` and `wire-protocol.md`? [Clarity, Spec §Summary, wire-protocol.md §Port Assignments]
+- [x] CHK031 — Bridging loss for non-PLI / non-GeoChat from Android-on-2.7.x to Apple-on-2.7.x documented (Android drops, Apple-only ATAK_FORWARDER doesn't help)? [Coverage, Spec §FR-012, Spec §Summary]
+
+## Requirement Clarity — UI Surface (SwiftUI)
+
+- [x] CHK032 — Combined identity-and-server settings screen documented as an Apple-specific UX choice (vs. Android's two-screen split)? [Clarity, Spec §Summary, research.md §R7]
+- [x] CHK033 — `fileExporter` vs `fileImporter` use cases distinguished — exporter for data package, importer for custom `.p12`? [Clarity, quickstart.md, spec.md §FR-009]
+- [x] CHK034 — `ZipDocument: FileDocument` and its `UTType.zip` typing called out? [Coverage, data-model.md / quickstart.md]
+- [x] CHK035 — `TAKModuleConfig` (standalone) vs. `TAKIdentitySection` (embedded in `TAKServerConfig`) relationship documented — both backed by the same admin-message round-trips? [Coverage, Spec §Architecture]
+
+## Requirement Clarity — Platform-Specific Behavior
+
+- [x] CHK036 — No PARTIAL_WAKE_LOCK equivalent on iOS — reliability bounded by BLE-peripheral background mode? [Clarity, Spec §Apple-Specific UX Surface §Background Execution, research.md]
+- [x] CHK037 — iOS Local Network permission — auto-prompted, no pre-flight UI? [Coverage, research.md §R10, Spec §Edge Cases]
+- [x] CHK038 — `Documents/TAK Routes/` visibility in Files app under "On My iPhone → Meshtastic → TAK Routes" documented? [Clarity, Spec §Apple-Specific UX Surface §Files App Integration]
+- [x] CHK039 — Mac Catalyst behavior called out (TAK server runs same NWListener path; macOS Finder for file access; macOS Notification Center for "Route Received")? [Coverage, Spec §Apple-Specific UX Surface §macOS]
+- [x] CHK040 — Per-send V2 receive `Task.detached(priority: .utility)` justified — keeps `@MainActor` AccessoryManager dispatch loop responsive? [Clarity, Spec §FR-018, research.md §R8]
+
+## Requirement Clarity — Route Receipt UX
+
+- [x] CHK041 — "Route Received" notification body text — exact string documented for review? [Clarity, Spec §FR-008]
+- [x] CHK042 — Route UID sanitization (`sanitizeForFilename`) defends against path traversal — documented with the exact stripped characters? [Coverage, Spec §FR-010]
+- [x] CHK043 — KML manifest value escaping (`escapeXml`) prevents XML injection in route name — documented? [Coverage, Spec §FR-010]
+- [x] CHK044 — Notification suppression / coalescing for rapid-succession route receipts — explicitly NOT implemented; flagged for backlog? [Gap, tasks.md T091]
+
+## Cross-Platform Parity Gates
+
+- [x] CHK045 — Apple SDK pin (`Meshtastic.xcworkspace/.../Package.resolved 0.2.3`) matches Android `core/proto/build.gradle.kts` SDK coord? [Consistency, research.md §R13]
+- [x] CHK046 — Embedded `MeshtasticProtobufs/Package.resolved` pin discrepancy (currently `0.2.2`) called out as a known issue with a follow-up task? [Coverage, research.md §R13, tasks.md T080]
+- [x] CHK047 — Wire-format equivalence on V2 explicitly asserted (Apple V2 wire bytes = Android V2 wire bytes)? [Clarity, wire-protocol.md §Port Assignments]
+- [x] CHK048 — Cross-platform fixture suite work flagged for backlog (T082)? [Coverage, tasks.md]
+- [x] CHK049 — Coordination requirement when SDK bumps documented in research.md (R13) and tasks.md (T122)? [Coverage]
+
+## Verification
+
+- [x] CHK050 — Spec verified against actual merged code as of 2026-05-14 (`HEAD = 72590684` on `main`; back-spec written on `spec-tak` branch)? [Consistency, plan.md]
+- [x] CHK051 — Apple-specific test files enumerated (8 files, ~172 `@Test` methods) in plan.md and quickstart.md? [Completeness]
+- [x] CHK052 — All FRs and NFRs have an identified code path / file location in plan.md? [Completeness]
+
+---
+
+## Notes
+
+- This checklist mirrors the Android `checklists/protocol.md` structure but the items are scoped to Apple's surface area.
+- Items marked complete reflect the back-spec status as of 2026-05-14; future SDK bumps or feature additions may unmark items for re-review.
+- Cross-platform items (CHK045-CHK049) are the most likely to drift; consider adding to PR templates so they're re-checked on any TAK-touching PR on either repo.

--- a/specs/010-tak-v2-protocol/checklists/requirements.md
+++ b/specs/010-tak-v2-protocol/checklists/requirements.md
@@ -1,0 +1,58 @@
+# Specification Quality Checklist: TAK v2 Protocol Integration (Apple)
+
+**Purpose**: Validate the back-spec is complete and faithful to the merged Apple TAK v2 implementation before tagging the spec done.
+**Created**: 2026-05-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No premature implementation details in the user-scenarios section (architecture is documented separately).
+- [x] Focused on user value and observable behavior in the User Stories section.
+- [x] Written so a non-iOS engineer (e.g., the Android maintainer) can review for parity.
+- [x] All mandatory sections completed (Summary, Goals, Non-Goals, User Scenarios, Edge Cases, Architecture, Requirements, Source-Set Impact, Design Standards, Privacy, Success Criteria, Assumptions).
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain.
+- [x] Requirements (FR-001 through FR-020) are testable and unambiguous.
+- [x] Non-functional requirements (NFR-001 through NFR-005) are measurable.
+- [x] Success criteria reference observable user-facing or wire-level outcomes (SC-001 through SC-007).
+- [x] Success criteria are technology-agnostic where possible (wire bytes, byte sizes, time windows) — Apple-specific framework choices live in `research.md`.
+- [x] All acceptance scenarios defined per user story.
+- [x] Edge cases enumerated (zstd decompression failures, port-in-use, malformed XML, unknown CoT types, offline-queue overflow, Local Network denial, mac Catalyst, missing firmware version, partial Fountain delivery, iTAK route-receive silent-ignore).
+- [x] Scope explicitly bounded (Non-Goals lists what we will NOT do).
+- [x] Dependencies and assumptions identified (SDK version, firmware version, Local Network entitlement, Files app access).
+
+## Feature Readiness
+
+- [x] All functional requirements map to a code location in `plan.md`'s structure.
+- [x] User scenarios cover the primary mesh-send, mesh-receive, mixed-firmware, lifecycle, identity-config, and dual-path flows.
+- [x] Feature meets the success criteria documented in `spec.md`.
+- [x] Architecture comparison with Android is explicit (table in `spec.md` § Architecture).
+
+## Apple-Specific Coverage
+
+- [x] iOS background-execution model documented (no PARTIAL_WAKE_LOCK equivalent; BLE-peripheral background mode noted).
+- [x] iOS Local Network permission flow documented (auto-prompted; loopback works without).
+- [x] iOS Files app integration documented (`Documents/TAK Routes/` user-visible).
+- [x] SwiftUI surface explicitly called out (`fileExporter`, `fileImporter`, `FileDocument`, `LocalNotificationManager`).
+- [x] Mac Catalyst support called out.
+- [x] Swift Testing framework usage documented (not XCTest).
+- [x] Network.framework usage documented (not JSSE).
+- [x] V1 ATAK_FORWARDER (Apple-only) called out in three separate places (spec § Goals, plan § Phase 0, research § R6).
+
+## Cross-Repo Parity
+
+- [x] Companion to Android `specs/005-tak-v2-protocol` linked from every doc.
+- [x] Wire-format equivalence with Android V2 explicitly asserted.
+- [x] Wire-format divergence (Apple's V1 ATAK_FORWARDER) explicitly called out as Apple-only.
+- [x] SDK pin version coordination requirement documented (FR-NFR-005, R13).
+- [x] Cross-platform fixture parity work flagged in `tasks.md` (T082).
+
+## Notes
+
+- Spec is retroactive: implementation is merged on `main`; back-spec written 2026-05-14.
+- All CoT types are owned by the SDK; this spec does not enumerate them inline. Cross-references to the SDK proto schema and Android `data-model.md` carry that information.
+- Apple's three-wire-format reality is the largest deviation from Android's two-format spec; called out in every doc.
+- Notification UX (route-received toast) is Apple-only with no Android equivalent — documented as such in `research.md` R11.
+- The combined identity-and-server settings screen is an Apple-specific UX decision (`research.md` R7); Android keeps the two surfaces separate.

--- a/specs/010-tak-v2-protocol/contracts/wire-protocol.md
+++ b/specs/010-tak-v2-protocol/contracts/wire-protocol.md
@@ -1,0 +1,370 @@
+# Wire Protocol Contract: TAK v2 Protocol Integration (Apple)
+
+## Overview
+
+The Apple TAK integration encodes CoT (Cursor-on-Target) events using three wire formats over the Meshtastic LoRa mesh — one V2 format and two V1 formats. This contract documents the encoding, port assignment, and interoperability guarantees from the Apple side.
+
+The V2 wire format is identical to Android's V2 format (defined by the SDK). The V1 ATAK_PLUGIN format (port 72) is also identical (interoperable with Meshtastic-Android). The V1 ATAK_FORWARDER format (port 257) was originally defined for the third-party [paulmandal/atak-forwarder Android plugin](https://github.com/paulmandal/atak-forwarder) (encoding: `libcotshrink`); the Apple Meshtastic app reuses the same portnum for arbitrary chunked CoT XML with its own zlib + Fountain framing. The official Meshtastic Android app does **not** implement a receive handler for port 257 — only the firmware mesh router forwards those bytes — so port 257 traffic from Apple is effectively visible only to (a) other Apple Meshtastic peers, or (b) anyone running the paulmandal plugin alongside the Meshtastic Android app (the wire-compatibility intent is asserted in `EXICodec.swift` comments but not currently verified by an automated test against `libcotshrink`).
+
+---
+
+## Port Assignments
+
+| Port | Protobuf PortNum | Originally for | Apple Send | Apple Receive | Meshtastic-Android App |
+|------|-----------------|----------------|-----------|---------------|------------------------|
+| 72 | `ATAK_PLUGIN` | Official Meshtastic ATAK plugin | ✅ PLI + GeoChat on firmware < 2.8.0 | ✅ always | ✅ implements both directions |
+| 78 | `ATAK_PLUGIN_V2` | Official Meshtastic ATAK plugin (v2) | ✅ all CoT on firmware ≥ 2.8.0 | ✅ always | ✅ implements both directions |
+| 257 | `ATAK_FORWARDER` | paulmandal `atak-forwarder` Android plugin (libcotshrink) | ✅ non-PLI / non-GeoChat on firmware < 2.8.0 (Apple's own zlib + Fountain framing) | ✅ always | ❌ no receive handler; firmware mesh router forwards bytes only |
+
+---
+
+## TAKPacketV2 Wire Format (Port 78)
+
+### Byte Layout
+
+```
+Offset  Size    Field
+0       1       Flags byte
+1       N       Payload (zstd-compressed or raw TAKPacketV2 protobuf)
+
+Total: 1 + N bytes, where (1 + N) ≤ 225 bytes (maxWirePayloadBytes)
+```
+
+### Flags Byte Encoding
+
+| Value | Meaning |
+|-------|---------|
+| 0x00 | Compressed with non-aircraft dictionary (ID 0) |
+| 0x01 | Compressed with aircraft dictionary (ID 1) |
+| 0x02-0xFE | Reserved for future dictionaries |
+| 0xFF | Uncompressed raw TAKPacketV2 protobuf (TAK_TRACKER firmware) — Apple receives these via the SDK's decompress entry point |
+
+### Compression
+
+- **Algorithm**: zstd (Zstandard) with pre-trained dictionaries — same dictionaries as Android (shipped inside the SDK).
+- **Dictionary selection**: based on CoT type — aircraft types (`a-*-A-*`) use dict 1, all others use dict 0. Selection happens inside `MeshtasticTAK.TakCompressor.compress(_:)` — Apple does not see the dictionary ID at the call site.
+- **Library**: `MeshtasticTAK` Swift Package (vendored zstd C library inside the SDK; no zstd-jni equivalent on Apple).
+- **Apple compress API**: `MeshtasticTAK.TakCompressor().compressWithRemarksFallback(_:maxWireBytes:) throws -> Data?` — returns `nil` if even remarks-stripped payload exceeds the wire limit. The Apple bridge translates `nil` to `AccessoryError.ioFailed`.
+- **Apple decompress API**: `MeshtasticTAK.TakCompressor().decompress(_:) throws -> TAKPacketV2`.
+- **Max decompressed size**: enforced by the SDK; Apple does not configure a separate limit.
+
+### TAKPacketV2 Protobuf Schema
+
+Schema is defined upstream in `meshtastic/protobufs`. Apple consumes the generated bindings via the `MeshtasticTAK` package (Kotlin/Native Swift export). Key payload variant names match Android:
+
+| Payload Variant | CoT Types Covered |
+|-----------------|-------------------|
+| `pli` | All `a-*` position reports |
+| `chat` | `b-t-f` GeoChat (with optional ACK:D / ACK:R receipt prefix) |
+| `aircraft` | `a-*-A-*` aircraft (uses aircraft dictionary) |
+| `shape` | DrawnShape kinds (circle, ellipse, freeform, polygon, rectangle, telestration) |
+| `marker` | Marker kinds (spot, waypoint, named markers) |
+| `route` | `b-m-r` route waypoints |
+| `casevac` | `b-r-f-h-c` |
+| `emergency` | `b-a-o-pan` |
+| `task` | `b-i-v` |
+| `rab` | Range-and-bearing |
+| `raw_detail` | Fallback for unrecognized types (preserves inner `<detail>` bytes) |
+
+#### Apple Send-Path Pipeline
+
+```
+CoTMessage (from TAK client)
+  ↓ sourceEventXml ?? toXML()
+Raw CoT XML
+  ↓ ensureMinimumStaleForMesh(_:)        ← 15-min stale floor
+  ↓ stripNonEssentialElements(_:)         ← 24-pattern strip
+Stripped CoT XML
+  ↓ MeshtasticTAK.CotXmlParser.parse(_:)
+TAKPacketV2 protobuf
+  ↓ TakCompressor.compressWithRemarksFallback(_:maxWireBytes: 225)
+Data (flags byte + zstd protobuf)
+  ↓ sendTAKV2Packet(_:channel:)
+MeshPacket on port 78
+```
+
+#### Apple Receive-Path Pipeline
+
+```
+MeshPacket on port 78
+  ↓ handleATAKPluginV2Packet(_:)
+  ↓ Task.detached(priority: .utility)     ← hop off @MainActor
+Data (flags byte + zstd protobuf)
+  ↓ TakCompressor.decompress(_:)
+TAKPacketV2 protobuf
+  ↓ CotXmlBuilder.build(_:)
+Rebuilt CoT XML
+  ↓ strip <?xml ?> prologue + collapse > whitespace <
+Forwardable CoT XML
+  ↓ TAKServerManager.shared.broadcastRawXml(_:)   ← preserves shape detail
+TAK client TCP stream
+  ↓ (if type == "b-m-r")
+RouteDataPackageGenerator.generateDataPackage + saveToDocuments
+  ↓
+Documents/TAK Routes/<sanitizedUid>.zip
+  ↓ MainActor.run
+LocalNotificationManager "Route Received" notification
+```
+
+---
+
+## TAKPacket Wire Format (Port 72, V1 ATAK_PLUGIN, Legacy)
+
+### Byte Layout
+
+```
+Offset  Size    Field
+0       N       Raw TAKPacket protobuf (no header, no compression)
+```
+
+### Supported Payload Types (V1)
+
+| Type | Apple Send | Apple Receive | Notes |
+|------|-----------|---------------|-------|
+| PLI (position) | ✅ | ✅ | Apple ↔ Android interop |
+| GeoChat | ✅ | ✅ | Apple ↔ Android interop |
+| Markers / Shapes / Routes | ❌ | ❌ | Not representable in V1 schema — falls through to V1 ATAK_FORWARDER on Apple |
+
+### Apple Send Entry Point
+
+`AccessoryManager+TAK.swift::sendTAKPacket(_:channel:)`:
+
+```swift
+func sendTAKPacket(_ takPacket: MeshtasticProtobufs.TAKPacket, channel: UInt32 = 0) async throws {
+    // ...
+    var dataMessage = DataMessage()
+    dataMessage.portnum = .atakPlugin  // Port 72 (legacy V1)
+    dataMessage.payload = try takPacket.serializedData()
+    // ... build MeshPacket, set hopLimit, send via ToRadio
+}
+```
+
+### Apple Receive Entry Point
+
+`AccessoryManager+TAK.swift::handleATAKPluginPacket(_:)`:
+- Decodes bare `TAKPacket` protobuf via `MeshtasticProtobufs.TAKPacket(serializedData:)`.
+- Converts PLI / chat variants to `CoTMessage` (via `CoTMessage.init(takPacket:)`).
+- Forwards to TAK clients via `TAKServerManager.shared.broadcast(_:)`.
+
+---
+
+## V1 ATAK_FORWARDER Wire Format (Port 257, Apple-only)
+
+### Byte Layout (Single Fragment — `.exiDirect`)
+
+```
+Offset  Size    Field
+0       N       zlib-compressed CoT XML (no Fountain framing)
+```
+
+### Byte Layout (Multi-Fragment — `.exiFountain`)
+
+Multiple LoRa packets, each containing a Luby-Transform (LT) erasure-code fragment of the zlib-compressed CoT XML. Fragments include the LT codec's own framing (block size, seed, payload).
+
+```
+Per-packet:
+Offset  Size    Field
+0       4       LT header (block size + seed)
+4       M       LT-coded fragment of zlib(CoT XML)
+```
+
+### Apple Send Entry Point
+
+`Meshtastic/Helpers/TAK/GenericCoTHandler.swift::sendGenericCoT(_:channel:)`:
+- Calls `EXICodec.encode(cotXml)` to zlib-compress.
+- If the result fits in one LoRa MTU (~225 bytes after Meshtastic framing) → `.exiDirect`: single packet on port 257.
+- Otherwise → `.exiFountain`: `FountainCodec.encode(_:)` produces N+M LT fragments (where N is the minimum needed to decode and M is the redundancy budget); each fragment is sent as a separate MeshPacket on port 257.
+
+### Apple Receive Entry Point
+
+`AccessoryManager+TAK.swift::handleATAKForwarderPacket(_:)`:
+- Hands off to `GenericCoTHandler.handleIncomingForwarderPacket(_:)`.
+- Maintains a per-source-uid buffer of incoming fragments.
+- Once enough LT fragments accumulate (decoder reaches steady state), `FountainCodec.decode(_:)` produces the original zlib stream.
+- `EXICodec.decode(_:)` reconstitutes the CoT XML.
+- Forwards via `TAKServerManager.shared.broadcastRawXml(_:)`.
+
+### Interop Caveat
+
+The **official Meshtastic Android app does not decode `ATAK_FORWARDER` packets**. They appear in `MeshPacket` traffic with `portnum: .atakForwarder` but `core/takserver` (Android-side) has no receive handler — the firmware's mesh router relays the bytes hop-to-hop, but no Android-side app code surfaces them to a connected ATAK client.
+
+The portnum itself was originally defined for the third-party [paulmandal/atak-forwarder](https://github.com/paulmandal/atak-forwarder) Android plugin (encoded via `libcotshrink`). Apple's `EXICodec` header asserts wire-compatibility with that ecosystem ("Uses standard zlib format (78 xx header) for Android interoperability"), but the assertion is not currently exercised by an automated cross-codec test — interop with paulmandal's plugin is plausible but unverified.
+
+Net effect:
+
+- **Apple → Apple, same mesh**: full round trip. ATAK_FORWARDER fragments transit any Android relays as opaque bytes and reassemble correctly on the receiving Apple peer.
+- **Apple → official Meshtastic Android app**: bytes reach the Android device but never surface to a TAK client.
+- **Apple → Android running paulmandal/atak-forwarder plugin**: theoretically works if Apple's zlib + Fountain framing matches paulmandal's `libcotshrink` wire format; not currently verified by test.
+- **Android → Apple (any direction)**: the official Meshtastic Android app does not send on port 257 at all, so the inverse case has no traffic to consider.
+
+---
+
+## TAK Server Protocol (Port 8089)
+
+Apple uses the same TAK Server protocol as Android. Listener implementation differs but the wire bytes are identical.
+
+### Transport
+
+- **Protocol**: TCP with TLS 1.2+ (mTLS required)
+- **Port**: 8089
+- **Binding**: All interfaces (loopback + LAN)
+- **TLS Library**: `Network.framework` `NWProtocolTLS` (vs. Android's `javax.net.ssl`)
+- **Authentication**: Mutual TLS — server presents `server.p12`, client presents `client.p12`, both trust `ca.pem`. Certs are bundled in the app's Resources by default; users may import custom `.p12` via `TAKCertificateManager` (persisted in Keychain).
+- **TCP Keepalive**: `tcpOptions.enableKeepalive = true`, `keepaliveIdle = 60` (seconds)
+
+### Message Framing
+
+CoT events are sent as complete XML documents over the TLS stream, framed by detecting the closing `</event>` tag. Apple's `TAKConnection` reads from the `NWConnection` `receive` callback and accumulates bytes into a framing buffer until a complete `<event>...</event>` is recognized.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<event version="2.0" uid="..." type="..." time="..." start="..." stale="..." how="...">
+  <point lat="..." lon="..." hae="..." ce="..." le="..."/>
+  <detail>
+    <!-- Type-specific detail elements -->
+  </detail>
+</event>
+```
+
+**Apple-specific framing note**: Inbound XML from iTAK / ATAK Civ can include a `<?xml ?>` prologue per message. Apple's parser handles either prologue-present or prologue-absent.
+
+**Apple-specific outbound note**: V2 receive rebuilds CoT XML via `MeshtasticTAK.CotXmlBuilder` which emits a prologue. The Apple receive handler strips the prologue and collapses inter-tag whitespace before forwarding via `broadcastRawXml(_:)` — leaking the prologue mid-stream tears down the iTAK / ATAK TCP streaming parser. The strip uses a permissive regex (`^\s*<\?xml[^>]*\?>`) so it works regardless of attribute order or quote style.
+
+### Keepalive
+
+- **Interval**: 10 seconds (`TAKConnection.keepaliveInterval = 10_000_000_000` ns)
+- **Format**: Ping CoT event sent over the TCP stream by `TAKConnection.startKeepalive()`
+- **Purpose**: Stay below ATAK's `RX_STALE_SECONDS = 15` threshold so the client doesn't mark the server stale.
+
+### Read-Only Mode
+
+`TAKServerManager.userReadOnlyMode` (AppStorage) suppresses outbound CoT from TAK clients to the mesh. Inbound mesh-to-client traffic continues. The bridge checks this flag in `sendToMesh` and short-circuits with a `Logger.tak.info("TAK Server in read-only mode: Ignoring message from TAK client")` log.
+
+---
+
+## Data Package Format (.zip)
+
+### Connection Data Package
+
+Exported via `TAKDataPackageGenerator.generateDataPackage()` for ATAK Civ / iTAK client configuration. UTType: `.zip`. Surfaced through SwiftUI's `fileExporter` modifier.
+
+```
+Meshtastic_TAK_Server.zip
+├── meshtastic-server.pref    # ATAK / iTAK connection preferences (XML)
+├── truststore.p12            # CA certificate for server verification
+├── client.p12                # Client identity for mTLS
+└── manifest.xml              # MissionPackageManifest v2
+```
+
+### Route Data Package
+
+Generated on receiving end for iTAK route import. Saved to `Documents/TAK Routes/<sanitizedUid>.zip` and surfaced via a `LocalNotificationManager` "Route Received" notification.
+
+```
+{sanitized_route_uid}.zip
+├── {sanitized_route_uid}.kml   # KML LineString with waypoints
+└── manifest.xml                 # MissionPackageManifest v2
+```
+
+**UID sanitization**: `RouteDataPackageGenerator.sanitizeForFilename(_:)` strips path separators, control characters, and `..` sequences so user-controlled UIDs can't escape the `Documents/TAK Routes/` directory.
+
+**XML escaping**: `escapeXml(_:)` separately escapes values before interpolation into the manifest's `value="..."` attribute (preventing manifest XML injection).
+
+---
+
+## Inbound Processing Rules (Apple)
+
+| Source Port | Apple Local Firmware | Apple Action |
+|-------------|---------------------|--------------|
+| 78 (V2) | Any | Detach `Task.utility` → SDK decompress → `CotXmlBuilder.build` → strip prologue/whitespace → `broadcastRawXml` |
+| 78 (V2) + route type (`b-m-r`) | Any | All of the above, plus `generateDataPackage` + `saveToDocuments` + "Route Received" notification |
+| 72 (V1 ATAK_PLUGIN) | Any | Decode `TAKPacket` proto → `CoTMessage.init(takPacket:)` → `broadcast` |
+| 257 (V1 ATAK_FORWARDER) | Any | Hand off to `GenericCoTHandler.handleIncomingForwarderPacket` → reassemble Fountain → zlib-decompress → `broadcastRawXml` |
+
+---
+
+## Outbound Processing Rules (Apple)
+
+`TAKMeshtasticBridge.sendToMesh(_:clientInfo:)` is the single entry point.
+
+| CoT Type | Apple Local Firmware ≥ 2.8.0 | Apple Local Firmware < 2.8.0 |
+|----------|------------------------------|------------------------------|
+| PLI (`a-*`) | V2 (port 78, compressed) | V1 ATAK_PLUGIN (port 72, raw `TAKPacket` proto) |
+| GeoChat (`b-t-f`) | V2 (port 78, compressed) | V1 ATAK_PLUGIN (port 72, raw `TAKPacket` proto) |
+| Marker (`b-m-p-*`) | V2 (port 78, compressed) | V1 ATAK_FORWARDER (port 257, zlib + optional LT) |
+| Route (`b-m-r`) | V2 (port 78, compressed) | V1 ATAK_FORWARDER (port 257, zlib + optional LT) |
+| Shape (`u-d-*`) | V2 (port 78, compressed) | V1 ATAK_FORWARDER (port 257, zlib + optional LT) |
+| Casevac (`b-r-f-h-c`) | V2 (port 78, compressed) | V1 ATAK_FORWARDER (port 257, zlib + optional LT) |
+| Emergency (`b-a-o-pan`) | V2 (port 78, compressed) | V1 ATAK_FORWARDER (port 257, zlib + optional LT) |
+| Task (`b-i-v`) | V2 (port 78, compressed) | V1 ATAK_FORWARDER (port 257, zlib + optional LT) |
+| Other / unknown | V2 (port 78, compressed; SDK may throw) | V1 ATAK_FORWARDER (port 257, zlib + optional LT) |
+
+### Per-Send Fork Code
+
+```swift
+if accessoryManager.supportsTAKv2 {
+    let cotXml = (cotMessage.type != "b-t-f" ? cotMessage.sourceEventXml : nil)
+        ?? enrichedMessage.toXML()
+    try await accessoryManager.sendCoTToMeshV2(cotXml, channel: channel)
+} else {
+    let sendMethod = GenericCoTHandler.shared.classifySendMethod(for: enrichedMessage)
+    switch sendMethod {
+    case .takPacketPLI, .takPacketChat:
+        guard let pkt = convertToTAKPacket(cot: enrichedMessage) else { return }
+        try await accessoryManager.sendTAKPacket(pkt, channel: channel)
+    case .exiDirect, .exiFountain:
+        try await GenericCoTHandler.shared.sendGenericCoT(enrichedMessage, channel: channel)
+    }
+}
+```
+
+### MTU Enforcement (V2)
+
+- Max wire payload: `maxWirePayloadBytes = 225` bytes (after Meshtastic protobuf framing within the 237-byte LoRa MTU).
+- `compressWithRemarksFallback` attempts full-detail compression. If the result exceeds 225 bytes, it retries with `<remarks>` stripped. If still over, returns `nil`.
+- On `nil`: `sendCoTToMeshV2` throws `AccessoryError.ioFailed("TAK V2 payload exceeds LoRa wire size limit (225 bytes) even with remarks stripped")`.
+- No fragmentation, no queueing of oversized packets.
+
+### MTU Enforcement (V1 ATAK_PLUGIN)
+
+- V1 PLI / GeoChat is bounded by the proto schema; in practice always fits. No explicit size check.
+
+### MTU Enforcement (V1 ATAK_FORWARDER)
+
+- Single fragment (`.exiDirect`): zlib-compressed CoT XML must fit one LoRa MTU. If not → `.exiFountain`.
+- Multi-fragment (`.exiFountain`): unlimited size (within reason — receivers may time out if too many fragments are needed). Practical ceiling ~6 fragments.
+
+---
+
+## Hop-Limit Handling
+
+V2 sends must set `meshPacket.hopLimit` to a non-zero value. The protobuf default of `0` is treated by the firmware as "already exhausted" and the packet is silently dropped before TX — the queueStatus comes back clean and the "Sent TAK V2 packet to mesh" log fires, but peers never hear it on the air.
+
+Apple's `sendTAKV2Packet` uses `takBroadcastHopLimit(forDevice:)` which reads the LoRa config's `hop_limit` field with a 3-hop fallback when the config hasn't been received yet or is left at the protobuf default. V1 sends (both ATAK_PLUGIN and ATAK_FORWARDER) follow the same pattern.
+
+---
+
+## Test Coverage
+
+Apple-side tests for the wire-format contract:
+
+| Test File | Coverage |
+|-----------|----------|
+| `MeshtasticTests/TAKBridgeTests.swift` | `sendToMesh` fork logic, contact enrichment, callsign registration |
+| `MeshtasticTests/TAKBridgeDetailedTests.swift` | `parseReceipt`, `parseDeviceCallsign`, `createSmuggledDeviceCallsign`, round-trips |
+| `MeshtasticTests/TAKCodecTests.swift` | EXI / Fountain codec round-trips, fragment reassembly |
+| `MeshtasticTests/CoTMessageTests.swift` | `CoTMessage.toXML` / `init(takPacket:)` round-trips |
+| `MeshtasticTests/CoTMessageDetailedTests.swift` | Edge cases: malformed XML, missing fields, stale-time handling |
+| `MeshtasticTests/CoTXMLParserTests.swift` | Streaming parser correctness on iTAK / ATAK Civ source XML |
+| `MeshtasticTests/CoTExtensionTests.swift` | CoT type classification, helper extensions |
+| `MeshtasticTests/GenericCoTHandlerTests.swift` | V1 `.exiDirect` / `.exiFountain` classification |
+
+V2 wire-format round-trips (Apple ↔ Android) are not currently tested in-repo; planned via shared SDK fixtures in a future release.
+
+---
+
+## Cross-Reference
+
+For the parallel Android contract, see [Meshtastic-Android `contracts/wire-protocol.md`](https://github.com/meshtastic/Meshtastic-Android/blob/main/specs/005-tak-v2-protocol/contracts/wire-protocol.md).
+
+For the SDK that owns the V2 wire bytes, see [`meshtastic/TAKPacket-SDK`](https://github.com/meshtastic/TAKPacket-SDK).

--- a/specs/010-tak-v2-protocol/data-model.md
+++ b/specs/010-tak-v2-protocol/data-model.md
@@ -1,0 +1,456 @@
+# Data Model: TAK v2 Protocol Integration (Apple)
+
+Apple-side data model for TAK v2. Mirrors the Android `data-model.md` where the structures are equivalent (`CoTMessage`, the offline queue, the protocol selection state machine) and documents Apple-specific divergences (Swift value types, `NWEndpoint` references, SwiftData context, `LocalNotificationManager` interactions).
+
+## Core Entities
+
+### CoTMessage (Central Domain Model)
+
+The Apple `CoTMessage` is a value type (`struct`) — Android's is a `data class` with the same semantics. Apple's `CoTMessage` is `Sendable` and `Identifiable`, with `id: UUID` for SwiftUI list diffing.
+
+```swift
+struct CoTMessage: Identifiable, Sendable {
+    let id = UUID()
+
+    // Core CoT event attributes
+    var uid: String                 // Unique event ID (e.g., "ANDROID-device-uuid", "iOS-ABC123")
+    var type: String                // CoT type string (e.g., "a-f-G-U-C", "b-t-f")
+    var time: Date                  // Event creation time
+    var start: Date                 // Event validity start
+    var stale: Date                 // Event expiry time
+    var how: String                 // How generated (e.g., "m-g", "h-e", "h-g-i-g-o")
+
+    // Point element (location)
+    var latitude: Double            // WGS84 latitude
+    var longitude: Double           // WGS84 longitude
+    var hae: Double                 // Height above ellipsoid (meters)
+    var ce: Double                  // Circular error (meters)
+    var le: Double                  // Linear error (meters)
+
+    // Detail sub-elements
+    var contact: CoTContact?        // <contact callsign="..." endpoint="..." phone="..."/>
+    var group: CoTGroup?            // <__group name="Cyan" role="Team Member"/>
+    var status: CoTStatus?          // <status battery="85"/>
+    var track: CoTTrack?            // <track speed="..." course="..."/>
+    var chat: CoTChat?              // <__chat ...> + <__group>
+    var remarks: String?            // <remarks>...</remarks> free-text
+
+    // Round-trip preservation
+    var rawDetailXML: String?       // Preserved inner <detail> XML for V2 raw_detail fallback
+    var sourceEventXml: String?     // Full source XML — preferred over toXML() for V2 non-chat
+}
+```
+
+### Supporting Detail Models
+
+```swift
+struct CoTContact: Sendable, Equatable {
+    var callsign: String
+    var endpoint: String?
+    var phone: String?
+}
+
+struct CoTGroup: Sendable, Equatable {
+    var name: String                // Team color name (e.g., "Cyan", "Red", "Blue")
+    var role: String                // Member role (e.g., "Team Member", "TeamLead", "HQ")
+}
+
+struct CoTStatus: Sendable, Equatable {
+    var battery: Int                // 0–100 percent
+}
+
+struct CoTTrack: Sendable, Equatable {
+    var speed: Double               // m/s
+    var course: Double              // degrees
+}
+
+struct CoTChat: Sendable, Equatable {
+    var chatroom: String?           // "All Chat Rooms" or recipient UID
+    var id: String?                 // Chat ID
+    var senderCallsign: String?     // Sender's callsign (fallback when <contact callsign> empty)
+}
+```
+
+### TAKClientInfo
+
+Tracks a connected TAK client's state. Apple-specific: holds an `NWEndpoint` reference so `TAKConnection` can surface the peer address in logs / UI.
+
+```swift
+struct TAKClientInfo: Identifiable, Sendable {
+    let id = UUID()
+    let endpoint: NWEndpoint        // Apple-only — Android uses a SocketAddress equivalent
+    var callsign: String?           // Client's callsign (from first PLI)
+    var uid: String?                // Client's self-reported UID
+    let connectedAt: Date
+
+    var displayName: String {
+        callsign ?? uid ?? endpoint.debugDescription
+    }
+}
+```
+
+### TAKConnectionEvent
+
+Per-connection event stream emitted by `TAKConnection`. Drives both the `TAKServerManager.connectedClients` published list and the routing decisions in `TAKMeshtasticBridge`.
+
+```swift
+enum TAKConnectionEvent: Sendable {
+    case connected(TAKClientInfo)
+    case clientInfoUpdated(TAKClientInfo)
+    case message(CoTMessage, TAKClientInfo?)
+    case disconnected
+    case error(Error)
+}
+```
+
+### TAKConnectionError
+
+```swift
+enum TAKConnectionError: LocalizedError {
+    case connectionClosed
+    case notConnected
+    case encodingFailed
+    case sendFailed(String)
+}
+```
+
+### Chat Receipt Models (V2 GeoChat extension)
+
+V2 GeoChat adds delivered / read receipts that ride in the GeoChat message body with an `ACK:D` / `ACK:R` prefix. The parsing helpers in `TAKMeshtasticBridge` cover both inbound and outbound:
+
+```swift
+extension TAKMeshtasticBridge {
+    enum ReceiptType {
+        case delivered  // "ACK:D"
+        case read       // "ACK:R"
+    }
+
+    struct ParsedReceipt {
+        let type: ReceiptType
+        let messageId: String
+    }
+}
+```
+
+### Offline Queue Entry
+
+`TAKServerManager` queues both parsed messages and raw XML so V2 shape / route / marker detail elements survive the round trip when no client is connected. The dual-variant queue is Apple-specific (Android's queue is `CoTMessage`-only at present).
+
+```swift
+private enum QueuedPayload {
+    case message(CoTMessage)        // Parsed CoT — usable on V1 fallback path
+    case rawXml(String)             // Raw V2 XML — preserves <link point>, colors, stroke
+}
+
+private struct QueuedMessage {
+    let payload: QueuedPayload
+    let enqueuedAt: Date
+}
+```
+
+---
+
+## Enum Mappings (V2 Path)
+
+CoT type mappings are owned by the SDK (`MeshtasticTAK`); Apple does not maintain its own copy. The set is the same as Android's — see [Android `data-model.md` § Enum Mappings](https://github.com/meshtastic/Meshtastic-Android/blob/main/specs/005-tak-v2-protocol/data-model.md#enum-mappings) for the full table.
+
+Apple-side gating: enum values arrive via `MeshtasticTAK.TakCompressor.decompress(_:)` returning a `TAKPacketV2` protobuf; `CotXmlBuilder.build(_:)` lifts them back to CoT XML for `TAKServerManager.broadcastRawXml(_:)`.
+
+---
+
+## V1 ATAK_FORWARDER Classification
+
+`GenericCoTHandler.classifySendMethod(for:)` returns one of four enum cases when running on a firmware ≤ 2.7.x radio:
+
+```swift
+enum CoTSendMethod {
+    case takPacketPLI              // → port 72, bare TAKPacket protobuf (official Meshtastic ATAK plugin's portnum)
+    case takPacketChat             // → port 72, bare TAKPacket protobuf (official Meshtastic ATAK plugin's portnum)
+    case exiDirect                 // → port 257, zlib-compressed CoT XML, single fragment
+    case exiFountain               // → port 257, zlib-compressed CoT XML, LT-coded fragments
+}
+```
+
+Classification rule of thumb: PLI (`a-*`) and chat (`b-t-f`) take the proto-only paths on port 72; everything else gets zlib-compressed onto port 257. If the compressed payload fits in a single LoRa MTU (~225 bytes after framing), `.exiDirect`; otherwise `.exiFountain` with Luby-Transform erasure codes spread across multiple packets.
+
+Port 257 is `ATAK_FORWARDER`, originally defined for the third-party [paulmandal/atak-forwarder Android plugin](https://github.com/paulmandal/atak-forwarder) (encoded via `libcotshrink`). The Apple-side reimplementation uses standard zlib + Fountain framing and asserts Android interoperability in `EXICodec.swift` ("Uses standard zlib format (78 xx header) for Android interoperability"). The official Meshtastic Android app does NOT implement a receive handler for port 257 — Apple → official Meshtastic Android app traffic on this port surfaces nowhere; Apple → Apple works fully; Apple → Android-with-paulmandal-plugin is plausible but not currently verified by automated test.
+
+---
+
+## State Machines
+
+### TAK Server Lifecycle
+
+```
+     ┌──────────┐
+     │  STOPPED │ (toggle off)
+     └────┬─────┘
+          │ takServerEnabled didSet → true
+          ▼
+     ┌──────────┐
+     │ STARTING │ (bind 8089, load certs from bundle / Keychain)
+     └────┬─────┘
+          │ NWListener.start completes; .ready state received
+          ▼
+     ┌──────────┐  newConnectionHandler  ┌─────────────────┐
+     │ RUNNING  │ ◄────────────────────  │ CLIENT_CONNECTED│
+     │(0 clients)│                       │(n clients)      │
+     └────┬─────┘                        └────────┬────────┘
+          │ takServerEnabled didSet → false       │ stop() / all disconnect / NWListener .failed
+          ▼                                        ▼
+     ┌──────────┐
+     │  STOPPED │
+     └──────────┘
+```
+
+### TAK Client Connection Lifecycle
+
+```
+     ┌──────────────┐
+     │  CONNECTED   │ (NWConnection .ready, mTLS handshake complete)
+     └──────┬───────┘
+            │ first inbound PLI received → callsign extracted
+            ▼
+     ┌──────────────┐
+     │  IDENTIFIED  │ (TAKClientInfo.callsign + uid populated)
+     │  + KEEPALIVE │ (10s ping CoT task started)
+     └──────┬───────┘
+            │ NWConnection .cancelled / .failed / .waiting → timeout
+            │ keepaliveTask cancelled, connection removed from TAKServerManager.connections
+            ▼
+     ┌──────────────┐
+     │ DISCONNECTED │ (CoroutineScope ≈ Task cancelled; entry removed from connectedClients)
+     └──────────────┘
+```
+
+### Protocol Version Selection (per-send)
+
+```
+     ┌─────────────────────────────┐
+     │ CoT message from TAK client │
+     │ (TAKMeshtasticBridge.sendToMesh)
+     └──────────────┬──────────────┘
+                    │
+       ┌────────────▼─────────────┐
+       │ accessoryManager.supportsTAKv2? │
+       │ (= checkIsVersionSupported("2.8.0"))
+       └────────────┬─────────────┘
+              yes   │ no
+                    ▼
+          ┌─────────────────┐         ┌──────────────────────────────────┐
+          │  V2 Path        │         │  V1 Dispatch                     │
+          │  (port 78)      │         │  GenericCoTHandler.classifySend  │
+          └────────┬────────┘         └──────────────┬───────────────────┘
+                   │                                  │
+                   ▼                                  ▼
+          ┌─────────────────┐         ┌──────────────────────────────────┐
+          │ sourceEventXml  │         │ .takPacketPLI / .takPacketChat   │
+          │   ?? toXML()    │         │   → port 72, bare TAKPacket      │
+          │ (non-chat       │         │ .exiDirect                       │
+          │  prefers source │         │   → port 257, zlib + 1 frag       │
+          │  for shape geom)│         │ .exiFountain                     │
+          └────────┬────────┘         │   → port 257, zlib + LT frags    │
+                   │                  └──────────────┬───────────────────┘
+                   ▼                                 │
+          ┌─────────────────┐                        │
+          │ ensureMinimum   │                        │
+          │ StaleForMesh    │                        │
+          │ (15-min floor)  │                        │
+          └────────┬────────┘                        │
+                   ▼                                 │
+          ┌─────────────────┐                        │
+          │ stripNonEssent. │                        │
+          │ Elements (24x)  │                        │
+          └────────┬────────┘                        │
+                   ▼                                 │
+          ┌─────────────────┐                        │
+          │ SDK CotXmlParser│                        │
+          │ → TAKPacketV2   │                        │
+          └────────┬────────┘                        │
+                   ▼                                 │
+          ┌──────────────────────────────┐           │
+          │ TakCompressor                │           │
+          │ .compressWithRemarksFallback │           │
+          │ (maxWireBytes: 225)          │           │
+          └────────┬────────┬────────────┘           │
+                   │        │                        │
+                   │ Data?  │ nil (overflow)         │
+                   ▼        ▼                        │
+          ┌────────────┐  ┌──────────────────┐       │
+          │ port 78    │  │ throw AccessoryError      │
+          │ send       │  │   .ioFailed             │
+          └────────────┘  └──────────────────┘       │
+                                                     ▼
+                                          ┌──────────────────┐
+                                          │ Apple-to-Apple   │
+                                          │ legacy path      │
+                                          │ (Android peers   │
+                                          │  see opaque bytes)
+                                          └──────────────────┘
+```
+
+### V2 Receive Pipeline (Detached Task)
+
+```
+     ┌────────────────────────────────┐
+     │ MeshPacket arrives at          │
+     │ AccessoryManager dispatch loop │
+     │ (portnum = .atakPluginV2)      │
+     └──────────────┬─────────────────┘
+                    │
+                    ▼  handleATAKPluginV2Packet(_:)
+     ┌─────────────────────────────────┐
+     │ Task.detached(priority: .utility)│
+     │ (hop off @MainActor)             │
+     └──────────────┬──────────────────┘
+                    │
+                    ▼
+     ┌─────────────────────────────────┐
+     │ TakCompressor.decompress(_:)    │
+     └──────────────┬──────────────────┘
+                    │
+                    ▼
+     ┌─────────────────────────────────┐
+     │ CotXmlBuilder.build(packetV2)   │
+     └──────────────┬──────────────────┘
+                    │
+                    ▼
+     ┌─────────────────────────────────┐
+     │ Strip <?xml ?> prologue         │
+     │ Collapse > whitespace <         │
+     └──────────────┬──────────────────┘
+                    │
+                    ▼
+     ┌─────────────────────────────────┐
+     │ TAKServerManager.broadcastRawXml│
+     │   (preserves <link point>, colors)│
+     └──────────────┬──────────────────┘
+                    │
+                    ▼ if route type ("b-m-r")
+     ┌─────────────────────────────────┐
+     │ RouteDataPackageGenerator       │
+     │   .generateDataPackage           │
+     │   .saveToDocuments               │
+     └──────────────┬──────────────────┘
+                    │
+                    ▼ MainActor.run
+     ┌─────────────────────────────────┐
+     │ LocalNotificationManager        │
+     │ schedules "Route Received"      │
+     └─────────────────────────────────┘
+```
+
+---
+
+## Validation Rules
+
+| Field | Rule | Error Handling |
+|-------|------|----------------|
+| V2 compressed payload size | ≤ 225 bytes (`maxWirePayloadBytes`) | `compressWithRemarksFallback` returns `nil` → `sendCoTToMeshV2` throws `AccessoryError.ioFailed`; bridge logs and aborts send |
+| V2 wire payload before flags byte | ≥ 2 bytes | `handleATAKPluginV2Packet` logs warning, returns |
+| V1 ATAK_PLUGIN (port 72) PLI | Has `pli` or `chat` payload variant | Bridge logs "V1 send: failed to convert CoT to TAKPacket" and returns |
+| V1 ATAK_FORWARDER (port 257) classify | `.exiDirect` / `.exiFountain` | Bridge logs "V1 send: EXI failed" and returns |
+| CoT XML structure | Valid `<event>` root with `<point>` | `CoTXMLParser` returns nil; logs |
+| Stale time | Must be ≥ now + 15 min for V2 outbound | `ensureMinimumStaleForMesh` rewrites the `stale` attribute and logs the adjustment |
+| Offline queue | ≤ 50 messages, ≤ 5 min TTL | Oldest evicted on overflow; expired purged on drain |
+| Port 8089 binding | Must succeed | `NWListener.start` failure → `TAKServerManager.lastError` populated, UI surfaces error |
+| Route UID for filename | No path separators, no control chars, no `..` | `RouteDataPackageGenerator.sanitizeForFilename` rewrites or rejects |
+
+---
+
+## Wire Format (Apple)
+
+See `contracts/wire-protocol.md` for the full wire-format contract. Brief summary here for parity with Android's `data-model.md`:
+
+### TAKPacketV2 (Port 78)
+
+```
+┌─────────┬────────────────────────────────┐
+│ Flags   │ Compressed TAKPacketV2 Protobuf │
+│ (1 byte)│ (variable, ≤224 bytes)          │
+└─────────┴────────────────────────────────┘
+
+Flags byte:
+  Bits 0-5: Dictionary ID (0 = non-aircraft, 1 = aircraft)
+  Bits 6-7: Reserved
+  0xFF: Uncompressed (raw protobuf follows, for TAK_TRACKER firmware)
+```
+
+### TAKPacket (Port 72, V1 ATAK_PLUGIN, Legacy)
+
+```
+┌──────────────────────────────┐
+│ Raw TAKPacket Protobuf       │
+│ (no compression, no header)  │
+└──────────────────────────────┘
+```
+
+### V1 ATAK_FORWARDER (Port 257)
+
+Port 257 was originally defined for the [paulmandal/atak-forwarder Android plugin](https://github.com/paulmandal/atak-forwarder); Apple reuses the same portnum for its own zlib + Fountain CoT-XML framing. The official Meshtastic Android app does not decode this port — see `contracts/wire-protocol.md` § Interop Caveat for the full receiver matrix.
+
+```
+Single-fragment (.exiDirect):
+┌──────────────────────────────┐
+│ zlib-compressed CoT XML       │
+└──────────────────────────────┘
+
+Multi-fragment (.exiFountain):
+┌─────────────────────────┐ ┌─────────────────────────┐ ┌─────────────────────────┐ ...
+│ LT(zlib(CoT XML)) frag 1 │ │ LT(zlib(CoT XML)) frag 2 │ │ LT(zlib(CoT XML)) frag N │
+└─────────────────────────┘ └─────────────────────────┘ └─────────────────────────┘
+```
+
+---
+
+## Key Constants
+
+```swift
+// TAKServerManager
+static let defaultTLSPort = 8089
+static let defaultTCPPort = 8087        // Legacy, not used
+
+// V2 wire MTU
+let maxWirePayloadBytes = 225            // Used in sendCoTToMeshV2
+
+// Stale extension floor for V2 outbound
+private static let minimumMeshStaleTTL: TimeInterval = 900   // 15 minutes
+
+// Offline queue
+private let offlineQueueTTL: TimeInterval = 5 * 60           // 5 minutes
+private let offlineQueueMaxSize = 50
+
+// Keepalive
+private let keepaliveInterval: UInt64 = 10_000_000_000        // 10 seconds (nanoseconds)
+
+// TCP layer
+tcpOptions.enableKeepalive = true
+tcpOptions.keepaliveIdle = 60                                 // 60-second TCP keepalive idle
+
+// Capability gate
+var supportsTAKv2: Bool { checkIsVersionSupported(forVersion: "2.8.0") }
+```
+
+---
+
+## Persistent State
+
+| Key | Type | Storage | Purpose |
+|-----|------|---------|---------|
+| `takServerEnabled` | `Bool` | `@AppStorage` (UserDefaults) | Toggle state; `didSet` triggers start/stop |
+| `takServerChannel` | `Int` | `@AppStorage` | Mesh channel index used for V1 / V2 sends |
+| `takServerReadOnly` | `Bool` | `@AppStorage` | Suppress outbound CoT (still receive) |
+| `takServerMeshToCot` | `Bool` | `@AppStorage` | Bridge mesh telemetry into CoT (separate feature) |
+| `tak.custom.server.p12.data` | `Data` | Keychain (via `TAKCertificateManager`) | User-imported server `.p12` cert |
+| `tak.custom.client.p12.data` | `Data` | Keychain | User-imported client `.p12` cert |
+| `Documents/TAK Routes/<uid>.zip` | File | App container `Documents/` | KML data package for iTAK route import |
+
+---
+
+## Cross-Reference
+
+For wire-format details (flags byte encoding, compression algorithm, schema fields) see `contracts/wire-protocol.md`.
+
+For design decisions and rationale (why three formats, why Network.framework, why detached Task, why 24 strip patterns) see `research.md`.
+
+For Android-side parity (CoT type table, enum mappings) see [Android `data-model.md`](https://github.com/meshtastic/Meshtastic-Android/blob/main/specs/005-tak-v2-protocol/data-model.md).

--- a/specs/010-tak-v2-protocol/plan.md
+++ b/specs/010-tak-v2-protocol/plan.md
@@ -13,7 +13,7 @@ Apple-specific stack: `Network.framework` for the TLS listener (vs. Android's JS
 
 ## Technical Context
 
-**Language / Version**: Swift 5.9+, targeting iOS 16+, iPadOS 16+, macOS via Mac Catalyst (Catalyst 16+ / macOS 13+).
+**Language / Version**: Swift 5.9+, targeting iOS 17.5+, iPadOS 17.5+, macOS via Mac Catalyst (Catalyst 17.5+ / macOS 14.6+).
 **Primary Dependencies**: TAKPacket-SDK (SPM, pinned `0.2.3`), MeshtasticProtobufs (Swift Package), CocoaMQTT, CoreBluetooth, Network.framework, SwiftData (for node lookups in the bridge), SwiftUI, OSLog (Logger.tak channel).
 **Storage**: App Documents for route KML data packages (`Documents/TAK Routes/`); Keychain for custom `.p12` certificates (`TAKCertificateManager`); App bundle for default `.p12` and `.pref` resources; `@AppStorage` for `takServerEnabled`, `takServerChannel`, `takServerReadOnly`, `takServerMeshToCot`.
 **Testing**: Swift Testing framework (`@Suite`, `@Test`); ~172 TAK-tagged `@Test` methods across `MeshtasticTests/{TAKBridgeTests,TAKBridgeDetailedTests,TAKCodecTests,CoTMessageTests,CoTMessageDetailedTests,CoTXMLParserTests,CoTExtensionTests,GenericCoTHandlerTests}.swift`.

--- a/specs/010-tak-v2-protocol/plan.md
+++ b/specs/010-tak-v2-protocol/plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan: TAK v2 Protocol Integration (Apple)
+
+**Branch**: `spec-tak` | **Date**: 2026-05-14 | **Spec**: `specs/010-tak-v2-protocol/spec.md`
+**Input**: Feature specification from `/specs/010-tak-v2-protocol/spec.md`
+**Status**: Retroactive — documents the existing merged Apple TAK v2 implementation (`Meshtastic/Helpers/TAK/`, `Meshtastic/Accessory/Accessory Manager/AccessoryManager+TAK.swift`, `Meshtastic/Views/Settings/TAKServerConfig.swift`, ~7,000 LOC).
+**Companion**: Meshtastic-Android [`specs/005-tak-v2-protocol/plan.md`](https://github.com/meshtastic/Meshtastic-Android/tree/main/specs/005-tak-v2-protocol).
+
+## Summary
+
+Documents the iOS / macOS Catalyst implementation of TAK v2 protocol support. Adds a third wire format on top of Android's two: the Apple-only V1 ATAK_FORWARDER (port 257) path with zlib + Fountain (LT) codes for non-PLI / non-GeoChat CoT between legacy Apple peers. The V2 path uses the same TAKPacket-SDK as Android — wire-format-identical, byte-for-byte — and the apps will interop on the V2 portnum (78) regardless of platform.
+
+Apple-specific stack: `Network.framework` for the TLS listener (vs. Android's JSSE), SwiftUI for the entire UI surface (vs. Android's Compose Multiplatform), SwiftUI `fileExporter` / `fileImporter` for cert / data-package I/O (vs. Android's SAF), `LocalNotificationManager` for the route-receive UX (no Android equivalent in the current Android impl), and the iOS Files app for the user-facing `Documents/TAK Routes/` surface.
+
+## Technical Context
+
+**Language / Version**: Swift 5.9+, targeting iOS 16+, iPadOS 16+, macOS via Mac Catalyst (Catalyst 16+ / macOS 13+).
+**Primary Dependencies**: TAKPacket-SDK (SPM, pinned `0.2.3`), MeshtasticProtobufs (Swift Package), CocoaMQTT, CoreBluetooth, Network.framework, SwiftData (for node lookups in the bridge), SwiftUI, OSLog (Logger.tak channel).
+**Storage**: App Documents for route KML data packages (`Documents/TAK Routes/`); Keychain for custom `.p12` certificates (`TAKCertificateManager`); App bundle for default `.p12` and `.pref` resources; `@AppStorage` for `takServerEnabled`, `takServerChannel`, `takServerReadOnly`, `takServerMeshToCot`.
+**Testing**: Swift Testing framework (`@Suite`, `@Test`); ~172 TAK-tagged `@Test` methods across `MeshtasticTests/{TAKBridgeTests,TAKBridgeDetailedTests,TAKCodecTests,CoTMessageTests,CoTMessageDetailedTests,CoTXMLParserTests,CoTExtensionTests,GenericCoTHandlerTests}.swift`.
+**Target Platform**: iOS / iPadOS (primary), macOS via Mac Catalyst (secondary). Not supported: watchOS, tvOS, visionOS, pure AppKit macOS.
+**Project Type**: iOS app with embedded Swift Packages (`MeshtasticProtobufs`).
+**Performance Goals**: V2 send round-trip < 100ms (including SDK parse, zstd compress, mesh tx); V2 receive processing (zstd decompress + XML build + optional KML/zip write) MUST NOT block `@MainActor`.
+**Constraints**: 225-byte usable LoRa wire payload (per FR-001); iOS Local Network prompt; no PARTIAL_WAKE_LOCK equivalent — reliability bounded by BLE-peripheral background mode lifetime.
+**Scale / Scope**: Same CoT type coverage as Android (defined by the SDK); ~7,000 LOC in `Meshtastic/Helpers/TAK/` + `AccessoryManager+TAK.swift` + `TAKServerConfig.swift`; 3 wire formats (V2 + 2 V1 variants); 1 combined settings screen + 1 module-config screen.
+
+## Constitution Check
+
+*All Apple-side principles evaluated.*
+
+- **I. Single-Source Wire Protocol**: ✅ V2 wire bytes are defined entirely by `TAKPacket-SDK`; Apple does not maintain its own copy of the V2 parser / builder / compressor. SDK pin lives in `Meshtastic.xcworkspace/.../Package.resolved` and `Meshtastic.xcodeproj/project.xcworkspace/.../Package.resolved` (both at `0.2.3`).
+- **II. Zero Lint Tolerance**: ✅ Verification commands:
+  ```bash
+  xcodebuild -workspace Meshtastic.xcworkspace -scheme Meshtastic -destination 'platform=iOS Simulator,name=iPhone 17' test
+  ```
+- **III. SwiftUI on Apple**: ✅ All TAK config UI is SwiftUI (`TAKServerConfig`, `TAKModuleConfig`, `TAKIdentitySection`). No UIKit storyboards or AppKit code.
+- **IV. Privacy First**: ✅ No PII / location / crypto-key logging. CoT data stays local. SDK and Protobufs packages not modified.
+- **V. Single Settings Surface**: ✅ Combined identity + server controls in `TAKServerConfig` rather than splitting across two screens. Both nav entry points (Module Configuration → TAK and Settings → TAK Server) route to the same destination.
+- **VI. Verify Before Push**: ✅ Local verification:
+  ```bash
+  xcodebuild -workspace Meshtastic.xcworkspace -scheme Meshtastic -destination 'platform=iOS Simulator,name=iPhone 17' build test
+  gh pr checks
+  ```
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-tak-v2-protocol/
+├── plan.md              # This file
+├── spec.md              # Functional specification (back-spec of merged state)
+├── research.md          # Phase 0: Technology decisions and rationale
+├── data-model.md        # Phase 1: Entity models and state machines
+├── quickstart.md        # Phase 1: Developer onboarding guide
+├── contracts/
+│   └── wire-protocol.md # Wire protocol contract (companion to Android's)
+├── checklists/
+│   ├── requirements.md  # FR / NFR completion gate
+│   └── protocol.md      # Wire-format and interop gate
+└── tasks.md             # Phase 2 retrospective tasks (back-fill)
+```
+
+### Source Code (repository root)
+
+```text
+Meshtastic/
+├── Helpers/TAK/
+│   ├── TAKMeshtasticBridge.swift         # Per-send V1/V2 fork; main orchestrator (1462 LOC)
+│   ├── TAKServerManager.swift            # NWListener lifecycle, offline queue (839 LOC)
+│   ├── TAKConnection.swift               # Per-client NWConnection state machine + keepalive (550 LOC)
+│   ├── TAKCertificateManager.swift       # .p12 loading + Keychain persistence + mTLS trust (788 LOC)
+│   ├── CoTMessage.swift                  # Domain model + toXML() serialization (545 LOC)
+│   ├── CoTXMLParser.swift                # Streaming XML → CoTMessage (333 LOC)
+│   ├── EXICodec.swift                    # V1 ATAK_FORWARDER zlib path (148 LOC)
+│   ├── FountainCodec.swift               # V1 ATAK_FORWARDER LT-code fragmentation (627 LOC)
+│   ├── GenericCoTHandler.swift           # V1 ATAK_FORWARDER classifier + dispatch (399 LOC)
+│   ├── RouteDataPackageGenerator.swift   # b-m-r CoT → KML data package (262 LOC)
+│   └── TAKDataPackageGenerator.swift     # Connection .zip generator (290 LOC)
+│
+├── Accessory/Accessory Manager/
+│   ├── AccessoryManager.swift            # supportsTAKv2 property (line 860)
+│   └── AccessoryManager+TAK.swift        # Send/receive handlers, dispatch (492 LOC)
+│
+├── Views/Settings/
+│   ├── TAKServerConfig.swift             # Combined identity + server UI; ZipDocument; fileExporter (800 LOC)
+│   └── Config/Module/
+│       └── TAKModuleConfig.swift         # Standalone firmware module config (268 LOC)
+│
+└── Resources/docs/markdown/developer/
+    └── tak-protocol.md                   # In-app developer guide (rendered via WKWebView)
+
+MeshtasticTests/
+├── TAKBridgeTests.swift                  # @Suite — bridge unit tests
+├── TAKBridgeDetailedTests.swift          # @Suite — bridge edge cases (parseReceipt, smuggled UID, etc.)
+├── TAKCodecTests.swift                   # @Suite — EXI / Fountain codec tests
+├── CoTMessageTests.swift                 # @Suite — CoTMessage round-trip
+├── CoTMessageDetailedTests.swift         # @Suite — CoTMessage edge cases
+├── CoTXMLParserTests.swift               # @Suite — streaming parser tests
+├── CoTExtensionTests.swift               # @Suite — CoT extension helpers
+└── GenericCoTHandlerTests.swift          # @Suite — V1 classification tests
+
+MeshtasticProtobufs/                      # Swift Package — generated protobuf bindings
+└── Package.resolved                      # TAKPacket-SDK pin (currently 0.2.2 here, 0.2.3 in workspace)
+
+Meshtastic.xcworkspace/xcshareddata/swiftpm/
+└── Package.resolved                      # TAKPacket-SDK pin 0.2.3 (authoritative for app target)
+```
+
+**Structure Decision**: Single-target Xcode workspace. All TAK code lives in `Meshtastic/Helpers/TAK/`, `Meshtastic/Accessory/Accessory Manager/AccessoryManager+TAK.swift`, and `Meshtastic/Views/Settings/TAKServerConfig.swift`. The SDK is consumed as a Swift Package via SPM (separate from the embedded `MeshtasticProtobufs` package, which generates the firmware protobuf bindings).
+
+## Phases (Retrospective)
+
+This is a back-spec; the work is already merged. Phases below describe the historical sequence rather than future work.
+
+### Phase 0: Legacy V1 Foundation (pre-2.8.0 firmware era)
+
+- Bridge pattern (`TAKMeshtasticBridge.sendToMesh`)
+- V1 ATAK_PLUGIN (port 72) send/receive for PLI / GeoChat
+- V1 ATAK_FORWARDER (port 257) with EXI + Fountain for non-PLI/Chat CoT
+- `TAKServerManager` with bundled `.p12` certs, NWListener mTLS on 8089
+- `RouteDataPackageGenerator` (KML data packages for iTAK route import)
+- `TAKDataPackageGenerator` (connection .zip for client config)
+
+### Phase 1: V2 Protocol Integration
+
+- Added `AccessoryManager.supportsTAKv2` capability check (firmware ≥ 2.8.0).
+- Added `sendCoTToMeshV2` / `sendTAKV2Packet` / `handleATAKPluginV2Packet` in `AccessoryManager+TAK.swift`.
+- Wired `TAKMeshtasticBridge.sendToMesh` to fork on `supportsTAKv2`.
+- Integrated `TAKPacket-SDK` via SPM: `MeshtasticTAK.CotXmlParser`, `TakCompressor`, `CotXmlBuilder`.
+- Added `stripNonEssentialElements` (24 patterns) and `ensureMinimumStaleForMesh` (15-min floor) to maximize V2 wire-payload fit.
+- Pinned SDK to `0.2.3` in workspace `Package.resolved`.
+
+### Phase 2: UX Refinements (combined identity surface)
+
+- Merged the firmware `ModuleConfig.TAKConfig` editor into `TAKServerConfig` as `TAKIdentitySection`.
+- Routed both Module Configuration → TAK and Settings → TAK Server nav entries to the same combined screen.
+- Added `requestTakConfigIfNeeded()` on appear to populate first-time values without a perma-spinner.
+- Standalone `TAKModuleConfig` retained for direct module-config navigation.
+
+### Phase 3: Reliability & UX Polish
+
+- `Task.detached(priority: .utility)` on V2 receive to keep `@MainActor` responsive on large routes.
+- "Route Received" `LocalNotificationManager` toast on first KML data package save.
+- Offline queue with `.message` and `.rawXml` variants (50-cap, 5-min TTL) in `TAKServerManager`.
+- Hop-limit fix on V2 sends (`takBroadcastHopLimit(forDevice:)` with 3-hop fallback) to avoid silent firmware drop on `hop_limit=0`.
+
+### Phase 4 (current): Cross-Repo Parity
+
+- This back-spec.
+- SDK ABI alignment via `TAKPacket-SDK` strip strategy (issues #5, #6 in the SDK repo).
+- Future: shared cross-platform fixture suite consumed by both Apple and Android tests.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| Three wire formats (V1, V1 ATAK_FORWARDER, V2) on Apple vs. two on Android | V1 ATAK_FORWARDER predates this spec and is the only path for shape / marker / route exchange between two Apple peers on firmware ≤ 2.7.x. Dropping it would regress Apple-to-Apple legacy users. | Dropping the V1 ATAK_FORWARDER path entirely was considered but rejected: legacy radios are still common in deployed fleets, and the Apple-side EXI + Fountain code paid its complexity cost years ago. |
+| 24 strip patterns (Apple) vs. 16 (Android) | iTAK / ATAK Civ on iOS emit different bloat element sets than ATAK on Android — extra `<voice>`, `<__geofence>`, `<__shapeExtras>`, `<creator>`, `<strokeStyle>` patterns plus 6 attribute strips. Stripping more on Apple costs nothing on the wire but recovers 50-100 bytes per shape. | Sharing a single strip list with Android would either (a) over-strip on Android (no harm but no benefit) or (b) under-strip on Apple. Apple's superset matches the iOS-client behavior. |
+| Inline `Task.detached` on V2 receive instead of a dedicated `OperationQueue` | One-call site; the V2 receive path is the only `@MainActor` hot path that does heavy CPU + filesystem work. A dedicated queue would add abstraction with no other callers. | An `OperationQueue` was considered but rejected — single call site, no priority interactions to manage. |
+| Branch name `spec-tak` (no numeric prefix) | This branch is dedicated to writing the back-spec; the implementation is on `main`. The numbered `010-` directory is the spec convention; the branch convention is informal. | N/A — branch naming doesn't affect the artifact. |
+| SDK pin discrepancy between `MeshtasticProtobufs/Package.resolved` (`0.2.2`) and `Meshtastic.xcworkspace/.../Package.resolved` (`0.2.3`) | Embedded Swift Packages resolve their own `Package.resolved` independently from the workspace; the workspace pin is authoritative for the app target. | Aligning them every release is a discipline issue; the next SDK bump should sync both. |

--- a/specs/010-tak-v2-protocol/quickstart.md
+++ b/specs/010-tak-v2-protocol/quickstart.md
@@ -9,7 +9,7 @@ For the spec / requirements: see `spec.md`. For implementation phasing and struc
 ## Prerequisites
 
 - Xcode 16+ (Swift 5.9+, Swift Testing framework support).
-- An iOS device or simulator (iOS 16+). Apple Silicon Mac running Mac Catalyst also works.
+- An iOS device or simulator (iOS 17.5+). Apple Silicon Mac running Mac Catalyst also works.
 - Optional but recommended for end-to-end testing:
   - A Meshtastic radio with firmware ≥ 2.8.0 (for V2 path testing).
   - A second Meshtastic radio with firmware ≤ 2.7.x (for V1 ATAK_PLUGIN fallback testing).

--- a/specs/010-tak-v2-protocol/quickstart.md
+++ b/specs/010-tak-v2-protocol/quickstart.md
@@ -1,0 +1,282 @@
+# Quickstart: TAK v2 Protocol Integration (Apple)
+
+Developer onboarding for the Apple TAK v2 surface. Aimed at engineers landing in `Meshtastic/Helpers/TAK/`, `AccessoryManager+TAK.swift`, or `Views/Settings/TAKServerConfig.swift` for the first time.
+
+For the spec / requirements: see `spec.md`. For implementation phasing and structure: see `plan.md`. For data structures: see `data-model.md`. For wire details: see `contracts/wire-protocol.md`.
+
+---
+
+## Prerequisites
+
+- Xcode 16+ (Swift 5.9+, Swift Testing framework support).
+- An iOS device or simulator (iOS 16+). Apple Silicon Mac running Mac Catalyst also works.
+- Optional but recommended for end-to-end testing:
+  - A Meshtastic radio with firmware ≥ 2.8.0 (for V2 path testing).
+  - A second Meshtastic radio with firmware ≤ 2.7.x (for V1 ATAK_PLUGIN fallback testing).
+  - iTAK installed on iPhone / iPad ([App Store](https://apps.apple.com/us/app/itak/id1561656396)) and / or ATAK Civ on Android.
+
+## First Build
+
+```bash
+git clone https://github.com/meshtastic/Meshtastic-Apple.git
+cd Meshtastic-Apple
+git submodule update --init --recursive   # protobufs submodule
+open Meshtastic.xcworkspace                # always the workspace, not the .xcodeproj
+```
+
+Build the `Meshtastic` scheme for an iPhone simulator. The `TAKPacket-SDK` Swift Package resolves from `Meshtastic.xcworkspace/.../Package.resolved` (pinned `0.2.3`). First-time resolution takes ~30 seconds.
+
+## Run the TAK-Tagged Tests
+
+The Swift Testing framework exposes test filtering by file:
+
+```bash
+xcodebuild test \
+  -workspace Meshtastic.xcworkspace \
+  -scheme Meshtastic \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:MeshtasticTests/TAKBridgeTests \
+  -only-testing:MeshtasticTests/TAKBridgeDetailedTests \
+  -only-testing:MeshtasticTests/TAKCodecTests \
+  -only-testing:MeshtasticTests/CoTMessageTests \
+  -only-testing:MeshtasticTests/CoTMessageDetailedTests \
+  -only-testing:MeshtasticTests/CoTXMLParserTests \
+  -only-testing:MeshtasticTests/CoTExtensionTests \
+  -only-testing:MeshtasticTests/GenericCoTHandlerTests
+```
+
+Or just run all tests:
+
+```bash
+xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+---
+
+## Architecture at a Glance
+
+```
+                       ┌──────────────────────┐
+                       │  iTAK / ATAK Civ     │
+                       │  (port 8089, mTLS)   │
+                       └──────────┬───────────┘
+                                  │
+                                  ▼
+                     ┌─────────────────────────┐
+                     │   TAKServerManager      │ ← NWListener, offline queue,
+                     │   (Helpers/TAK)         │   per-client connections
+                     └────┬────────────────┬───┘
+                          │                │
+              broadcast()│                │ inbound CoTMessage (from client)
+                          ▼                ▼
+                     ┌─────────────────────────┐
+                     │  TAKMeshtasticBridge    │ ← sendToMesh: V1/V2 fork
+                     │  (Helpers/TAK)          │   receivedFromMesh: dispatch
+                     └────┬────────────────┬───┘
+                          │                │
+                          │                │ sendCoTToMeshV2 / sendTAKPacket /
+            broadcast()  │                │ GenericCoTHandler.sendGenericCoT
+            broadcastRawXml                ▼
+                          │       ┌─────────────────────────┐
+                          │       │ AccessoryManager+TAK    │ ← send / receive
+                          │       │ (Accessory Manager)     │   handlers per portnum
+                          │       └────┬────────────────────┘
+                          │            │
+                          │            │ MeshPacket on port 72 / 78 / 257
+                          │            ▼
+                          │       ┌─────────────────────────┐
+                          │       │ AccessoryManager         │ ← BLE / TCP / Serial
+                          │       │ (BLE / TCP / Serial)     │   transports
+                          │       └────┬────────────────────┘
+                          │            │
+                          │            │ to Meshtastic firmware → LoRa
+                          │            ▼
+                          │       ┌─────────────────────────┐
+                          │       │     LoRa Mesh            │
+                          │       └─────────────────────────┘
+                          │
+                          └──── route CoT receive: also writes
+                                Documents/TAK Routes/<uid>.zip
+                                and posts "Route Received" notification
+```
+
+---
+
+## Common Tasks
+
+### Task 1: Trace a CoT Send (TAK Client → Mesh)
+
+You want to follow an event from iTAK drawing a circle on the map to it appearing on a remote iTAK over the mesh.
+
+1. **Entry**: `TAKConnection.handleReceivedData(_:)` parses framed CoT XML and emits `.message(CoTMessage, TAKClientInfo?)`.
+2. **Dispatch**: `TAKServerManager` forwards the message to `TAKMeshtasticBridge.sendToMesh(_:clientInfo:)`.
+3. **Enrichment**: For GeoChat without a `<contact>`, synthesize one from `clientInfo` or `<__chat senderCallsign>`.
+4. **Fork on `supportsTAKv2`**:
+   - **V2 branch**: `cotMessage.sourceEventXml` (preferred) or `enrichedMessage.toXML()` → `accessoryManager.sendCoTToMeshV2(_:channel:)` → SDK parse → compress → `sendTAKV2Packet` on port 78.
+   - **V1 branch**: `GenericCoTHandler.classifySendMethod(for:)` → `.takPacketPLI/.takPacketChat` → `convertToTAKPacket` → `sendTAKPacket` on port 72. OR `.exiDirect/.exiFountain` → `GenericCoTHandler.sendGenericCoT` on port 257.
+
+Set a breakpoint in `TAKMeshtasticBridge.swift:187` (the `if accessoryManager.supportsTAKv2` line) to watch the fork happen.
+
+### Task 2: Trace a CoT Receive (Mesh → TAK Client)
+
+1. **Entry**: `AccessoryManager.swift` dispatch loop receives a `MeshPacket`, switches on `decodedInfo.packet.decoded.portnum`.
+2. **V2 branch (portnum 78)**: `handleATAKPluginV2Packet(_:)` → `Task.detached(priority: .utility)` → SDK decompress → SDK build CoT XML → strip prologue/whitespace → `TAKServerManager.shared.broadcastRawXml(_:)`. For routes: also `RouteDataPackageGenerator.generateDataPackage` → `saveToDocuments` → `LocalNotificationManager.schedule`.
+3. **V1 ATAK_PLUGIN branch (portnum 72)**: `handleATAKPluginPacket(_:)` → decode `TAKPacket` proto → `CoTMessage(takPacket:)` → `TAKServerManager.shared.broadcast(_:)`.
+4. **V1 ATAK_FORWARDER branch (portnum 257)**: `handleATAKForwarderPacket(_:)` → `GenericCoTHandler.handleIncomingForwarderPacket(_:)` → Fountain reassembly → EXI/zlib decode → broadcast.
+
+### Task 3: Add a New V2 Strip Pattern
+
+`stripNonEssentialElements(_:)` lives in `AccessoryManager+TAK.swift` around line 422. Adding a new strip:
+
+1. Identify the bloat element in a captured iTAK / ATAK Civ CoT XML (use the in-app TAK Test screen or `Logger.tak.debug` logs).
+2. Add an entry to the `patterns` array. Use `[^>]*` for attribute-tolerant matching, and add both self-closing (`<foo[^>]*/>`) and paired (`<foo[^>]*>.*?</foo>`) variants when ATAK / iTAK can emit either.
+3. Make sure the regex uses `[.dotMatchesLineSeparators]` (it does — set globally in the existing factory).
+4. Add a test to `MeshtasticTests/TAKBridgeDetailedTests.swift` or `CoTXMLParserTests.swift` asserting the pattern is stripped.
+
+### Task 4: Update the TAKPacket-SDK Pin
+
+When a new SDK release lands (and Android has bumped `core/proto/build.gradle.kts` in the corresponding PR):
+
+1. In Xcode, open `File → Packages → Update to Latest Package Versions`.
+2. Or edit `Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved` directly: bump `revision` and `version` for `TAKPacket-SDK`.
+3. Also bump `MeshtasticProtobufs/Package.resolved` to keep the embedded package in sync.
+4. Build, run the full test suite (especially `TAKBridgeTests` and `TAKCodecTests`).
+5. Manually exercise the V2 send and receive paths against a V2-capable radio with iTAK connected.
+6. If the SDK changed any wire-format-affecting behavior (compression dict, schema), update `contracts/wire-protocol.md` and bump the spec date.
+
+### Task 5: Add a New TAK-Server Setting
+
+`TAKServerManager`'s persisted state lives in `@AppStorage` properties:
+
+```swift
+@AppStorage("takServerEnabled") var enabled = false { didSet { ... } }
+@AppStorage("takServerChannel") var channel: Int = 0
+@AppStorage("takServerReadOnly") var userReadOnlyMode = false
+@AppStorage("takServerMeshToCot") var meshToCotEnabled = false
+```
+
+To add another:
+
+1. Add a new `@AppStorage` property to `TAKServerManager`.
+2. If the setting needs to trigger server restart, mirror the `didSet` pattern from `enabled`.
+3. Add a SwiftUI control to `TAKServerConfig.swift` in the appropriate section (Server Configuration, Certificates, Data Package, etc.).
+4. Use `@ObservedObject var manager = TAKServerManager.shared` to bind in the view.
+5. Add tests in `MeshtasticTests/` for any behavioral implications.
+
+### Task 6: Run iTAK or ATAK Civ Against a Local Server
+
+1. Launch Meshtastic on iPhone / Mac Catalyst.
+2. Connect to a Meshtastic radio (BLE / TCP / USB).
+3. Settings → TAK Server → toggle Enable on.
+4. Tap "Export Data Package" → Save to Files (or AirDrop to another device).
+5. In iTAK: Settings → Servers → + → Import Data Package → pick the saved zip.
+6. iTAK shows the server as Connected in green.
+7. Drop a marker on iTAK; verify it appears in `Logger.tak.info("TAK → mesh: ...")` and on a peer's iTAK over the mesh.
+
+If iTAK can't connect from off-device, iOS Settings → Privacy → Local Network → enable for Meshtastic.
+
+### Task 7: Verify a Route Receipt End-to-End
+
+1. Have two Meshtastic / iPhone setups, both with the app running and iTAK connected.
+2. On Phone A, create a route in iTAK with 3 waypoints.
+3. On Phone B, observe:
+   - `Logger.tak.info("Decompressed ATAK V2 packet from node ...")` log.
+   - `Logger.tak.info("Forwarded ATAK V2 to TAK clients (raw XML)")` log.
+   - `Logger.tak.info("Route data package saved: <path>")` log.
+   - A "Route Received" notification banner.
+   - The route zip in Files → On My iPhone → Meshtastic → TAK Routes.
+4. In iTAK on Phone B: Files → import the route zip → verify the route renders with all 3 waypoints.
+
+---
+
+## File Cheatsheet
+
+| File | Lines | Key Symbols |
+|------|-------|-------------|
+| `Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift` | 1462 | `sendToMesh`, `convertToTAKPacket`, `parseReceipt`, `registerContact`, `parseDeviceCallsign`, `createSmuggledDeviceCallsign` |
+| `Meshtastic/Helpers/TAK/TAKServerManager.swift` | 839 | `start`, `stop`, `broadcast`, `broadcastRawXml`, `drainOfflineQueue`, `connectedClients` |
+| `Meshtastic/Helpers/TAK/TAKConnection.swift` | 550 | `connect`, `disconnect`, `startKeepalive`, `handleReceivedData`, `TAKClientInfo`, `TAKConnectionEvent` |
+| `Meshtastic/Helpers/TAK/TAKCertificateManager.swift` | 788 | `loadServerCertificate`, `loadCustomServerCertificate`, `persistCustomServerCertificate`, `regenerateCertificates` |
+| `Meshtastic/Helpers/TAK/CoTMessage.swift` | 545 | `CoTMessage`, `CoTContact`, `CoTGroup`, `CoTStatus`, `CoTTrack`, `CoTChat`, `init(takPacket:)`, `toXML` |
+| `Meshtastic/Helpers/TAK/CoTXMLParser.swift` | 333 | `CoTXMLParser`, `parse(xmlString:)` |
+| `Meshtastic/Helpers/TAK/EXICodec.swift` | 148 | `encode(_:)`, `decode(_:)` (zlib) |
+| `Meshtastic/Helpers/TAK/FountainCodec.swift` | 627 | `encode(_:)`, `decode(_:)` (LT erasure codes) |
+| `Meshtastic/Helpers/TAK/GenericCoTHandler.swift` | 399 | `classifySendMethod(for:)`, `sendGenericCoT(_:channel:)`, `handleIncomingForwarderPacket(_:)` |
+| `Meshtastic/Helpers/TAK/RouteDataPackageGenerator.swift` | 262 | `generateKml`, `generateDataPackage`, `saveToDocuments`, `sanitizeForFilename`, `escapeXml` |
+| `Meshtastic/Helpers/TAK/TAKDataPackageGenerator.swift` | 290 | `generateDataPackage()` (for client config export) |
+| `Meshtastic/Accessory/Accessory Manager/AccessoryManager+TAK.swift` | 492 | `handleATAKPluginPacket`, `handleATAKForwarderPacket`, `handleATAKPluginV2Packet`, `sendTAKPacket`, `sendTAKV2Packet`, `sendCoTToMeshV2`, `stripNonEssentialElements`, `ensureMinimumStaleForMesh` |
+| `Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift` (line 860) | — | `supportsTAKv2` |
+| `Meshtastic/Views/Settings/TAKServerConfig.swift` | 800 | `TAKServerConfig`, `TAKIdentitySection`, `ZipDocument` (`FileDocument`) |
+| `Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift` | 268 | `TAKModuleConfig` (standalone firmware module config) |
+
+---
+
+## Debugging Tips
+
+### Logger Channels
+
+All TAK code uses `Logger.tak` (defined in `OSLog` extension). Filter Console.app or `xcrun simctl spawn booted log stream` by `subsystem:"com.meshtastic.app" category:"tak"`.
+
+### Common Failures
+
+| Symptom | Likely Cause | Where to Look |
+|---------|--------------|---------------|
+| "Sent TAK V2 packet" log fires but peers don't receive | `hopLimit = 0` (firmware silently drops). Should be fixed; check `takBroadcastHopLimit(forDevice:)` returned non-zero. | `AccessoryManager+TAK.swift:sendTAKV2Packet` |
+| iTAK disconnects every 15 seconds | Keepalive task not running, or `keepaliveInterval` too long. | `TAKConnection.swift:startKeepalive` |
+| iTAK can't import data package | Cert chain mismatch or expired `ca.pem`. Regenerate via Settings → TAK Server → Regenerate Certificates. | `TAKCertificateManager.swift` |
+| "Route Received" notification missing | Receiver didn't get past `Task.detached`. Check the V2 decompress log. Could be malformed wire bytes. | `AccessoryManager+TAK.swift:handleATAKPluginV2Packet` |
+| Shape arrives without geometry | Bridge sent `toXML()` instead of `sourceEventXml`. Verify the type check on the `cotXml` line. | `TAKMeshtasticBridge.swift:194` |
+| V2 send fails with `AccessoryError.ioFailed` "payload exceeds wire size" | Compressed payload too large even after `<remarks>` strip. Check the CoT shape — it likely has too many waypoints / complex detail. | `AccessoryManager+TAK.swift:sendCoTToMeshV2` |
+| GeoChat receipts not surfacing | `parseReceipt` regex failed. Check the inbound message body for `ACK:D:` or `ACK:R:` prefix and a valid messageId. | `TAKMeshtasticBridge.swift` |
+
+### Useful Breakpoints
+
+- `TAKMeshtasticBridge.swift:187` — the V1/V2 fork
+- `AccessoryManager+TAK.swift:124` — V2 receive entry
+- `AccessoryManager+TAK.swift:260` — V2 send entry
+- `TAKServerManager.swift:start()` — listener bind
+- `TAKConnection.swift:startKeepalive` — keepalive task start
+
+### In-App Diagnostic
+
+There's no in-app TAK test harness yet on Apple (Android has `TakMeshTestRunner`). Adding one is on the backlog — see `tasks.md`.
+
+---
+
+## Coding Conventions
+
+- **`@MainActor`**: `TAKServerManager` and `TAKMeshtasticBridge` are main-actor isolated. CPU-heavy work in `handleATAKPluginV2Packet` hops to `Task.detached(priority: .utility)`.
+- **Sendability**: `CoTMessage` and its sub-types are `Sendable` (value types with `Sendable`-conforming fields). New CoT-domain types should follow the same pattern.
+- **No force-unwraps**: Use `guard let` / `if let`; surface errors via `Logger.tak.error` or `AccessoryError`.
+- **No `print`**: Always use `Logger.tak` so output is searchable via Console.app and the in-app log viewer.
+- **SDK imports**: `import MeshtasticTAK` (not `import TAKPacket_SDK` or similar — the module name is `MeshtasticTAK`).
+- **AppStorage keys**: Prefix with `takServer` so they group together in user defaults browsers.
+- **Tests**: Swift Testing framework (`@Suite`, `@Test`). Don't add XCTest cases; the project standardized on Swift Testing.
+
+---
+
+## Where Things Don't Live
+
+To prevent the next-engineer rabbit-hole:
+
+- **There is no `core:takserver` module on Apple** — Apple is single-target. Everything lives in `Meshtastic/Helpers/TAK/`.
+- **There is no `commonMain` source set** — Apple isn't KMP. The naming convention is iOS-flat.
+- **There is no PARTIAL_WAKE_LOCK equivalent** — iOS doesn't expose one. Reliability is bounded by BLE-peripheral background mode.
+- **There is no `useTakV2()` per-send function** — Apple inlines the `accessoryManager.supportsTAKv2` check in `sendToMesh`.
+- **There is no Foundation `JSON Schema` validation** — CoT XML is parsed by `CoTXMLParser` (streaming) and SDK builders / parsers; no schema validator.
+- **There is no `MAX_DECOMPRESSED_SIZE` constant** — Apple delegates the limit to the SDK's `TakCompressor.decompress`.
+- **There is no separate `iosMain` / `iosTest` source set** — all tests live in `MeshtasticTests/`.
+
+---
+
+## Next Reading
+
+- `spec.md` — what / why / acceptance scenarios.
+- `plan.md` — implementation phasing and structure.
+- `data-model.md` — entities, state machines, wire-format summary.
+- `research.md` — design decisions and alternatives considered.
+- `contracts/wire-protocol.md` — full wire-format contract (Apple flavor).
+- [Meshtastic-Android `specs/005-tak-v2-protocol`](https://github.com/meshtastic/Meshtastic-Android/tree/main/specs/005-tak-v2-protocol) — Android companion spec.
+- [`meshtastic/TAKPacket-SDK`](https://github.com/meshtastic/TAKPacket-SDK) — wire-protocol source of truth (Swift Package source).
+- In-app developer guide: Settings → About → Developer → TAK Protocol (renders `Meshtastic/Resources/docs/markdown/developer/tak-protocol.md`).

--- a/specs/010-tak-v2-protocol/research.md
+++ b/specs/010-tak-v2-protocol/research.md
@@ -1,0 +1,248 @@
+# Research: TAK v2 Protocol Integration (Apple)
+
+**Status**: Complete (retroactive — documents decisions made across the V1 ATAK_FORWARDER era, the V2 cutover, and the issue-#6 SDK refactor).
+
+This document captures the technology decisions in the merged Apple TAK v2 implementation. Where a decision matches Android's, this file references the Android `research.md` rather than restating; where Apple diverges, the rationale lives here in full.
+
+---
+
+## R1: Zstd Compression Strategy for LoRa MTU
+
+**Decision**: Identical to Android — use pre-trained zstd dictionaries via `meshtastic/TAKPacket-SDK` (SPM pin `0.2.3`) with a 1-byte flags header encoding dictionary ID.
+
+**Cross-reference**: See [Android `research.md` R1](https://github.com/meshtastic/Meshtastic-Android/blob/main/specs/005-tak-v2-protocol/research.md#r1-zstd-compression-strategy-for-lora-mtu). Wire-format identical.
+
+**Apple-side surface**: `MeshtasticTAK.TakCompressor().compressWithRemarksFallback(_:maxWireBytes:)` returns `Data?`; a `nil` return means the packet won't fit even after `<remarks>` strip. The Apple bridge translates `nil` into `AccessoryError.ioFailed(...)` so the caller's `do/catch` doesn't treat the drop as a successful send.
+
+---
+
+## R2: Platform Abstraction for Compression
+
+**Decision**: Apple uses the SDK directly — no expect/actual abstraction needed. The SDK ships an iOS-compatible Swift Package that calls into a vendored zstd C library (no Kotlin/Native shim).
+
+**Rationale**: Unlike Android which has to share a `TakV2Compressor` between JVM and iOS via expect/actual, Apple consumes the SDK's iOS klib (Kotlin/Native via the Swift bridging layer) directly. No platform stub is required.
+
+**Implication**: Apple does NOT have an "uncompressed TAK_TRACKER mode" fallback path on the send side — compression always runs. On the receive side, the SDK's decompressor handles the `0xFF` flags byte (TAK_TRACKER firmware sends raw protobuf) so we still interop with those packets.
+
+**Alternatives Considered**:
+- Wrap the SDK with our own Swift facade: rejected — adds maintenance with no value; the SDK API is already Swift-idiomatic from `MeshtasticTAK.CotXmlParser` / `TakCompressor` / `CotXmlBuilder`.
+
+---
+
+## R3: CoT XML Processing Approach
+
+**Decision**: Hand-written streaming parser (`CoTXMLParser`) for inbound CoT from TAK clients (V1 path + V2 enrichment context); SDK builders for V2 outbound serialization.
+
+**Rationale**:
+- Inbound TAK-client XML can contain ATAK-Civ / iTAK-specific bloat elements that the SDK parser doesn't tolerate. The hand-written `CoTXMLParser` is permissive — it round-trips unknown elements into `rawDetailXML` and preserves the source XML in `sourceEventXml`.
+- Outbound V2: use `MeshtasticTAK.CotXmlParser` + `TakCompressor` because they're the wire-protocol owners. The strip-then-parse pattern in `sendCoTToMeshV2` removes 24 bloat patterns first (`stripNonEssentialElements`) so the SDK parser sees clean input.
+
+**Alternatives Considered**:
+- Use the SDK parser for both inbound and outbound: rejected — the SDK is strict about element shapes (it expects clean wire CoT, not the verbose ATAK-Civ / iTAK source XML).
+- Use `XMLParser` (Foundation): used internally inside `CoTXMLParser`; the overall flow is a hand-written state machine on top of `XMLParser` callbacks for performance and to preserve raw inner-element XML.
+
+---
+
+## R4: TLS Server Architecture
+
+**Decision**: `Network.framework` (`NWListener`, `NWConnection`, `NWProtocolTLS`) with mTLS — NOT JSSE.
+
+**Rationale**:
+- `Network.framework` is the Apple-recommended modern API for TCP/TLS servers. Replaces the older `CFNetwork` / `Stream` APIs with structured-concurrency-friendly callbacks.
+- `sec_protocol_options_set_min_tls_protocol_version(_, .TLSv12)` enforces TLS 1.2+; client cert verification is set up via `sec_protocol_options_set_verify_block` on the TLS options.
+- Per-connection serial queue (`DispatchQueue(label: "tak.server", qos: .userInitiated)`) prevents concurrent broadcast corruption without explicit mutexes.
+- TCP-layer keepalive (`tcpOptions.enableKeepalive = true`, `keepaliveIdle = 60`) handles NAT mappings; app-layer 10-second ping CoT keeps ATAK / iTAK's `RX_STALE_SECONDS = 15` counter under threshold.
+
+**Alternatives Considered**:
+- `URLSession` / `URLProtocol`: client-side only; not a server library.
+- Vapor / Hummingbird: heavyweight HTTP-server framework; we need raw TLS sockets, not HTTP.
+- BSD socket APIs (`socket`, `bind`, `listen` with manual `Security.framework` SSLContext): explicitly deprecated by Apple; supplanted by `Network.framework`.
+- Vendored Java JSSE port: nonsense on Apple platforms.
+
+---
+
+## R5: Version Gating Strategy
+
+**Decision**: Same as Android — runtime firmware version check via `AccessoryManager.supportsTAKv2` (`checkIsVersionSupported(forVersion: "2.8.0")`), evaluated per-send.
+
+**Cross-reference**: See [Android `research.md` R5](https://github.com/meshtastic/Meshtastic-Android/blob/main/specs/005-tak-v2-protocol/research.md#r5-version-gating-strategy). Same rationale, same per-send pattern, same handling of firmware OTA mid-session.
+
+**Apple-side surface**: `AccessoryManager.supportsTAKv2` is a computed property on the singleton `AccessoryManager.shared`; the bridge calls it from inside `sendToMesh(_:clientInfo:)` (line 187 of `TAKMeshtasticBridge.swift`). When firmware is unknown (handshake not complete), the version check returns false → bridge defaults to V1 → safe.
+
+---
+
+## R6: Three-Format Wire Strategy (ATAK_FORWARDER on Apple)
+
+**Decision**: Apple keeps the V1 ATAK_FORWARDER (port 257) path with zlib + Fountain (LT) codes indefinitely, even after the V2 cutover. The official Meshtastic Android app does not implement send or receive on this portnum.
+
+**Context — what port 257 actually is**: per the upstream `meshtastic/protobufs` documentation, `ATAK_PLUGIN` (72) is the portnum for the **official Meshtastic ATAK plugin** (carrying the slim `TAKPacket` protobuf — PLI and GeoChat only), and `ATAK_PLUGIN_V2` (78) is its V2 successor. `ATAK_FORWARDER` (257) is defined for the third-party [paulmandal/atak-forwarder](https://github.com/paulmandal/atak-forwarder) Android plugin, which carries arbitrary CoT XML via `libcotshrink`. So port 257 is the conventional "arbitrary CoT XML" channel in the Meshtastic mesh, distinct from port 72's slim PLI/Chat subset.
+
+**Rationale for preserving it on Apple**:
+- Before V2 existed, Apple's TAK integration relied on port 257 for any CoT type other than PLI / GeoChat. This is the only legacy path for shape / marker / route CoT exchange when both peers are on firmware ≤ 2.7.x.
+- The Apple `EXICodec` produces standard zlib (78 xx header) with a comment explicitly noting "for Android interoperability" — the implementation was designed to interop with whichever Android-side decoder lives on the same portnum (the paulmandal plugin, primarily; possibly other compatible implementations). The Meshtastic Android *app* itself does not implement decode for this portnum, but the firmware mesh router still relays the bytes hop-to-hop.
+- Dropping ATAK_FORWARDER on Apple would regress Apple-to-Apple legacy users (who still exist in deployed fleets) without buying anything.
+- The code paid its complexity cost years ago — `EXICodec`, `FountainCodec`, and `GenericCoTHandler` all exist, are tested, and aren't significantly maintained anymore.
+
+**Trade-offs**:
+- Three send formats on Apple (V1 ATAK_PLUGIN, V1 ATAK_FORWARDER, V2) vs. two on Android (V1 ATAK_PLUGIN, V2 only).
+- Apple's `GenericCoTHandler.classifySendMethod(for:)` is the only place the multi-format dispatch lives; the bridge calls it once per V1 send.
+- Fountain-coded payloads can take 2–6 LoRa packets to deliver; receiving Apple peers wait for enough fragments to decode (LT codes are erasure-tolerant).
+- Wire-compatibility with paulmandal's `libcotshrink` is asserted by code comments but not currently exercised by an automated cross-codec test (see `tasks.md` T101-adjacent for a follow-up).
+
+**Alternatives Considered**:
+- Drop ATAK_FORWARDER entirely (match Meshtastic-Android): rejected — regresses Apple-to-Apple legacy users.
+- Backport ATAK_FORWARDER send/receive into the Meshtastic-Android app: rejected — significant Kotlin codegen, no production demand for a sunset path, and the paulmandal plugin already exists as a parallel Android-side implementation for users who want this functionality.
+- Custom Apple-only wire format for legacy chunked CoT: rejected — port 257 with `libcotshrink`-compatible framing is already a community convention; designing a new portnum would orphan the existing receive-side implementations.
+
+---
+
+## R7: Combined Identity + Server Settings Screen
+
+**Decision**: Embed the firmware `ModuleConfig.TAKConfig` editor (`TAKIdentitySection`) inside the in-app TAK server settings screen (`TAKServerConfig`) instead of splitting across two navigation destinations.
+
+**Rationale**:
+- Android keeps the firmware module config and the in-app server config in separate screens (Module Configuration → TAK and Settings → TAK Server). Users have to navigate between two screens to set their team color (firmware module config) and toggle the server (app config).
+- On Apple, both nav entry points (`Settings → Modules → TAK Server` and `Settings → TAK Server`) route to the combined `TAKServerConfig` screen. The user sees identity controls at the top and server controls below — one screen, one mental model.
+- The standalone `TAKModuleConfig.swift` still exists (and is accessible) for users who navigate directly to it, but the primary entry point is the combined screen.
+
+**Implementation note**: `TAKIdentitySection` calls `requestTakConfigIfNeeded()` on appear (which fires `AccessoryManager.requestTAKModuleConfig`) so first-time users see a populated team / role rather than a perma-spinner.
+
+**Alternatives Considered**:
+- Match Android's split: rejected — adds navigation friction; the team / role values are commonly tweaked when configuring the server for the first time.
+- Move all server config to the firmware module config screen: rejected — server config is app-state (AppStorage), not firmware state; conflating them confuses the persistence model.
+
+---
+
+## R8: V2 Receive on a Detached Task
+
+**Decision**: `handleATAKPluginV2Packet(_:)` immediately hops to `Task.detached(priority: .utility)` for decompression, XML build, and KML / zip generation. Notifications hop back to `MainActor` for `LocalNotificationManager`.
+
+**Rationale**:
+- `AccessoryManager` is `@MainActor`-isolated. Without a detach, zstd decompression + SDK XML build + regex cleanup + KML / zip generation + `Data.write(to:)` into `Documents/TAK Routes/` would all run on the main actor.
+- A large route or shape used to freeze the UI for hundreds of milliseconds. Copilot flagged this as a UI hang risk, and the `AccessoryManager` dispatch loop would stall because every other portnum handler was `await`ing the same actor.
+- `Task.detached` (not just `Task`) so we don't inherit `@MainActor` from the enclosing `AccessoryManager` actor context.
+- `priority: .utility` because this work is user-perceivable (a route should arrive promptly) but not latency-critical.
+
+**Alternatives Considered**:
+- Move `AccessoryManager` off the main actor: rejected — pervasive change touching every transport, requires re-auditing all `@Published` and SwiftData interactions.
+- Dedicated `OperationQueue` for TAK work: rejected — single call site; over-abstracted.
+- `DispatchQueue.global(qos: .utility).async { … }`: works, but `Task.detached` plays better with structured concurrency cancellation and the eventual `await MainActor.run { … }` for notifications.
+
+---
+
+## R9: Detail Stripping (24 patterns, Apple-side)
+
+**Decision**: Strip 24 element / attribute patterns from outbound V2 CoT in `stripNonEssentialElements(_:)` — broader than Android's 16-element list.
+
+**Rationale**:
+- iTAK and ATAK Civ on iOS emit a different bloat element set than ATAK on Android. Patterns Apple strips that Android doesn't: `<voice>`, `<__geofence>`, `<__shapeExtras>`, `<creator>`, `<strokeStyle>`, attribute-level strips (`routetype=...`, `order=...`, `color=...`, `access=...`, empty `callsign=""`, empty `phone=""`), and UID strip on route waypoint `<link>` elements.
+- The UID-strip on `<link point="..."/>` elements is the biggest single win: each route waypoint has a 36-char UUID that costs ~40 bytes on the wire, and the receiving TAK client derives its own UIDs anyway. Stripping recovers 40 × N bytes per route.
+- Stripping before compression (not after) gives the zstd compressor cleaner input and smaller output.
+
+**Apple-specific patterns vs. Android's 16**:
+
+| Apple-only pattern | What it strips | Why iOS-specific |
+|--------------------|----------------|------------------|
+| `<voice[^>]*/>` | iTAK voice-chat state | Android ATAK doesn't emit this |
+| `<__geofence[^>]*/>` | Geofence config metadata | ATAK Civ iOS-specific |
+| `<__shapeExtras[^>]*/>` | Shape display extras | ATAK Civ iOS-specific |
+| `<creator[^>]*/>` | Creator metadata block | Both emit, but Apple sees it more often |
+| `<strokeStyle[^>]*/>` | Stroke style (SDK uses color fields) | Both, but Apple's version has more attributes |
+| `routetype="..."` | Route display type label | iTAK / ATAK Civ |
+| `order="..."` | Checkpoint order label | iTAK route waypoints |
+| `color="..."` on link_attr | SDK uses strokeColor instead | iTAK overlay |
+| `access="..."` | Access control attribute | iTAK |
+| `callsign=""` | Empty callsign attribute | iTAK chat |
+| `phone=""` | Empty phone attribute | iTAK contact |
+| `uid="..."` on `<link point="..."/>` | Per-waypoint UUIDs | All — biggest single recovery |
+
+**Alternatives Considered**:
+- Use Android's 16-pattern list: rejected — leaves bloat on the wire that the Apple-side TAK clients regularly emit.
+- Move strip logic into the SDK: considered for a future release; the strip is currently in `AccessoryManager+TAK.swift` to evolve independently of the SDK release cycle.
+- Configurable strip list via Settings: over-engineered; patterns are stable.
+
+---
+
+## R10: iOS Local Network Permission (No Pre-Prompt)
+
+**Decision**: Do not pre-request the Local Network entitlement; let iOS prompt the user on first inbound LAN connection attempt.
+
+**Rationale**:
+- iOS auto-prompts the user when an app first tries to bind to `0.0.0.0` or accept LAN connections. Pre-prompting requires using a `MultipeerConnectivity` or `Bonjour` discovery trick, which is opaque to users.
+- The TAK server binds to all interfaces but ATAK / iTAK typically connect over `127.0.0.1` (when running on the same iPhone). Loopback doesn't require Local Network — so the user can use the app fully without granting Local Network unless they want LAN-side clients.
+- When iTAK on iPad connects to Meshtastic on iPhone over Wi-Fi, iOS shows the standard "Allow [App] to find and connect to devices on your local network?" sheet; this is the expected UX.
+
+**Implication**:
+- No pre-flight permission state UI on Apple. The Server section just shows "Server running on 8089" and the user discovers Local Network requirement on the first off-device connection attempt.
+- If Local Network is denied, iTAK / ATAK off-device clients fail to connect. There is no in-app explanation prompt currently — the user would need to find Settings → Meshtastic → Local Network to flip it on. (Documented in the in-app developer guide.)
+
+**Alternatives Considered**:
+- Pre-prompt via Bonjour discovery: rejected — gimmicky, surprises the user with a Wi-Fi permission prompt before they touch any networking feature.
+- In-app explanation modal pointing at Settings → Local Network when the server starts: deferred (could be added later; current state matches the iOS default UX for similar apps).
+
+---
+
+## R11: Route Receipt Notification
+
+**Decision**: Post a `UNUserNotification` titled "Route Received" (subtitle = route callsign, body = "Saved to Files → Meshtastic → TAK Routes. Open in iTAK to import.") when a `b-m-r` CoT generates a saved KML data package.
+
+**Rationale**:
+- iTAK silently ignores route CoT (`b-m-r`) received over its TCP streaming connection — known iTAK limitation.
+- Without a notification, the user has no signal that a route arrived. They'd find the file in `Documents/TAK Routes/` only if they happened to open the Files app.
+- A local notification (no server push, no permissions beyond the standard notification grant) lets the user know to switch to iTAK and import.
+- The body text spells out the exact path so the user doesn't need to hunt for it.
+
+**Apple-specific** (no Android equivalent currently). Android's KML files are written to `Documents/` (or the SAF-selected location) without a notification.
+
+**Alternatives Considered**:
+- In-app banner: rejected — only visible while Meshtastic is foreground; user is presumably switching to iTAK.
+- Auto-import via Universal Links from Meshtastic → iTAK: blocked — iTAK doesn't currently expose a Universal Link for data package import; would require iTAK changes.
+- Persistent badge on TAK Server tab: rejected — non-standard; badge semantics conflict with notification-count expectations.
+
+---
+
+## R12: Source Event XML vs. Re-serialized XML (V2 Outbound)
+
+**Decision**: For V2 non-chat outbound, prefer `cotMessage.sourceEventXml` (the original XML from the TAK client) over `cotMessage.toXML()` (re-serialized from parsed fields). For chat (`b-t-f`), use `toXML()` because the bridge mutates the contact during enrichment.
+
+**Rationale**:
+- `toXML()` writes only the fields the `CoTMessage` struct knows about — it loses shape geometry (`<link point="..."/>` vertices), strokeColor / fillColor, and custom detail elements that the parser strips as "unknown."
+- The SDK parser (`MeshtasticTAK.CotXmlParser`) handles the full element vocabulary including shape geometry. Feeding it the original XML preserves data that would otherwise be lost.
+- For GeoChat (`b-t-f`), `sendToMesh` enriches the message with a synthesized `<contact callsign="...">` element (when iTAK / ATAK emit only `<__chat senderCallsign>`). The enrichment modifies the in-memory `CoTMessage` but doesn't write back to `sourceEventXml` — so we must use `toXML()` to pick up the synthesized contact.
+
+**Code**:
+```swift
+let cotXml = (cotMessage.type != "b-t-f" ? cotMessage.sourceEventXml : nil)
+    ?? enrichedMessage.toXML()
+try await accessoryManager.sendCoTToMeshV2(cotXml, channel: channel)
+```
+
+**Alternatives Considered**:
+- Always use `sourceEventXml`: rejected — loses chat enrichment.
+- Always use `toXML()`: rejected — loses shape geometry.
+- Add shape geometry fields to `CoTMessage` struct: deferred (the SDK is the source of truth for the full schema; mirroring it in the bridge struct is duplicative).
+
+---
+
+## R13: SDK Version Pinning (`0.2.3`)
+
+**Decision**: Pin `TAKPacket-SDK` to `0.2.3` in `Meshtastic.xcworkspace/.../Package.resolved` (authoritative for the app target). The embedded `MeshtasticProtobufs/Package.resolved` is also pinned but at `0.2.2` (older state).
+
+**Rationale**:
+- `0.2.3` is the first SDK release where:
+  - `SensorFov.range_m` is correctly typed as `Int?` (issue #5 in the SDK repo: the proto regen broke the Kotlin serializer, fix landed in `26dce30`).
+  - The Android-side JAR strip strategy (issue #6) is wire-format-compatible with the Apple SDK consumption pattern (the strip only affects the Android JVM JAR, not the iOS klib).
+- Pinning to a specific release (not a branch) ensures reproducible builds across CI / development machines.
+- The workspace `.resolved` is the authoritative pin for the Meshtastic app target. The `MeshtasticProtobufs` package has its own `.resolved` because it's an embedded Swift Package — but when both are in the same workspace, the workspace pin wins for the app target.
+
+**Discrepancy Note**: The embedded `MeshtasticProtobufs/Package.resolved` is at `0.2.2`. This is a known dependency-graph quirk — the embedded package resolves independently, but at build time the workspace pin (`0.2.3`) wins. Next SDK bump should sync both files in the same PR.
+
+**Cross-repo SDK release coordination** (issue #6 sequel): when Android bumps its SDK coord (in `core/proto/build.gradle.kts`), Apple should bump `Package.resolved` to the same release tag in the same PR cycle to avoid wire-format drift.
+
+---
+
+## Cross-Reference
+
+For wire-format details (flags byte encoding, compression algorithm, schema fields) see `contracts/wire-protocol.md`.
+
+For Android decisions on the same topics (where they overlap) see [Android `research.md`](https://github.com/meshtastic/Meshtastic-Android/blob/main/specs/005-tak-v2-protocol/research.md).

--- a/specs/010-tak-v2-protocol/spec.md
+++ b/specs/010-tak-v2-protocol/spec.md
@@ -1,0 +1,327 @@
+# Feature Specification: TAK v2 Protocol Integration (Apple)
+
+**Feature Branch**: `spec-tak`
+**Created**: 2026-05-14
+**Status**: Retroactive — back-specifies the merged Apple TAK v2 implementation; companion to Meshtastic-Android [`specs/005-tak-v2-protocol`](https://github.com/meshtastic/Meshtastic-Android/tree/main/specs/005-tak-v2-protocol)
+**Input**: User description: "Write an Apple spec for TAK v2 — Apple already ships TAK v2 (`supportsTAKv2`, firmware ≥ 2.8.0) but with no formal spec. An Apple companion spec scopes the iOS/macOS UX surface differences and ensures ongoing parity as the protocol evolves."
+**Cross-Platform Spec**: iOS (iPhone, iPad) and macOS (via Mac Catalyst). Wire protocol defined by [TAKPacket-SDK](https://github.com/meshtastic/TAKPacket-SDK) (Swift Package via SPM); pinned at `0.2.3` in `Meshtastic.xcworkspace/.../Package.resolved`.
+
+## Summary
+
+This feature documents the Apple Meshtastic app's TAK (Team Awareness Kit) integration as it shipped. The app exposes a local TLS/mTLS server (port 8089) that ATAK Civ and iTAK clients connect to. Outbound CoT (Cursor-on-Target) events are forwarded over the LoRa mesh via one of three wire formats, picked per-send based on the connected radio's firmware version:
+
+1. **V2** `ATAK_PLUGIN_V2` (port 78) — TAKPacketV2 protobuf with zstd dictionary compression via the [TAKPacket-SDK](https://github.com/meshtastic/TAKPacket-SDK). Used when `AccessoryManager.supportsTAKv2` returns true (firmware ≥ 2.8.0). Carries the full typed CoT vocabulary: PLI, GeoChat, shapes, markers, routes, casevac, emergency, task.
+
+2. **V1 ATAK_PLUGIN** (port 72) — bare `TAKPacket` protobuf (PLI and GeoChat only). Used when the radio firmware is ≤ 2.7.x and the CoT message is a PLI or chat.
+
+3. **V1 ATAK_FORWARDER** (port 257) — zlib-compressed CoT XML, optionally Fountain (LT) coded across multiple packets when payload exceeds one LoRa MTU. Used when the radio firmware is ≤ 2.7.x and the CoT message is anything other than PLI / GeoChat (markers, routes, shapes, etc.). The portnum itself was originally defined for the third-party [paulmandal/atak-forwarder Android plugin](https://github.com/paulmandal/atak-forwarder) (which encodes via `libcotshrink`); the Apple-side stack reimplements compatible zlib framing — see `EXICodec.swift`'s header for the "for Android interoperability" intent. In practice the common counterparty on this port is another Apple Meshtastic peer; the **official Meshtastic Android app does not implement a receive handler for port 257** (its mesh router just forwards the bytes), so an Android peer running only the official ATAK plugin won't see these packets surface. Whether the wire framing exactly matches paulmandal's `libcotshrink` output (and would therefore interop with that plugin) is asserted by code comments but not currently verified by an automated test.
+
+The inbound path always listens on all three portnums regardless of local firmware, so a v2-capable phone connected to a 2.7.x radio still receives PLI and GeoChat from older mesh nodes, and a 2.7.x Apple phone still receives full V1 ATAK_FORWARDER traffic from other Apple peers (or any port-257-compatible source).
+
+Architectural parity with Android is intentional for the V2 path (same wire bytes, same SDK, same prune-list and detail-stripper philosophy). Divergence is concentrated in the V1 fallback (Apple's EXI + Fountain path has no Android equivalent), the TLS stack (Network.framework vs. JSSE), the UI toolkit (SwiftUI vs. Compose Multiplatform), background-execution model (iOS background-mode entitlements vs. Android PARTIAL_WAKE_LOCK), filesystem surface (Files app + UTType vs. SAF), and permission model (Local Network entitlement vs. ACCESS_LOCAL_NETWORK).
+
+## Goals
+
+1. **Full CoT type coverage on V2**: Match Android's V2 type coverage byte-for-byte over the air — PLI, GeoChat, Marker, Route, DrawnShape (circle, ellipse, freeform, polygon, rectangle, telestration), Aircraft, Casevac, Emergency, Task, Ranging, Alert, Delete, Chat Receipts, Waypoints. CoT-typed payloads round-trip Apple ↔ Android via the SDK without bridging loss.
+2. **Efficient wire encoding**: Same 225-byte usable LoRa wire-payload budget as Android (`maxWirePayloadBytes = 225`). Use the SDK's `compressWithRemarksFallback` to attempt full-detail compression, then re-attempt with `<remarks>` stripped if the first pass overflows. Apple additionally strips a 24-pattern element/attribute list before compression (Android strips 16) to claw back bytes on ATAK CIV's verbose detail blocks.
+3. **Backward compatibility with two paths**: Auto-detect firmware version and gracefully fall back. PLI / GeoChat on legacy go via V1 ATAK_PLUGIN (port 72 — the **official Meshtastic ATAK plugin's** portnum; fully interoperable with the Meshtastic-Android app). All other CoT types on legacy fall through to V1 ATAK_FORWARDER (port 257 — originally the **paulmandal atak-forwarder Android plugin's** portnum, repurposed Apple-side for arbitrary chunked CoT XML; the Meshtastic-Android *app* does not implement a receive handler for this portnum). The threshold (firmware ≥ 2.8.0) is gated by `AccessoryManager.supportsTAKv2`.
+4. **Reliable local TAK server**: Always-on TLS listener on `127.0.0.1:8089` via `Network.framework`'s `NWListener` with `NWProtocolTLS`. Survives backgrounding for as long as iOS keeps the BLE / TCP / USB transport alive (no foreground service equivalent; relies on BLE-peripheral and the AccessoryManager's background mode handoff).
+5. **Route interoperability for iTAK**: iTAK silently ignores route CoT (`b-m-r`) received over its TCP streaming connection. Generate a KML-inside-zip data package and save to `Documents/TAK Routes/` so the user can sideload via the iOS Files app, plus surface a local notification ("Route Received — Saved to Files → Meshtastic → TAK Routes. Open in iTAK to import.") so the receipt is visible.
+6. **Identity admin from inside TAK Server config**: Embed the firmware `ModuleConfig.TAKConfig` editor (team color + member role) inside the same screen as the in-app TAK server controls so users configure the full identity surface in one place. Use SwiftUI directly with admin-message round-trips via `AccessoryManager.requestTAKModuleConfig` / `saveTAKModuleConfig`.
+
+## Non-Goals
+
+- Implementing a full TAK Server with mission sync, federation, or enterprise features (same as Android).
+- Supporting TAK protocols over non-mesh transports (WiFi-direct, Bluetooth peer-to-peer).
+- Modifying the Meshtastic firmware or protobuf schema (consumed read-only from upstream).
+- Providing a standalone TAK client UI within the Meshtastic app (ATAK and iTAK remain the clients).
+- Supporting CoT streaming to remote TAK servers over the internet.
+- macOS-native (AppKit) TAK Server UI — runs via Mac Catalyst with the iOS SwiftUI surface.
+- Watch / TV / visionOS surface — out of scope; AccessoryManager limits TAK to iOS / iPadOS / macCatalyst.
+- Pure macOS (non-Catalyst) builds — `targetEnvironment(macCatalyst)` adds a `SerialTransport` for the lab; standalone macOS isn't a supported deployment target.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Send Rich Tactical Data Over Mesh (Priority: P1)
+
+A TAK operator using iTAK on iPhone connects to the Meshtastic app's built-in TAK server (data package import) and drops a marker, draws a shape, or creates a route on the iTAK map. The Meshtastic app converts the CoT event into a compressed TAKPacketV2 and transmits it over the mesh. All other mesh nodes with TAK-connected clients see the marker / shape / route appear on their maps. For routes specifically, the receiving Apple node also writes a KML data package to `Documents/TAK Routes/` and posts a "Route Received" notification so the user can sideload it into iTAK.
+
+**Why this priority**: This is the core value proposition — extending TAK's situational awareness beyond PLI to include all tactical overlays over LoRa mesh, with the iTAK route-import affordance closing the one workflow gap iTAK has.
+
+**Independent Test**: Connect two Meshtastic radios (firmware ≥ 2.8.0) each with iTAK or ATAK Civ connected. Drop a hostile marker on one client and verify it appears on the other with correct type, icon, and position. For routes, verify the "Route Received" local notification fires and that `Documents/Meshtastic/TAK Routes/<sanitized-uid>.zip` exists and opens cleanly in iTAK's "Import" sheet.
+
+**Acceptance Scenarios**:
+
+1. **Given** two mesh nodes running firmware ≥ 2.8.0 with TAK clients (iTAK and / or ATAK Civ) connected, **When** a user places a marker (type `a-h-G`) on one TAK client, **Then** the marker appears on the remote TAK client with correct hostile type, position, and callsign within one mesh transmission cycle.
+2. **Given** a mesh node with firmware ≥ 2.8.0, **When** a TAK user creates a route with 3 waypoints, **Then** the route is transmitted over port 78 AND on the receiving node `Documents/TAK Routes/<sanitized-uid>.zip` is created and a `Notification` with title "Route Received" is posted via `LocalNotificationManager`.
+3. **Given** a TAKPacketV2 payload exceeding 225 bytes after compression and remarks stripping, **When** the system attempts transmission, **Then** it throws `AccessoryError.ioFailed("TAK V2 payload exceeds LoRa wire size limit ...")` from `sendCoTToMeshV2(_:channel:)` so `TAKMeshtasticBridge.sendToMesh` logs the failure rather than treating the drop as a successful send.
+
+---
+
+### User Story 2 — Legacy Fallback for Mixed Firmware (Priority: P1)
+
+A team has a mix of older radios (firmware 2.7.x) and newer radios (firmware 2.8.0+). The app detects each radio's capability and uses the appropriate protocol version. PLI and GeoChat round-trip Apple ↔ Android on V1 (port 72). For non-PLI / non-GeoChat CoT types on legacy radios, Apple peers exchange full CoT over V1 ATAK_FORWARDER (port 257) via Apple's EXI + Fountain stack; Android-to-Apple traffic for these types is dropped at the Android sender (Android logs a warning rather than attempt the Apple-only fallback).
+
+**Why this priority**: Mixed-firmware deployments are the reality during any firmware upgrade cycle; breaking backward compatibility would render the feature unusable for most teams. Apple's V1 ATAK_FORWARDER path is the only way to ship shapes / markers / routes between two Apple peers when neither radio supports V2.
+
+**Independent Test**: Connect two iPhones each paired with firmware-2.7.x radios. Drop a marker on iTAK A; confirm it appears on iTAK B via the ATAK_FORWARDER path. Reconnect iPhone A to a firmware-2.8.0+ radio mid-session; confirm the next marker drop goes out on port 78 (V2) without restarting the app.
+
+**Acceptance Scenarios**:
+
+1. **Given** a radio running firmware < 2.8.0, **When** a TAK user sends a PLI update, **Then** the app encodes it as a legacy `TAKPacket` on port 72 (`ATAK_PLUGIN`) via `sendTAKPacket(_:channel:)`.
+2. **Given** a radio running firmware < 2.8.0, **When** a TAK user drops a marker, **Then** `GenericCoTHandler.classifySendMethod` returns `.exiDirect` or `.exiFountain` and the app encodes the CoT XML via the EXI + Fountain pipeline and sends it on port 257 (`ATAK_FORWARDER`). Receiving Apple peers reassemble and decode; receiving Android peers see only opaque bytes.
+3. **Given** a radio running firmware ≥ 2.8.0, **When** a legacy `TAKPacket` arrives on port 72 from an older mesh node, **Then** `handleATAKPluginPacket(_:)` decodes it, converts to `CoTMessage`, and `TAKServerManager.shared.broadcast(_:)` forwards it to connected TAK clients.
+4. **Given** a radio that upgrades firmware OTA mid-session, **When** the next CoT send happens, **Then** the per-send `accessoryManager.supportsTAKv2` check picks up the new firmware version and switches to V2 immediately (no app restart required — the fork is per-send, not per-session).
+
+---
+
+### User Story 3 — TAK Server Lifecycle and Reliability (Priority: P2)
+
+A user enables the TAK server from the Meshtastic app's Settings → TAK Server screen. The server starts an `NWListener` with mTLS on `127.0.0.1:8089`, accepts ATAK Civ / iTAK connections, and remains operational across screen-off and background transitions for as long as iOS keeps the BLE / TCP transport alive via the app's BLE-peripheral background mode. Users can export a connection data package (`.zip` with `.p12` certs + ATAK `.pref` file) via the SwiftUI `fileExporter` modifier, opening the system share sheet so the file can be AirDropped, saved to Files, or attached to a message.
+
+**Why this priority**: Without a reliable local server, TAK clients cannot maintain connectivity, making all other features unreliable.
+
+**Independent Test**: Enable TAK server from Settings → TAK Server. Tap "Export Data Package" → save to Files. Open iTAK, import the data package, verify TLS connection to `127.0.0.1:8089` succeeds. Background the Meshtastic app for 10 minutes (screen off), bring it back, confirm iTAK still shows connected.
+
+**Acceptance Scenarios**:
+
+1. **Given** the TAK server is disabled, **When** the user toggles `takServerEnabled` to `true` in Settings, **Then** `TAKServerManager.shared.start()` runs (via the `didSet` observer on `enabled`), an `NWListener` binds 8089 / TLS, and the UI shows `isRunning = true` with `connectedClients.count = 0`.
+2. **Given** the TAK server is running with iTAK connected, **When** the device screen turns off, **Then** the TLS connection is held by `NWConnection` and the per-client keepalive task (10-second interval, well under ATAK's 15-second `RX_STALE_SECONDS`) continues running for the duration of the BLE / TCP transport's background allowance. (No PARTIAL_WAKE_LOCK equivalent on iOS; reliability is bounded by iOS background-mode policy.)
+3. **Given** the TAK server is running, **When** the user taps "Export Data Package," **Then** `TAKDataPackageGenerator.generateDataPackage()` produces a `.zip` containing `truststore.p12`, `client.p12`, `meshtastic-server.pref`, and `manifest.xml`. The SwiftUI `fileExporter` modifier opens the share sheet so the file can be saved to Files, AirDropped, or imported directly by ATAK / iTAK.
+
+---
+
+### User Story 4 — TAK Identity + Server Configuration (Priority: P2)
+
+A user navigates to Settings → TAK Server. The screen renders, top to bottom: the firmware `ModuleConfig.TAKConfig` editor (team color + member role) as `TAKIdentitySection`, the in-app TAK server controls (Enable, channel, read-only mode), certificate management (import / regenerate `.p12`), and data package export. Toggling Enable starts / stops the server. Saving identity sends an admin message via `AccessoryManager.saveTAKModuleConfig` to update the connected radio's firmware module config.
+
+**Why this priority**: Users need a single screen to configure their tactical identity (team / role) AND the local server. Splitting these across two screens (as Android does separately in Module Config → TAK and Settings → TAK Server) creates discoverability friction; combining them was a deliberate Apple-side choice.
+
+**Independent Test**: Navigate to Settings → TAK Server. Change team color to "Cyan" and role to "Team Member". Verify outgoing PLI packets carry the selected team and role. Toggle Enable off and on; verify server restart. Tap "Regenerate Certificates"; verify new `.p12` files are persisted and previously-connected clients are disconnected (must re-import the data package).
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on Settings → TAK Server, **When** they select a team color and role and tap "Save Identity," **Then** `AccessoryManager.saveTAKModuleConfig(config:fromUser:toUser:)` packages a `ModuleConfig.TAKConfig` in an `AdminMessage` and ships it on the admin port. Subsequent V2 outbound PLIs carry the new team / role values.
+2. **Given** the user is on Settings → TAK Server and the connected node has no cached TAK config, **When** the screen appears, **Then** `requestTakConfigIfNeeded()` fires an admin request via `AccessoryManager.requestTAKModuleConfig(fromUser:toUser:)` so first-time users don't see a perma-spinner.
+
+---
+
+### User Story 5 — Inbound Dual-Path Tolerance (Priority: P3)
+
+A v2-capable node receives packets from V1 (port 72), V1 ATAK_FORWARDER (port 257), and V2 (port 78). All three are decoded and forwarded to connected TAK clients regardless of the local radio's firmware version. V2 raw XML is forwarded via `broadcastRawXml` to preserve shape geometry (link-point vertices, colors); V1 paths convert to `CoTMessage` and forward via `broadcast`.
+
+**Why this priority**: Ensures no tactical data is lost in mixed deployments where some nodes only send V1 (Android or Apple) and some send V1 ATAK_FORWARDER (Apple-to-Apple shapes).
+
+**Independent Test**: Send a legacy `TAKPacket` (port 72) PLI from an Android peer to an Apple node on firmware ≥ 2.8.0; verify the iTAK client receives the PLI. Send a Fountain-coded shape from another Apple peer on firmware ≤ 2.7.x; verify the iTAK client receives the shape after reassembly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a node with firmware ≥ 2.8.0, **When** it receives a `TAKPacket` on port 72, **Then** `handleATAKPluginPacket(_:)` decodes the packet and broadcasts it to connected TAK clients.
+2. **Given** a node with firmware ≥ 2.8.0, **When** it receives a `TAKPacketV2` on port 78, **Then** `handleATAKPluginV2Packet(_:)` decompresses on a detached utility-priority `Task` (so the main actor doesn't stall on large routes), rebuilds the CoT XML via `MeshtasticTAK.CotXmlBuilder`, strips the XML prologue and inter-tag whitespace, and forwards the raw XML via `TAKServerManager.shared.broadcastRawXml(_:)`.
+3. **Given** an Apple node on any firmware, **When** it receives an `ATAK_FORWARDER` (port 257) packet, **Then** `handleATAKForwarderPacket(_:)` hands off to `GenericCoTHandler.handleIncomingForwarderPacket(_:)`, which reassembles Fountain fragments and zlib-decompresses the resulting CoT XML before forwarding to TAK clients.
+
+---
+
+### Edge Cases
+
+- What happens when V2 zstd decompression produces malformed protobuf? → `try compressor.decompress(wirePayload)` throws; the detached `Task` catches and logs `Failed to decompress ATAK V2 packet:` without dropping any other in-flight traffic.
+- What happens when the TAK server port 8089 is already in use? → `NWListener` start fails and `TAKServerManager.lastError` is populated with a user-visible string; the toggle in Settings returns to off.
+- What happens when a CoT XML contains malformed or hostile content? → `stripNonEssentialElements` regex-strips 24 patterns including unknown-value attributes (`xxx="???"`) before compression; the receiver's `CoTXmlBuilder` rebuilds well-formed XML; the prologue-regex defends against `<?xml ...?>` mid-stream which would tear down the TCP connection.
+- What happens when iTAK sends a CoT type the SDK parser doesn't recognize? → `MeshtasticTAK.CotXmlParser.parse(_:)` throws; `sendCoTToMeshV2` catches it and the bridge logs `Failed to send V2 to mesh:` — the bridge does NOT fall back to V1 ATAK_FORWARDER from a V2-capable radio (no V2 receiver path for partial conversions).
+- What happens when a connected TAK client disconnects and reconnects within 5 minutes? → `TAKServerManager`'s `offlineQueue` (50-message cap, 5-minute TTL) holds both `.message` (parsed CoT) and `.rawXml` (V2 shape/route detail) entries; `drainOfflineQueue()` dispatches the right path per payload variant on the next `onClientConnected` callback.
+- What happens when the user denies the Local Network permission prompt on iOS 14+? → The `NWListener` binds successfully to `127.0.0.1` but is unreachable from off-device clients (still works for iTAK / ATAK running on the same iPhone or via Hotspot when the user grants Local Network later). iOS auto-prompts on first inbound connection attempt; the app does not pre-request.
+- What happens when the user runs the app via Mac Catalyst? → `TAKServerManager` runs the same NWListener path. `TAKServerConfig` renders via the Catalyst SwiftUI bridge. There is no `Documents/TAK Routes/` notification on macOS (still saved; user opens via Finder).
+- What happens when the radio's firmware version is unknown (handshake not yet complete)? → `checkIsVersionSupported(forVersion: "2.8.0")` returns false on missing metadata, so the bridge defaults to V1. After the first myNodeInfo, subsequent sends pick the right path automatically.
+- What happens when `GenericCoTHandler` classifies a CoT as `.exiFountain` but only one fragment is sent before the app backgrounds? → Fountain (LT) codes are erasure-tolerant; the receiving Apple peer waits for enough fragments to decode. If too few arrive before the per-message timeout, the receiver drops silently.
+- What happens when iTAK receives a `b-m-r` route over its TCP streaming connection? → iTAK silently ignores the event (this is a known iTAK limitation). The receiving Apple node always also writes the KML data package and posts the "Route Received" notification so the user has a recovery path.
+
+## Architecture
+
+### Key Components
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| `TAKMeshtasticBridge` | `Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift` | Bidirectional bridge; per-send V1 / V2 fork in `sendToMesh(_:clientInfo:)`. |
+| `TAKServerManager` | `Meshtastic/Helpers/TAK/TAKServerManager.swift` | `NWListener` lifecycle, mTLS setup via `NWProtocolTLS`, per-client connection management, offline queue (50 / 5 min). |
+| `TAKConnection` | `Meshtastic/Helpers/TAK/TAKConnection.swift` | Per-client `NWConnection` state machine, framing buffer, 10-second keepalive task. |
+| `TAKCertificateManager` | `Meshtastic/Helpers/TAK/TAKCertificateManager.swift` | `.p12` loading (bundled + Keychain-stored custom), regenerate, mTLS trust evaluation. |
+| `AccessoryManager+TAK` | `Meshtastic/Accessory/Accessory Manager/AccessoryManager+TAK.swift` | Send / receive handlers for all three portnums (`atakPlugin`, `atakPluginV2`, `atakForwarder`). |
+| `CoTMessage` / `CoTXMLParser` | `Meshtastic/Helpers/TAK/CoTMessage.swift`, `CoTXMLParser.swift` | Domain model + streaming parser for inbound CoT from TAK clients. |
+| `GenericCoTHandler` | `Meshtastic/Helpers/TAK/GenericCoTHandler.swift` | V1-only: classifies non-PLI / non-GeoChat CoT into `.exiDirect` / `.exiFountain`, dispatches over `ATAK_FORWARDER`. |
+| `EXICodec` | `Meshtastic/Helpers/TAK/EXICodec.swift` | zlib compression for the V1 ATAK_FORWARDER path. |
+| `FountainCodec` | `Meshtastic/Helpers/TAK/FountainCodec.swift` | Luby-Transform fountain codes for multi-fragment V1 ATAK_FORWARDER payloads. |
+| `RouteDataPackageGenerator` | `Meshtastic/Helpers/TAK/RouteDataPackageGenerator.swift` | Converts route CoT (`b-m-r`) to KML-inside-zip. Writes to `Documents/TAK Routes/<sanitizedUid>.zip`. |
+| `TAKDataPackageGenerator` | `Meshtastic/Helpers/TAK/TAKDataPackageGenerator.swift` | Generates the connection `.zip` for ATAK / iTAK import (`.p12` + `.pref` + manifest). |
+| `TAKServerConfig` | `Meshtastic/Views/Settings/TAKServerConfig.swift` | Combined SwiftUI screen: identity (`TAKIdentitySection`) + server toggle + cert mgmt + data package export. |
+| `TAKModuleConfig` | `Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift` | Standalone firmware module config screen (also accessible from Module Config nav; same backing admin-message round-trips as `TAKIdentitySection`). |
+| `ZipDocument` | `Meshtastic/Views/Settings/TAKServerConfig.swift` (`struct ZipDocument: FileDocument`) | UTType-typed `FileDocument` for SwiftUI `fileExporter`. |
+| `AccessoryManager.supportsTAKv2` | `Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift:860` | `checkIsVersionSupported(forVersion: "2.8.0")` — single gate property used by the bridge. |
+
+### Comparison with Android Architecture
+
+| Concern | Android (Kotlin / KMP) | Apple (Swift / SwiftUI) |
+|---------|------------------------|-------------------------|
+| TLS server stack | `javax.net.ssl.SSLServerSocket` (JSSE), `BufferedOutputStream` + `writeMutex` for stream framing | `Network.framework` (`NWListener`, `NWConnection`, `NWProtocolTLS`), per-connection serial queue |
+| Background execution | `PARTIAL_WAKE_LOCK` held by `MeshService` foreground service | No equivalent; relies on BLE-peripheral background mode of the AccessoryManager transport |
+| Permission model | `ACCESS_LOCAL_NETWORK` runtime permission (Android 17+, API 37) | Local Network entitlement, auto-prompted by iOS on first inbound LAN connection attempt |
+| UI toolkit | Compose Multiplatform (KMP, shared with iOS stubs) | SwiftUI (iOS / iPadOS / macCatalyst); no shared KMP UI on Apple |
+| File export | Storage Access Framework (SAF) document picker, written to `Documents` provider | SwiftUI `fileExporter` modifier with `UTType` typing; `Documents/TAK Routes/` integrated with Files app |
+| Route receipt UX | KML written to app-private dir; no notification in current Android impl | KML written to `Documents/TAK Routes/`; local notification ("Route Received") posted via `LocalNotificationManager` |
+| V1 fallback for non-PLI/Chat | **Dropped** with warning log | **ATAK_FORWARDER (port 257)**: zlib + Fountain codes — Apple-to-Apple only |
+| Test surface | Multiplatform tests in `commonTest` with shared fixtures | Swift Testing framework (`@Suite`, `@Test`) in `MeshtasticTests/`; ~172 TAK-tagged tests across 8 files |
+| SDK consumption | Gradle / JitPack: `com.github.meshtastic.TAKPacket-SDK:takpacket-sdk:v0.2.3` | SPM: `https://github.com/meshtastic/TAKPacket-SDK.git` pinned at `0.2.3` |
+| Detail strip count | 16 element patterns | 24 patterns (24 elements + 6 attributes + UID-stripping on route waypoint `<link>` elements) |
+
+The wire formats and CoT type mappings are identical (defined by the SDK). All divergence is at the platform-integration layer.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect firmware version via `AccessoryManager.supportsTAKv2` (`checkIsVersionSupported(forVersion: "2.8.0")`) and use TAKPacketV2 (port 78) for radios ≥ 2.8.0, falling back to the V1 dispatch table for older firmware.
+- **FR-002**: System MUST support encoding and decoding of all CoT types covered by `TAKPacket-SDK` 0.2.3 on the V2 path: PLI, GeoChat, Marker, Route, DrawnShape (circle, ellipse, freeform, polygon, rectangle, telestration), Aircraft, Casevac, Emergency, Task, Ranging, Alert, Delete, Chat Receipts, Waypoints.
+- **FR-003**: System MUST compress V2 outbound payloads via `MeshtasticTAK.TakCompressor().compressWithRemarksFallback(_:maxWireBytes:)`, which selects the right zstd dictionary (aircraft vs non-aircraft) and attempts a remarks-stripped retry on overflow.
+- **FR-004**: System MUST throw `AccessoryError.ioFailed` from `sendCoTToMeshV2` when `compressWithRemarksFallback` returns `nil` (payload exceeds 225 bytes even without `<remarks>`), so the caller's `do/catch` doesn't treat the drop as a successful send.
+- **FR-005**: System MUST accept inbound packets on all three portnums (`atakPlugin` 72, `atakForwarder` 257, `atakPluginV2` 78) regardless of local firmware version.
+- **FR-006**: System MUST run a local mTLS server on port 8089 (`TAKServerManager.defaultTLSPort`) via `Network.framework`'s `NWListener` with `NWProtocolTLS` and `tcp.enableKeepalive = true`, `keepaliveIdle = 60`.
+- **FR-007**: System MUST send TAK-protocol keepalive ping events at 10-second intervals from `TAKConnection.startKeepalive()` to remain below ATAK's 15-second `RX_STALE_SECONDS` threshold.
+- **FR-008**: System MUST generate KML data packages for route CoT (`b-m-r`) events via `RouteDataPackageGenerator.generateDataPackage(routeXml:)` and write them to `Documents/TAK Routes/<sanitizedUid>.zip` on receive. iOS surface MUST post a `LocalNotificationManager` notification titled "Route Received" with subtitle = route callsign and body = "Saved to Files → Meshtastic → TAK Routes. Open in iTAK to import."
+- **FR-009**: System MUST export connection data packages via `TAKDataPackageGenerator.generateDataPackage()` containing `truststore.p12`, `client.p12`, `meshtastic-server.pref`, and `manifest.xml`, surfaced through the SwiftUI `fileExporter` modifier with `UTType.zip`.
+- **FR-010**: System MUST sanitize route UIDs via `RouteDataPackageGenerator.sanitizeForFilename(_:)` (strips path separators, control characters, and `..` sequences) before constructing file paths, and MUST escape values via `escapeXml(_:)` before interpolation into the manifest's `value="..."` attribute.
+- **FR-011**: System MUST preserve the source event XML for V2 outbound when the CoT type is not `b-t-f` (GeoChat) so the SDK parser receives the original element shape (vertices, colors) — `cotMessage.sourceEventXml` is preferred over `enrichedMessage.toXML()` for non-chat events.
+- **FR-012**: System MUST drop V2-only CoT types when the radio is on legacy firmware AND the type is not classifiable as `.takPacketPLI` / `.takPacketChat` / `.exiDirect` / `.exiFountain` (no V1 representation). The drop MUST be logged but not bubbled up to the user — the V1 ATAK_FORWARDER fallback covers all reachable cases between Apple peers.
+- **FR-013**: System MUST strip 24 element / attribute patterns from outbound V2 CoT via `stripNonEssentialElements(_:)` before compression — including `<takv>`, `<voice>`, `<marti>`, `<__geofence>`, `<__shapeExtras>`, `<creator>`, empty `<remarks>`, `<strokeStyle>`, `<precisionlocation>` / `<precisionLocation>` (both casings), empty / placeholder attributes, and `uid="..."` on route waypoint `<link>` elements (~40 bytes saved per waypoint).
+- **FR-014**: System MUST maintain an offline message queue with both `.message(CoTMessage)` and `.rawXml(String)` variants (50-entry cap, 5-minute TTL) in `TAKServerManager` and drain on `onClientConnected`. The `.rawXml` variant preserves V2 shape/route detail elements that `CoTMessage` strips.
+- **FR-015**: System MUST extend `stale` timestamps of static-object CoT (routes, shapes, markers) up to `minimumMeshStaleTTL = 15 minutes` from now in `ensureMinimumStaleForMesh(_:)` so multi-hop mesh delivery doesn't deliver objects that immediately appear stale. The extension preserves the original stale only when it's already ≥ now + 15 min.
+- **FR-016**: System MUST enrich GeoChat (`b-t-f`) CoT with a synthesized `<contact callsign="...">` element when the source XML lacks one (iTAK / ATAK put sender identity in `<__chat senderCallsign>` instead). The fallback chain is `cotMessage.chat?.senderCallsign` → `clientInfo?.callsign` → literal `"UNKNOWN"`. Applies only on the outbound (TAK client → mesh) path.
+- **FR-017**: System MUST set `meshPacket.hopLimit` on V2 sends from `takBroadcastHopLimit(forDevice:)` (LoRa-config value with 3-hop fallback) — the protobuf default of 0 makes firmware treat the packet as already-exhausted and silently drop before TX.
+- **FR-018**: System MUST process incoming V2 packets on a detached `Task.detached(priority: .utility)` so zstd decompression, KML / zip generation, and `Data.write(to:)` into `Documents/TAK Routes/` don't stall the `@MainActor` `AccessoryManager` dispatch loop. Notifications are dispatched back to `MainActor` for `LocalNotificationManager`.
+- **FR-019**: System MUST strip the `<?xml ...?>` prologue and inter-tag whitespace from rebuilt V2 CoT XML before forwarding to TAK clients — leaking a mid-stream prologue tears down the iTAK / ATAK TCP streaming parser. Regex-based strip (`^\s*<\?xml[^>]*\?>`) so it works even if the SDK ever emits single quotes / different attribute order.
+- **FR-020**: System MUST embed the firmware `ModuleConfig.TAKConfig` editor (`TAKIdentitySection`) inside `TAKServerConfig` and trigger `requestTakConfigIfNeeded()` on appear so first-time users see populated team / role values rather than a perma-spinner.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Compressed V2 wire payloads MUST fit within `maxWirePayloadBytes = 225` bytes for single-packet LoRa transmission.
+- **NFR-002**: TAK client connection SHOULD survive screen-off for the duration of the BLE / TCP / USB transport's background allowance — no PARTIAL_WAKE_LOCK equivalent on iOS, but `NWConnection` keepalive (`keepaliveIdle = 60` at the TCP layer, plus 10s app-layer pings) keeps NAT mappings and idle-timeouts at bay.
+- **NFR-003**: V2 receive processing (zstd decompress + XML rebuild + optional KML/zip write) MUST NOT block the `@MainActor` `AccessoryManager` dispatch loop — `handleATAKPluginV2Packet` MUST hop to `Task.detached(priority: .utility)`.
+- **NFR-004**: Route KML data packages MUST be written to `Documents/TAK Routes/`, accessible to the user via the Files app without any additional permission grant. App-private container is sufficient; no `MANAGE_EXTERNAL_STORAGE`-equivalent is required (iOS Files just shows `Documents`).
+- **NFR-005**: Apple SDK pin MUST track Android's released version. When Android bumps `takpacket-sdk` in `core/proto/build.gradle.kts`, Apple's `Package.resolved` SHOULD be updated to the same release tag in the same PR cycle to avoid wire-format drift.
+
+## Apple-Specific UX Surface
+
+This section is the part Android's spec doesn't have: the iOS / macOS app surface elements that exist purely because Apple's platform model differs.
+
+### Settings Navigation
+
+```
+Settings (root)
+└── Modules
+    └── TAK Server  ← single nav entry to the combined screen (target.icon)
+        ├── TAKIdentitySection (firmware ModuleConfig.TAKConfig)
+        │   ├── Team color picker (Cyan / Red / Blue / Green / ... )
+        │   └── Member role picker (Team Member / TeamLead / HQ / ... )
+        ├── Primary Channel Warning (if channel name conflicts)
+        ├── Server Status section
+        │   ├── isRunning indicator
+        │   ├── Connected clients list
+        │   └── lastError display
+        ├── Server Configuration section
+        │   ├── Enable toggle (@AppStorage takServerEnabled)
+        │   ├── Channel picker (@AppStorage takServerChannel)
+        │   └── Read-only mode toggle
+        ├── Certificates section
+        │   ├── Import custom .p12 (fileImporter)
+        │   ├── Regenerate certificates
+        │   └── Reset to bundled defaults
+        └── Data Package section
+            └── Export connection .zip (fileExporter → share sheet)
+```
+
+Also accessible from **Module Configuration → TAK** (same `SettingsNavigationState.tak` destination → same `TAKServerConfig`). Both nav entry points were intentionally pointed at the combined screen rather than the standalone `TAKModuleConfig` so users see the full identity + server surface in one place.
+
+### Files App Integration
+
+- **Export path**: SwiftUI `fileExporter` on the "Export Data Package" button opens the share sheet. The user picks Save to Files, AirDrop, or any registered share target (iTAK and ATAK both register data-package handlers).
+- **Route receipt path**: KML data packages are written to `Documents/TAK Routes/<sanitizedUid>.zip` and become visible in the Files app under "On My iPhone → Meshtastic → TAK Routes". The "Route Received" local notification's body text tells the user the exact path.
+- **Import path**: Custom `.p12` certificates use `fileImporter` (also SwiftUI) to pick from Files / iCloud Drive / third-party providers. The picked file is read into memory and persisted via `TAKCertificateManager` to Keychain-protected storage (key `tak.custom.server.p12.data`).
+
+### Notifications
+
+- **Notification scope**: iOS only — `LocalNotificationManager` schedules `UNUserNotification` requests with `MainActor` dispatch.
+- **Trigger**: First receive of a route CoT (`b-m-r`) that successfully generates a KML data package.
+- **Suppression**: None currently. Each route notification is a separate notification — multiple route receipts in quick succession produce multiple banners.
+
+### Background Execution
+
+iOS does not have a wake-lock primitive. Reliability is bounded by:
+
+1. **BLE Peripheral background mode** (`UIBackgroundModes` → `bluetooth-peripheral`): keeps the AccessoryManager BLE transport alive while suspended. This is the dominant lever for TAK server uptime when the device is on battery.
+2. **NWConnection keepalive**: TCP-layer `tcp.enableKeepalive = true` with `keepaliveIdle = 60` keeps the iTAK / ATAK TCP socket alive across NAT timeouts.
+3. **Per-connection 10-second pings**: app-layer ping CoT events keep the TAK protocol's `RX_STALE_SECONDS` counter under 15 seconds.
+
+The trade-off: no equivalent of Android's PARTIAL_WAKE_LOCK + foreground-service guarantee. When iOS aggressively suspends the app (e.g., long battery-saver, low-memory eviction), TAK clients will see disconnections. The offline queue (FR-014) catches up on reconnect.
+
+### macOS (Mac Catalyst)
+
+Mac Catalyst runs the same SwiftUI views via the iOS framework adapter. Behavioral notes:
+
+- TAK server runs the same `NWListener` path; binds 8089 on the Mac's loopback.
+- `targetEnvironment(macCatalyst)` enables `SerialTransport` in `AccessoryManager.shared.transports` for USB-attached radios.
+- File save / export uses the macOS Save Panel via Catalyst's `fileExporter` bridge.
+- Local notifications are delivered via macOS Notification Center, but the body text still references "Files → Meshtastic" — the user opens the saved zip via Finder.
+
+## Source-Set / Module Impact
+
+Apple does NOT use KMP source sets. The closest analogs are:
+
+| Layer | Files | Justification |
+|-------|-------|---------------|
+| Domain model + parser | `Meshtastic/Helpers/TAK/CoTMessage.swift`, `CoTXMLParser.swift` | Used by both V1 and V2 paths; pure Swift, no platform imports beyond `Foundation`. |
+| V2 send + receive | `Meshtastic/Accessory/Accessory Manager/AccessoryManager+TAK.swift`, `Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift` (`sendToMesh` V2 branch) | Touches `MeshtasticTAK` (SDK) and `MeshtasticProtobufs`. |
+| V1 ATAK_PLUGIN | `AccessoryManager+TAK.swift` (`sendTAKPacket`, `handleATAKPluginPacket`), `TAKMeshtasticBridge.convertToTAKPacket` | Used for legacy interop with Android peers. |
+| V1 ATAK_FORWARDER (Apple-only) | `EXICodec.swift`, `FountainCodec.swift`, `GenericCoTHandler.swift` | Has no Android equivalent; preserved indefinitely for Apple-to-Apple legacy paths. |
+| TLS server | `TAKServerManager.swift`, `TAKConnection.swift`, `TAKCertificateManager.swift` | `Network.framework` only; would not port to Android. |
+| UX | `Meshtastic/Views/Settings/TAKServerConfig.swift`, `TAKModuleConfig.swift` | SwiftUI; iOS / iPadOS / macCatalyst. |
+| Tests | `MeshtasticTests/{TAKBridgeTests,TAKBridgeDetailedTests,TAKCodecTests,CoTMessageTests,CoTMessageDetailedTests,CoTXMLParserTests,CoTExtensionTests,GenericCoTHandlerTests}.swift` | Swift Testing framework; ~172 `@Test` methods. |
+
+## Design Standards Compliance
+
+- [x] `TAKServerConfig` and `TAKIdentitySection` use standard SwiftUI `Form` / `Section` / `Label` patterns
+- [x] System SF Symbols only (`target`, `network`, `lock.shield`, etc.)
+- [x] VoiceOver / Accessibility: standard SwiftUI labeling on toggles, pickers, buttons
+- [x] Typography: system text styles (`.title`, `.body`, `.caption`); no hand-rolled font sizes
+- [x] Dynamic Type: respected (no fixed-width `Text` containers in the TAK surface)
+
+## Privacy Assessment
+
+- [x] No PII, location data, or cryptographic keys logged. CoT data stays local to device / mesh.
+- [x] No new network calls that transmit user data (the TAK server is loopback / LAN only — does not initiate outbound connections).
+- [x] Custom `.p12` certificates persisted in Keychain (`TAKCertificateManager`), not in `UserDefaults`.
+- [x] `MeshtasticProtobufs` Swift Package not modified (read-only upstream).
+- [x] Routes / KML packages written to app-private `Documents/`; user has full access to delete via Files app.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All SDK-defined CoT types round-trip Apple → mesh → Android (and vice versa) without bridging loss on the V2 path — verified by cross-platform fixture tests using shared fixtures from the SDK repo.
+- **SC-002**: Compressed PLI < 100 bytes on the wire (well within the 225-byte LoRa budget).
+- **SC-003**: Mixed-firmware mesh (2.7.x + 2.8.0+) maintains PLI and GeoChat across Apple ↔ Android via V1 ATAK_PLUGIN. Shape / marker / route exchange between two Apple peers on 2.7.x radios works via V1 ATAK_FORWARDER.
+- **SC-004**: TAK server maintains TAK-client connections for 30+ minutes with iPhone screen off (BLE-peripheral background mode + keepalives).
+- **SC-005**: Route CoT events on the receive path produce a saved KML data package in `Documents/TAK Routes/` and a "Route Received" notification within 2 seconds of mesh receive.
+- **SC-006**: Swift Testing suite (~172 `@Test` methods across 8 TAK-related files) passes; new tests added for each FR.
+- **SC-007**: SDK version pin in `Meshtastic.xcworkspace/.../Package.resolved` matches the latest tagged release of `meshtastic/TAKPacket-SDK` within one release cycle of the Android `core/proto/build.gradle.kts` bump.
+
+## Assumptions
+
+- All TAK logic lives in `Meshtastic/Helpers/TAK/` and `Meshtastic/Accessory/Accessory Manager/AccessoryManager+TAK.swift`; the bridge is the single entry point for both send paths.
+- The connected radio's firmware version is available from the AccessoryManager's myNodeInfo metadata at send time.
+- ATAK Civ and iTAK both support the standard TAK Server protocol (TLS on 8089, data package import).
+- The TAKPacket-SDK is published as a Swift Package and pinned to a tagged release in `Package.resolved`.
+- Zstd dictionaries are bundled inside the SDK; the Apple app does not train or load them directly.
+- The 237-byte raw LoRa MTU is a hard limit; usable wire payload after Meshtastic framing is 225 bytes.
+- Route data packages are written to the app's `Documents` directory and become visible in the Files app under On My iPhone → Meshtastic without any further permission grant.
+- iOS Local Network entitlement is declared in the app's Info.plist; iOS auto-prompts on first inbound LAN connection.
+- macOS Catalyst is a supported target; pure macOS (AppKit / non-Catalyst) is not.
+- The V1 ATAK_FORWARDER path will NOT be backported to Android — it is preserved on Apple indefinitely for Apple-to-Apple legacy interop.
+- Future TAK SDK features that require a higher firmware version should add a sibling property on `AccessoryManager` (alongside `supportsTAKv2`) with a clear cut-off so the bridge stays declarative.

--- a/specs/010-tak-v2-protocol/tasks.md
+++ b/specs/010-tak-v2-protocol/tasks.md
@@ -1,0 +1,132 @@
+# Tasks: TAK v2 Protocol Integration (Apple)
+
+This is a retrospective task list. The implementation is merged on `main`. Checked items reflect what's shipped; unchecked items are open work for follow-on parity with Android and improvements identified during the back-spec audit.
+
+For the parallel Android tasks (which served as the structural reference for this spec), see [Meshtastic-Android `specs/005-tak-v2-protocol/tasks.md`](https://github.com/meshtastic/Meshtastic-Android/blob/main/specs/005-tak-v2-protocol/tasks.md).
+
+---
+
+## Phase 0 — Legacy V1 Foundation (Pre-2.8.0 Era)
+
+- [x] **T001** Create `Meshtastic/Helpers/TAK/` directory and add the bridge skeleton.
+- [x] **T002** Implement `CoTMessage` value type with `CoTContact`, `CoTGroup`, `CoTStatus`, `CoTTrack`, `CoTChat` sub-types.
+- [x] **T003** Implement `CoTXMLParser` (Foundation `XMLParser`-based streaming parser).
+- [x] **T004** Implement `TAKMeshtasticBridge.sendToMesh(_:clientInfo:)` with V1-only dispatch (port 72 + port 257).
+- [x] **T005** Implement `TAKServerManager` with `NWListener` + `NWProtocolTLS` mTLS on port 8089.
+- [x] **T006** Implement `TAKConnection` per-client state machine with framing buffer.
+- [x] **T007** Implement `TAKCertificateManager` with bundled `.p12` cert loading and Keychain custom-cert persistence.
+- [x] **T008** Implement `EXICodec` (zlib compress/decompress) and `FountainCodec` (LT erasure codes).
+- [x] **T009** Implement `GenericCoTHandler.classifySendMethod(for:)` and `sendGenericCoT(_:channel:)`.
+- [x] **T010** Implement `RouteDataPackageGenerator` (KML + manifest + zip; save to `Documents/TAK Routes/`).
+- [x] **T011** Implement `TAKDataPackageGenerator` (`.p12` + `.pref` + manifest export zip).
+- [x] **T012** Implement `TAKServerConfig` SwiftUI screen with toggle, cert mgmt, data package export.
+- [x] **T013** Add `TAKModuleConfig` SwiftUI screen for firmware module config.
+- [x] **T014** Add Swift Testing suites: `TAKBridgeTests`, `TAKBridgeDetailedTests`, `TAKCodecTests`, `CoTMessageTests`, `CoTMessageDetailedTests`, `CoTXMLParserTests`, `CoTExtensionTests`, `GenericCoTHandlerTests`.
+
+---
+
+## Phase 1 — V2 Protocol Integration
+
+- [x] **T020** Add `TAKPacket-SDK` as Swift Package via SPM, pin in `Meshtastic.xcworkspace/.../Package.resolved`.
+- [x] **T021** Add `AccessoryManager.supportsTAKv2` computed property (`checkIsVersionSupported(forVersion: "2.8.0")`).
+- [x] **T022** Implement `AccessoryManager+TAK::sendTAKV2Packet(_:channel:)` with `portnum = .atakPluginV2`.
+- [x] **T023** Implement `AccessoryManager+TAK::sendCoTToMeshV2(_:channel:)` with SDK `CotXmlParser` + `TakCompressor.compressWithRemarksFallback`.
+- [x] **T024** Implement `AccessoryManager+TAK::handleATAKPluginV2Packet(_:)` with SDK `TakCompressor.decompress` + `CotXmlBuilder.build`.
+- [x] **T025** Add `stripNonEssentialElements(_:)` with 24 element/attribute patterns (including UID strip on `<link point>` waypoints).
+- [x] **T026** Add `ensureMinimumStaleForMesh(_:)` with 15-minute stale floor.
+- [x] **T027** Wire V1/V2 fork in `TAKMeshtasticBridge.sendToMesh` on `accessoryManager.supportsTAKv2`.
+- [x] **T028** Add `sourceEventXml` vs. `toXML()` preference: use source for non-chat V2 to preserve shape geometry.
+- [x] **T029** Add GeoChat contact enrichment (synthesize `<contact callsign>` from `<__chat senderCallsign>` or `TAKClientInfo`).
+- [x] **T030** Throw `AccessoryError.ioFailed` from `sendCoTToMeshV2` when `compressWithRemarksFallback` returns `nil` (don't silently drop).
+
+---
+
+## Phase 2 — UX Polish
+
+- [x] **T040** Combine firmware module config (team/role) and in-app server config in one screen (`TAKServerConfig` + `TAKIdentitySection`).
+- [x] **T041** Route both Settings → Modules → TAK Server and Settings → TAK Server nav entries to the same combined screen.
+- [x] **T042** Add `requestTakConfigIfNeeded()` on `TAKIdentitySection.appear` to populate first-time values.
+- [x] **T043** Implement SwiftUI `fileExporter` modifier on "Export Data Package" with `UTType.zip`.
+- [x] **T044** Implement SwiftUI `fileImporter` modifier on "Import Custom Server Certificate" with `.p12` UTType.
+- [x] **T045** Implement `ZipDocument: FileDocument` for the file exporter.
+- [x] **T046** Add "Route Received" `LocalNotificationManager` notification with body "Saved to Files → Meshtastic → TAK Routes. Open in iTAK to import."
+- [x] **T047** Primary channel warning section in `TAKServerConfig` when channel name conflicts with TAK chat-room semantics.
+
+---
+
+## Phase 3 — Reliability & Performance
+
+- [x] **T050** Hop off `@MainActor` on V2 receive: `Task.detached(priority: .utility)` in `handleATAKPluginV2Packet`.
+- [x] **T051** Add `MainActor.run` hop for `LocalNotificationManager` schedule in the detached task.
+- [x] **T052** Add `takBroadcastHopLimit(forDevice:)` with 3-hop fallback for V2 sends (avoid firmware silent drop on `hop_limit = 0`).
+- [x] **T053** Add TCP-layer keepalive on `NWListener` (`tcpOptions.enableKeepalive = true`, `keepaliveIdle = 60`).
+- [x] **T054** Add per-connection 10-second app-layer ping CoT keepalive in `TAKConnection.startKeepalive`.
+- [x] **T055** Add offline queue to `TAKServerManager` with `.message(CoTMessage)` and `.rawXml(String)` variants (50-cap, 5-min TTL).
+- [x] **T056** Add `drainOfflineQueue()` on `onClientConnected` callback.
+- [x] **T057** Add XML prologue + inter-tag whitespace strip on V2 receive (so SDK-emitted prologue doesn't tear down the TAK TCP parser mid-stream).
+
+---
+
+## Phase 4 — Cross-Repo Parity (this back-spec)
+
+- [x] **T060** Write `specs/010-tak-v2-protocol/spec.md`.
+- [x] **T061** Write `specs/010-tak-v2-protocol/plan.md`.
+- [x] **T062** Write `specs/010-tak-v2-protocol/data-model.md`.
+- [x] **T063** Write `specs/010-tak-v2-protocol/research.md`.
+- [x] **T064** Write `specs/010-tak-v2-protocol/contracts/wire-protocol.md`.
+- [x] **T065** Write `specs/010-tak-v2-protocol/quickstart.md`.
+- [x] **T066** Write `specs/010-tak-v2-protocol/tasks.md` (this file).
+- [x] **T067** Write `specs/010-tak-v2-protocol/checklists/requirements.md`.
+- [x] **T068** Write `specs/010-tak-v2-protocol/checklists/protocol.md`.
+
+---
+
+## Open Work — Parity Backlog
+
+These tasks are not yet shipped. They're items identified during the back-spec audit where Apple could match Android, or where the Apple surface has gaps worth closing.
+
+### Parity Gaps
+
+- [ ] **T080** Sync `MeshtasticProtobufs/Package.resolved` SDK pin (currently `0.2.2`) with `Meshtastic.xcworkspace/.../Package.resolved` (currently `0.2.3`). Track on next SDK bump.
+- [ ] **T081** Add an in-app TAK test runner (parallel to Android's `TakMeshTestRunner`). Show per-CoT-type send / receive byte sizes and round-trip success.
+- [ ] **T082** Add a shared cross-platform fixture suite (iOS + Android both consume the same CoT XML fixtures from the SDK repo) for V2 wire-format parity tests.
+- [ ] **T083** Document the `MeshtasticProtobufs` Swift Package's role in the Apple build (it's separate from `MeshtasticTAK`, and that's not obvious from the file layout).
+
+### UX Polish
+
+- [ ] **T090** Surface a Local Network permission explanation when the server starts and no clients connect within N seconds (current UX requires the user to discover Settings → Local Network on their own).
+- [ ] **T091** Add suppression / coalescing for "Route Received" notifications when multiple routes arrive in quick succession.
+- [ ] **T092** Add an Apple-side equivalent of the Android primary-channel warning when the user's `takServerChannel` selection conflicts with a non-TAK channel.
+- [ ] **T093** Surface SDK version in Settings → About so users can see the wire-protocol version their app is on.
+
+### Reliability
+
+- [ ] **T100** Add a unit test asserting that V2 receive doesn't block `@MainActor` for more than 50ms on a 200-waypoint route fixture.
+- [ ] **T101** Add a unit test asserting that `compressWithRemarksFallback` returning `nil` produces `AccessoryError.ioFailed` (not a silent drop).
+- [ ] **T102** Add an integration test exercising the offline queue across a simulated disconnect/reconnect cycle.
+- [ ] **T103** Add a metric (or `Logger.tak.info` line) tracking V2 send / receive byte sizes per CoT type for field debugging.
+
+### V1 ATAK_FORWARDER Sunset Planning (No Action Yet)
+
+- [ ] **T110** Document an end-of-life plan for V1 ATAK_FORWARDER (port 257) once firmware ≤ 2.7.x deployment drops below a defined threshold. No work yet — preserve indefinitely.
+- [ ] **T111** Add deprecation telemetry: count V1 ATAK_FORWARDER send/receive events to inform the EOL decision.
+- [ ] **T112** Verify (or refute) wire-format interop with [paulmandal/atak-forwarder](https://github.com/paulmandal/atak-forwarder)'s `libcotshrink` encoding. `EXICodec.swift`'s header comment claims "for Android interoperability" but there's no automated test asserting bidirectional decode against a known-good `libcotshrink` fixture. Either confirm and document the interop guarantee, or downgrade the assertion to "Apple-to-Apple only" once and for all.
+
+### Cross-Platform Protocol Evolution
+
+- [ ] **T120** When the SDK adds a new CoT type, mirror the Android `tasks.md` change here (in `tasks.md` and `data-model.md`).
+- [ ] **T121** When the SDK changes its dictionary set (e.g., adds a third dictionary for a new payload class), update `contracts/wire-protocol.md` flags-byte table on both sides.
+- [ ] **T122** Set up a Renovate / Dependabot rule (or manual checklist) so the Apple SDK pin is bumped in the same release window as the Android coord. (Android already has its Renovate setup; mirror in `.github/renovate.json` here.)
+
+---
+
+## Out-of-Scope
+
+These were considered and explicitly deferred. Not on the backlog above.
+
+- ❌ Port the Android `KMP TAK module` directly to Apple (rejected — Apple is single-target Swift; KMP would introduce massive build complexity for one shared module).
+- ❌ Backport V1 ATAK_FORWARDER to Android (rejected — significant Kotlin codegen, no production demand, increases Android binary size for a sunset path).
+- ❌ Replace `Network.framework` with a third-party Swift TLS library (e.g., NIOSSL) (rejected — `Network.framework` is the Apple-recommended modern API and ships with the platform).
+- ❌ Implement a TAK Server with mission sync / federation / enterprise features (out of scope; same as Android).
+- ❌ Build a standalone in-app TAK client UI (out of scope; iTAK / ATAK remain the clients).
+- ❌ Move TAK logic to a separate Swift Package within the workspace (current single-target layout works; modularization is a separate refactor concern).


### PR DESCRIPTION
Introduce a complete back-spec for the TAK v2 integration on Apple: adds wire protocol contract, data model, spec, quickstart, research, plan, tasks, and verification checklists. Documents port assignments (72/78/257), V2 zstd flags and MTU handling, V1 ATAK_PLUGIN/ATAK_FORWARDER behavior, TAK server lifecycle (NWListener/TLS/keepalive), offline-queue rules, filename/XML sanitization, and cross-platform interop caveats. Intended as a retroactive, cross-repo parity reference for reviewers and implementers.


