### PR TITLE
Fix SwiftData #Predicate nil-relationship crashes on iOS 26 (2.7.13 TestFlight)

### DIFF
--- a/Meshtastic/AppState.swift
+++ b/Meshtastic/AppState.swift
@@ -33,18 +33,17 @@ class AppState: ObservableObject {
 	/// after any bulk read/delete operation to keep the badge in sync.
 	@MainActor
 	func refreshBadgeCount(context: ModelContext) {
-		let channelDescriptor = FetchDescriptor<MessageEntity>(
+		// NOTE: Comparing an optional relationship to nil in a #Predicate crashes SwiftData on
+		// iOS 26 (SIGTRAP / heap corruption from the @Query machinery). Fetch all unread messages
+		// and split channel vs DM in Swift — unread counts are small so this is inexpensive.
+		let unreadDescriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> { msg in
-				msg.toUser == nil && msg.isEmoji == false && msg.read == false
+				msg.isEmoji == false && msg.read == false
 			}
 		)
-		let dmDescriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> { msg in
-				msg.toUser != nil && msg.isEmoji == false && msg.read == false && msg.admin == false
-			}
-		)
-		let channelCount = (try? context.fetchCount(channelDescriptor)) ?? 0
-		let dmCount = (try? context.fetchCount(dmDescriptor)) ?? 0
+		let unread = (try? context.fetch(unreadDescriptor)) ?? []
+		let channelCount = unread.filter { $0.toUser == nil }.count
+		let dmCount = unread.filter { $0.toUser != nil && !$0.admin }.count
 		if unreadChannelMessages != channelCount {
 			unreadChannelMessages = channelCount
 		}

--- a/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
+++ b/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
@@ -420,12 +420,12 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 
 		let descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate { message in
-				message.read == false && message.toUser == nil
+				message.read == false
 			}
 		)
 		let results = (try? context.fetch(descriptor)) ?? []
 		var counts = [Int32: Int]()
-		for message in results where channelSet.contains(message.channel) {
+		for message in results where message.toUser == nil && channelSet.contains(message.channel) {
 			counts[message.channel, default: 0] += 1
 		}
 		return counts
@@ -511,14 +511,15 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 				message.read == false &&
 				message.admin == false &&
 				message.isEmoji == false &&
-				message.toUser == nil &&
 				message.channel == channelIndex
 			},
 			sortBy: [SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse)]
 		)
-		descriptor.fetchLimit = 1
+		// toUser == nil intentionally absent from predicate (crashes SwiftData on iOS 26).
+		// Fetch a small batch and pick the first channel message in Swift.
+		descriptor.fetchLimit = 5
 
-		guard let message = (try? context.fetch(descriptor))?.first,
+		guard let message = (try? context.fetch(descriptor))?.first(where: { $0.toUser == nil }),
 			  let fromUser = message.fromUser else { return }
 
 		postCommunicationNotification(

--- a/Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift
@@ -13,27 +13,32 @@ extension ChannelEntity {
 	var allPrivateMessages: [MessageEntity] {
 		let context = PersistenceController.shared.context
 		let channelIndex = self.index
+		// NOTE: toUser == nil is intentionally absent from the predicate — comparing an optional
+		// relationship to nil in a #Predicate crashes SwiftData on iOS 26. Filter in Swift instead.
 		var descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> { msg in
-				msg.channel == channelIndex && msg.toUser == nil && msg.isEmoji == false
+				msg.channel == channelIndex && msg.isEmoji == false
 			},
 			sortBy: [SortDescriptor(\.messageTimestamp, order: .forward)]
 		)
-		return (try? context.fetch(descriptor)) ?? []
+		let messages = (try? context.fetch(descriptor)) ?? []
+		return messages.filter { $0.toUser == nil }
 	}
 
 	@MainActor
 	var mostRecentPrivateMessage: MessageEntity? {
 		let context = PersistenceController.shared.context
 		let channelIndex = self.index
+		// Fetch a small batch and find the first channel message in Swift.
 		var descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> { msg in
-				msg.channel == channelIndex && msg.toUser == nil && msg.isEmoji == false
+				msg.channel == channelIndex && msg.isEmoji == false
 			},
 			sortBy: [SortDescriptor(\.messageTimestamp, order: .reverse)]
 		)
-		descriptor.fetchLimit = 1
-		return try? context.fetch(descriptor).first
+		descriptor.fetchLimit = 10
+		let batch = (try? context.fetch(descriptor)) ?? []
+		return batch.first { $0.toUser == nil }
 	}
 
 	@MainActor
@@ -41,10 +46,11 @@ extension ChannelEntity {
 		let channelIndex = self.index
 		let descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> { msg in
-				msg.channel == channelIndex && msg.toUser == nil && msg.isEmoji == false && msg.read == false
+				msg.channel == channelIndex && msg.isEmoji == false && msg.read == false
 			}
 		)
-		return (try? context.fetchCount(descriptor)) ?? 0
+		let messages = (try? context.fetch(descriptor)) ?? []
+		return messages.filter { $0.toUser == nil }.count
 	}
 
 	@MainActor

--- a/Meshtastic/Extensions/SwiftData/MyInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/MyInfoEntityExtension.swift
@@ -14,21 +14,23 @@ extension MyInfoEntity {
 		let context = PersistenceController.shared.context
 		let descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> { msg in
-				msg.toUser == nil && msg.isEmoji == false
+				msg.isEmoji == false
 			},
 			sortBy: [SortDescriptor(\MessageEntity.messageTimestamp, order: .forward)]
 		)
-		return (try? context.fetch(descriptor)) ?? []
+		let messages = (try? context.fetch(descriptor)) ?? []
+		return messages.filter { $0.toUser == nil }
 	}
 
 	@MainActor
 	func unreadMessages(context: ModelContext) -> Int {
 		let descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> { msg in
-				msg.toUser == nil && msg.isEmoji == false && msg.read == false
+				msg.isEmoji == false && msg.read == false
 			}
 		)
-		return (try? context.fetchCount(descriptor)) ?? 0
+		let messages = (try? context.fetch(descriptor)) ?? []
+		return messages.filter { $0.toUser == nil }.count
 	}
 
 	@MainActor

--- a/Meshtastic/MeshtasticAppDelegate.swift
+++ b/Meshtastic/MeshtasticAppDelegate.swift
@@ -70,11 +70,11 @@ class MeshtasticAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificat
 			} else if conversationId.hasPrefix("channel-"), let channelIndex = Int32(conversationId.replacingOccurrences(of: "channel-", with: "")) {
 				let descriptor = FetchDescriptor<MessageEntity>(
 					predicate: #Predicate { message in
-						message.read == false && message.toUser == nil && message.channel == channelIndex
+						message.read == false && message.channel == channelIndex
 					}
 				)
 				let messages = try context.fetch(descriptor)
-				for message in messages {
+				for message in messages where message.toUser == nil {
 					message.read = true
 				}
 			}

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -121,12 +121,12 @@ extension MeshPackets {
 		let channelIndex = channel.index
 		let descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> { msg in
-				msg.channel == channelIndex && msg.toUser == nil && msg.isEmoji == false
+				msg.channel == channelIndex && msg.isEmoji == false
 			}
 		)
 		do {
 			let objects = try modelContext.fetch(descriptor)
-			for object in objects {
+			for object in objects where object.toUser == nil {
 				modelContext.delete(object)
 			}
 			try modelContext.save()

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -27,16 +27,24 @@ struct ChannelMessageList: View {
 	@State private var tapbackTargetMessage: MessageEntity?
 	@State private var tapbackText = ""
 	@FocusState var tapbackFocused: Bool
-	@Query private var allPrivateMessages: [MessageEntity]
-	
+	/// All messages for this channel index, non-emoji. Does NOT include the toUser == nil
+	/// guard because comparing an optional relationship to nil in a #Predicate crashes
+	/// SwiftData on iOS 26. The channel-only filter is applied in the computed property below.
+	@Query private var allChannelMessages: [MessageEntity]
+
+	/// Channel (non-DM) messages only — filters out direct messages in Swift after the fetch.
+	private var allPrivateMessages: [MessageEntity] {
+		allChannelMessages.filter { $0.toUser == nil }
+	}
+
 	init(myInfo: MyInfoEntity, channel: ChannelEntity) {
 		self.myInfo = myInfo
 		self.channel = channel
 		
 		let channelIndex = channel.index
-		_allPrivateMessages = Query(
+		_allChannelMessages = Query(
 			filter: #Predicate<MessageEntity> {
-				$0.channel == channelIndex && $0.toUser == nil && $0.isEmoji == false
+				$0.channel == channelIndex && $0.isEmoji == false
 			},
 			sort: \MessageEntity.messageTimestamp
 		)


### PR DESCRIPTION
## What changed

Remove `toUser == nil` and `toUser != nil` from all SwiftData `#Predicate` filter clauses across 7 files, replacing them with Swift `.filter {}` / `where` post-filters on the fetched results.

**Files changed:**
- `Meshtastic/Views/Messages/ChannelMessageList.swift`
- `Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift`
- `Meshtastic/Extensions/SwiftData/MyInfoEntityExtension.swift`
- `Meshtastic/AppState.swift`
- `Meshtastic/MeshtasticAppDelegate.swift`
- `Meshtastic/CarPlay/CarPlaySceneDelegate.swift`
- `Meshtastic/Persistence/UpdateSwiftData.swift`

## Why it changed

SwiftData on iOS 26 crashes (SIGTRAP / heap-corruption SIGABRT) when a `#Predicate` compares an optional `@Relationship` property directly to `nil` (e.g. `$0.toUser == nil`). This is a regression in the SwiftData predicate compiler on iOS 26.

Datadog RUM identified 21 crashes in 2.7.13 TestFlight across two fingerprints:
- **75636A5D** (9 crashes) — SIGTRAP in `ChannelMessageList.allPrivateMessages` `@Query`
- **4684CE79** (12 crashes) — SIGABRT heap corruption from concurrent SwiftData access racing with the `@Query` refresh triggered by the nil-relationship predicate

The crash trace points directly to the macro-synthesised query file:
`@__swiftmacro_10Meshtastic18ChannelMessageListV18allPrivateMessages33_...LL5QueryfMa_.swift`

## How it was tested

- Verified no new SwiftLint errors introduced by the changes
- All existing compilation checks pass
- The two pre-existing SwiftLint body-length warnings in `CarPlaySceneDelegate` and `UpdateSwiftData` are unrelated to these changes

## Screenshots / videos

N/A — logic-only fix, no UI changes