### PR TITLE
Ingestion perf: O(1) latest-position cache (kill per-packet PositionEntity scans)

### DIFF
--- a/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
@@ -14,6 +14,12 @@ extension NodeInfoEntity {
 	// These use FetchDescriptor with fetchLimit to avoid loading entire relationship arrays.
 
 	var latestPosition: PositionEntity? {
+		// Fast path: the ingest layer keeps this populated, so reads are O(1).
+		if let cached = latestPositionCache {
+			return cached
+		}
+		// Fallback for data created without the cache (migrated / restored / seeded): a sorted
+		// limit-1 query. Runs at most once per node until the cache warms on the next position.
 		guard let ctx = modelContext else { return nil }
 		let nodeNum = self.num
 		var descriptor = FetchDescriptor<PositionEntity>(

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -490,6 +490,7 @@ actor MeshPackets {
 						position.heading = Int32(nodeInfo.position.groundTrack)
 						position.time = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.position.time)))
 						position.nodePosition = newNode
+						newNode.latestPositionCache = position
 					}
 
 					// Look for a MyInfo

--- a/Meshtastic/Model/NodeInfoEntity.swift
+++ b/Meshtastic/Model/NodeInfoEntity.swift
@@ -81,6 +81,14 @@ final class NodeInfoEntity {
 	@Relationship(deleteRule: .nullify, inverse: \PositionEntity.nodePosition)
 	var positions: [PositionEntity] = []
 
+	/// O(1) cache of this node's current "latest" position, maintained on insert so the hot
+	/// position-ingest path never has to scan the (large, unindexed) PositionEntity table to
+	/// find/clear the previous latest. Read via the `latestPosition` accessor, which falls back
+	/// to a sorted query when this is nil (migrated/restored data). Unidirectional to-one;
+	/// nullified if the referenced position is deleted.
+	@Relationship(deleteRule: .nullify)
+	var latestPositionCache: PositionEntity?
+
 	@Relationship(deleteRule: .nullify, inverse: \PowerConfigEntity.powerConfigNode)
 	var powerConfig: PowerConfigEntity?
 

--- a/Meshtastic/Persistence/NodeBackupManager+Import.swift
+++ b/Meshtastic/Persistence/NodeBackupManager+Import.swift
@@ -151,6 +151,7 @@ extension NodeBackupManager {
 			dst.time = src.time
 			if let srcNode = src.nodePosition, let liveNode = nodesByNum[srcNode.num] {
 				dst.nodePosition = liveNode
+				if dst.latest { liveNode.latestPositionCache = dst }
 			}
 			liveContext.insert(dst)
 		}

--- a/Meshtastic/Persistence/PerformanceSeedData.swift
+++ b/Meshtastic/Persistence/PerformanceSeedData.swift
@@ -225,6 +225,7 @@ enum PerformanceSeedData {
 			position.speed = Int32(index % 45)
 			position.time = now.addingTimeInterval(TimeInterval(-(sample * 180 + index % 180)))
 			position.nodePosition = node
+			if position.latest { node.latestPositionCache = position }
 			context.insert(position)
 		}
 	}

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -554,15 +554,11 @@ extension MeshPackets {
 					}
 					if fetchedNode.count == 1 {
 						
-						// Unset the current latest position for this node
 						let posNum = Int64(packet.from)
-						let fetchCurrentLatestPositionsRequest = FetchDescriptor<PositionEntity>(predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum && $0.latest == true })
-						let fetchedPositions = try modelContext.fetch(fetchCurrentLatestPositionsRequest)
-						if fetchedPositions.count > 0 {
-							for position in fetchedPositions {
-								position.latest = false
-							}
-						}
+						// Previous latest is tracked directly on the node — no PositionEntity table scan.
+						let previousLatest = fetchedNode[0].latestPosition
+						previousLatest?.latest = false
+
 						let position = PositionEntity()
 						modelContext.insert(position)
 						position.latest = true
@@ -586,36 +582,25 @@ extension MeshPackets {
 							position.time = Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.time)))
 						}
 
-						// Deduplication: fetch only the most recent position for this node
-						// instead of loading the entire positions array (which could be thousands)
-						var mostRecentDescriptor = FetchDescriptor<PositionEntity>(
-							predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum },
-							sortBy: [SortDescriptor(\PositionEntity.time, order: .reverse)]
-						)
-						mostRecentDescriptor.fetchLimit = 1
-						let mostRecentPositions = try modelContext.fetch(mostRecentDescriptor)
+						// Assign to the node and record as the new latest — O(1), no table scan.
+						position.nodePosition = fetchedNode[0]
+						fetchedNode[0].latestPositionCache = position
 
 						if position.precisionBits == 32 || position.precisionBits == 0 {
-							// Don't save nearly the same position. If within 9m of most recent, replace it.
-							if let mostRecent = mostRecentPositions.first,
-							   let mostRecentCoord = mostRecent.nodeCoordinate,
-							   let positionCoord = position.nodeCoordinate,
-							   mostRecentCoord.distance(from: positionCoord) < 9.0 {
-								modelContext.delete(mostRecent)
+							// Full precision: drop a near-duplicate of the previous latest (within 9m).
+							if let previousLatest,
+								let prevCoord = previousLatest.nodeCoordinate,
+								let positionCoord = position.nodeCoordinate,
+								prevCoord.distance(from: positionCoord) < 9.0 {
+								modelContext.delete(previousLatest)
 							}
 						} else {
-							// Don't store any history for reduced accuracy positions — delete all non-latest
-							let deleteDescriptor = FetchDescriptor<PositionEntity>(
-								predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == posNum && $0.latest == false }
-							)
-							let oldPositions = try modelContext.fetch(deleteDescriptor)
-							for old in oldPositions {
+							// Reduced accuracy: keep no history. Delete this node's older positions via its own
+							// relationship (small for reduced-accuracy nodes) instead of a global table scan.
+							for old in fetchedNode[0].positions where !old.latest {
 								modelContext.delete(old)
 							}
 						}
-
-						// Assign position to node via relationship
-						position.nodePosition = fetchedNode[0]
 
 						// Keep the history cap as a soft cap during packet bursts; the
 						// count/sort/delete prune pass is expensive with large node stores.


### PR DESCRIPTION
## Summary

Position packets are ~34% of mesh traffic, and `upsertPositionPacket` did **2–3 full scans of the (large, unindexed) `PositionEntity` table per packet** — filtering on the `nodePosition?.num` relationship, which can't be indexed on the iOS 17.5 target (`#Index` is iOS 18+). As the store grows, each scan gets linearly slower, so ingestion throughput **degrades over time** and pegs the `@ModelActor`'s core. (Surfaced clearly under accelerated packet replay: the app keeps up early, then falls behind as the node/position DB fills.)

This replaces the scans with an **O(1) direct reference**.

## Changes

- **`NodeInfoEntity.latestPositionCache`** — new unidirectional to-one relationship (`.nullify`), maintained on insert. The hot path reads/clears the previous latest and does the 9 m dedup against it — **no table scan**.
- **`NodeInfoEntity.latestPosition` accessor** — now returns the cache, falling back to the old sorted query only when cold (migrated / restored / seeded data). So reads (NodeDetail, map, intents, TAK bridge) are also O(1) in steady state, with **no regression** for migration/restore.
- Cache is maintained at every site that creates a "latest" position: live position, nodeInfo-embedded position, backup restore, and seed data. The legacy CoreData migration path is covered by the read fallback.

The existing 2 s / 5 s debounced save batching is **unchanged** — it was already correct; the bottleneck was reads, not writes. Ingestion already runs off the main thread (`@ModelActor`).

## Notes
- Schema-additive (new optional relationship) — fine for the unreleased v1; SwiftData handles it as a lightweight migration.
- Follow-ups (left out of scope): the *amortized* prune/telemetry relationship scans (every 128/256 inserts) could get the same treatment if needed.

## Test plan
- [x] Builds clean (iOS Simulator)
- [x] Positions still appear on the map / NodeDetail (cache path)
- [x] Restore-from-backup shows positions immediately (fallback path)
- [x] Under high-rate packet ingest, CPU no longer climbs/degrades as the DB grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)