### PR TITLE
Avoid live SwiftData sample row in App Settings

### DIFF
--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -258,37 +258,210 @@ struct AppSettings: View {
 struct BuildTestNode: View {
 	@Environment(\.modelContext) private var context
 	@Binding var nodeListDensity: NodeListDensity
+	@State private var previewNode: BuildTestNodeSnapshot?
 	
 	init(nodeListDensity: Binding<NodeListDensity>) {
 		self._nodeListDensity = nodeListDensity
 	}
 
-	private var exampleNode: NodeInfoEntity? {
+	var body: some View {
+		VStack {
+			if let previewNode {
+				switch nodeListDensity {
+				case .standard:
+					BuildTestNodeStandardRow(node: previewNode)
+				case .compact:
+					BuildTestNodeCompactRow(node: previewNode)
+				}
+			}
+		}
+		.task {
+			loadPreviewNode()
+		}
+	}
+
+	@MainActor
+	private func loadPreviewNode() {
 		var descriptor = FetchDescriptor<NodeInfoEntity>(
 			sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)]
 		)
 		descriptor.fetchLimit = 1
-		return try? context.fetch(descriptor).first
+		guard let exampleNode = try? context.fetch(descriptor).first else {
+			previewNode = nil
+			return
+		}
+		previewNode = BuildTestNodeSnapshot(node: exampleNode)
 	}
+}
+
+private struct BuildTestNodeSnapshot {
+	let shortName: String
+	let longName: String
+	let isFavorite: Bool
+	let isOnline: Bool
+	let lastHeardText: String
+	let roleName: String
+	let roleSystemName: String
+	let isUnmonitored: Bool
+	let isStoreForwardRouter: Bool
+	let viaMqtt: Bool
+	let channel: Int
+	let hopsAway: Int
+	let snr: Float
+	let keyStatusImage: String
+	let keyStatusColor: Color
+
+	init(node: NodeInfoEntity) {
+		let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
+		shortName = node.user?.shortName ?? "?"
+		longName = node.user?.longName?.addingVariationSelectors ?? "Unknown".localized
+		isFavorite = node.favorite
+		isOnline = node.isOnline
+		lastHeardText = node.lastHeard?.formatted(date: .numeric, time: .shortened) ?? "Unknown Age".localized
+		roleName = role?.name ?? "Unknown".localized
+		roleSystemName = role?.systemName ?? "figure"
+		isUnmonitored = node.user?.unmessagable ?? false
+		isStoreForwardRouter = node.storeForwardConfig?.isRouter ?? false
+		viaMqtt = node.viaMqtt
+		channel = Int(node.channel)
+		hopsAway = Int(node.hopsAway)
+		snr = node.snr
+
+		if node.user?.pkiEncrypted ?? false {
+			if node.user?.keyMatch ?? false {
+				keyStatusImage = "lock.fill"
+				keyStatusColor = .green
+			} else {
+				keyStatusImage = "key.slash"
+				keyStatusColor = .red
+			}
+		} else {
+			keyStatusImage = "lock.open.fill"
+			keyStatusColor = .yellow
+		}
+	}
+}
+
+private struct BuildTestNodeStandardRow: View {
+	let node: BuildTestNodeSnapshot
+	private var modemPreset: ModemPresets { ModemPresets(rawValue: UserDefaults.modemPreset) ?? .longFast }
 
 	var body: some View {
-		VStack {
-			if let exampleNode {
-				switch nodeListDensity {
-				case .standard:
-					NodeListItem(
-						node: exampleNode,
-						isDirectlyConnected: true,
-						connectedNode: 0,
-					)
-				case .compact:
-					NodeListItemCompact(
-						node: exampleNode,
-						isDirectlyConnected: true,
-						connectedNode: 0
-					)
+		LazyVStack(alignment: .leading) {
+			HStack {
+				VStack(alignment: .center) {
+					CircleText(text: node.shortName, color: Color(UIColor(hex: 0x76A5AF)), circleSize: 70)
+						.padding(.trailing, 5)
+				}
+				VStack(alignment: .leading) {
+					HStack {
+						IconAndText(systemName: node.keyStatusImage,
+									imageColor: node.keyStatusColor,
+									text: node.longName,
+									textColor: .primary)
+						if node.isFavorite {
+							Spacer()
+							Image(systemName: "star.fill")
+								.symbolRenderingMode(.multicolor)
+						}
+					}
+					IconAndText(systemName: "antenna.radiowaves.left.and.right.circle.fill",
+								imageColor: .green,
+								text: "Connected".localized)
+					IconAndText(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
+								imageColor: node.isOnline ? .green : .orange,
+								text: node.lastHeardText)
+					IconAndText(systemName: node.roleSystemName,
+								text: "Role: \(node.roleName)")
+					if node.isUnmonitored {
+						IconAndText(systemName: "iphone.slash",
+									renderingMode: .multicolor,
+									text: "Unmonitored")
+					}
+					if node.isStoreForwardRouter {
+						IconAndText(systemName: "envelope.arrow.triangle.branch",
+									renderingMode: .multicolor,
+									text: "Store & Forward".localized)
+					}
+					HStack {
+						if node.channel > 0 {
+							IconAndText(systemName: "\(node.channel).circle.fill", text: "Channel")
+						}
+						if node.viaMqtt {
+							IconAndText(systemName: "dot.radiowaves.up.forward",
+										renderingMode: .multicolor,
+										text: "MQTT")
+						}
+					}
+					if node.hopsAway > 0 {
+						HStack {
+							IconAndText(systemName: "hare", text: "Hops Away:")
+							Image(systemName: "\(node.hopsAway).square")
+								.font(.title2)
+						}
+					} else if node.snr != 0 && !node.viaMqtt {
+						LoRaSignalStrengthMeter(snr: node.snr, rssi: 0, preset: modemPreset, compact: true)
+							.padding(.top, 15)
+					}
 				}
 			}
 		}
+	}
+}
+
+private struct BuildTestNodeCompactRow: View {
+	let node: BuildTestNodeSnapshot
+
+	var body: some View {
+		LazyVStack(alignment: .leading) {
+			HStack {
+				VStack(alignment: .center) {
+					CircleText(text: node.shortName, color: Color(UIColor(hex: 0x76A5AF)), circleSize: 42)
+						.padding(.trailing, 5)
+				}
+				VStack(alignment: .leading, spacing: 2) {
+					HStack(alignment: .firstTextBaseline) {
+						IconAndText(systemName: node.keyStatusImage,
+									imageColor: node.keyStatusColor,
+									text: node.longName,
+									textColor: .primary)
+						if node.isFavorite {
+							Spacer()
+							Image(systemName: "star.fill")
+								.symbolRenderingMode(.multicolor)
+						}
+					}
+					IconAndText(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
+								imageColor: node.isOnline ? .green : .orange,
+								text: node.lastHeardText)
+					HStack(alignment: .center, spacing: 6) {
+						if node.hopsAway > 0 {
+							DefaultIconCompact(systemName: "\(node.hopsAway).square")
+						} else if node.snr != 0 && !node.viaMqtt {
+							DefaultIconCompact(systemName: "dot.radiowaves.left.and.right")
+						}
+						if node.channel > 0 {
+							Divider().frame(height: 15)
+							DefaultIconCompact(systemName: "\(node.channel).circle.fill")
+						}
+						Divider().frame(height: 15)
+						DefaultIconCompact(systemName: node.roleSystemName)
+						if node.isUnmonitored {
+							DefaultIconCompact(systemName: "iphone.slash")
+						}
+						if node.isStoreForwardRouter {
+							DefaultIconCompact(systemName: "envelope.arrow.triangle.branch")
+						}
+						if node.viaMqtt {
+							DefaultIconCompact(systemName: "dot.radiowaves.up.forward")
+						}
+					}
+					.padding(EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 0))
+				}
+				.frame(maxWidth: .infinity, alignment: .leading)
+			}
+		}
+		.padding(.top, 2)
+		.padding(.bottom, 2)
 	}
 }


### PR DESCRIPTION
## Summary
- detach the App Settings sample node row from live SwiftData entities
- snapshot only the fields needed for the preview row
- render lightweight preview rows instead of full SwiftData-backed node list views

## Testing
- get_errors on Meshtastic/Views/Settings/AppSettings.swift