### PR TITLE
Fix missing Siri intent vocabulary locales for ko, zh-Hant, pt-BR

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -706,6 +706,9 @@
         AA000401SIRI000000000021 /* se */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = se; path = se.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
         AA000401SIRI000000000022 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "zh-Hans"; path = "zh-Hans.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
         AA000401SIRI000000000023 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
+        AA000401SIRI000000000024 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = ko; path = ko.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
+        AA000401SIRI000000000025 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "zh-Hant"; path = "zh-Hant.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
+        AA000401SIRI000000000026 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "pt-BR"; path = "pt-BR.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
         AA0005WTCH00000000FR0001 /* MeshtasticWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshtasticWatchApp.swift; sourceTree = "<group>"; };
         AA0005WTCH00000000FR0002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
         AA0005WTCH00000000FR0003 /* MeshNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshNode.swift; sourceTree = "<group>"; };
@@ -3076,6 +3079,9 @@
                 AA000401SIRI000000000021 /* se */,
                 AA000401SIRI000000000022 /* zh-Hans */,
                 AA000401SIRI000000000023 /* zh-Hant-TW */,
+                AA000401SIRI000000000024 /* ko */,
+                AA000401SIRI000000000025 /* zh-Hant */,
+                AA000401SIRI000000000026 /* pt-BR */,
             );
             name = AppIntentVocabulary.plist;
             sourceTree = "<group>";


### PR DESCRIPTION
## What changed
Registered `ko`, `zh-Hant`, and `pt-BR` `AppIntentVocabulary.plist` files as variant group members in `project.pbxproj`.

## Why
The three `.plist` files existed on disk with correct example phrases for all three Siri intents (`INSendMessageIntent`, `INSearchForMessagesIntent`, `INSetMessageAttributeIntent`), but were not referenced in the Xcode project. Xcode never included them in the app bundle, causing App Store Connect to emit **ITMS-90626** warnings on every delivery since the locales were added.

## How it was tested
Verified the three `PBXFileReference` entries and `PBXVariantGroup` children are present and build cleanly. No logic changes — project file only.

## Checklist
- [x] No new warnings introduced
- [x] No user-visible UI changes
- [x] No SwiftData schema changes