### PR TITLE
Reduce nested NavigationStacks in filter sheets

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -2,7 +2,7 @@
 	"servers": {
 		"datadog": {
 			"type": "http",
-			"url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+			"url": "https://mcp.us5.datadoghq.com/api/unstable/mcp-server/mcp"
 		}
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/Metrics Columns/MetricsColumnDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Metrics Columns/MetricsColumnDetail.swift
@@ -25,73 +25,71 @@ struct MetricsColumnDetail: View {
 	@State private var selectedView: ViewOption = .chart
 	
 	var body: some View {
-		NavigationStack {
-			Form {
-				Section {
-					Picker("", selection: $selectedView) {
-						ForEach(ViewOption.allCases) { option in
-							Text(option.rawValue)
-								.tag(option)
-						}
-					}
-					.pickerStyle(.segmented)
-				}.listRowBackground(Color.clear)
-				
-				switch selectedView {
-				case .chart:
-					ForEach(seriesList) { series in
-						HStack {
-							Path { path in
-								path.move(to: CGPoint(x: 10, y: 0))
-								path.addLine(to: CGPoint(x: 10, y: 20))
-							}
-							.stroke(series.foregroundStyle(0.0...100.0) ?? AnyShapeStyle(.clear),
-									style: series.strokeStyle)
-							.frame(width: 20.0, height: 20.0)
-							.rotationEffect(.degrees(90.0))
-							Text(series.name)
-							Spacer()
-							if series.visible {
-								Image(systemName: "checkmark")
-									.foregroundColor(.blue)
-							}
-						}.contentShape(Rectangle())  // Ensures the entire row is tappable
-							.onTapGesture {
-								seriesList.toggleVisibity(for: series)
-							}
-					}
-				case .table:
-					ForEach(columnList.columns) { column in
-						HStack {
-							Text(column.name)
-							Spacer()
-							if column.visible {
-								Image(systemName: "checkmark")
-									.foregroundColor(.blue)
-							}
-						}.contentShape(Rectangle())  // Ensures the entire row is tappable
-							.onTapGesture {
-								columnList.objectWillChange.send()
-								columnList.toggleVisibity(for: column)
-							}
+		Form {
+			Section {
+				Picker("", selection: $selectedView) {
+					ForEach(ViewOption.allCases) { option in
+						Text(option.rawValue)
+							.tag(option)
 					}
 				}
+				.pickerStyle(.segmented)
+			}.listRowBackground(Color.clear)
+			
+			switch selectedView {
+			case .chart:
+				ForEach(seriesList) { series in
+					HStack {
+						Path { path in
+							path.move(to: CGPoint(x: 10, y: 0))
+							path.addLine(to: CGPoint(x: 10, y: 20))
+						}
+						.stroke(series.foregroundStyle(0.0...100.0) ?? AnyShapeStyle(.clear),
+								style: series.strokeStyle)
+						.frame(width: 20.0, height: 20.0)
+						.rotationEffect(.degrees(90.0))
+						Text(series.name)
+						Spacer()
+						if series.visible {
+							Image(systemName: "checkmark")
+								.foregroundColor(.blue)
+						}
+					}.contentShape(Rectangle())  // Ensures the entire row is tappable
+						.onTapGesture {
+							seriesList.toggleVisibity(for: series)
+						}
+				}
+			case .table:
+				ForEach(columnList.columns) { column in
+					HStack {
+						Text(column.name)
+						Spacer()
+						if column.visible {
+							Image(systemName: "checkmark")
+								.foregroundColor(.blue)
+						}
+					}.contentShape(Rectangle())  // Ensures the entire row is tappable
+						.onTapGesture {
+							columnList.objectWillChange.send()
+							columnList.toggleVisibity(for: column)
+						}
+				}
 			}
-			.listStyle(.insetGrouped)
-			.listSectionSpacing(12)
-#if targetEnvironment(macCatalyst)
-			Spacer()
-			Button {
-				dismiss()
-			} label: {
-				Label("Close", systemImage: "xmark")
-			}
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding(.bottom)
-#endif
 		}
+		.listStyle(.insetGrouped)
+		.listSectionSpacing(12)
+#if targetEnvironment(macCatalyst)
+		Spacer()
+		Button {
+			dismiss()
+		} label: {
+			Label("Close", systemImage: "xmark")
+		}
+		.buttonStyle(.bordered)
+		.buttonBorderShape(.capsule)
+		.controlSize(.large)
+		.padding(.bottom)
+#endif
 		.presentationDetents([.medium, .large], selection: $currentDetent)
 		.presentationContentInteraction(.scrolls)
 		.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Nodes/Helpers/NodeListFilter.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListFilter.swift
@@ -28,97 +28,95 @@ struct NodeListFilter: View {
 	
 	var body: some View {
 
-		NavigationStack {
-			Form {
-				Section(header: Text(filterTitle)) {
-					Toggle(isOn: $filters.viaLora) {
+		Form {
+			Section(header: Text(filterTitle)) {
+				Toggle(isOn: $filters.viaLora) {
+
+					Label {
+						Text("Via Lora")
+					} icon: {
+						Image(systemName: "dot.radiowaves.left.and.right")
+							.rotationEffect(.degrees(-90))
+							.symbolRenderingMode(.multicolor)
+					}
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+				Toggle(isOn: $filters.viaMqtt) {
+
+					Label {
+						Text("Via Mqtt")
+					} icon: {
+						Image(systemName: "dot.radiowaves.up.forward")
+							.symbolRenderingMode(.multicolor)
+					}
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+				.listRowSeparator(.visible)
+
+				Toggle(isOn: $filters.isOnline) {
+
+					Label {
+						Text("Online")
+					} icon: {
+						Image(systemName: "checkmark.circle.fill")
+							.foregroundColor(.green)
+							.symbolRenderingMode(.hierarchical)
+					}
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+				.listRowSeparator(.visible)
+
+				Toggle(isOn: $filters.isPkiEncrypted) {
+
+					Label {
+						Text("Encrypted")
+					} icon: {
+						Image(systemName: "lock.fill")
+							.foregroundColor(.green)
+							.symbolRenderingMode(.hierarchical)
+					}
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+				.listRowSeparator(.visible)
+
+				Toggle(isOn: $filters.isFavorite) {
+
+					Label {
+						Text("Favorites")
+					} icon: {
+
+						Image(systemName: "star.fill")
+							.symbolRenderingMode(.multicolor)
+					}
+				}
+				.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+				.listRowSeparator(.visible)
+
+				if filterTitle == "Node Filters" {
+					Toggle(isOn: $filters.isIgnored) {
 
 						Label {
-							Text("Via Lora")
+							Text("Ignored")
 						} icon: {
-							Image(systemName: "dot.radiowaves.left.and.right")
-								.rotationEffect(.degrees(-90))
+
+							Image(systemName: "minus.circle.fill")
 								.symbolRenderingMode(.multicolor)
-						}
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					Toggle(isOn: $filters.viaMqtt) {
-
-						Label {
-							Text("Via Mqtt")
-						} icon: {
-							Image(systemName: "dot.radiowaves.up.forward")
-								.symbolRenderingMode(.multicolor)
-						}
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					.listRowSeparator(.visible)
-
-					Toggle(isOn: $filters.isOnline) {
-
-						Label {
-							Text("Online")
-						} icon: {
-							Image(systemName: "checkmark.circle.fill")
-								.foregroundColor(.green)
-								.symbolRenderingMode(.hierarchical)
-						}
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					.listRowSeparator(.visible)
-
-					Toggle(isOn: $filters.isPkiEncrypted) {
-
-						Label {
-							Text("Encrypted")
-						} icon: {
-							Image(systemName: "lock.fill")
-								.foregroundColor(.green)
-								.symbolRenderingMode(.hierarchical)
-						}
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					.listRowSeparator(.visible)
-
-					Toggle(isOn: $filters.isFavorite) {
-
-						Label {
-							Text("Favorites")
-						} icon: {
-
-							Image(systemName: "star.fill")
-								.symbolRenderingMode(.multicolor)
-						}
-					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					.listRowSeparator(.visible)
-
-					if filterTitle == "Node Filters" {
-						Toggle(isOn: $filters.isIgnored) {
-
-							Label {
-								Text("Ignored")
-							} icon: {
-
-								Image(systemName: "minus.circle.fill")
-									.symbolRenderingMode(.multicolor)
-							}
 						}
 						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 						.listRowSeparator(.visible)
 
-						Toggle(isOn: $filters.isEnvironment) {
-							Label {
-								Text("Environment")
-							} icon: {
-								Image(systemName: "cloud.sun")
-									.symbolRenderingMode(.multicolor)
-							}
+					Toggle(isOn: $filters.isEnvironment) {
+						Label {
+							Text("Environment")
+						} icon: {
+							Image(systemName: "cloud.sun")
+								.symbolRenderingMode(.multicolor)
 						}
-						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-						.listRowSeparator(.visible)
 					}
-					Toggle(isOn: $filters.distanceFilter) {
+					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+					.listRowSeparator(.visible)
+					}
+				Toggle(isOn: $filters.distanceFilter) {
 						Label {
 							Text("Distance")
 						} icon: {
@@ -177,36 +175,35 @@ struct NodeListFilter: View {
 						}
 					}
 					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					if filters.roleFilter {
-						VStack {
-							List(DeviceRoles.allCases, selection: $filters.deviceRoles) { dr in
-								Label {
-									Text("\(dr.name)")
-								} icon: {
-									Image(systemName: dr.systemName)
-								}
+				if filters.roleFilter {
+					VStack {
+						List(DeviceRoles.allCases, selection: $filters.deviceRoles) { dr in
+							Label {
+								Text("\(dr.name)")
+							} icon: {
+								Image(systemName: dr.systemName)
 							}
-							.listStyle(.plain)
-							.environment(\.editMode, $editMode) /// bind it here!
-							.frame(minHeight: 510, maxHeight: .infinity)
 						}
+						.listStyle(.plain)
+						.environment(\.editMode, $editMode) /// bind it here!
+						.frame(minHeight: 510, maxHeight: .infinity)
 					}
 				}
 			}
-			.listStyle(.insetGrouped)
-#if targetEnvironment(macCatalyst)
-			Spacer()
-			Button {
-				dismiss()
-			} label: {
-				Label("Close", systemImage: "xmark")
-			}
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding(.bottom)
-#endif
 		}
+		.listStyle(.insetGrouped)
+#if targetEnvironment(macCatalyst)
+		Spacer()
+		Button {
+			dismiss()
+		} label: {
+			Label("Close", systemImage: "xmark")
+		}
+		.buttonStyle(.bordered)
+		.buttonBorderShape(.capsule)
+		.controlSize(.large)
+		.padding(.bottom)
+#endif
 		.presentationDetents([.large])
 		.presentationContentInteraction(.scrolls)
 		.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Settings/Channels/ChannelForm.swift
+++ b/Meshtastic/Views/Settings/Channels/ChannelForm.swift
@@ -25,9 +25,8 @@ struct ChannelForm: View {
 	@Binding var supportedVersion: Bool
 
 	var body: some View {
-		NavigationStack {
-			Form {
-				Section(header: Text("Channel Details")) {
+		Form {
+			Section(header: Text("Channel Details")) {
 					HStack {
 						Text("Name")
 						Spacer()
@@ -181,71 +180,70 @@ struct ChannelForm: View {
 					}
 					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 				}
+		}
+		.onChange(of: channelName) {
+			hasChanges = true
+		}
+		.onChange(of: channelKeySize) {
+			if channelKeySize == -1 {
+				channelKey = "AQ=="
+			} else {
+				let key = generateChannelKey(size: channelKeySize)
+				channelKey = key
 			}
-			.onChange(of: channelName) {
-				hasChanges = true
+			hasChanges = true
+		}
+		.onChange(of: channelKey) {
+			hasChanges = true
+		}
+		.onChange(of: channelKeySize) {
+			if channelKeySize == -1 {
+				if channelRole == 0 {
+					preciseLocation = false
+				}
+				channelKey = "AQ=="
 			}
-			.onChange(of: channelKeySize) {
-				if channelKeySize == -1 {
-					channelKey = "AQ=="
+		}
+		.onChange(of: channelRole) {
+			hasChanges = true
+		}
+		.onChange(of: preciseLocation) { _, loc in
+			if loc == true {
+				if channelKey == "AQ==" || channelKeySize <= 1 {
+					preciseLocation = false
 				} else {
-					let key = generateChannelKey(size: channelKeySize)
-					channelKey = key
+					positionPrecision = 32
 				}
-				hasChanges = true
+			} else {
+				positionPrecision = 14
 			}
-			.onChange(of: channelKey) {
-				hasChanges = true
-			}
-			.onChange(of: channelKeySize) {
-				if channelKeySize == -1 {
-					if channelRole == 0 {
-						preciseLocation = false
-					}
-					channelKey = "AQ=="
+			hasChanges = true
+		}
+		.onChange(of: positionPrecision) {
+			hasChanges = true
+		}
+		.onChange(of: positionsEnabled) { _, pe in
+			if pe {
+				if positionPrecision == 0 {
+					positionPrecision = 15
 				}
+			} else {
+				positionPrecision = 0
 			}
-			.onChange(of: channelRole) {
-				hasChanges = true
-			}
-			.onChange(of: preciseLocation) { _, loc in
-				if loc == true {
-					if channelKey == "AQ==" || channelKeySize <= 1 {
-						preciseLocation = false
-					} else {
-						positionPrecision = 32
-					}
-				} else {
-					positionPrecision = 14
-				}
-				hasChanges = true
-			}
-			.onChange(of: positionPrecision) {
-				hasChanges = true
-			}
-			.onChange(of: positionsEnabled) { _, pe in
-				if pe {
-					if positionPrecision == 0 {
-						positionPrecision = 15
-					}
-				} else {
-					positionPrecision = 0
-				}
-				hasChanges = true
-			}
-			.onChange(of: uplink) {
-				hasChanges = true
-			}
-			.onChange(of: downlink) {
-				hasChanges = true
-			}
-			.onFirstAppear {
-				let tempKey = Data(base64Encoded: channelKey) ?? Data()
-				if tempKey.count == channelKeySize || channelKeySize == -1 {
-					hasValidKey = true
-				} else {
-					hasValidKey = false
-				}
+			hasChanges = true
+		}
+		.onChange(of: uplink) {
+			hasChanges = true
+		}
+		.onChange(of: downlink) {
+			hasChanges = true
+		}
+		.onFirstAppear {
+			let tempKey = Data(base64Encoded: channelKey) ?? Data()
+			if tempKey.count == channelKeySize || channelKeySize == -1 {
+				hasValidKey = true
+			} else {
+				hasValidKey = false
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Logs/AppLogFilter.swift
+++ b/Meshtastic/Views/Settings/Logs/AppLogFilter.swift
@@ -109,60 +109,58 @@ struct AppLogFilter: View {
 
 	var body: some View {
 
-		NavigationStack {
-			Form {
-				Section(header: HStack {
-					Text("Categories")
-					Spacer()
-					Button {
-						categories.formUnion(LogCategories.allCases.map(\.id))
-					} label: {
-						Text("All")
-					}
-				}) {
-					VStack {
-						List(LogCategories.allCases, selection: $categories) { cat in
-							Text(cat.description)
-						}
-						.listStyle(.plain)
-						.environment(\.editMode, $editMode) /// bind it here!
-						.frame(minHeight: 338, maxHeight: .infinity)
-					}
+		Form {
+			Section(header: HStack {
+				Text("Categories")
+				Spacer()
+				Button {
+					categories.formUnion(LogCategories.allCases.map(\.id))
+				} label: {
+					Text("All")
 				}
-				Section(header: HStack {
-					Text("Log Levels")
-					Spacer()
-					Button {
-						levels.formUnion(LogLevels.allCases.map(\.id))
-					} label: {
-						Text("All")
+			}) {
+				VStack {
+					List(LogCategories.allCases, selection: $categories) { cat in
+						Text(cat.description)
 					}
-				}) {
-					VStack {
-						List(LogLevels.allCases, selection: $levels) { level in
-							Text(level.description)
-								.foregroundStyle(level.color)
-						}
-						.listStyle(.plain)
-						.environment(\.editMode, $editMode) /// bind it here!
-						.frame(minHeight: 210, maxHeight: .infinity)
-					}
+					.listStyle(.plain)
+					.environment(\.editMode, $editMode) /// bind it here!
+					.frame(minHeight: 338, maxHeight: .infinity)
 				}
 			}
+			Section(header: HStack {
+				Text("Log Levels")
+				Spacer()
+				Button {
+					levels.formUnion(LogLevels.allCases.map(\.id))
+				} label: {
+					Text("All")
+				}
+			}) {
+				VStack {
+					List(LogLevels.allCases, selection: $levels) { level in
+						Text(level.description)
+							.foregroundStyle(level.color)
+					}
+					.listStyle(.plain)
+					.environment(\.editMode, $editMode) /// bind it here!
+					.frame(minHeight: 210, maxHeight: .infinity)
+				}
+			}
+		}
 
 #if targetEnvironment(macCatalyst)
-			Spacer()
-			Button {
-				dismiss()
-			} label: {
-				Label("Close", systemImage: "xmark")
-			}
-			.buttonStyle(.bordered)
-			.buttonBorderShape(.capsule)
-			.controlSize(.large)
-			.padding(.bottom)
-#endif
+		Spacer()
+		Button {
+			dismiss()
+		} label: {
+			Label("Close", systemImage: "xmark")
 		}
+		.buttonStyle(.bordered)
+		.buttonBorderShape(.capsule)
+		.controlSize(.large)
+		.padding(.bottom)
+#endif
 		.presentationDetents([.large], selection: $currentDetent)
 		.presentationContentInteraction(.scrolls)
 		.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Settings/RouteRecorder.swift
+++ b/Meshtastic/Views/Settings/RouteRecorder.swift
@@ -85,8 +85,7 @@ struct RouteRecorder: View {
 				.padding()
 			}
 			.sheet(isPresented: $isShowingDetails) {
-				NavigationStack {
-					VStack {
+				VStack {
 						if locationsHandler.isRecording {
 							HStack(alignment: .center) {
 								Image(systemName: "record.circle.fill")
@@ -280,7 +279,6 @@ struct RouteRecorder: View {
 
 						}
 					}
-				}
 				.presentationDetents([.fraction(0.45), .fraction(0.65)])
 				.presentationDragIndicator(.hidden)
 				.interactiveDismissDisabled(false)


### PR DESCRIPTION
## Summary
- remove the extra NavigationStack wrapper from NodeListFilter
- remove the extra NavigationStack wrapper from AppLogFilter
- point the local Datadog MCP config at the US5 endpoint

## Why
These sheets are already presented within higher-level navigation flows, so the extra stack is unnecessary and adds more hosting-controller churn on iOS 17.

## Testing
- validated the touched files report no editor errors
- verified the branch diff is limited to the three intended files