### PR TITLE
Packet Stream: telemetry→mesh, adaptive reveal, consistent log format, S&F fix

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -301,9 +301,9 @@ extension AccessoryManager {
 			// Handle each of the store and forward request / response messages
 			switch storeAndForwardMessage.rr {
 			case .unset:
-				Logger.mesh.info("📮 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .routerError:
-				Logger.mesh.info("☠️ Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .routerHeartbeat:
 				/// When we get a router heartbeat we know there is a store and forward node on the network
 				/// Check if it is the primary S&F Router and save the timestamp of the last heartbeat so that we can show the request message history menu item on node long press if the router has been seen recently
@@ -331,13 +331,13 @@ extension AccessoryManager {
 						Logger.data.error("Save Store and Forward Router Error")
 					}
 				}
-				Logger.mesh.info("💓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .routerPing:
-				Logger.mesh.info("🏓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .routerPong:
-				Logger.mesh.info("🏓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .routerBusy:
-				Logger.mesh.info("🐝 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .routerHistory:
 				/// Set the Router History Last Request Value
 				guard let routerNode = getNodeInfo(id: Int64(packet.from), context: context) else {
@@ -357,26 +357,26 @@ extension AccessoryManager {
 				} catch {
 					Logger.data.error("Save Store and Forward Router Error")
 				}
-				Logger.mesh.info("📜 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .routerStats:
-				Logger.mesh.info("📊 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .clientError:
-				Logger.mesh.info("☠️ Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .clientHistory:
-				Logger.mesh.info("📜 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .clientStats:
-				Logger.mesh.info("📊 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .clientPing:
-				Logger.mesh.info("🏓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .clientPong:
-				Logger.mesh.info("🏓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .clientAbort:
-				Logger.mesh.info("🛑 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .UNRECOGNIZED:
-				Logger.mesh.info("📮 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 			case .routerTextDirect:
 				Task {
-					Logger.mesh.info("💬 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+					Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 					await MeshPackets.shared.textMessageAppPacket(
 						packet: packet,
 						wantRangeTestPackets: false,
@@ -387,7 +387,7 @@ extension AccessoryManager {
 				}
 			case .routerTextBroadcast:
 				Task {
-					Logger.mesh.info("✉️ Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
+					Logger.mesh.info("[Store & Forward] packet received from \(packet.from.toHex(), privacy: .public) — \(String(describing: storeAndForwardMessage.rr), privacy: .public)")
 					await MeshPackets.shared.textMessageAppPacket(
 						packet: packet,
 						wantRangeTestPackets: false,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -301,9 +301,9 @@ extension AccessoryManager {
 			// Handle each of the store and forward request / response messages
 			switch storeAndForwardMessage.rr {
 			case .unset:
-				Logger.mesh.info("\("📮 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("📮 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .routerError:
-				Logger.mesh.info("\("☠️ Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("☠️ Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .routerHeartbeat:
 				/// When we get a router heartbeat we know there is a store and forward node on the network
 				/// Check if it is the primary S&F Router and save the timestamp of the last heartbeat so that we can show the request message history menu item on node long press if the router has been seen recently
@@ -331,13 +331,13 @@ extension AccessoryManager {
 						Logger.data.error("Save Store and Forward Router Error")
 					}
 				}
-				Logger.mesh.info("\("💓 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("💓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .routerPing:
-				Logger.mesh.info("\("🏓 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("🏓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .routerPong:
-				Logger.mesh.info("\("🏓 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("🏓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .routerBusy:
-				Logger.mesh.info("\("🐝 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("🐝 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .routerHistory:
 				/// Set the Router History Last Request Value
 				guard let routerNode = getNodeInfo(id: Int64(packet.from), context: context) else {
@@ -357,26 +357,26 @@ extension AccessoryManager {
 				} catch {
 					Logger.data.error("Save Store and Forward Router Error")
 				}
-				Logger.mesh.info("\("📜 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("📜 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .routerStats:
-				Logger.mesh.info("\("📊 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("📊 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .clientError:
-				Logger.mesh.info("\("☠️ Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("☠️ Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .clientHistory:
-				Logger.mesh.info("\("📜 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("📜 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .clientStats:
-				Logger.mesh.info("\("📊 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("📊 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .clientPing:
-				Logger.mesh.info("\("🏓 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("🏓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .clientPong:
-				Logger.mesh.info("\("🏓 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("🏓 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .clientAbort:
-				Logger.mesh.info("\("🛑 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("🛑 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .UNRECOGNIZED:
-				Logger.mesh.info("\("📮 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+				Logger.mesh.info("📮 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 			case .routerTextDirect:
 				Task {
-					Logger.mesh.info("\("💬 Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+					Logger.mesh.info("💬 Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 					await MeshPackets.shared.textMessageAppPacket(
 						packet: packet,
 						wantRangeTestPackets: false,
@@ -387,7 +387,7 @@ extension AccessoryManager {
 				}
 			case .routerTextBroadcast:
 				Task {
-					Logger.mesh.info("\("✉️ Store and Forward \(storeAndForwardMessage.rr) message received from \(packet.from.toHex())")")
+					Logger.mesh.info("✉️ Store and Forward \(String(describing: storeAndForwardMessage.rr), privacy: .public) message received from \(packet.from.toHex(), privacy: .public)")
 					await MeshPackets.shared.textMessageAppPacket(
 						packet: packet,
 						wantRangeTestPackets: false,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -598,7 +598,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 						}
 					}
 				case .remoteHardwareApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Remote Hardware App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Remote Hardware] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .positionApp:
 					await MeshPackets.shared.upsertPositionPacket(packet: packet)
 					WatchSessionManager.shared.sendNodesToWatch()
@@ -642,16 +642,16 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 				case .adminApp:
 					await MeshPackets.shared.adminAppPacket(packet: packet)
 				case .replyApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Reply App handling as a text message")
+					Logger.mesh.info("[Reply] packet received from \(packet.from.toHex(), privacy: .public)")
 					guard let deviceNum = activeConnection?.device.num else {
 						Logger.mesh.error("🕸️ No active connection. Unable to determine connectedNodeNum for replyApp.")
 						return
 					}
 					await MeshPackets.shared.textMessageAppPacket(packet: packet, wantRangeTestPackets: wantRangeTestPackets, connectedNode: deviceNum, appState: appState)
 				case .ipTunnelApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for IP Tunnel App UNHANDLED UNHANDLED")
+					Logger.mesh.info("[IP Tunnel] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .serialApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Serial App UNHANDLED UNHANDLED")
+					Logger.mesh.info("[Serial] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .storeForwardApp:
 					guard let deviceNum = activeConnection?.device.num else {
 						Logger.mesh.error("🕸️ No active connection. Unable to determine connectedNodeNum for storeAndForward.")
@@ -671,7 +671,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 							appState: appState
 						)
 					} else {
-						Logger.mesh.info("🕸️ MESH PACKET received for Range Test App Range testing is disabled.")
+						Logger.mesh.info("[Range Test] packet received from \(packet.from.toHex(), privacy: .public)")
 					}
 				case .telemetryApp:
 					guard let deviceNum = activeConnection?.device.num else {
@@ -680,21 +680,21 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 					}
 					await MeshPackets.shared.telemetryPacket(packet: packet, connectedNode: deviceNum)
 				case .textMessageCompressedApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Text Message Compressed App UNHANDLED")
+					Logger.mesh.info("[Text Message Compressed] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .zpsApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Zero Positioning System App UNHANDLED")
+					Logger.mesh.info("[Zero Positioning System] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .privateApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Private App UNHANDLED UNHANDLED")
+					Logger.mesh.info("[Private] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .atakForwarder:
 					handleATAKForwarderPacket(packet)
 				case .simulatorApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Simulator App UNHANDLED UNHANDLED")
+					Logger.mesh.info("[Simulator] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .storeForwardPlusplusApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for SFPP App UNHANDLED UNHANDLED")
+					Logger.mesh.info("[SFPP] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .audioApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Audio App UNHANDLED UNHANDLED")
+					Logger.mesh.info("[Audio] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .nodeStatusApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Node Status App UNHANDLED")
+					Logger.mesh.info("[Node Status] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .tracerouteApp:
 					handleTraceRouteApp(packet)
 				case .neighborinfoApp:
@@ -702,15 +702,15 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 						if let engine = discoveryScanEngine, engine.isScanning {
 							engine.handleNeighborInfo(neighborInfo, packet: decodedInfo.packet)
 						} else {
-							Logger.mesh.info("🕸️ MESH PACKET received for Neighbor Info App UNHANDLED \((try? neighborInfo.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+							Logger.mesh.info("[Neighbor Info] packet received from \(packet.from.toHex(), privacy: .public)")
 						}
 					}
 				case .paxcounterApp:
 					await MeshPackets.shared.paxCounterPacket(packet: decodedInfo.packet)
 				case .mapReportApp:
-					Logger.mesh.info("🕸️ MESH PACKET received Map Report App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Map Report] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .UNRECOGNIZED:
-					Logger.mesh.info("🕸️ MESH PACKET received UNRECOGNIZED App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Unrecognized] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .max:
 					Logger.services.info("MAX PORT NUM OF 511")
 				case .atakPlugin:
@@ -718,21 +718,21 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 				case .atakPluginV2:
 					handleATAKPluginV2Packet(packet)
 				case .powerstressApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Power Stress App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Power Stress] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .reticulumTunnelApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Reticulum Tunnel App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Reticulum Tunnel] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .keyVerificationApp:
-					Logger.mesh.warning("🕸️ MESH PACKET received for Key Verification App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Key Verification] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .cayenneApp:
-					Logger.mesh.info("🕸️ MESH PACKET received Cayenne App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Cayenne] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .groupalarmApp:
-					Logger.mesh.info("🕸️ MESH PACKET received Group Alarm App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Group Alarm] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .lorawanBridge:
-					Logger.mesh.info("🕸️ MESH PACKET received for LoRaWAN Bridge UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[LoRaWAN Bridge] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .remoteShellApp:
-					Logger.mesh.info("🕸️ MESH PACKET received for Remote Shell UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Remote Shell] packet received from \(packet.from.toHex(), privacy: .public)")
 				case .unknownApp:
-					Logger.mesh.warning("🕸️ MESH PACKET received for unknown App UNHANDLED \((try? decodedInfo.packet.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
+					Logger.mesh.info("[Unknown] packet received from \(packet.from.toHex(), privacy: .public)")
 				}
 			}
 			// Save any pending updateAnyPacketFrom changes for packets that

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -741,8 +741,7 @@ actor MeshPackets {
 	}
 
 	func paxCounterPacket (packet: MeshPacket) {
-		let logString = String.localizedStringWithFormat("PAX Counter message received from: %@".localized, String(packet.from))
-		Logger.mesh.info("🧑‍🤝‍🧑 \(logString, privacy: .public)")
+		Logger.mesh.info("[PAX Counter] packet received from \(packet.from.toHex(), privacy: .public)")
 
 		let packetFrom = Int64(packet.from)
 		var fetchDescriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == packetFrom })
@@ -831,7 +830,7 @@ actor MeshPackets {
 			// localStats (from == connectedNode) is local, not OTA, so it stays on
 			// .data/.statistics below and out of the Mesh category.
 			if connectedNode != Int64(packet.from) {
-				Logger.mesh.info("📈 [Telemetry] received over the mesh from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("[Telemetry] packet received from \(packet.from.toHex(), privacy: .public)")
 			}
 			let telemetry = TelemetryEntity()
 			modelContext.insert(telemetry)
@@ -1045,7 +1044,7 @@ actor MeshPackets {
 			}
 
 			if messageText?.count ?? 0 > 0 {
-				Logger.mesh.info("💬 \("Message received from the text message app.".localized, privacy: .public)")
+				Logger.mesh.info("[Text Message] packet received from \(packet.from.toHex(), privacy: .public)")
 				let toNum = Int64(packet.to)
 				let fromNum = Int64(packet.from)
 				let fetchDescriptor = FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == toNum || $0.num == fromNum })
@@ -1272,8 +1271,7 @@ actor MeshPackets {
 	}
 
 	func waypointPacket (packet: MeshPacket) {
-		let logString = String.localizedStringWithFormat("Waypoint Packet received from node: %@".localized, String(packet.from))
-		Logger.mesh.info("📍 \(logString, privacy: .public)")
+		Logger.mesh.info("[Waypoint] packet received from \(packet.from.toHex(), privacy: .public)")
 
 		do {
 			if let waypointMessage = try? Waypoint(serializedBytes: packet.decoded.payload) {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -825,6 +825,14 @@ actor MeshPackets {
 				/// Other unhandled telemetry packets
 				return
 			}
+			// Mesh-category audit (spec 012): telemetry received over the air from a
+			// remote node is genuine mesh traffic and belongs in the Packet Stream,
+			// consistent with text/position/nodeinfo. The connected node's own
+			// localStats (from == connectedNode) is local, not OTA, so it stays on
+			// .data/.statistics below and out of the Mesh category.
+			if connectedNode != Int64(packet.from) {
+				Logger.mesh.info("📈 [Telemetry] received over the mesh from \(packet.from.toHex(), privacy: .public)")
+			}
 			let telemetry = TelemetryEntity()
 			modelContext.insert(telemetry)
 			let packetFrom = Int64(packet.from)

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -284,11 +284,10 @@ extension MeshPackets {
 	///   (e.g. the favorite action), which did not cross the mesh and log on .data.
 	func upsertNodeInfoPacket (packet: MeshPacket, favorite: Bool = false, overTheMesh: Bool = true) {
 
-		let logString = String.localizedStringWithFormat("[NodeInfo] received for: %@".localized, packet.from.toHex())
 		if overTheMesh {
-			Logger.mesh.info("📟 \(logString, privacy: .public)")
+			Logger.mesh.info("[NodeInfo] packet received from \(packet.from.toHex(), privacy: .public)")
 		} else {
-			Logger.data.info("📟 \(logString, privacy: .public)")
+			Logger.data.info("[NodeInfo] packet received from \(packet.from.toHex(), privacy: .public)")
 		}
 
 		guard packet.from > 0 else { return }
@@ -532,8 +531,7 @@ extension MeshPackets {
 	
 	func upsertPositionPacket (packet: MeshPacket) {
 		
-		let logString = String.localizedStringWithFormat("[Position] received from node: %@".localized, String(packet.from))
-		Logger.mesh.info("📍 \(logString, privacy: .public)")
+		Logger.mesh.info("[Position] packet received from \(packet.from.toHex(), privacy: .public)")
 		
 		let fetchNum = Int64(packet.from)
 			var fetchNodePositionRequest = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate<NodeInfoEntity> { $0.num == fetchNum })

--- a/Meshtastic/Views/Settings/Logs/PacketStreamModel.swift
+++ b/Meshtastic/Views/Settings/Logs/PacketStreamModel.swift
@@ -152,10 +152,19 @@ final class PacketStreamModel: ObservableObject {
 		}
 	}
 
-	/// Reveal at most one pending entry per tick (~6/sec). Below the threshold the queue
-	/// drains immediately; pacing throttles only the reveal, never ingestion (FR-022).
+	/// Adaptive reveal: a gentle ~6/sec when traffic is calm and readable, scaling up
+	/// per tick as the pending backlog grows so a burst (or a fast replay) scrolls quickly
+	/// and catches up instead of crawling. Pacing throttles only the reveal, never
+	/// ingestion (FR-021/FR-022).
 	func revealTick() {
-		if buffer.reveal(1) > 0 { syncFromBuffer() }
+		let perTick: Int
+		switch buffer.pending.count {
+		case 0:       perTick = 0
+		case 1...10:  perTick = 1    // ~6/sec  — calm, fully readable
+		case 11...40: perTick = 4    // ~24/sec — busy mesh
+		default:      perTick = 12   // ~72/sec — drain a firehose / fast replay quickly
+		}
+		if perTick > 0, buffer.reveal(perTick) > 0 { syncFromBuffer() }
 	}
 
 	private func syncFromBuffer() {


### PR DESCRIPTION
## Summary

Refinements to the spec-012 Packet Stream / Mesh log category so the live tail is complete, consistent, and readable.

## Changes

**1. Telemetry logged as mesh (OTA)**
Telemetry received over the air from a remote node now emits a `Logger.mesh` entry, so it appears in the Packet Stream consistently with text/position/nodeinfo/routing. The connected node's own `localStats` stays on `.data`/`.statistics` (local, not over-the-mesh). Previously all telemetry logged only to `.data`, so the largest non-text OTA type was invisible in the stream.

**2. Adaptive reveal pacing**
`PacketStreamModel.revealTick()` now scales how many pending entries it reveals per tick with the backlog — ~6/sec when calm and readable, up to ~72/sec when the queue is deep — so bursts (and fast replays) scroll quickly and catch up instead of crawling at a flat 6/sec. Pacing still throttles only the reveal, never ingestion (FR-021/022).

**3. Consistent mesh-category log format**
Every Mesh-category "packet received" log now reads uniformly, e.g. `[Telemetry] packet received from !43b57d20` — dropping the mixed emojis / `MESH PACKET received for X App UNHANDLED` / decimal node-number phrasings, always including the sender as `!hex`. Covers handled types and all the previously-inconsistent unhandled portnums. **Routing and Traceroute are left as-is** (custom RequestID/ack + traceroute content); admin/transport lines are not mesh-category and are unchanged.

**4. Store & Forward `<private>` fix**
The 17 S&F log lines wrapped the whole message in an outer interpolation with no privacy marker, so OSLog redacted every S&F packet to a blank `<private>` row. Unwrapped and marked the interpolations public (matching the other mesh handlers).

## Test plan
- [x] Builds clean (iOS + Mac Catalyst)
- [x] Telemetry from remote nodes appears in the Packet Stream; connected-node localStats does not
- [x] Stream scrolls faster under bursts, gentle when calm
- [x] Mesh log entries all read `[Type] packet received from !id`; routing/traceroute unchanged
- [x] Store & Forward entries are readable (no `<private>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)