### PR TITLE
Fix CI: use standalone datadog-ci binary (npm unavailable in Xcode Cloud)

### DIFF
--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -24,9 +24,6 @@ echo "Found $DSYM_COUNT dSYM bundles in $DSYM_DIR"
 find "$DSYM_DIR" -name "*.dSYM" -type d | while read -r dsym; do
 	echo "  $dsym"
 done
-find "$DSYM_DIR" -name "*.dSYM" -type d | while read -r dsym; do
-	echo "  $dsym"
-done
 
 if [ "$DSYM_COUNT" -eq 0 ]; then
 	echo "No dSYM files to upload."
@@ -39,23 +36,49 @@ if [ -z "$DATADOG_API_KEY" ]; then
 	exit 0
 fi
 
-# Install datadog-ci if not already present
+# Install datadog-ci if not already present.
 if ! command -v datadog-ci >/dev/null 2>&1; then
-	npm install -g @datadog/datadog-ci
+	ARCH=$(uname -m)
+	case "$ARCH" in
+		arm64|aarch64)
+			DATADOG_CI_ARCH="darwin-arm64"
+			;;
+		x86_64)
+			DATADOG_CI_ARCH="darwin-x64"
+			;;
+		*)
+			echo "ERROR: Unsupported macOS architecture: $ARCH"
+			exit 1
+			;;
+	esac
+
+	DATADOG_CI_BIN_DIR="${TMPDIR:-/tmp}/datadog-ci-bin"
+	DATADOG_CI_BIN="$DATADOG_CI_BIN_DIR/datadog-ci"
+	DATADOG_CI_VERSION="v5.17.0"
+	DATADOG_CI_URL="https://github.com/DataDog/datadog-ci/releases/download/$DATADOG_CI_VERSION/datadog-ci_$DATADOG_CI_ARCH"
+
+	echo "datadog-ci not found, downloading standalone binary for $DATADOG_CI_ARCH..."
+	mkdir -p "$DATADOG_CI_BIN_DIR"
+	if ! curl -L --fail "$DATADOG_CI_URL" --output "$DATADOG_CI_BIN"; then
+		echo "ERROR: Failed to download datadog-ci from $DATADOG_CI_URL"
+		exit 1
+	fi
+	chmod +x "$DATADOG_CI_BIN"
+	PATH="$DATADOG_CI_BIN_DIR:$PATH"
+	export PATH
+fi
+
+# Verify installation succeeded
+if ! command -v datadog-ci >/dev/null 2>&1; then
+	echo "ERROR: datadog-ci still not found after install attempt."
+	echo "PATH: $PATH"
+	exit 1
 fi
 
 # Upload dSYMs
 export DATADOG_SITE="us5.datadoghq.com"
 echo "Uploading dSYMs to Datadog ($DATADOG_SITE)..."
 datadog-ci dsyms upload "$DSYM_DIR"
-UPLOAD_EXIT=$?
-
-if [ $UPLOAD_EXIT -ne 0 ]; then
-	echo "ERROR: dSYM upload failed with exit code $UPLOAD_EXIT"
-	exit $UPLOAD_EXIT
-fi
-
-echo "dSYM upload succeeded."
 UPLOAD_EXIT=$?
 
 if [ $UPLOAD_EXIT -ne 0 ]; then


### PR DESCRIPTION
## What changed

Replaces the `npm install -g @datadog/datadog-ci` approach with a direct download of the standalone `datadog-ci` binary from GitHub Releases.

## Why it changed

Xcode Cloud does not have `npm` installed, causing `ci_post_xcodebuild.sh` to fail with exit code 127 on every archive build.

## How it was tested

- Verified the download URL resolves for both `darwin-arm64` and `darwin-x64`
- Script includes architecture detection, download verification, and PATH update