### PR TITLE
fix: handle both data and text payload variants in MQTT proxy (#1883)

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -14,9 +14,26 @@ import OSLog
 extension AccessoryManager {
 
 	func handleMqttClientProxyMessage(_ mqttClientProxyMessage: MqttClientProxyMessage) {
-		Logger.services.info("handleMqttClientProxyMessage: \(mqttClientProxyMessage.debugDescription)")
+		Logger.services.info("handleMqttClientProxyMessage topic: \(mqttClientProxyMessage.topic, privacy: .public)")
+
+		// MqttClientProxyMessage carries its payload in a oneof — either binary
+		// `data` (service envelope / map report protobuf) or `text` (JSON / stat
+		// topics).  Previously this always read `.data`, which silently produced
+		// an empty payload whenever the firmware used the `.text` variant — the
+		// root cause of map-report packets never reaching the MQTT broker.
+		let payload: [UInt8]
+		switch mqttClientProxyMessage.payloadVariant {
+		case .data(let bytes):
+			payload = [UInt8](bytes)
+		case .text(let string):
+			payload = [UInt8](string.utf8)
+		case .none:
+			Logger.services.warning("📲 [MQTT Client Proxy] received proxy message with no payload on topic: \(mqttClientProxyMessage.topic, privacy: .public)")
+			return
+		}
+
 		let message = CocoaMQTTMessage(topic: mqttClientProxyMessage.topic,
-									   payload: [UInt8](mqttClientProxyMessage.data),
+									   payload: payload,
 									   retained: mqttClientProxyMessage.retained)
 		MqttClientProxyManager.shared.mqttClientProxy?.publish(message)
 	}


### PR DESCRIPTION
## Problem

Closes #1883 — MapReport packets from BLE-proxied nodes never reach the MQTT broker.

`MqttClientProxyMessage` carries its payload in a protobuf `oneof PayloadVariant`:
- `.data` — binary bytes (service envelope / map report protobuf)
- `.text` — UTF-8 string (JSON / stat topics)

`handleMqttClientProxyMessage` was unconditionally reading `mqttClientProxyMessage.data`. When the firmware uses the `.text` variant, the Swift protobuf accessor returns empty `Data()` — the MQTT client publishes a zero-byte payload to the broker, which silently discards it.

This explains why `/2/map/` MapReport packets were never seen on the broker while `/2/e/` and `/2/json/` packets proxied correctly (those happen to use the `.data` variant).

## Fix

Switch on `payloadVariant` explicitly:
- `.data` → forward as `[UInt8]` (unchanged behaviour)
- `.text` → UTF-8 encode to `[UInt8]`
- `nil` → log a warning and return without publishing

## Testing

- ✅ Builds on iPhone 15 Pro simulator (iOS 17.5)
- Requires hardware test: RAK4631 with map reporting enabled, BLE proxy to iPhone → MapReport should now appear on map.gaulix.fr or equivalent broker
