### PR TITLE
Fix launch-time MQTT SIGABRT: upgrade CocoaMQTT 2.1.9 → 2.2.3, add 1 s startup delay

### DIFF
--- a/Meshtastic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Meshtastic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/emqx/CocoaMQTT",
       "state" : {
-        "revision" : "22b98acc75bdca77917a1093bd3e1b45ef6e9718",
-        "version" : "2.1.9"
+        "revision" : "7ad043c42b91944958bc81f8694eba1fde55ff0d",
+        "version" : "2.2.3"
       }
     },
     {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
@@ -28,6 +28,9 @@ extension AccessoryManager {
 			if fetchedNodeInfo.count == 1 {
 				// Subscribe to Mqtt Client Proxy if enabled
 				if fetchedNodeInfo[0].mqttConfig != nil && fetchedNodeInfo[0].mqttConfig?.enabled ?? false && fetchedNodeInfo[0].mqttConfig?.proxyToClientEnabled ?? false {
+					// Brief delay so CFNetwork callbacks don't fire before the app is fully
+					// initialised — prevents a launch-time SIGABRT in CocoaMQTT's stream parser.
+					try? await Task.sleep(for: .seconds(1))
 					mqttManager.connectFromConfigSettings(node: fetchedNodeInfo[0])
 				} else {
 					if mqttProxyConnected {


### PR DESCRIPTION
## What changed
Fixes the SIGABRT launch crash (Datadog issue `6536c396`, 1,412 events, first seen v2.7.7) that fires at `time_since_app_start = 0` via `CFNetwork → CocoaMQTT stream parser → Swift preconditionFailure`.

### 1. CocoaMQTT 2.1.9 → 2.2.3
Key upstream fixes included:
- **2.2.0**: `ConcurrentAtomic` data-race fix; thread-safe property access; reconnect regression fixes
- **2.2.2**: **"Fix malformed PUBLISH parsing and handle protocol errors safely"** — directly addresses the precondition failure in the stream parser
- **2.2.3**: Additional hardening and Swift 6 core compile check

### 2. 1-second startup delay before `connectFromConfigSettings`
CocoaMQTT's `autoReconnect = true` causes `connect()` to immediately trigger CFNetwork callbacks (e.g. retained-message delivery from the broker). These arrived before the app's run loop and SwiftUI actor context were fully settled, causing the crash. The 1 s `Task.sleep` ensures the app is stable before any incoming MQTT frames are processed.

## Why it changed
The crash has existed since v2.7.7 (4+ months, multiple releases) because CocoaMQTT was never updated and `autoReconnect` fired synchronously during app init.

## How it was tested
- Code review; crash is not reproducible deterministically in a local simulator
- Datadog will confirm via reduced SIGABRT rate after next release

## Screenshots
N/A — internal crash fix, no UI change