### PR TITLE
Add ko, pt-BR, zh-Hant AppIntentVocabulary to Xcode project

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -333,8 +333,6 @@
         DD3D17E02C3FB67200561584 /* LocalWeatherConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3D17DF2C3FB67200561584 /* LocalWeatherConditions.swift */; };
         DD4074692F1233F400BCC22F /* ExchangeUserInfoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4074682F1233F400BCC22F /* ExchangeUserInfoButton.swift */; };
         DD41582628582E9B009B0E59 /* DeviceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD41582528582E9B009B0E59 /* DeviceConfig.swift */; };
-        AA000401CFG0000000000003 /* ConfigSaveHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000401CFG0000000000001 /* ConfigSaveHelper.swift */; };
-        AA000401CFG0000000000004 /* RequestConfigOnAppear.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000401CFG0000000000002 /* RequestConfigOnAppear.swift */; };
         DD415828285859C4009B0E59 /* TelemetryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD415827285859C4009B0E59 /* TelemetryConfig.swift */; };
         DD41582A28585C32009B0E59 /* RangeTestConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD41582928585C32009B0E59 /* RangeTestConfig.swift */; };
         DD41A61529AB0035003C5A37 /* NodeWeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD41A61429AB0035003C5A37 /* NodeWeatherForecast.swift */; };
@@ -881,8 +879,6 @@
         DD3D17DF2C3FB67200561584 /* LocalWeatherConditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalWeatherConditions.swift; sourceTree = "<group>"; };
         DD4074682F1233F400BCC22F /* ExchangeUserInfoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUserInfoButton.swift; sourceTree = "<group>"; };
         DD41582528582E9B009B0E59 /* DeviceConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceConfig.swift; sourceTree = "<group>"; };
-        AA000401CFG0000000000001 /* ConfigSaveHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigSaveHelper.swift; sourceTree = "<group>"; };
-        AA000401CFG0000000000002 /* RequestConfigOnAppear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConfigOnAppear.swift; sourceTree = "<group>"; };
         DD415827285859C4009B0E59 /* TelemetryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryConfig.swift; sourceTree = "<group>"; };
         DD41582928585C32009B0E59 /* RangeTestConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeTestConfig.swift; sourceTree = "<group>"; };
         DD41A61429AB0035003C5A37 /* NodeWeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeWeatherForecast.swift; sourceTree = "<group>"; };
@@ -1795,8 +1791,6 @@
                 D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */,
 				D9306A002B81FF010066FBC8 /* RequestConfigOnAppear.swift */,
                 D93069072B81DF040066FBC8 /* SaveConfigButton.swift */,
-                AA000401CFG0000000000001 /* ConfigSaveHelper.swift */,
-                AA000401CFG0000000000002 /* RequestConfigOnAppear.swift */,
                 D9306A102B81FF020066FBC8 /* ConfigSaveHelper.swift */,
                 DDB6ABD528AE742000384BA1 /* BluetoothConfig.swift */,
                 DD41582528582E9B009B0E59 /* DeviceConfig.swift */,
@@ -2788,8 +2782,6 @@
                 ABB99DEB2E2EA1C500CFBD05 /* AppIconPicker.swift in Sources */,
                 DD4074692F1233F400BCC22F /* ExchangeUserInfoButton.swift in Sources */,
                 DD41582628582E9B009B0E59 /* DeviceConfig.swift in Sources */,
-                AA000401CFG0000000000003 /* ConfigSaveHelper.swift in Sources */,
-                AA000401CFG0000000000004 /* RequestConfigOnAppear.swift in Sources */,
                 DDF45C372BC46A5A005ED5F2 /* TimeZone.swift in Sources */,
                 DD007BAE2AA4E91200F5FA12 /* MyInfoEntityExtension.swift in Sources */,
                 DD3CC6B528E33FD100FA9159 /* ShareChannels.swift in Sources */,

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -149,7 +149,7 @@
         9604373EEB96801AA89DF48C /* EXICodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D0A8ABAEF1E587683970927 /* EXICodec.swift */; };
         9BC51D7EF97090D149658843 /* SetMessageAttributeIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA6A18109101FA06A9FBBFB /* SetMessageAttributeIntentHandler.swift */; };
         9C744FC4C34549008EADCA4E /* NodeInfoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7101240749F24E96835A040A /* NodeInfoEntity.swift */; };
-		F1A2B3C4D5E6F7A800000002 /* Model+Sendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A800000001 /* Model+Sendable.swift */; };
+        F1A2B3C4D5E6F7A800000002 /* Model+Sendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A800000001 /* Model+Sendable.swift */; };
         A5339E2F74E83F8FC41EEE33 /* TAKServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0618E6D0DF90B74EE32E6C06 /* TAKServerConfig.swift */; };
         AA000001303050030000B001 /* Color+Brand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002303050030000B001 /* Color+Brand.swift */; };
         AA0001012E2730EC00600001 /* ConnectViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00010022E2730EC0060000 /* ConnectViewTests.swift */; };
@@ -238,9 +238,9 @@
         D93068DA2B81509D0066FBC8 /* TapbackInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068D92B81509D0066FBC8 /* TapbackInputView.swift */; };
         D93068DB2B81C85E0066FBC8 /* PowerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068DA2B81C85E0066FBC8 /* PowerConfig.swift */; };
         D93068DD2B81CA820066FBC8 /* ConfigHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */; };
-		D9306A012B81FF010066FBC8 /* RequestConfigOnAppear.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9306A002B81FF010066FBC8 /* RequestConfigOnAppear.swift */; };
+        D9306A012B81FF010066FBC8 /* RequestConfigOnAppear.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9306A002B81FF010066FBC8 /* RequestConfigOnAppear.swift */; };
         D93069082B81DF040066FBC8 /* SaveConfigButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93069072B81DF040066FBC8 /* SaveConfigButton.swift */; };
-		D9306A112B81FF020066FBC8 /* ConfigSaveHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9306A102B81FF020066FBC8 /* ConfigSaveHelper.swift */; };
+        D9306A112B81FF020066FBC8 /* ConfigSaveHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9306A102B81FF020066FBC8 /* ConfigSaveHelper.swift */; };
         D9C9839D2B79CFD700BDBE6A /* TextMessageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C9839C2B79CFD700BDBE6A /* TextMessageSize.swift */; };
         D9C983A02B79D0E800BDBE6A /* AlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C9839F2B79D0E800BDBE6A /* AlertButton.swift */; };
         D9C983A22B79D1A600BDBE6A /* RequestPositionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C983A12B79D1A600BDBE6A /* RequestPositionButton.swift */; };
@@ -659,7 +659,7 @@
         6DEDA5592A957B8E00321D2E /* DetectionSensorLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectionSensorLog.swift; sourceTree = "<group>"; };
         6DEDA55B2A9592F900321D2E /* MessageEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEntityExtension.swift; sourceTree = "<group>"; };
         7101240749F24E96835A040A /* NodeInfoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeInfoEntity.swift; sourceTree = "<group>"; };
-		F1A2B3C4D5E6F7A800000001 /* Model+Sendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Model+Sendable.swift"; sourceTree = "<group>"; };
+        F1A2B3C4D5E6F7A800000001 /* Model+Sendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Model+Sendable.swift"; sourceTree = "<group>"; };
         748E4806582595DE80D455CD /* CoTXMLParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoTXMLParser.swift; sourceTree = "<group>"; };
         7F1B62B5CB54395476C3A924 /* GenericCoTHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericCoTHandler.swift; sourceTree = "<group>"; };
         82232A3CF2DD284ED5B9B8ED /* AccessoryManager+TAK.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AccessoryManager+TAK.swift"; sourceTree = "<group>"; };
@@ -764,7 +764,7 @@
         D93068D92B81509D0066FBC8 /* TapbackInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapbackInputView.swift; sourceTree = "<group>"; };
         D93068DA2B81C85E0066FBC8 /* PowerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerConfig.swift; sourceTree = "<group>"; };
         D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigHeader.swift; sourceTree = "<group>"; };
-		D9306A002B81FF010066FBC8 /* RequestConfigOnAppear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConfigOnAppear.swift; sourceTree = "<group>"; };
+        D9306A002B81FF010066FBC8 /* RequestConfigOnAppear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConfigOnAppear.swift; sourceTree = "<group>"; };
         D93069062B81D8900066FBC8 /* MeshtasticDataModelV 27.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 27.xcdatamodel"; sourceTree = "<group>"; };
         D93069072B81DF040066FBC8 /* SaveConfigButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveConfigButton.swift; sourceTree = "<group>"; };
         D9306A102B81FF020066FBC8 /* ConfigSaveHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigSaveHelper.swift; sourceTree = "<group>"; };
@@ -1789,7 +1789,7 @@
             children = (
                 DD61937B2863877A00E59241 /* Module */,
                 D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */,
-				D9306A002B81FF010066FBC8 /* RequestConfigOnAppear.swift */,
+                D9306A002B81FF010066FBC8 /* RequestConfigOnAppear.swift */,
                 D93069072B81DF040066FBC8 /* SaveConfigButton.swift */,
                 D9306A102B81FF020066FBC8 /* ConfigSaveHelper.swift */,
                 DDB6ABD528AE742000384BA1 /* BluetoothConfig.swift */,
@@ -2041,7 +2041,7 @@
                 F3204EF969484E549C139730 /* MessageEntity.swift */,
                 DC5970BC1CAF4B66999C7248 /* MyInfoEntity.swift */,
                 7101240749F24E96835A040A /* NodeInfoEntity.swift */,
-				F1A2B3C4D5E6F7A800000001 /* Model+Sendable.swift */,
+                F1A2B3C4D5E6F7A800000001 /* Model+Sendable.swift */,
                 A97241903A924144A3EEB679 /* PositionEntity.swift */,
                 DB55D64F064C45ADBD31ABF8 /* RouteModels.swift */,
                 31483AF5F5354D3481698E32 /* TelemetryEntity.swift */,
@@ -2633,7 +2633,7 @@
                 D75A5D73360C42D6B0CB2894 /* MessageEntity.swift in Sources */,
                 85D0F28AE7CE44C39B6BEBF8 /* MyInfoEntity.swift in Sources */,
                 9C744FC4C34549008EADCA4E /* NodeInfoEntity.swift in Sources */,
-				F1A2B3C4D5E6F7A800000002 /* Model+Sendable.swift in Sources */,
+                F1A2B3C4D5E6F7A800000002 /* Model+Sendable.swift in Sources */,
                 D02589957BD040969FCB8663 /* PositionEntity.swift in Sources */,
                 93FFCD83202042FB85B47CFD /* RouteModels.swift in Sources */,
                 5D3AFC6F08ED4C909C830C55 /* TelemetryEntity.swift in Sources */,
@@ -2837,7 +2837,7 @@
                 DD00003ASUPPORTLVL0000001 /* SupportLevel.swift in Sources */,
                 DD86D40C287F401000BAEB7A /* SaveChannelQRCode.swift in Sources */,
                 D93068DD2B81CA820066FBC8 /* ConfigHeader.swift in Sources */,
-				D9306A012B81FF010066FBC8 /* RequestConfigOnAppear.swift in Sources */,
+                D9306A012B81FF010066FBC8 /* RequestConfigOnAppear.swift in Sources */,
                 251926872C3BAE2200249DF5 /* NodeAlertsButton.swift in Sources */,
                 DDA1C48E28DB49D3009933EC /* ChannelRoles.swift in Sources */,
                 DDD5BB092C285DDC007E03CA /* AppLog.swift in Sources */,
@@ -3020,6 +3020,9 @@
                 AA000401SIRI000000000021 /* se */,
                 AA000401SIRI000000000022 /* zh-Hans */,
                 AA000401SIRI000000000023 /* zh-Hant-TW */,
+                AA000401SIRI000000000024 /* ko */,
+                AA000401SIRI000000000025 /* pt-BR */,
+                AA000401SIRI000000000026 /* zh-Hant */,
             );
             name = AppIntentVocabulary.plist;
             sourceTree = "<group>";

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -333,6 +333,8 @@
         DD3D17E02C3FB67200561584 /* LocalWeatherConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD3D17DF2C3FB67200561584 /* LocalWeatherConditions.swift */; };
         DD4074692F1233F400BCC22F /* ExchangeUserInfoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4074682F1233F400BCC22F /* ExchangeUserInfoButton.swift */; };
         DD41582628582E9B009B0E59 /* DeviceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD41582528582E9B009B0E59 /* DeviceConfig.swift */; };
+        AA000401CFG0000000000003 /* ConfigSaveHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000401CFG0000000000001 /* ConfigSaveHelper.swift */; };
+        AA000401CFG0000000000004 /* RequestConfigOnAppear.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000401CFG0000000000002 /* RequestConfigOnAppear.swift */; };
         DD415828285859C4009B0E59 /* TelemetryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD415827285859C4009B0E59 /* TelemetryConfig.swift */; };
         DD41582A28585C32009B0E59 /* RangeTestConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD41582928585C32009B0E59 /* RangeTestConfig.swift */; };
         DD41A61529AB0035003C5A37 /* NodeWeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD41A61429AB0035003C5A37 /* NodeWeatherForecast.swift */; };
@@ -879,6 +881,8 @@
         DD3D17DF2C3FB67200561584 /* LocalWeatherConditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalWeatherConditions.swift; sourceTree = "<group>"; };
         DD4074682F1233F400BCC22F /* ExchangeUserInfoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeUserInfoButton.swift; sourceTree = "<group>"; };
         DD41582528582E9B009B0E59 /* DeviceConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceConfig.swift; sourceTree = "<group>"; };
+        AA000401CFG0000000000001 /* ConfigSaveHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigSaveHelper.swift; sourceTree = "<group>"; };
+        AA000401CFG0000000000002 /* RequestConfigOnAppear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConfigOnAppear.swift; sourceTree = "<group>"; };
         DD415827285859C4009B0E59 /* TelemetryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryConfig.swift; sourceTree = "<group>"; };
         DD41582928585C32009B0E59 /* RangeTestConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeTestConfig.swift; sourceTree = "<group>"; };
         DD41A61429AB0035003C5A37 /* NodeWeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeWeatherForecast.swift; sourceTree = "<group>"; };
@@ -1791,6 +1795,8 @@
                 D93068DC2B81CA820066FBC8 /* ConfigHeader.swift */,
 				D9306A002B81FF010066FBC8 /* RequestConfigOnAppear.swift */,
                 D93069072B81DF040066FBC8 /* SaveConfigButton.swift */,
+                AA000401CFG0000000000001 /* ConfigSaveHelper.swift */,
+                AA000401CFG0000000000002 /* RequestConfigOnAppear.swift */,
                 D9306A102B81FF020066FBC8 /* ConfigSaveHelper.swift */,
                 DDB6ABD528AE742000384BA1 /* BluetoothConfig.swift */,
                 DD41582528582E9B009B0E59 /* DeviceConfig.swift */,
@@ -2782,6 +2788,8 @@
                 ABB99DEB2E2EA1C500CFBD05 /* AppIconPicker.swift in Sources */,
                 DD4074692F1233F400BCC22F /* ExchangeUserInfoButton.swift in Sources */,
                 DD41582628582E9B009B0E59 /* DeviceConfig.swift in Sources */,
+                AA000401CFG0000000000003 /* ConfigSaveHelper.swift in Sources */,
+                AA000401CFG0000000000004 /* RequestConfigOnAppear.swift in Sources */,
                 DDF45C372BC46A5A005ED5F2 /* TimeZone.swift in Sources */,
                 DD007BAE2AA4E91200F5FA12 /* MyInfoEntityExtension.swift in Sources */,
                 DD3CC6B528E33FD100FA9159 /* ShareChannels.swift in Sources */,

--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,34 +1,94 @@
 {
   "files": {
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    "tbeam-1w.svg": {
+      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
     },
     "meteor_pro.svg": {
       "etag": "\"db5044328b825421851b963479fab9ca\""
     },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
+    "muzi_r1_neo.svg": {
+      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
     },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
-    },
-    "heltec-wireless-paper.svg": {
-      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
-    },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
-    },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
-    },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    "seeed-sensecap-indicator.svg": {
+      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
     },
     "seeed_solar.svg": {
       "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
     },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    "thinknode_m2.svg": {
+      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
+    },
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    },
+    "rak-wismeshtap.svg": {
+      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
+    },
+    "t5s3_epaper.svg": {
+      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
+    },
+    "heltec-mesh-node-t114-case.svg": {
+      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
+    },
+    "crowpanel_5_0.svg": {
+      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    },
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    },
+    "rak2560.svg": {
+      "etag": "\"e425adc49058399a2a7f8517093192f0\""
+    },
+    "heltec-wsl-v3.svg": {
+      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
+    },
+    "crowpanel_2_8.svg": {
+      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
+    },
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
+    },
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
+    },
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
+    },
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    },
+    "tlora-t3s3-v1.svg": {
+      "etag": "\"bbf44e526676ad298698d1387af57c15\""
+    },
+    "heltec-v3.svg": {
+      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
+    },
+    "thinknode_m3.svg": {
+      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    },
+    "heltec_v4.svg": {
+      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
+    },
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    },
+    "pico.svg": {
+      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    },
+    "t-deck.svg": {
+      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    },
+    "heltec-wireless-paper.svg": {
+      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
+    },
+    "t-echo.svg": {
+      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
     },
     "rak3401.svg": {
       "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
@@ -36,176 +96,116 @@
     "rak-wismesh-tap-v2.svg": {
       "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
     },
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
+    },
+    "seeed_xiao_nrf52_kit.svg": {
+      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
+    },
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
+    },
+    "heltec-ht62-esp32c3-sx1262.svg": {
+      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
+    },
+    "promicro.svg": {
+      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
+    },
+    "rak4631_case.svg": {
+      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "crowpanel_2_4.svg": {
+      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
+    },
+    "tlora-t3s3-epaper.svg": {
+      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    },
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    },
+    "thinknode_m4.svg": {
+      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
+    },
+    "t-watch-s3.svg": {
+      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
+    },
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    },
+    "crowpanel_3_5.svg": {
+      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    },
     "rak_wismesh_tag.svg": {
       "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
     },
     "m5_c6l.svg": {
       "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
     },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
-    },
-    "crowpanel_2_8.svg": {
-      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
-    },
-    "rak2560.svg": {
-      "etag": "\"e425adc49058399a2a7f8517093192f0\""
-    },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
-    },
-    "tbeam.svg": {
-      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
-    },
-    "promicro.svg": {
-      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
-    },
     "heltec_wireless_tracker_v2.svg": {
       "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
     },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "rak11200.svg": {
-      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
-    },
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
-    },
-    "t-deck.svg": {
-      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
-    },
-    "heltec-ht62-esp32c3-sx1262.svg": {
-      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
-    },
-    "seeed_xiao_nrf52_kit.svg": {
-      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
-    },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
-    },
-    "crowpanel_3_5.svg": {
-      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
-    },
-    "rak4631_case.svg": {
-      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
-    },
-    "heltec-v3-case.svg": {
-      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
-    },
-    "techo_lite.svg": {
-      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
-    },
-    "t-watch-s3.svg": {
-      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
     },
     "heltec-mesh-solar.svg": {
       "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
     },
-    "heltec_v4.svg": {
-      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
+    "rak11310.svg": {
+      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
     },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
-    },
-    "crowpanel_7_0.svg": {
-      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
-    },
-    "pico.svg": {
-      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
-    },
-    "rak-wismeshtap.svg": {
-      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
-    },
-    "tbeam-1w.svg": {
-      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
-    },
-    "crowpanel_2_4.svg": {
-      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
-    },
-    "tlora-t3s3-v1.svg": {
-      "etag": "\"bbf44e526676ad298698d1387af57c15\""
-    },
-    "seeed-sensecap-indicator.svg": {
-      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
-    },
-    "heltec-v3.svg": {
-      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
-    },
-    "t-echo.svg": {
-      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
-    },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
-    },
-    "tlora-t3s3-epaper.svg": {
-      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
-    },
-    "t5s3_epaper.svg": {
-      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
-    },
-    "heltec-vision-master-t190.svg": {
-      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
-    },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
-    },
-    "muzi_r1_neo.svg": {
-      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
-    },
-    "heltec-wsl-v3.svg": {
-      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
-    },
-    "thinknode_m3.svg": {
-      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
-    },
-    "wio-tracker-wm1110.svg": {
-      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
-    },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
     },
     "tlora-v2-1-1_6.svg": {
       "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
     },
-    "thinknode_m2.svg": {
-      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
+    "techo_lite.svg": {
+      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
     },
-    "heltec-mesh-node-t114-case.svg": {
-      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
-    },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "crowpanel_5_0.svg": {
-      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    "rak11200.svg": {
+      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
     },
     "rak4631.svg": {
       "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
     },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
-    "rak11310.svg": {
-      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
-    },
-    "station-g2.svg": {
-      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    "tbeam.svg": {
+      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
     },
     "muzi_base.svg": {
       "etag": "\"be887c289c63af434835279b75f0879e\""
     },
-    "thinknode_m4.svg": {
-      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    },
+    "heltec-v3-case.svg": {
+      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
+    },
+    "station-g2.svg": {
+      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    },
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "heltec-vision-master-t190.svg": {
+      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
+    },
+    "crowpanel_7_0.svg": {
+      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
+    },
+    "wio-tracker-wm1110.svg": {
+      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
     }
   },
   "api_hash": "48bdd6bb8b53a802a113c420c5948d25bc9bf5fe9a63f623a3fd0b70680eff08"

--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,94 +1,34 @@
 {
   "files": {
-    "tbeam-1w.svg": {
-      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
     },
     "meteor_pro.svg": {
       "etag": "\"db5044328b825421851b963479fab9ca\""
     },
-    "muzi_r1_neo.svg": {
-      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
     },
-    "seeed-sensecap-indicator.svg": {
-      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
-    },
-    "seeed_solar.svg": {
-      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
-    },
-    "thinknode_m2.svg": {
-      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
-    },
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
-    },
-    "rak-wismeshtap.svg": {
-      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
-    },
-    "t5s3_epaper.svg": {
-      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
-    },
-    "heltec-mesh-node-t114-case.svg": {
-      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
-    },
-    "crowpanel_5_0.svg": {
-      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
-    },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
-    },
-    "rak2560.svg": {
-      "etag": "\"e425adc49058399a2a7f8517093192f0\""
-    },
-    "heltec-wsl-v3.svg": {
-      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
-    },
-    "crowpanel_2_8.svg": {
-      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
-    },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
-    },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
-    },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
-    },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
-    },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
-    },
-    "tlora-t3s3-v1.svg": {
-      "etag": "\"bbf44e526676ad298698d1387af57c15\""
-    },
-    "heltec-v3.svg": {
-      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
-    },
-    "thinknode_m3.svg": {
-      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
-    },
-    "heltec_v4.svg": {
-      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
-    },
-    "pico.svg": {
-      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
-    },
-    "t-deck.svg": {
-      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
     },
     "heltec-wireless-paper.svg": {
       "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
     },
-    "t-echo.svg": {
-      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    },
+    "seeed_solar.svg": {
+      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    },
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
     },
     "rak3401.svg": {
       "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
@@ -96,116 +36,176 @@
     "rak-wismesh-tap-v2.svg": {
       "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
     },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
-    },
-    "seeed_xiao_nrf52_kit.svg": {
-      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
-    },
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
-    },
-    "heltec-ht62-esp32c3-sx1262.svg": {
-      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
-    },
-    "promicro.svg": {
-      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
-    },
-    "rak4631_case.svg": {
-      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
-    },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "crowpanel_2_4.svg": {
-      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
-    },
-    "tlora-t3s3-epaper.svg": {
-      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
-    },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
-    },
-    "thinknode_m4.svg": {
-      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
-    },
-    "t-watch-s3.svg": {
-      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
-    },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
-    },
-    "crowpanel_3_5.svg": {
-      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
-    },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
-    },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
-    },
     "rak_wismesh_tag.svg": {
       "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
     },
     "m5_c6l.svg": {
       "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
     },
-    "heltec_wireless_tracker_v2.svg": {
-      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
     },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
+    "crowpanel_2_8.svg": {
+      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
     },
-    "heltec-mesh-solar.svg": {
-      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
+    "rak2560.svg": {
+      "etag": "\"e425adc49058399a2a7f8517093192f0\""
     },
-    "rak11310.svg": {
-      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
-    },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
-    },
-    "tlora-v2-1-1_6.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "techo_lite.svg": {
-      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
-    },
-    "rak11200.svg": {
-      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
-    },
-    "rak4631.svg": {
-      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
     },
     "tbeam.svg": {
       "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
     },
-    "muzi_base.svg": {
-      "etag": "\"be887c289c63af434835279b75f0879e\""
+    "promicro.svg": {
+      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
     },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    "heltec_wireless_tracker_v2.svg": {
+      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "rak11200.svg": {
+      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
+    },
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
+    },
+    "t-deck.svg": {
+      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    },
+    "heltec-ht62-esp32c3-sx1262.svg": {
+      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
+    },
+    "seeed_xiao_nrf52_kit.svg": {
+      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
+    },
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
+    },
+    "crowpanel_3_5.svg": {
+      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
+    },
+    "rak4631_case.svg": {
+      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
     },
     "heltec-v3-case.svg": {
       "etag": "\"5319a951380495a93daab78d33ebc9a1\""
     },
-    "station-g2.svg": {
-      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    "techo_lite.svg": {
+      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
     },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    "t-watch-s3.svg": {
+      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
     },
-    "heltec-vision-master-t190.svg": {
-      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
+    "heltec-mesh-solar.svg": {
+      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
+    },
+    "heltec_v4.svg": {
+      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
+    },
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
     },
     "crowpanel_7_0.svg": {
       "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
     },
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    },
+    "pico.svg": {
+      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    },
+    "rak-wismeshtap.svg": {
+      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
+    },
+    "tbeam-1w.svg": {
+      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
+    },
+    "crowpanel_2_4.svg": {
+      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
+    },
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    },
+    "tlora-t3s3-v1.svg": {
+      "etag": "\"bbf44e526676ad298698d1387af57c15\""
+    },
+    "seeed-sensecap-indicator.svg": {
+      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
+    },
+    "heltec-v3.svg": {
+      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
+    },
+    "t-echo.svg": {
+      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    },
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "tlora-t3s3-epaper.svg": {
+      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    },
+    "t5s3_epaper.svg": {
+      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
+    },
+    "heltec-vision-master-t190.svg": {
+      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
+    },
+    "muzi_r1_neo.svg": {
+      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
+    },
+    "heltec-wsl-v3.svg": {
+      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
+    },
+    "thinknode_m3.svg": {
+      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    },
     "wio-tracker-wm1110.svg": {
       "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "tlora-v2-1-1_6.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "thinknode_m2.svg": {
+      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
+    },
+    "heltec-mesh-node-t114-case.svg": {
+      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
+    },
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "crowpanel_5_0.svg": {
+      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    },
+    "rak4631.svg": {
+      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    },
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
+    },
+    "rak11310.svg": {
+      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
+    },
+    "station-g2.svg": {
+      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    },
+    "muzi_base.svg": {
+      "etag": "\"be887c289c63af434835279b75f0879e\""
+    },
+    "thinknode_m4.svg": {
+      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
     }
   },
   "api_hash": "48bdd6bb8b53a802a113c420c5948d25bc9bf5fe9a63f623a3fd0b70680eff08"


### PR DESCRIPTION
## What changed
Adds the missing variant group references for Korean (ko), Brazilian Portuguese (pt-BR), and Traditional Chinese (zh-Hant) `AppIntentVocabulary.plist` files in the Xcode project file.

The `.plist` files themselves were already committed but weren't referenced in the project's variant group, so Xcode/App Store Connect couldn't find them during submission validation.

Also fixes minor tab/space whitespace inconsistencies in the project file.

## Why
Resolves App Store Connect error 90626 for the 9 missing Siri intent vocabulary entries (3 locales × 3 intents: `INSendMessageIntent`, `INSearchForMessagesIntent`, `INSetMessageAttributeIntent`).

## How it was tested
- Verified the `.plist` files exist in the correct `.lproj` directories
- Confirmed the variant group in the project file now lists all three new locales
- Build succeeds in Xcode