### PR TITLE
Use npx to run datadog-ci, drop global npm install

### DIFF
--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -36,24 +36,10 @@ if [ -z "$DATADOG_API_KEY" ]; then
 	exit 0
 fi
 
-# Install datadog-ci if not already present
-if ! command -v datadog-ci >/dev/null 2>&1; then
-	echo "datadog-ci not found, installing via npm..."
-	npm install -g @datadog/datadog-ci
-fi
-
-# Verify installation succeeded
-if ! command -v datadog-ci >/dev/null 2>&1; then
-	echo "ERROR: datadog-ci still not found after install attempt."
-	echo "npm global bin: $(npm bin -g 2>/dev/null || echo 'unknown')"
-	echo "PATH: $PATH"
-	exit 1
-fi
-
 # Upload dSYMs
 export DATADOG_SITE="us5.datadoghq.com"
 echo "Uploading dSYMs to Datadog ($DATADOG_SITE)..."
-datadog-ci dsyms upload "$DSYM_DIR"
+npx --yes @datadog/datadog-ci dsyms upload "$DSYM_DIR"
 UPLOAD_EXIT=$?
 
 if [ $UPLOAD_EXIT -ne 0 ]; then


### PR DESCRIPTION
Replaces the `npm install -g` approach with `npx --yes @datadog/datadog-ci`. Xcode Cloud has `npx` available via Node but `npm` is not in the default PATH. Using `npx` requires no install step and no PATH manipulation.