### PR TITLE
Fix NodeDetail weather section pinning a CPU core (layout feedback loop)

### DIFF
--- a/Meshtastic/Views/Helpers/Weather/LocalWeatherConditions.swift
+++ b/Meshtastic/Views/Helpers/Weather/LocalWeatherConditions.swift
@@ -20,47 +20,41 @@ struct LocalWeatherConditions: View {
 	@State private var attributionLink: URL?
 	@State private var attributionLogo: URL?
 	@Environment(\.colorScheme) var colorScheme: ColorScheme
+	@Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
 	var body: some View {
 		if location != nil {
-			GeometryReader { geometry in
-				VStack(alignment: .center) {
-					// Determine the number of columns based on the screen width
-					let columns = geometry.size.width > 600 ? 4 : 2
-					let gridItemLayout = Array(repeating: GridItem(.flexible(), spacing: 20), count: columns)
+			VStack(alignment: .center) {
+				// Column count from the size class so this view sizes to its content. A root
+				// GeometryReader is greedy (reports no intrinsic height), which forced the parent
+				// to feed a measured height back in — a layout feedback loop that pinned the CPU.
+				let columns = horizontalSizeClass == .regular ? 4 : 2
+				let gridItemLayout = Array(repeating: GridItem(.flexible(), spacing: 20), count: columns)
 
-					LazyVGrid(columns: gridItemLayout) {
-						WeatherConditionsCompactWidget(temperature: temperature, symbolName: symbolName, description: condition?.description.uppercased() ?? "??")
-							.padding(.bottom, columns == 2 ? 10 : 0)
-						HumidityCompactWidget(humidity: humidity ?? 0, dewPoint: dewPoint)
-							.padding(.bottom, columns == 2 ? 10 : 0)
-						PressureCompactWidget(pressure: String(pressure?.value ?? 0.0 / 100), unit: pressure?.unit.symbol ?? "??", low: pressure?.value ?? 0.0 <= 1009.144)
-						WindCompactWidget(speed: windSpeed, gust: windGust, direction: windCompassDirection)
-					}
-					
-					HStack {
-						AsyncImage(url: attributionLogo) { image in
-							image
-								.resizable()
-								.scaledToFit()
-							    .frame(height: 10)
-						} placeholder: {
-							ProgressView()
-								.controlSize(.mini)
-						}
-						Link("Other data sources", destination: attributionLink ?? URL(string: "https://weather-data.apple.com/legal-attribution.html")!)
-							.font(.caption2)
-					}
-					.offset(y: -2)
-					.padding(.bottom, -15)
+				LazyVGrid(columns: gridItemLayout) {
+					WeatherConditionsCompactWidget(temperature: temperature, symbolName: symbolName, description: condition?.description.uppercased() ?? "??")
+						.padding(.bottom, columns == 2 ? 10 : 0)
+					HumidityCompactWidget(humidity: humidity ?? 0, dewPoint: dewPoint)
+						.padding(.bottom, columns == 2 ? 10 : 0)
+					PressureCompactWidget(pressure: String(pressure?.value ?? 0.0 / 100), unit: pressure?.unit.symbol ?? "??", low: pressure?.value ?? 0.0 <= 1009.144)
+					WindCompactWidget(speed: windSpeed, gust: windGust, direction: windCompassDirection)
 				}
-				.background(
-					// Use GeometryReader here to get the VGrid's height
-					GeometryReader { proxy in
-						// Set the preference key with the VGrid's height
-						Color.clear.preference(key: WeatherKitTilesHeightKey.self, value: proxy.size.height)
+				
+				HStack {
+					AsyncImage(url: attributionLogo) { image in
+						image
+							.resizable()
+							.scaledToFit()
+						    .frame(height: 10)
+					} placeholder: {
+						ProgressView()
+							.controlSize(.mini)
 					}
-				)
+					Link("Other data sources", destination: attributionLink ?? URL(string: "https://weather-data.apple.com/legal-attribution.html")!)
+						.font(.caption2)
+				}
+				.offset(y: -2)
+				.padding(.bottom, -15)
 			}
 			.task {
 				do {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -41,7 +41,6 @@ struct NodeDetail: View {
 	@State private var dateFormatRelative: Bool = true
 	@Bindable	var node: NodeInfoEntity
 	var showMapLink: Bool = true
-	@State private var environmentSectionHeight: CGFloat = 0
 	@State private var latestPosition: PositionEntity?
 	@State private var latestDeviceMetrics: TelemetryEntity?
 	@State private var latestEnvironmentMetrics: TelemetryEntity?
@@ -320,10 +319,6 @@ struct NodeDetail: View {
 				VStack(spacing: 0) {
 					if latestEnvironmentMetrics == nil {
 						LocalWeatherConditions(location: latestPosition?.nodeLocation)
-							.frame(height: environmentSectionHeight)
-							.onPreferenceChange(WeatherKitTilesHeightKey.self) { newHeight in
-								self.environmentSectionHeight = newHeight
-							}
 					} else if let metrics = latestEnvironmentMetrics {
 						VStack {
 							if metrics.iaq ?? -1 > 0 {

--- a/Meshtastic/Views/Nodes/Helpers/PreferenceKeys/TileHeightKeys.swift
+++ b/Meshtastic/Views/Nodes/Helpers/PreferenceKeys/TileHeightKeys.swift
@@ -7,15 +7,6 @@
 
 import SwiftUI
 
-struct WeatherKitTilesHeightKey: PreferenceKey {
-	static var defaultValue: CGFloat = 0
-	
-	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-		// This method combines values from multiple child views if needed
-		value = max(value, nextValue())
-	}
-}
-
 struct EnvironmentMetricsTilesHeightKey: PreferenceKey {
 	static var defaultValue: CGFloat = 0
 	


### PR DESCRIPTION
## Problem

Opening a node's detail with the WeatherKit tiles visible (node has a position, WeatherKit enabled, no live environment metrics) pins a CPU core at ~100% on Mac (and burns battery on iOS). A `sample` of the running Mac app showed the main thread re-running `NodeDetail.body` on **every display-link frame** via `CATransaction.commit → flushTransactions → render`.

## Root cause

A SwiftUI layout feedback loop in `NodeDetail`'s Environment section:

```swift
LocalWeatherConditions(location: …)
    .frame(height: environmentSectionHeight)            // applies measured height back
    .onPreferenceChange(WeatherKitTilesHeightKey.self) { environmentSectionHeight = $0 }  // measures it
```

`LocalWeatherConditions`' root was a greedy `GeometryReader` (no intrinsic height), so the parent fed a measured height back into the same view's `.frame(height:)`. Inner negative padding (`.padding(.bottom, -15)`) meant the measured height never equalled the applied frame, so it never reached a fixed point → re-render every frame.

Pre-existing since #1415; the recent per-render SwiftData fetches in `NodeDetail` (`connectedNode`/`hasLocalStats`) made each wasted frame costlier, so it now burns a full core.

## Fix

- **LocalWeatherConditions** sizes to its content: pick the column count from `horizontalSizeClass` instead of a root `GeometryReader`, and drop the height-reporting `.background(GeometryReader …)`.
- **NodeDetail**: remove the `.frame(height:)` / `onPreferenceChange` / `@State environmentSectionHeight` plumbing.
- Remove the now-unused `WeatherKitTilesHeightKey`.

## Testing

- Builds clean on **Mac Catalyst**.
- Diagnosed via `sample` of the live app (hot stack was `NodeDetail.body → environmentSection` lines 320–325 every frame). Empirical CPU re-check pending a run from Xcode on the node-detail screen — the loop is removed by construction (the view no longer consumes its own measurement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)