### PR TITLE
Use standalone datadog-ci binary in Xcode Cloud

### DIFF
--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -36,10 +36,49 @@ if [ -z "$DATADOG_API_KEY" ]; then
 	exit 0
 fi
 
+# Install datadog-ci if not already present.
+if ! command -v datadog-ci >/dev/null 2>&1; then
+	ARCH=$(uname -m)
+	case "$ARCH" in
+		arm64|aarch64)
+			DATADOG_CI_ARCH="darwin-arm64"
+			;;
+		x86_64)
+			DATADOG_CI_ARCH="darwin-x64"
+			;;
+		*)
+			echo "ERROR: Unsupported macOS architecture: $ARCH"
+			exit 1
+			;;
+	esac
+
+	DATADOG_CI_BIN_DIR="${TMPDIR:-/tmp}/datadog-ci-bin"
+	DATADOG_CI_BIN="$DATADOG_CI_BIN_DIR/datadog-ci"
+	DATADOG_CI_VERSION="v5.17.0"
+	DATADOG_CI_URL="https://github.com/DataDog/datadog-ci/releases/download/$DATADOG_CI_VERSION/datadog-ci_$DATADOG_CI_ARCH"
+
+	echo "datadog-ci not found, downloading standalone binary for $DATADOG_CI_ARCH..."
+	mkdir -p "$DATADOG_CI_BIN_DIR"
+	if ! curl -L --fail "$DATADOG_CI_URL" --output "$DATADOG_CI_BIN"; then
+		echo "ERROR: Failed to download datadog-ci from $DATADOG_CI_URL"
+		exit 1
+	fi
+	chmod +x "$DATADOG_CI_BIN"
+	PATH="$DATADOG_CI_BIN_DIR:$PATH"
+	export PATH
+fi
+
+# Verify installation succeeded
+if ! command -v datadog-ci >/dev/null 2>&1; then
+	echo "ERROR: datadog-ci still not found after install attempt."
+	echo "PATH: $PATH"
+	exit 1
+fi
+
 # Upload dSYMs
 export DATADOG_SITE="us5.datadoghq.com"
 echo "Uploading dSYMs to Datadog ($DATADOG_SITE)..."
-npx --yes @datadog/datadog-ci dsyms upload "$DSYM_DIR"
+datadog-ci dsyms upload "$DSYM_DIR"
 UPLOAD_EXIT=$?
 
 if [ $UPLOAD_EXIT -ne 0 ]; then


### PR DESCRIPTION
Replaces the current npx-based dSYM upload path with Datadog's standalone macOS binary. This avoids the missing npm/npx commands seen in Xcode Cloud and also avoids the Homebrew tap access requirement. The script detects arm64 vs x64 with uname -m, downloads a pinned datadog-ci binary release, adds it to PATH for the current job, verifies it is available, and uploads dSYMs as before.