### PR TITLE
Packet Stream: fix ingest stall + richer, cleaner mesh log lines

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -702,7 +702,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 						if let engine = discoveryScanEngine, engine.isScanning {
 							engine.handleNeighborInfo(neighborInfo, packet: decodedInfo.packet)
 						} else {
-							Logger.mesh.info("[Neighbor Info] packet received from \(packet.from.toHex(), privacy: .public)")
+							Logger.mesh.info("[Neighbor Info] packet received from \(packet.from.toHex(), privacy: .public) — \(neighborInfo.neighbors.count, privacy: .public) neighbors")
 						}
 					}
 				case .paxcounterApp:

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -618,7 +618,7 @@ actor MeshPackets {
 						}
 						if !deferSave {
 							savePendingChanges()
-							Logger.data.info("💾 [NodeInfo] saved for \(nodeInfo.num.toHex(), privacy: .public)")
+							Logger.data.info("💾 [Node Info] saved for \(nodeInfo.num.toHex(), privacy: .public)")
 						}
 						return fetchedNode[0].persistentModelID
 					} catch {
@@ -1076,7 +1076,16 @@ actor MeshPackets {
 			}
 
 			if messageText?.count ?? 0 > 0 {
-				Logger.mesh.info("[Text Message] packet received from \(packet.from.toHex(), privacy: .public)")
+				// Show channel/broadcast text in the stream; redact direct-message content (only
+				// mark it "(DM)") so private 1:1 text isn't persisted to the unified log.
+				let messageDetail: String
+				if packet.to == Constants.maximumNodeNum {
+					let preview = (messageText ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+					messageDetail = preview.count > 100 ? String(preview.prefix(100)) + "…" : preview
+				} else {
+					messageDetail = "(DM)"
+				}
+				Logger.mesh.info("💬 [Text Message] packet received from \(packet.from.toHex(), privacy: .public) — \(messageDetail, privacy: .public)")
 				let toNum = Int64(packet.to)
 				let fromNum = Int64(packet.from)
 				let fetchDescriptor = FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == toNum || $0.num == fromNum })

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -742,7 +742,8 @@ actor MeshPackets {
 	}
 
 	func paxCounterPacket (packet: MeshPacket) {
-		Logger.mesh.info("[PAX Counter] packet received from \(packet.from.toHex(), privacy: .public)")
+		let paxDetail = (try? Paxcount(serializedBytes: packet.decoded.payload)).map { " — \($0.wifi) wifi \($0.ble) ble" } ?? ""
+		Logger.mesh.info("[PAX Counter] packet received from \(packet.from.toHex(), privacy: .public)\(paxDetail, privacy: .public)")
 
 		let packetFrom = Int64(packet.from)
 		var fetchDescriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == packetFrom })
@@ -1076,6 +1077,14 @@ actor MeshPackets {
 			}
 
 			if messageText?.count ?? 0 > 0 {
+				// Detection-sensor and alert events ride the text-message port; label them
+				// distinctly in the stream.
+				let messageLabel: String
+				switch packet.decoded.portnum {
+				case .detectionSensorApp: messageLabel = "🔔 [Detection Sensor]"
+				case .alertApp:           messageLabel = "🔔 [Alert]"
+				default:                  messageLabel = "💬 [Text Message]"
+				}
 				// Show channel/broadcast text in the stream; redact direct-message content (only
 				// mark it "(DM)") so private 1:1 text isn't persisted to the unified log.
 				let messageDetail: String
@@ -1085,7 +1094,7 @@ actor MeshPackets {
 				} else {
 					messageDetail = "(DM)"
 				}
-				Logger.mesh.info("💬 [Text Message] packet received from \(packet.from.toHex(), privacy: .public) — \(messageDetail, privacy: .public)")
+				Logger.mesh.info("\(messageLabel, privacy: .public) packet received from \(packet.from.toHex(), privacy: .public) — \(messageDetail, privacy: .public)")
 				let toNum = Int64(packet.to)
 				let fromNum = Int64(packet.from)
 				let fetchDescriptor = FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == toNum || $0.num == fromNum })
@@ -1312,7 +1321,16 @@ actor MeshPackets {
 	}
 
 	func waypointPacket (packet: MeshPacket) {
-		Logger.mesh.info("[Waypoint] packet received from \(packet.from.toHex(), privacy: .public)")
+		let waypointDetail = (try? Waypoint(serializedBytes: packet.decoded.payload)).map { w -> String in
+			var parts: [String] = []
+			let name = w.name.trimmingCharacters(in: .whitespacesAndNewlines)
+			if !name.isEmpty { parts.append(name) }
+			if w.latitudeI != 0 || w.longitudeI != 0 {
+				parts.append(String(format: "%.5f,%.5f", Double(w.latitudeI) / 1e7, Double(w.longitudeI) / 1e7))
+			}
+			return parts.isEmpty ? "" : " — " + parts.joined(separator: " ")
+		} ?? ""
+		Logger.mesh.info("[Waypoint] packet received from \(packet.from.toHex(), privacy: .public)\(waypointDetail, privacy: .public)")
 
 		do {
 			if let waypointMessage = try? Waypoint(serializedBytes: packet.decoded.payload) {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -392,7 +392,7 @@ actor MeshPackets {
 		// This path handles the connected device's local node-DB dump during wantConfig
 		// (FromRadio.nodeInfo), not packets that crossed the mesh — log it as admin/setup.
 		// Over-the-air NodeInfo arrives via upsertNodeInfoPacket and stays on .mesh.
-		let logString = String.localizedStringWithFormat("[NodeInfo] received for: %@".localized, String(nodeInfo.num))
+		let logString = String.localizedStringWithFormat("📟 [NodeInfo] received for: %@".localized, String(nodeInfo.num))
 		Logger.admin.info("📟 \(logString, privacy: .public)")
 
 		guard nodeInfo.num > 0 else { return nil }
@@ -819,6 +819,37 @@ actor MeshPackets {
 		}
 	}
 
+	/// Compact, human-readable summary of a Telemetry packet for the mesh log line, e.g.
+	/// " — device 87% 4.05V ch 12.3% air 3.1%" or " — env 23.5°C 45% 1013hPa". Reads the salient
+	/// metrics per variant (not raw JSON); returns "" for unhandled variants.
+	private func telemetryLogDetails(_ telemetry: Telemetry) -> String {
+		var parts: [String] = []
+		switch telemetry.variant {
+		case .deviceMetrics(let m)?:
+			parts.append("device")
+			if m.hasBatteryLevel { parts.append("\(m.batteryLevel)%") }
+			if m.hasVoltage { parts.append(String(format: "%.2fV", m.voltage)) }
+			if m.hasChannelUtilization { parts.append(String(format: "ch %.1f%%", m.channelUtilization)) }
+			if m.hasAirUtilTx { parts.append(String(format: "air %.1f%%", m.airUtilTx)) }
+		case .environmentMetrics(let m)?:
+			parts.append("env")
+			if m.hasTemperature { parts.append(String(format: "%.1f°C", m.temperature)) }
+			if m.hasRelativeHumidity { parts.append(String(format: "%.0f%%", m.relativeHumidity)) }
+			if m.hasBarometricPressure { parts.append(String(format: "%.0fhPa", m.barometricPressure)) }
+		case .powerMetrics(let m)?:
+			parts.append("power")
+			if m.hasCh1Voltage { parts.append(String(format: "ch1 %.2fV", m.ch1Voltage)) }
+			if m.hasCh2Voltage { parts.append(String(format: "ch2 %.2fV", m.ch2Voltage)) }
+			if m.hasCh3Voltage { parts.append(String(format: "ch3 %.2fV", m.ch3Voltage)) }
+		case .localStats(let m)?:
+			parts.append("stats")
+			parts.append("\(m.numOnlineNodes)/\(m.numTotalNodes) nodes")
+		default:
+			return ""
+		}
+		return " — " + parts.joined(separator: " ")
+	}
+
 	func telemetryPacket(packet: MeshPacket, connectedNode: Int64) {
 		if let telemetryMessage = try? Telemetry(serializedBytes: packet.decoded.payload) {
 			if telemetryMessage.variant != Telemetry.OneOf_Variant.deviceMetrics(telemetryMessage.deviceMetrics) && telemetryMessage.variant != Telemetry.OneOf_Variant.environmentMetrics(telemetryMessage.environmentMetrics) && telemetryMessage.variant != Telemetry.OneOf_Variant.localStats(telemetryMessage.localStats) && telemetryMessage.variant != Telemetry.OneOf_Variant.powerMetrics(telemetryMessage.powerMetrics) {
@@ -831,7 +862,7 @@ actor MeshPackets {
 			// localStats (from == connectedNode) is local, not OTA, so it stays on
 			// .data/.statistics below and out of the Mesh category.
 			if connectedNode != Int64(packet.from) {
-				Logger.mesh.info("[Telemetry] packet received from \(packet.from.toHex(), privacy: .public)")
+				Logger.mesh.info("📈 [Telemetry] packet received from \(packet.from.toHex(), privacy: .public)\(self.telemetryLogDetails(telemetryMessage), privacy: .public)")
 			}
 			let telemetry = TelemetryEntity()
 			modelContext.insert(telemetry)

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -279,15 +279,41 @@ extension MeshPackets {
 		}
 	}
 	
+	/// Compact, human-readable summary of a NodeInfo packet's `User` payload, appended to the mesh
+	/// log line so the Packet Stream shows the decoded protobuf at a glance (not raw JSON), e.g.
+	/// " — Long Name (SHRT) client TBEAM 🔐". Returns "" when there's no usable identity.
+	private func nodeInfoLogDetails(from packet: MeshPacket) -> String {
+		guard let user = try? User(serializedBytes: packet.decoded.payload), !user.id.isEmpty else {
+			return ""
+		}
+		var parts: [String] = []
+		let long = user.longName.trimmingCharacters(in: .whitespacesAndNewlines)
+		let short = user.shortName.trimmingCharacters(in: .whitespacesAndNewlines)
+		switch (long.isEmpty, short.isEmpty) {
+		case (false, false): parts.append("\(long) (\(short))")
+		case (false, true):  parts.append(long)
+		case (true, false):  parts.append(short)
+		case (true, true):   break
+		}
+		parts.append(String(describing: user.role))
+		let hw = String(describing: user.hwModel).uppercased()
+		if hw != "UNSET" { parts.append(hw) }
+		if user.isLicensed { parts.append("licensed") }
+		if !user.publicKey.isEmpty { parts.append("🔐") }
+		if user.hasIsUnmessagable && user.isUnmessagable { parts.append("unmessagable") }
+		return parts.isEmpty ? "" : " — " + parts.joined(separator: " ")
+	}
+
 	/// - Parameter overTheMesh: true when this NodeInfo arrived as an over-the-air packet from a
 	///   remote node — logged on .mesh so it appears in the Packet Stream. false for local updates
 	///   (e.g. the favorite action), which did not cross the mesh and log on .data.
 	func upsertNodeInfoPacket (packet: MeshPacket, favorite: Bool = false, overTheMesh: Bool = true) {
 
+		let details = nodeInfoLogDetails(from: packet)
 		if overTheMesh {
-			Logger.mesh.info("[NodeInfo] packet received from \(packet.from.toHex(), privacy: .public)")
+			Logger.mesh.info("📟 [NodeInfo] packet received from \(packet.from.toHex(), privacy: .public)\(details, privacy: .public)")
 		} else {
-			Logger.data.info("[NodeInfo] packet received from \(packet.from.toHex(), privacy: .public)")
+			Logger.data.info("📟 [NodeInfo] packet received from \(packet.from.toHex(), privacy: .public)\(details, privacy: .public)")
 		}
 
 		guard packet.from > 0 else { return }
@@ -529,9 +555,24 @@ extension MeshPackets {
 		}
 	}
 	
+	/// Compact, human-readable summary of a Position packet's payload for the mesh log line, e.g.
+	/// " — 40.78661,-119.20650 1234m 8 sats 14-bit". Returns "" for empty/null-island positions.
+	private func positionLogDetails(from packet: MeshPacket) -> String {
+		guard let pos = try? Position(serializedBytes: packet.decoded.payload),
+			  pos.latitudeI != 0 || pos.longitudeI != 0 else {
+			return ""
+		}
+		var parts: [String] = []
+		parts.append(String(format: "%.5f,%.5f", Double(pos.latitudeI) / 1e7, Double(pos.longitudeI) / 1e7))
+		if pos.altitude != 0 { parts.append("\(pos.altitude)m") }
+		if pos.satsInView > 0 { parts.append("\(pos.satsInView) sats") }
+		if pos.precisionBits > 0 && pos.precisionBits < 32 { parts.append("\(pos.precisionBits)-bit") }
+		return parts.isEmpty ? "" : " — " + parts.joined(separator: " ")
+	}
+
 	func upsertPositionPacket (packet: MeshPacket) {
-		
-		Logger.mesh.info("[Position] packet received from \(packet.from.toHex(), privacy: .public)")
+
+		Logger.mesh.info("📍 [Position] packet received from \(packet.from.toHex(), privacy: .public)\(self.positionLogDetails(from: packet), privacy: .public)")
 		
 		let fetchNum = Int64(packet.from)
 			var fetchNodePositionRequest = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate<NodeInfoEntity> { $0.num == fetchNum })

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -312,9 +312,9 @@ extension MeshPackets {
 
 		let details = nodeInfoLogDetails(from: packet)
 		if overTheMesh {
-			Logger.mesh.info("📟 [NodeInfo] packet received from \(packet.from.toHex(), privacy: .public)\(details, privacy: .public)")
+			Logger.mesh.info("📟 [Node Info] packet received from \(packet.from.toHex(), privacy: .public)\(details, privacy: .public)")
 		} else {
-			Logger.data.info("📟 [NodeInfo] packet received from \(packet.from.toHex(), privacy: .public)\(details, privacy: .public)")
+			Logger.data.info("📟 [Node Info] packet received from \(packet.from.toHex(), privacy: .public)\(details, privacy: .public)")
 		}
 
 		guard packet.from > 0 else { return }
@@ -452,7 +452,7 @@ extension MeshPackets {
 				}
 				
 				savePendingChanges()
-				Logger.data.info("💾 [NodeInfo] Saved a NodeInfo for node number: \(packet.from.toHex(), privacy: .public)")
+				Logger.data.info("💾 [Node Info] Saved a Node Info for node number: \(packet.from.toHex(), privacy: .public)")
 				
 			} else {
 				// Update an existing node

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -281,7 +281,7 @@ extension MeshPackets {
 	
 	/// Compact, human-readable summary of a NodeInfo packet's `User` payload, appended to the mesh
 	/// log line so the Packet Stream shows the decoded protobuf at a glance (not raw JSON), e.g.
-	/// " — Long Name (SHRT) client TBEAM 🔐". Returns "" when there's no usable identity.
+	/// " — 🔐 Long Name (SHRT) client TBEAM". Returns "" when there's no usable identity.
 	private func nodeInfoLogDetails(from packet: MeshPacket) -> String {
 		guard let user = try? User(serializedBytes: packet.decoded.payload), !user.id.isEmpty else {
 			return ""
@@ -299,8 +299,9 @@ extension MeshPackets {
 		let hw = String(describing: user.hwModel).uppercased()
 		if hw != "UNSET" { parts.append(hw) }
 		if user.isLicensed { parts.append("licensed") }
-		if !user.publicKey.isEmpty { parts.append("🔐") }
 		if user.hasIsUnmessagable && user.isUnmessagable { parts.append("unmessagable") }
+		// Lock leads the line so PKI-encrypted nodes are obvious at a glance.
+		if !user.publicKey.isEmpty { parts.insert("🔐", at: 0) }
 		return parts.isEmpty ? "" : " — " + parts.joined(separator: " ")
 	}
 

--- a/Meshtastic/Resources/DeviceHardware.json
+++ b/Meshtastic/Resources/DeviceHardware.json
@@ -1437,5 +1437,18 @@
     "images": [
       "heltec-t096.svg"
     ]
+  },
+  {
+    "hwModel": 129,
+    "hwModelSlug": "THINKNODE_M7",
+    "platformioTarget": "thinknode_m7",
+    "architecture": "esp32-s3",
+    "activelySupported": false,
+    "supportLevel": 1,
+    "displayName": "ThinkNode M7",
+    "tags": [
+      "Elecrow"
+    ],
+    "requiresDfu": false
   }
 ]

--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,215 +1,215 @@
 {
   "files": {
-    "promicro.svg": {
-      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
-    },
-    "m5_c6l.svg": {
-      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
-    },
-    "t-watch-s3.svg": {
-      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
-    },
-    "heltec-mesh-solar.svg": {
-      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
-    },
-    "crowpanel_5_0.svg": {
-      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
-    },
-    "heltec-wireless-paper.svg": {
-      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
-    },
-    "thinknode_m4.svg": {
-      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
-    },
-    "rak-wismeshtap.svg": {
-      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
-    },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
-    },
-    "rak3401.svg": {
-      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
-    },
-    "tlora-v2-1-1_6.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "heltec-wsl-v3.svg": {
-      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
-    },
-    "muzi_base.svg": {
-      "etag": "\"be887c289c63af434835279b75f0879e\""
-    },
-    "rak_wismesh_tag.svg": {
-      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
-    },
-    "crowpanel_2_4.svg": {
-      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
-    },
-    "crowpanel_7_0.svg": {
-      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
-    },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
-    },
-    "wio-tracker-wm1110.svg": {
-      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
-    },
-    "thinknode_m3.svg": {
-      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
-    },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
-    },
-    "heltec-ht62-esp32c3-sx1262.svg": {
-      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
-    },
-    "meteor_pro.svg": {
-      "etag": "\"db5044328b825421851b963479fab9ca\""
-    },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
-    },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
-    },
-    "seeed_solar.svg": {
-      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
-    },
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
-    },
     "muzi_r1_neo.svg": {
       "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
-    },
-    "heltec_v4.svg": {
-      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
-    },
-    "heltec-mesh-node-t114-case.svg": {
-      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
-    },
-    "t-deck.svg": {
-      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
-    },
-    "seeed-sensecap-indicator.svg": {
-      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
-    },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
-    "techo_lite.svg": {
-      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
-    },
-    "thinknode_m2.svg": {
-      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
     },
     "tbeam.svg": {
       "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
     },
-    "crowpanel_2_8.svg": {
-      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
-    },
-    "rak4631_case.svg": {
-      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
-    },
-    "tbeam-1w.svg": {
-      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
-    },
     "rak2560.svg": {
       "etag": "\"e425adc49058399a2a7f8517093192f0\""
     },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
-    },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
-    },
-    "t5s3_epaper.svg": {
-      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
-    },
-    "heltec_wireless_tracker_v2.svg": {
-      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
-    },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "rak11200.svg": {
-      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
-    },
-    "tlora-t3s3-epaper.svg": {
-      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
-    },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
-    },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
-    },
-    "crowpanel_3_5.svg": {
-      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
-    },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
-    },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
     },
     "heltec-vision-master-t190.svg": {
       "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
     },
-    "rak4631.svg": {
-      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    "heltec-ht62-esp32c3-sx1262.svg": {
+      "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
     },
-    "heltec-v3.svg": {
-      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
     },
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
-    },
-    "pico.svg": {
-      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
-    },
-    "rak-wismesh-tap-v2.svg": {
-      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
-    },
-    "seeed_xiao_nrf52_kit.svg": {
-      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
-    },
-    "heltec-v3-case.svg": {
-      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
-    },
-    "rak11310.svg": {
-      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
-    },
-    "station-g2.svg": {
-      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
-    },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
-    },
-    "t-echo.svg": {
-      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
-    },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
+    "m5_c6l.svg": {
+      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
     },
     "heltec-t096.svg": {
       "etag": "\"686fe6ac17fea4e6ff34aca78ca610f9\""
     },
+    "station-g2.svg": {
+      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    },
+    "t5s3_epaper.svg": {
+      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
+    },
+    "crowpanel_5_0.svg": {
+      "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
+    },
+    "rak3401.svg": {
+      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
+    },
+    "crowpanel_3_5.svg": {
+      "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
+    },
+    "pico.svg": {
+      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    },
+    "tbeam-1w.svg": {
+      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "rak-wismeshtap.svg": {
+      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
+    },
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
+    },
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
+    },
+    "heltec_v4.svg": {
+      "etag": "\"57666cd119ac01e74716bef5f785e2df\""
+    },
+    "rak11200.svg": {
+      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
+    },
+    "seeed_solar.svg": {
+      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    },
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "thinknode_m4.svg": {
+      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
+    },
+    "heltec-wireless-paper.svg": {
+      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
+    },
+    "crowpanel_7_0.svg": {
+      "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
+    },
+    "rak11310.svg": {
+      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
+    },
+    "rak4631_case.svg": {
+      "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
+    },
+    "t-echo.svg": {
+      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    },
+    "meteor_pro.svg": {
+      "etag": "\"db5044328b825421851b963479fab9ca\""
+    },
+    "heltec-wsl-v3.svg": {
+      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
+    },
+    "promicro.svg": {
+      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
+    },
+    "crowpanel_2_8.svg": {
+      "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
+    },
     "tlora-t3s3-v1.svg": {
       "etag": "\"bbf44e526676ad298698d1387af57c15\""
+    },
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    },
+    "seeed-sensecap-indicator.svg": {
+      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
+    },
+    "tlora-v2-1-1_6.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "heltec-mesh-solar.svg": {
+      "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
+    },
+    "heltec-mesh-node-t114-case.svg": {
+      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
+    },
+    "t-watch-s3.svg": {
+      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
+    },
+    "crowpanel_2_4.svg": {
+      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
+    },
+    "thinknode_m3.svg": {
+      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    },
+    "wio-tracker-wm1110.svg": {
+      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    },
+    "rak4631.svg": {
+      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
+    },
+    "tlora-t3s3-epaper.svg": {
+      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    },
+    "techo_lite.svg": {
+      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
+    },
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
+    },
+    "heltec-v3-case.svg": {
+      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
+    },
+    "t-deck.svg": {
+      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    },
+    "thinknode_m2.svg": {
+      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
+    },
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
+    },
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "seeed_xiao_nrf52_kit.svg": {
+      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
+    },
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    },
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    },
+    "rak_wismesh_tag.svg": {
+      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
+    },
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    },
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
+    },
+    "muzi_base.svg": {
+      "etag": "\"be887c289c63af434835279b75f0879e\""
+    },
+    "rak-wismesh-tap-v2.svg": {
+      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
+    },
+    "heltec_wireless_tracker_v2.svg": {
+      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    },
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    },
+    "heltec-v3.svg": {
+      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
     }
   },
-  "api_hash": "52a72acd6420d178863eff62822397537f1e75e41c1a07b820593ad01b03c539"
+  "api_hash": "6dfff9f4d6c1950d193cb0ed1cc4369c68aae266951a4ac22789f8c6de4ca9c9"
 }

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -23,6 +23,9 @@ struct Connect: View {
 	@Environment(\.colorScheme) private var colorScheme
 	@State var router: Router
 	@State var node: NodeInfoEntity?
+	/// Cached battery level for the connected node. Refreshed on an interval (see `.task`)
+	/// rather than fetched in `body`, which re-ran a TelemetryEntity query on every render.
+	@State private var connectedBatteryLevel: Int32?
 	@State var isUnsetRegion = false
 	@State var invalidFirmwareVersion = false
 	@State var showSecurityVersionNag = false
@@ -65,7 +68,7 @@ struct Connect: View {
 									VStack(alignment: .center) {
 										CircleText(text: node?.user?.shortName?.addingVariationSelectors ?? "?", color: Color(UIColor(hex: UInt32(node?.num ?? 0))), circleSize: 90)
 											.padding(.trailing, 5)
-										if let batteryLevel = latestBatteryLevel(for: node) {
+										if let batteryLevel = connectedBatteryLevel {
 											BatteryCompact(batteryLevel: batteryLevel, font: .caption, iconFont: .callout, color: .accentColor)
 												.padding(.trailing, 5)
 										}
@@ -458,6 +461,15 @@ struct Connect: View {
 		.onChange(of: scenePhase) { _, _ in updateNymeaDiscovery() }
 		.onChange(of: accessoryManager.isConnected) { _, _ in updateNymeaDiscovery() }
 		.onChange(of: accessoryManager.isConnecting) { _, _ in updateNymeaDiscovery() }
+		.task(id: node?.num) {
+			// Refresh the connected node's battery on an interval instead of fetching in
+			// `body` (which re-ran the TelemetryEntity query on every render — costly while
+			// ingestion churns the node @Query). Battery changes slowly, so 15s is plenty.
+			while !Task.isCancelled {
+				connectedBatteryLevel = latestBatteryLevel(for: node)
+				try? await Task.sleep(for: .seconds(15))
+			}
+		}
 	}
 
 	/// Fetch only the latest device metrics battery level without faulting all telemetries.

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -363,6 +363,12 @@ struct ChannelMessageList: View {
 					scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 				}
 			}
+			// Incoming channel traffic bumps appState.unreadChannelMessages (set in
+			// textMessageAppPacket); refresh on that signal so messages land live instead
+			// of waiting up to 5s for the poll loop in .task above.
+			.onChange(of: appState.unreadChannelMessages) {
+				refreshIfNeeded()
+			}
 			.onChange(of: messageFieldFocused) {
 				if messageFieldFocused {
 					DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/Meshtastic/Views/Messages/TapbackResponses.swift
+++ b/Meshtastic/Views/Messages/TapbackResponses.swift
@@ -30,6 +30,9 @@ struct TapbackResponses: View {
 					}
 					.padding(10)
 				}
+				// Hug the reactions so the border wraps the content instead of leaving
+				// empty space; the up-to-two-rows layout keeps realistic counts on-screen.
+				.fixedSize(horizontal: true, vertical: false)
 				.overlay(
 					RoundedRectangle(cornerRadius: 18)
 						.stroke(Color.gray, lineWidth: 1)

--- a/Meshtastic/Views/Messages/TapbackResponses.swift
+++ b/Meshtastic/Views/Messages/TapbackResponses.swift
@@ -3,26 +3,33 @@ import SwiftUI
 struct TapbackResponses: View {
 	let tapbacks: [MessageEntity]
 
+	/// One row for a handful of reactions, two once there are several — then scroll
+	/// horizontally instead of overflowing the screen (matches the emoji picker styling).
+	private var rows: [GridItem] {
+		Array(repeating: GridItem(.fixed(38), spacing: 4), count: tapbacks.count > 6 ? 2 : 1)
+	}
+
 	@ViewBuilder
 	var body: some View {
 		if !tapbacks.isEmpty {
 			VStack(alignment: .trailing) {
-				HStack {
-					ForEach(tapbacks) { (tapback: MessageEntity) in
-						VStack {
-							Text(tapback.messagePayload ?? "")
-								.font(.system(size: 20))
-								.lineLimit(1)
-								.fixedSize()
-							Text("\(tapback.fromUser?.shortName ?? "?")")
-								.font(.caption2)
-								.foregroundColor(.gray)
-								.fixedSize()
-								.padding(.bottom, 1)
+				ScrollView(.horizontal, showsIndicators: false) {
+					LazyHGrid(rows: rows, spacing: 12) {
+						ForEach(tapbacks) { (tapback: MessageEntity) in
+							VStack(spacing: 1) {
+								Text(tapback.messagePayload ?? "")
+									.font(.system(size: 20))
+									.lineLimit(1)
+									.fixedSize()
+								Text("\(tapback.fromUser?.shortName ?? "?")")
+									.font(.caption2)
+									.foregroundColor(.gray)
+									.fixedSize()
+							}
 						}
 					}
+					.padding(10)
 				}
-				.padding(10)
 				.overlay(
 					RoundedRectangle(cornerRadius: 18)
 						.stroke(Color.gray, lineWidth: 1)

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -435,6 +435,11 @@ struct UserMessageList: View {
 						scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 					}
 				}
+				// Incoming DM traffic bumps appState.unreadDirectMessages; refresh on that
+				// signal so messages land live instead of waiting up to 5s for the poll.
+				.onChange(of: appState.unreadDirectMessages) {
+					refreshIfNeeded()
+				}
 				.onChange(of: messageFieldFocused) {
 					if messageFieldFocused {
 						DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -172,6 +172,10 @@ private struct FilteredNodeList: View {
 	@Query(sort: \NodeInfoEntity.lastHeard, order: .reverse)
 	private var allNodes: [NodeInfoEntity]
 	@Environment(\.modelContext) private var context
+	/// Throttled snapshot of the filtered/sorted nodes actually shown. Recomputed on a gentle
+	/// cadence (see `.task`) instead of in `body`, so the full-node-set scan in `displayNodes`
+	/// doesn't run on every SwiftData write — which pegged the CPU on reconnect with a large DB.
+	@State private var displayedNodes: [NodeInfoEntity] = []
 
 	var connectedNode: NodeInfoEntity?
 	@Binding var isPresentingDeleteNodeAlert: Bool
@@ -275,8 +279,7 @@ private struct FilteredNodeList: View {
 
 	// The body of the view
 	var body: some View {
-		let uniqueNodes = displayNodes(activeNodeNum: accessoryManager.activeDeviceNum)
-		List(uniqueNodes, id: \.num, selection: $selectedNodeNum) { node in
+		List(displayedNodes, id: \.num, selection: $selectedNodeNum) { node in
 			NavigationLink(value: node.num) {
 				switch nodeListDensity {
 				case .compact:
@@ -299,7 +302,17 @@ private struct FilteredNodeList: View {
 				)
 			}
 		}
-		.navigationTitle(String.localizedStringWithFormat("Nodes (%@)".localized, String(uniqueNodes.count)))
+		.navigationTitle(String.localizedStringWithFormat("Nodes (%@)".localized, String(displayedNodes.count)))
+		.task {
+			// Recompute the displayed list on a gentle cadence instead of inside `body`.
+			// During live ingestion the node @Query invalidates on every packet; running
+			// displayNodes (a scan over the whole node set) per write pegged the main thread
+			// on reconnect with a large DB. ~3/sec is imperceptible and keeps CPU sane.
+			while !Task.isCancelled {
+				displayedNodes = displayNodes(activeNodeNum: accessoryManager.activeDeviceNum)
+				try? await Task.sleep(for: .milliseconds(350))
+			}
+		}
 		.onAppear {
 			router.updateNodeIndex(from: allNodes)
 		}
@@ -355,6 +368,13 @@ private struct NodeListFilterLookup {
 		distanceBounds: NodeDistanceFilterBounds?,
 		context: ModelContext
 	) {
+		// Only materialize the node-num set (a scan over every node) when a filter actually
+		// needs it; the common no-filter case skips this work entirely.
+		guard needsEnvironment || distanceBounds != nil else {
+			self.environmentNodeNums = nil
+			self.distanceNodeNums = nil
+			return
+		}
 		let nodeNums = Array(Set(nodes.map(\.num)))
 		if needsEnvironment {
 			self.environmentNodeNums = Self.fetchEnvironmentNodeNums(nodeNums: nodeNums, context: context)

--- a/Meshtastic/Views/Settings/AppLog.swift
+++ b/Meshtastic/Views/Settings/AppLog.swift
@@ -295,16 +295,13 @@ struct AppLog: View {
 				.font(.caption)
 				.frame(maxWidth: .infinity, alignment: .leading)
 		} else {
+			// Packet Stream is always level=Info, category=Mesh, so those columns add no
+			// information — show just the timestamp and the message.
 			HStack(alignment: .top, spacing: 12) {
 				Text(Self.logDateFormatter.string(from: value.date))
 					.lineLimit(1)
 					.fixedSize(horizontal: true, vertical: false)
 					.frame(width: 240, alignment: .leading)
-				Text(value.level.description)
-					.foregroundStyle(value.level.color)
-					.frame(width: 100, alignment: .leading)
-				Text(value.category)
-					.frame(width: 110, alignment: .leading)
 				Text(value.composedMessage)
 					.foregroundStyle(value.level.color)
 					.frame(maxWidth: .infinity, alignment: .leading)

--- a/Meshtastic/Views/Settings/AppLog.swift
+++ b/Meshtastic/Views/Settings/AppLog.swift
@@ -25,6 +25,9 @@ struct AppLog: View {
 	@State private var isPacketStreamOn = false
 	@State private var categoriesExpanded = false
 	@State private var levelsExpanded = false
+	/// Throttles the stream's auto-scroll-to-bottom — resolving the bottom anchor of a large
+	/// LazyVStack is expensive, so cap it to a few times/sec instead of every new entry.
+	@State private var lastStreamScroll = Date.distantPast
 	@StateObject private var streamModel = PacketStreamModel()
 	@Environment(\.scenePhase) private var scenePhase
 
@@ -370,9 +373,14 @@ struct AppLog: View {
 				}
 			)
 			.onChange(of: streamModel.visibleEntries.count) {
-				if streamModel.isPinnedToLiveEdge {
-					proxy.scrollTo("streamBottom", anchor: .bottom)
-				}
+				guard streamModel.isPinnedToLiveEdge else { return }
+				// Throttle: scroll-to-bottom over a large lazy stack is a costly layout pass;
+				// at firehose rates doing it per-entry pegs the main actor (and starves the
+				// TCP reader). A few/sec keeps it visually pinned without the churn.
+				let now = Date()
+				guard now.timeIntervalSince(lastStreamScroll) >= 0.3 else { return }
+				lastStreamScroll = now
+				proxy.scrollTo("streamBottom", anchor: .bottom)
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Logs/PacketStreamModel.swift
+++ b/Meshtastic/Views/Settings/Logs/PacketStreamModel.swift
@@ -27,8 +27,10 @@ final class PacketStreamModel: ObservableObject {
 
 	// MARK: - Tuning
 
-	/// ~6 entries/sec readable cadence (FR-021).
-	private let revealIntervalNanos: UInt64 = 167_000_000
+	/// ~4 entries/sec readable cadence (FR-021). Each tick also drives a view re-render and
+	/// auto-scroll, so a slightly longer interval meaningfully cuts main-actor churn under load
+	/// while staying readable (the adaptive per-tick count keeps overall throughput up).
+	private let revealIntervalNanos: UInt64 = 250_000_000
 	/// Poll cadence for new entries (well under the 5s visibility target, SC-001).
 	private let pollIntervalNanos: UInt64 = 1_000_000_000
 

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -31,7 +31,12 @@ struct Settings: View {
 		return nodes.first(where: { $0.num == nodeNum })
 	}
 
-	private var showsAnyModuleConfiguration: Bool {
+	// The module-support helpers take a pre-resolved node + excluded-modules bitmask so
+	// `moduleConfigurationSection` can compute them ONCE per render. They used to read the
+	// `moduleConfigurationNode` computed property (a linear scan over the full node @Query
+	// plus a `.metadata` relationship fault) on every call, and the section calls them ~28×
+	// per render — which, under live ingestion re-rendering, pegged the main thread.
+	private func showsAnyModuleConfiguration(node: NodeInfoEntity?, excludedModules: Int) -> Bool {
 		isAnySupported([
 			.ambientlightingConfig,
 			.audioConfig,
@@ -45,19 +50,21 @@ struct Settings: View {
 			.serialConfig,
 			.storeforwardConfig,
 			.telemetryConfig
-		]) || isTAKModuleSupported() || isTrafficManagementModuleSupported()
+		], excludedModules: excludedModules)
+			|| isTAKModuleSupported(node)
+			|| isTrafficManagementModuleSupported(node)
 	}
 
-	private func isModuleSupported(_ module: ExcludedModules) -> Bool {
-		return Int(moduleConfigurationNode?.metadata?.excludedModules ?? Int32.zero) & module.rawValue == 0
+	private func isModuleSupported(_ module: ExcludedModules, excludedModules: Int) -> Bool {
+		return excludedModules & module.rawValue == 0
 	}
 
-	private func isAnySupported(_ modules: [ExcludedModules]) -> Bool {
-		return modules.map(isModuleSupported).contains(true)
+	private func isAnySupported(_ modules: [ExcludedModules], excludedModules: Int) -> Bool {
+		return modules.contains { isModuleSupported($0, excludedModules: excludedModules) }
 	}
 
-	private func isTAKModuleSupported() -> Bool {
-		guard let node = moduleConfigurationNode else { return false }
+	private func isTAKModuleSupported(_ node: NodeInfoEntity?) -> Bool {
+		guard let node else { return false }
 		if node.takConfig != nil {
 			return true
 		}
@@ -70,8 +77,8 @@ struct Settings: View {
 		return deviceRole == .tak || deviceRole == .takTracker
 	}
 
-	private func isTrafficManagementModuleSupported() -> Bool {
-		guard moduleConfigurationNode != nil else { return false }
+	private func isTrafficManagementModuleSupported(_ node: NodeInfoEntity?) -> Bool {
+		guard node != nil else { return false }
 		return accessoryManager.checkIsVersionSupported(forVersion: "2.8.0")
 	}
 
@@ -203,8 +210,13 @@ struct Settings: View {
 	}
 
 	var moduleConfigurationSection: some View {
-		Section {
-			if isModuleSupported(.ambientlightingConfig) {
+		// Resolve the target node and its excluded-modules bitmask ONCE per render, then feed
+		// them to the cheap per-module checks below (formerly each re-scanned the node @Query
+		// and re-faulted metadata — ~28× per render).
+		let node = moduleConfigurationNode
+		let excludedModules = Int(node?.metadata?.excludedModules ?? Int32.zero)
+		return Section {
+			if isModuleSupported(.ambientlightingConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.ambientLighting) {
 					Label {
 						Text("Ambient Lighting")
@@ -214,7 +226,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.audioConfig) {
+			if isModuleSupported(.audioConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.audio) {
 					Label {
 						Text("Audio")
@@ -224,7 +236,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.cannedmsgConfig) {
+			if isModuleSupported(.cannedmsgConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.cannedMessages) {
 					Label {
 						Text("Canned Messages")
@@ -234,7 +246,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.detectionsensorConfig) {
+			if isModuleSupported(.detectionsensorConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.detectionSensor) {
 					Label {
 						Text("Detection Sensor")
@@ -244,7 +256,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.extnotifConfig) {
+			if isModuleSupported(.extnotifConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.externalNotification) {
 					Label {
 						Text("External Notification")
@@ -254,7 +266,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.mqttConfig) {
+			if isModuleSupported(.mqttConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.mqtt) {
 					Label {
 						Text("MQTT")
@@ -264,7 +276,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.neighborinfoConfig) {
+			if isModuleSupported(.neighborinfoConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.neighborInfo) {
 					Label {
 						Text("Neighbor Info")
@@ -274,7 +286,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.rangetestConfig) {
+			if isModuleSupported(.rangetestConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.rangeTest) {
 					Label {
 						Text("Range Test")
@@ -284,7 +296,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.paxcounterConfig) {
+			if isModuleSupported(.paxcounterConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.paxCounter) {
 					Label {
 						Text("PAX Counter")
@@ -294,7 +306,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.extnotifConfig) {
+			if isModuleSupported(.extnotifConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.ringtone) {
 					Label {
 						Text("Ringtone")
@@ -304,7 +316,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.serialConfig) {
+			if isModuleSupported(.serialConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.serial) {
 					Label {
 						Text("Serial")
@@ -314,7 +326,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.storeforwardConfig) {
+			if isModuleSupported(.storeforwardConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.storeAndForward) {
 					Label {
 						Text("Store & Forward")
@@ -338,7 +350,7 @@ struct Settings: View {
 				}
 			}
 
-			if isModuleSupported(.telemetryConfig) {
+			if isModuleSupported(.telemetryConfig, excludedModules: excludedModules) {
 				NavigationLink(value: SettingsNavigationState.telemetry) {
 					Label {
 						Text("Telemetry")
@@ -348,7 +360,7 @@ struct Settings: View {
 				}
 			}
 
-			if isTrafficManagementModuleSupported() {
+			if isTrafficManagementModuleSupported(node) {
 				NavigationLink(value: SettingsNavigationState.trafficManagement) {
 					Label {
 						Text("Traffic Management")
@@ -358,7 +370,7 @@ struct Settings: View {
 				}
 			}
 
-			if !showsAnyModuleConfiguration {
+			if !showsAnyModuleConfiguration(node: node, excludedModules: excludedModules) {
 				Text("This node does not support any configurable modules.")
 					.foregroundColor(.secondary)
 			}


### PR DESCRIPTION
## Summary

Started as a Packet Stream performance investigation (CPU pegged ~100% and ingestion stalled while the stream was open under load) and grew into a perf fix plus a readability pass on the mesh log lines.

### Performance — the real fix
Profiling (`sample`) showed the stall was **not** the Packet Stream view. The main thread was pegged re-rendering alive views on every SwiftData write, dominated by:

- **`Settings.moduleConfigurationNode`** — a linear scan over the full node `@Query` plus a `.metadata` relationship fault, called **~28× per render** (the module-config section). Since the Packet Stream lives under Settings → Debug Logs, opening it kept `Settings.body` re-rendering on every ingested packet. **Fix:** resolve the node + excluded-modules bitmask **once per render** and pass them to now-pure per-module checks.
  - Result: recv-Q went from a runaway backlog (stalled) to **flat ~0 — ingestion keeps up** at the test rate; the dominant hotspot vanished from the profile.
- **`Connect.latestBatteryLevel`** — a sorted `TelemetryEntity` fetch run inside `body` on every render. **Fix:** cache in `@State`, refresh on a 15s `.task` (battery changes slowly).
- **Packet Stream view tidy-ups** — throttle the auto-scroll-to-bottom (expensive over a large `LazyVStack`) and a gentler reveal cadence.

### Display — cleaner, more informative stream
- Drop the always-constant **Level** ("Info") and **Category** ("Mesh") columns from the iPad/Mac stream rows — message gets the full width.
- Decode each packet's protobuf payload into a compact, human-readable summary appended to the log line (not raw JSON):
  - `📟 [Node Info]  … !id — 🔐 Long Name (SHRT) client TBEAM`
  - `📍 [Position]   … !id — 40.78661,-119.20650 1234m 8 sats 14-bit`
  - `📈 [Telemetry]  … !id — device 87% 4.05V ch 12.3% air 3.1%` / `env 23.5°C 45% 1013hPa`
  - `[Text Message]  … !id — <channel text>` (direct-message content redacted as `(DM)` so private 1:1 text isn't persisted to the unified log)
  - `[Neighbor Info] … !id — 6 neighbors`
  - **Routing** left as-is — it already renders its decoded payload (RequestID + Ack Status).

## Test plan
- Built Release (Mac Catalyst) clean throughout.
- Verified against a local replay device streaming captured mesh traffic: with the Settings fix, recv-Q stays flat and ingestion keeps up at the prior stall rate; profiles no longer show a dominant main-thread hotspot.
- Eyeballed the enriched stream lines for each packet type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)