### PR TITLE
Fix dSYM upload: npm path fallback and install verification

### DIFF
--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -38,7 +38,23 @@ fi
 
 # Install datadog-ci if not already present
 if ! command -v datadog-ci >/dev/null 2>&1; then
-	npm install -g @datadog/datadog-ci
+	echo "datadog-ci not found, installing..."
+	if command -v npm >/dev/null 2>&1; then
+		npm install -g @datadog/datadog-ci
+	elif command -v brew >/dev/null 2>&1; then
+		brew install datadog/datadog-ci/datadog-ci
+	else
+		echo "ERROR: Neither npm nor brew found — cannot install datadog-ci."
+		exit 1
+	fi
+fi
+
+# Verify installation succeeded
+if ! command -v datadog-ci >/dev/null 2>&1; then
+	echo "ERROR: datadog-ci still not found after install attempt."
+	echo "npm global bin: $(npm bin -g 2>/dev/null || echo 'unknown')"
+	echo "PATH: $PATH"
+	exit 1
 fi
 
 # Upload dSYMs


### PR DESCRIPTION
## What changed
The post-build script was silently failing with exit 127 (command not found) on Xcode Cloud after `npm install -g @datadog/datadog-ci`.

Root cause is one of:
- `npm` is not in PATH in the Xcode Cloud `/bin/sh` environment
- `npm install -g` succeeded but the global bin directory is not in PATH, so `datadog-ci` is still not found when called

## Changes
- Log which installer is being used
- Fall back to `brew install datadog/datadog-ci/datadog-ci` if npm is absent (Homebrew is always available in Xcode Cloud)
- Exit 1 immediately if neither npm nor brew is available  
- **Verify datadog-ci is actually in PATH after install** and exit 1 if not, printing `PATH` and npm global bin dir for diagnosis on the next attempt

## How to test
Next Xcode Cloud archive build will show exactly which install path was taken and whether it succeeded.