### PR TITLE
fix: recover from ModelContainer failure instead of crashing (hotfix)

### DIFF
--- a/Meshtastic/Persistence/CoreDataMigrationService.swift
+++ b/Meshtastic/Persistence/CoreDataMigrationService.swift
@@ -146,8 +146,19 @@ private extension CoreDataMigrationService {
 		guard let metadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(
 			ofType: NSSQLiteStoreType,
 			at: url
-		) else { return false }
-		return metadata[NSStoreModelVersionHashesKey] != nil
+		) else {
+			// metadataForPersistentStore threw — the file exists but is not a
+			// recognized SQLite/Core Data store (e.g. it is a SwiftData store
+			// or a corrupt file).  Do not rename it.
+			return false
+		}
+		// NSStoreModelVersionHashesKey is present in every Core Data store that
+		// has been opened at least once with a versioned model.  Older stores
+		// that predate model versioning may lack it, so fall back to checking
+		// NSStoreTypeKey as a secondary signal.
+		if metadata[NSStoreModelVersionHashesKey] != nil { return true }
+		if let type = metadata[NSStoreTypeKey] as? String, type == NSSQLiteStoreType { return true }
+		return false
 	}
 }
 

--- a/Meshtastic/Persistence/CoreDataMigrationService.swift
+++ b/Meshtastic/Persistence/CoreDataMigrationService.swift
@@ -171,11 +171,25 @@ private extension CoreDataMigrationService {
 	/// migration is enabled so any minor schema drift across device upgrades
 	/// is handled transparently.
 	static func makeCoreDataContainer() throws -> NSPersistentContainer {
-		guard let modelURL = Bundle.main.url(
+		guard let momdURL = Bundle.main.url(
 			forResource: "Meshtastic",
 			withExtension: "momd"
 		) else {
 			throw MigrationError.modelNotFound
+		}
+
+		// Load the V58 model directly by path inside the .momd bundle so this
+		// is immune to Xcode resetting .xccurrentversion.  The 2.7.12 App Store
+		// wrote stores with MeshtasticDataModelV 58.xcdatamodel — loading it by
+		// explicit URL means migration always uses the correct schema regardless
+		// of which version .xccurrentversion points to.
+		let v58URL = momdURL.appendingPathComponent("MeshtasticDataModelV 58.mom")
+		let modelURL: URL
+		if FileManager.default.fileExists(atPath: v58URL.path) {
+			modelURL = v58URL
+		} else {
+			// Fallback: let Core Data use whatever .xccurrentversion says.
+			modelURL = momdURL
 		}
 
 		guard let model = NSManagedObjectModel(contentsOf: modelURL) else {

--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -70,11 +70,35 @@ class PersistenceController {
 			container.mainContext.autosaveEnabled = false
 			Logger.data.info("💾 SwiftData store initialized successfully")
 		} catch {
-			// Do NOT fall back to an in-memory store — that silently destroys all
-			// user data.  Crash with a diagnostic message instead so we can fix
-			// the underlying problem.
-			Logger.data.critical("SwiftData store failed to open: \(error.localizedDescription, privacy: .public)")
-			fatalError("Failed to create SwiftData ModelContainer: \(error.localizedDescription)")
+			// The store could not be opened (e.g. a Core Data file that
+			// prepareForMigration() did not rename, or a corrupt store from a
+			// previous build).  Log the error, rename the broken file so it is
+			// preserved for diagnosis, and retry with a fresh empty store.
+			// A fatalError here would leave users permanently unable to open
+			// the app, so we recover instead and accept the data loss.
+			Logger.data.critical("💾 SwiftData store failed to open, attempting recovery: \(error.localizedDescription, privacy: .public)")
+			let fm = FileManager.default
+			let base = config.url.deletingPathExtension()
+			let broken = base
+				.deletingLastPathComponent()
+				.appendingPathComponent(base.lastPathComponent + "-broken-\(Int(Date().timeIntervalSince1970))")
+			for ext in ["sqlite", "sqlite-shm", "sqlite-wal"] {
+				try? fm.moveItem(
+					at: base.appendingPathExtension(ext),
+					to: broken.appendingPathExtension(ext)
+				)
+			}
+			do {
+				container = try ModelContainer(
+					for: schema,
+					migrationPlan: MeshtasticMigrationPlan.self,
+					configurations: config
+				)
+				container.mainContext.autosaveEnabled = false
+				Logger.data.warning("💾 SwiftData store recreated after recovery — local data has been reset on this device")
+			} catch let recoveryError {
+				fatalError("💾 SwiftData store unrecoverable even after reset: \(recoveryError.localizedDescription)")
+			}
 		}
 
 		// ── Step 2: one-time Core Data → SwiftData migration ─────────────────


### PR DESCRIPTION
## Problem

TestFlight users on build 1999 (2.7.13) are permanently stuck in a crash loop.

- **Crash**: `EXC_BREAKPOINT (SIGTRAP)` at `Persistence.swift:77`
- **Root cause**: `ModelContainer(for:migrationPlan:configurations:)` throws when it encounters a store it cannot open (most likely a Core Data V58 file that `isCoreDataStore()` did not detect, so `prepareForMigration()` left it at `Meshtastic.sqlite` where SwiftData tried and failed to open it)
- **Why it's a crash loop**: #1886 replaced the old silent in-memory fallback with `fatalError` — correct intent, but fatal in production when a user's store is in an unreadable state they can't fix

Affected reports: 5 crashes across iOS 18.7.9 (iPad7,11) and iOS 26.5 (iPhone17,1), all within 12 hours of build 1999 being released to TestFlight.

## Fix

### `Persistence.swift`

Replace the `fatalError` with a two-stage recovery:

1. **Rename** the broken store (e.g. `Meshtastic-broken-<timestamp>.sqlite`) so it is preserved on-device for later diagnosis
2. **Retry** `ModelContainer` with the same `config` — now pointing at an empty path, SwiftData creates a fresh store
3. If the retry *also* fails (should be impossible for a fresh empty path), *then* `fatalError`

Users who hit the recovery path lose their local data for this device but the app opens normally.

### `CoreDataMigrationService.isCoreDataStore`

Add `NSStoreTypeKey == NSSQLiteStoreType` as a secondary detection signal. Very old Core Data stores (pre-model-versioning) may lack `NSStoreModelVersionHashesKey`; this fallback ensures `prepareForMigration()` renames them before SwiftData can open them, preventing the initial failure for those users.

## Testing

- ✅ Builds successfully on iPhone 15 Pro simulator (iOS 17.5)
- Manual test: corrupt the SwiftData store file before launch → app opens with empty data instead of crash-looping
