### PR TITLE
feat: docs release versioning — strip pre-release banner on App Store release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -229,5 +229,5 @@ CI is handled by Xcode Cloud via `ci_scripts/ci_pre_xcodebuild.sh`. Do not modif
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at `specs/012-packet-stream-log-filter/plan.md`
+at `specs/013-docs-release-versioning/plan.md`
 <!-- SPECKIT END -->

--- a/.github/workflows/docs-release-gate.yml
+++ b/.github/workflows/docs-release-gate.yml
@@ -1,0 +1,53 @@
+name: Release Docs Gate
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-gate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate no pre-release banner in bundled HTML
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan bundled HTML for pre-release banner
+        id: scan
+        run: |
+          grep -rl "pre-release-banner" Meshtastic/Resources/docs/ --include="*.html" \
+            > /tmp/banner_files.txt 2>&1 || true
+          count=$(wc -l < /tmp/banner_files.txt | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Report results
+        run: |
+          count="${{ steps.scan.outputs.count }}"
+          total=$(find Meshtastic/Resources/docs -name '*.html' | wc -l | tr -d ' ')
+
+          if [[ "$count" -gt 0 ]]; then
+            echo "✗ pre-release-banner found in $count HTML file(s):" >&2
+            while IFS= read -r file; do
+              echo "  $file" >&2
+            done < /tmp/banner_files.txt
+            echo "" >&2
+            echo "To fix: run the following on your release branch, then delete and" >&2
+            echo "recreate this tag:" >&2
+            echo "  bash scripts/cut-release-docs.sh <version>" >&2
+            echo "  git push origin <branch>" >&2
+            echo "  git tag -d v<version> && git push origin :refs/tags/v<version>" >&2
+            echo "  git tag -a v<version> -m 'Release v<version>'" >&2
+            echo "  git push origin v<version>" >&2
+            exit 1
+          fi
+
+          echo "✓ No pre-release-banner found in bundled HTML"
+          echo "  Scanned: $total HTML file(s)"

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/012-packet-stream-log-filter"
+  "feature_directory": "specs/013-docs-release-versioning"
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,8 @@ This document outlines the process for preparing and making a release for Meshta
 1. [Branching Strategy](#branching-strategy)
 2. [Preparing for a Release](#preparing-for-a-release)
 3. [Creating a Release Branch](#creating-a-release-branch)
-4. [Finalizing the Release](#finalizing-the-release)
+4. [Docs Release Step](#docs-release-step)
+5. [Finalizing the Release](#finalizing-the-release)
 
 ## Branching Strategy
 
@@ -26,6 +27,33 @@ This document outlines the process for preparing and making a release for Meshta
    ```sh
    ./scripts/create-release-branch.sh
    ```
+
+## Docs Release Step
+
+Before creating the final tag, rebuild the in-app docs without the pre-release
+banner and commit the result. This ensures App Store users see clean documentation
+without the “Pre-release — subject to change” warning.
+
+1. Ensure `MARKETING_VERSION` in the Xcode project already matches the version
+   you are about to release (this is typically set weeks earlier when the build
+   entered TestFlight).
+2. Run the release docs script:
+   ```sh
+   bash scripts/cut-release-docs.sh X.YY.ZZ
+   ```
+   The script will:
+   - Verify `MARKETING_VERSION` matches the argument
+   - Rebuild all bundled HTML without the pre-release banner
+   - Commit the result with message `docs: rebuild for vX.YY.ZZ release`
+   - Create annotated tag `vX.YY.ZZ`
+3. Push the commit and tag:
+   ```sh
+   git push origin X.YY.ZZ-release
+   git push origin vX.YY.ZZ
+   ```
+
+For full details and error recovery, see
+[`specs/013-docs-release-versioning/quickstart.md`](specs/013-docs-release-versioning/quickstart.md).
 
 ## Finalizing the Release
 

--- a/scripts/cut-release-docs.sh
+++ b/scripts/cut-release-docs.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# scripts/cut-release-docs.sh
+# Rebuilds in-app HTML docs without the pre-release banner, commits, and tags.
+# Usage: bash scripts/cut-release-docs.sh <version>
+# See specs/013-docs-release-versioning/contracts/script-contract.md for full interface.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ── Output helpers ─────────────────────────────────────────────────────────────
+info()  { printf '\033[0;32m✓ %s\033[0m\n' "$*"; }
+warn()  { printf '\033[0;33mwarning: %s\033[0m\n' "$*" >&2; }
+error() { printf '\033[0;31merror: %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ── Usage ──────────────────────────────────────────────────────────────────────
+usage() {
+    printf 'Usage: bash scripts/cut-release-docs.sh <version>\n' >&2
+    printf '\n' >&2
+    printf '  <version>   Semantic version matching MARKETING_VERSION in project.pbxproj\n' >&2
+    printf '              Format: X.Y.Z (digits only, e.g. 2.7.14)\n' >&2
+    printf '\n' >&2
+    printf 'Example:\n' >&2
+    printf '  bash scripts/cut-release-docs.sh 2.7.14\n' >&2
+    if [[ -n "${1:-}" ]]; then
+        printf '\nerror: %s\n' "$1" >&2
+    fi
+    exit 1
+}
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+[[ $# -eq 0 ]] && usage "version argument is required"
+[[ $# -gt 1 ]] && usage "too many arguments (expected exactly one)"
+VERSION="$1"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || usage "invalid version '$VERSION' — expected X.Y.Z (e.g. 2.7.14)"
+
+# ── Pre-flight: MARKETING_VERSION consistency & match ─────────────────────────
+check_marketing_version() {
+    local pbxproj="$REPO_ROOT/Meshtastic.xcodeproj/project.pbxproj"
+    [[ -f "$pbxproj" ]] || error "project.pbxproj not found at $pbxproj"
+
+    mapfile -t versions < <(grep -E 'MARKETING_VERSION = [0-9]' "$pbxproj" \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)
+
+    if [[ ${#versions[@]} -eq 0 ]]; then
+        error "no MARKETING_VERSION entries found in project.pbxproj"
+    fi
+
+    if [[ ${#versions[@]} -gt 1 ]]; then
+        error "inconsistent MARKETING_VERSION values in project.pbxproj: ${versions[*]}"
+    fi
+
+    if [[ "${versions[0]}" != "$VERSION" ]]; then
+        error "argument '$VERSION' does not match MARKETING_VERSION '${versions[0]}' in project.pbxproj"
+    fi
+}
+
+# ── Pre-flight: git tag availability ──────────────────────────────────────────
+check_tag_available() {
+    local existing
+    existing="$(git -C "$REPO_ROOT" tag -l "v${VERSION}")"
+    if [[ -n "$existing" ]]; then
+        error "tag 'v${VERSION}' already exists — delete it first with: git tag -d v${VERSION}"
+    fi
+}
+
+# ── Pre-flight: docs-related paths are clean ──────────────────────────────────
+check_docs_clean() {
+    local dirty
+    dirty="$(git -C "$REPO_ROOT" status --porcelain \
+        -- docs/ Meshtastic/Resources/docs/ scripts/ \
+        | grep -v '^?' || true)"
+    if [[ -n "$dirty" ]]; then
+        error "$(printf 'docs-related paths have uncommitted changes:\n%s' "$dirty")"
+    fi
+}
+
+# ── Stale PNG warning ──────────────────────────────────────────────────────────
+warn_stale_pngs() {
+    local screenshots_dir="$REPO_ROOT/Meshtastic/Resources/docs/assets/screenshots"
+    [[ -d "$screenshots_dir" ]] || return 0
+
+    # Find newest .md modification time
+    local newest_md
+    newest_md="$(find "$REPO_ROOT/docs" -name '*.md' -print0 \
+        | xargs -0 stat -f '%m %N' 2>/dev/null \
+        | sort -rn | head -1 | awk '{print $2}')"
+    [[ -n "$newest_md" ]] || return 0
+
+    # Find all PNGs older than the newest .md
+    local stale_pngs=()
+    while IFS= read -r -d '' png; do
+        if [[ "$newest_md" -nt "$png" ]]; then
+            stale_pngs+=("$(basename "$png")")
+        fi
+    done < <(find "$screenshots_dir" -name '*.png' -print0)
+
+    if [[ ${#stale_pngs[@]} -gt 0 ]]; then
+        warn "the following doc screenshots may be stale (newer .md exists):"
+        for f in "${stale_pngs[@]}"; do
+            warn "  $f"
+        done
+        warn "run snapshot tests and copy-snapshots.sh before submitting to App Store"
+    fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+main() {
+    # Pre-flight checks (all read-only — no files modified on failure)
+    check_marketing_version
+    check_tag_available
+    check_docs_clean
+    info "All pre-flight checks passed (version: $VERSION)"
+
+    # Rebuild in-app docs without --beta
+    info "Rebuilding in-app docs without pre-release banner..."
+    bash "$REPO_ROOT/scripts/build-docs.sh" --output "$REPO_ROOT/Meshtastic/Resources/docs"
+
+    # Copy doc-referenced screenshots
+    info "Copying doc screenshots..."
+    bash "$REPO_ROOT/scripts/copy-snapshots.sh" \
+        --output "$REPO_ROOT/Meshtastic/Resources/docs/assets/screenshots"
+
+    # Warn on stale PNGs (non-blocking)
+    warn_stale_pngs
+
+    # Stage and commit
+    info "Staging Meshtastic/Resources/docs/..."
+    git -C "$REPO_ROOT" add Meshtastic/Resources/docs/
+    git -C "$REPO_ROOT" commit -m "docs: rebuild for v${VERSION} release"
+    local short_sha
+    short_sha="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+
+    # Count changed HTML files for summary
+    local changed_count
+    changed_count="$(git -C "$REPO_ROOT" diff-tree --no-commit-id -r --name-only HEAD \
+        | grep -c '\.html$' || true)"
+
+    # Create annotated tag
+    git -C "$REPO_ROOT" tag -a "v${VERSION}" -m "Release v${VERSION}"
+
+    # Success summary
+    echo ""
+    info "Rebuilt in-app docs without pre-release banner"
+    info "${changed_count} HTML file(s) changed in commit ${short_sha}"
+    info "Tag v${VERSION} created → ${short_sha}"
+    echo ""
+    printf 'Next steps:\n'
+    printf '  git push origin %s\n' "$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+    printf '  git push origin v%s\n' "$VERSION"
+}
+
+main

--- a/specs/013-docs-release-versioning/checklists/requirements.md
+++ b/specs/013-docs-release-versioning/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Docs Release Versioning
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-06-05  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Ready for `/speckit.plan`.
+- Validation iteration: 1 of 1 — no issues found.

--- a/specs/013-docs-release-versioning/contracts/script-contract.md
+++ b/specs/013-docs-release-versioning/contracts/script-contract.md
@@ -1,0 +1,114 @@
+# Contract: cut-release-docs.sh
+
+**Phase 1 output for plan.md**  
+**Script**: `scripts/cut-release-docs.sh`  
+**Date**: 2026-06-05
+
+---
+
+## Invocation
+
+```bash
+bash scripts/cut-release-docs.sh <version>
+```
+
+### Arguments
+
+| Argument | Type | Required | Format | Example |
+|---|---|---|---|---|
+| `<version>` | positional | yes | `X.Y.Z` (semantic version, digits only) | `2.7.14` |
+
+### Options
+
+None in v1.
+
+---
+
+## Pre-conditions (checked before any file modification)
+
+All checks are read-only. On any failure the script exits non-zero with a
+message to stderr and leaves the working tree unchanged.
+
+| # | Check | Command | Error message pattern |
+|---|---|---|---|
+| 1 | Version format valid | regex `^[0-9]+\.[0-9]+\.[0-9]+$` | `error: invalid version '<arg>' — expected X.Y.Z` |
+| 2 | MARKETING_VERSION consistent | `grep` in `project.pbxproj` + `sort -u` | `error: inconsistent MARKETING_VERSION values: <list>` |
+| 3 | MARKETING_VERSION matches arg | string equality | `error: argument '<arg>' does not match MARKETING_VERSION '<found>'` |
+| 4 | Tag does not already exist | `git tag -l "v<version>"` | `error: tag 'v<version>' already exists` |
+| 5 | Docs paths are clean | `git status --porcelain -- docs/ Meshtastic/Resources/docs/ scripts/` | `error: docs-related paths have uncommitted changes:\n<diff>` |
+
+---
+
+## Execution steps (in order)
+
+1. Validate version argument format (check 1)
+2. Extract and validate MARKETING_VERSION (checks 2 & 3)
+3. Assert tag does not exist (check 4)
+4. Assert docs paths are clean (check 5)
+5. `bash scripts/build-docs.sh --output Meshtastic/Resources/docs`  *(no `--beta`)*
+6. `bash scripts/copy-snapshots.sh --output Meshtastic/Resources/docs/assets/screenshots`
+7. Stale PNG warning (non-blocking) — compare newest `.md` vs oldest PNG mtime
+8. `git add Meshtastic/Resources/docs/`
+9. `git commit -m "docs: rebuild for v<version> release"`
+10. `git tag -a "v<version>" -m "Release v<version>"`
+11. Print success summary to stdout
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success — docs rebuilt, committed, and tagged |
+| `1` | Pre-condition failure (see error message for detail) |
+| `1` | `build-docs.sh` or `copy-snapshots.sh` failed (propagated via `set -e`) |
+
+---
+
+## Stdout (success)
+
+```
+✓ Rebuilt in-app docs without pre-release banner
+✓ <N> files changed in commit <short-sha>
+✓ Tag v<version> created → <short-sha>
+
+Next steps:
+  git push origin <branch>
+  git push origin v<version>
+```
+
+---
+
+## Stderr
+
+Warnings (non-zero exit not triggered):
+```
+warning: some doc screenshots may be stale (newest .md is newer than <file>)
+warning: run snapshot tests and copy-snapshots.sh before submitting to App Store
+```
+
+Errors (exit 1):
+```
+error: <reason>
+```
+
+---
+
+## Side effects
+
+| Effect | Reversible? | Notes |
+|---|---|---|
+| HTML files under `Meshtastic/Resources/docs/` rewritten | Yes — `git checkout` | Only `*.html` and `index.json` change |
+| Screenshots copied to `Meshtastic/Resources/docs/assets/screenshots/` | Yes | `copy-snapshots.sh` copies from `docs/assets/screenshots/` |
+| Git commit created on current branch | Yes — `git reset HEAD~1` | Message: `docs: rebuild for v<version> release` |
+| Annotated git tag created | Yes — `git tag -d v<version>` | Tag is local until explicitly pushed |
+| `cleanup-screenshots.sh` may delete orphaned PNGs from `docs/assets/screenshots/` | Recoverable via git | Called internally by `copy-snapshots.sh` |
+
+---
+
+## Non-goals (v1)
+
+- Does NOT push the commit or tag to `origin` (developer pushes explicitly)
+- Does NOT update `MARKETING_VERSION` in `project.pbxproj`
+- Does NOT regenerate snapshot PNGs (requires Xcode test run)
+- Does NOT interact with App Store Connect or Xcode Cloud

--- a/specs/013-docs-release-versioning/contracts/workflow-contract.md
+++ b/specs/013-docs-release-versioning/contracts/workflow-contract.md
@@ -1,0 +1,102 @@
+# Contract: docs-release-gate.yml
+
+**Phase 1 output for plan.md**  
+**Workflow**: `.github/workflows/docs-release-gate.yml`  
+**Date**: 2026-06-05
+
+---
+
+## Purpose
+
+Advisory validation workflow that fires on every `v*.*.*` tag push and confirms
+that no bundled HTML file in `Meshtastic/Resources/docs/` contains the
+`pre-release-banner` string. Fails loudly to alert the developer; does not block
+any other pipeline.
+
+---
+
+## Trigger
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+```
+
+---
+
+## Runner
+
+`ubuntu-latest` — no macOS runner needed; this is a plain `grep` operation.
+
+---
+
+## Inputs
+
+None. The workflow reads from the tag's committed state (the checked-out repo).
+
+---
+
+## Steps
+
+| # | Step | Action |
+|---|---|---|
+| 1 | Checkout | `actions/checkout@v4` at the pushed tag |
+| 2 | Scan HTML files | `grep -rl "pre-release-banner" Meshtastic/Resources/docs/ --include="*.html"` |
+| 3 | Report results | Output matching file list; fail if any found |
+
+> **Note**: The scan MUST be scoped to `*.html` files. `Meshtastic/Resources/docs/assets/docs.css`
+> always contains `.pre-release-banner` as a CSS class selector — an unscoped grep produces
+> a false-positive failure on every tag push.
+
+---
+
+## Outputs
+
+### On success (no banner found)
+
+```
+✓ No pre-release-banner found in Meshtastic/Resources/docs/
+  Scanned: <N> HTML files
+```
+Workflow exits 0.
+
+### On failure (banner found)
+
+```
+✗ pre-release-banner found in the following files:
+  Meshtastic/Resources/docs/user/messages.html
+  Meshtastic/Resources/docs/developer/architecture.html
+  ...
+
+Run 'bash scripts/cut-release-docs.sh <version>' and push the updated commit,
+then delete and recreate this tag.
+```
+Workflow exits 1.
+
+---
+
+## Advisory nature
+
+This workflow is **informational only**. It is not configured as a required
+status check on any branch protection rule. A failed run does not block:
+- The `docs-release.yml` Jekyll/GitHub Pages deploy
+- Xcode Cloud builds triggered by the same tag
+- App Store Connect submission
+
+The developer is responsible for observing the failure and recutting the tag.
+
+---
+
+## Relationship to docs-release.yml
+
+| Property | `docs-release.yml` | `docs-release-gate.yml` (new) |
+|---|---|---|
+| Trigger | `v*.*.*` tag push | `v*.*.*` tag push |
+| Purpose | Deploy Jekyll site to GitHub Pages | Validate in-app HTML has no beta banner |
+| Runner | `ubuntu-latest` (+ `macos-15` for snapshots) | `ubuntu-latest` |
+| Blocking | No | No (advisory) |
+| Target artifact | `docs/` Jekyll source → GitHub Pages | `Meshtastic/Resources/docs/*.html` |
+
+The two workflows are independent; neither depends on the other.

--- a/specs/013-docs-release-versioning/data-model.md
+++ b/specs/013-docs-release-versioning/data-model.md
@@ -1,0 +1,104 @@
+# Data Model: Docs Release Versioning
+
+**Phase 1 output for plan.md**  
+**Date**: 2026-06-05
+
+This feature has no database entities or SwiftData models. The "data" is a set
+of file-system artifacts whose state transitions are the core concern.
+
+---
+
+## Artifacts & State Transitions
+
+### 1. In-app HTML files (`Meshtastic/Resources/docs/**/*.html`)
+
+| State | Condition | Value of `BETA_FLAG` used to build |
+|---|---|---|
+| **pre-release** | Default development state | `true` (built with `--beta`) |
+| **release** | After `cut-release-docs.sh` is run | `false` (built without `--beta`) |
+
+**Invariant**: Every HTML file in `Meshtastic/Resources/docs/` must be in exactly
+one state at any time. Mixed states (some files with banner, some without) are not
+permitted and would be caught by the gate workflow.
+
+**Transition: pre-release → release**  
+Triggered by: `bash scripts/cut-release-docs.sh <version>`  
+Side effects:
+- All HTML files rebuilt without `pre-release-banner` div
+- Commit created on current branch
+- Annotated tag `v<version>` created
+
+**Transition: release → pre-release**  
+Triggered by: any subsequent `bash scripts/build-docs.sh --output Meshtastic/Resources/docs --beta` call (happens automatically on `main` via `docs-deploy.yml` after the next commit)  
+Side effects: HTML files rebuilt with `pre-release-banner` div; no tag action
+
+---
+
+### 2. Git tag (`v<version>`)
+
+| Field | Value |
+|---|---|
+| Format | `v` + `MARKETING_VERSION` (e.g., `v2.7.14`) |
+| Type | Annotated (`git tag -a`) |
+| Message | `Release v<version>` |
+| Target | The commit produced by step 5 of `cut-release-docs.sh` |
+| Lifecycle | Created once per release; never moved or deleted by this feature |
+
+**Validation**: The tag name's version component must equal the `MARKETING_VERSION`
+extracted from `project.pbxproj`. Enforced by FR-011.
+
+---
+
+### 3. MARKETING_VERSION (read-only entity)
+
+Sourced from `Meshtastic.xcodeproj/project.pbxproj`.
+
+| Property | Value |
+|---|---|
+| Location | Multiple `MARKETING_VERSION = X.Y.Z;` lines in `project.pbxproj` |
+| Cardinality | Multiple entries; all must be identical for a valid release |
+| Access | Read-only — the script never writes to `project.pbxproj` |
+| Format | Semantic version string matching `[0-9]+\.[0-9]+\.[0-9]+` |
+
+---
+
+### 4. Script pre-flight state (runtime only — not persisted)
+
+Before modifying any file, `cut-release-docs.sh` validates:
+
+| Check | Method | Fail condition |
+|---|---|---|
+| Version argument format | regex `^[0-9]+\.[0-9]+\.[0-9]+$` | Malformed version string |
+| MARKETING_VERSION consistency | `grep` + `sort -u` | Multiple distinct values found |
+| MARKETING_VERSION match | string equality | Extracted value ≠ argument |
+| Git tag availability | `git tag -l "v<version>"` | Tag already exists |
+| Docs-path cleanliness | `git status --porcelain -- docs/ ...` | Non-empty output |
+
+All checks are read-only and run before any file is written.
+
+---
+
+## Sequence Diagram
+
+```
+Developer                  cut-release-docs.sh         build-docs.sh     copy-snapshots.sh     git
+    |                             |                          |                    |               |
+    |-- bash cut-release-docs.sh 2.7.14 -->                 |                    |               |
+    |                      pre-flight checks                 |                    |               |
+    |                      (version format, MARKETING_VERSION, tag exists, dirty) |               |
+    |                      [FAIL → exit non-zero, no changes]|                    |               |
+    |                             |                          |                    |               |
+    |                      bash build-docs.sh --output ... --|-->                 |               |
+    |                             |                    (no --beta flag)           |               |
+    |                             |<-- HTML written ---------|                    |               |
+    |                             |                          |                    |               |
+    |                      bash copy-snapshots.sh -----------|-------------------->               |
+    |                             |<-- PNGs copied --------------------------------               |
+    |                      stale PNG check (warn only)       |                    |               |
+    |                             |                          |                    |               |
+    |                      git add Meshtastic/Resources/docs/ |                   |              -->
+    |                      git commit -m "docs: rebuild for v2.7.14 release"     |              -->
+    |                      git tag -a v2.7.14 -m "Release v2.7.14"              |              -->
+    |                             |                          |                    |               |
+    |<-- summary (files changed, commit hash, tag) ----------|                    |               |
+```

--- a/specs/013-docs-release-versioning/plan.md
+++ b/specs/013-docs-release-versioning/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Docs Release Versioning
+
+**Branch**: `013-docs-release-versioning` | **Date**: 2026-06-05 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `specs/013-docs-release-versioning/spec.md`
+
+## Summary
+
+Every App Store build currently ships the in-app HTML docs with a
+`pre-release-banner` div because `build-docs.sh` is always invoked with `--beta`
+during development. This feature adds a `scripts/cut-release-docs.sh` script that
+rebuilds the bundled HTML *without* `--beta`, verifies the Xcode project version
+matches, commits, and tags — and a lightweight GitHub Actions gate workflow
+(`docs-release-gate.yml`) that alerts on a banner-present tag push.
+
+**Technical approach**: Pure bash + GitHub Actions YAML. No Swift changes.
+Existing scripts (`build-docs.sh`, `copy-snapshots.sh`) are called as-is;
+no modifications to those files are required.
+
+## Technical Context
+
+**Language/Version**: bash 5+ (macOS zsh-compatible), GitHub Actions YAML  
+**Primary Dependencies**: `cmark-gfm` (Homebrew, already required by `build-docs.sh`), `git`  
+**Storage**: File system — `Meshtastic/Resources/docs/*.html` (in-app bundled HTML)  
+**Testing**: Manual script invocation on macOS; GitHub Actions workflow on tag push  
+**Target Platform**: macOS (developer machine) + GitHub Actions `ubuntu-latest` runner  
+**Project Type**: CLI release script + CI validation workflow  
+**Performance Goals**: Script completes in <60 seconds (SC-002) — snapshot regeneration is NOT part of this script  
+**Constraints**: Zero new runtime dependencies; bash only; must be idempotent on re-run after fixing a mismatch  
+**Scale/Scope**: 2 new files (`scripts/cut-release-docs.sh`, `.github/workflows/docs-release-gate.yml`); no existing files modified
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SwiftUI-Native | ✅ N/A | No UI code |
+| II. SwiftData Persistence | ✅ N/A | No persistence layer |
+| III. Protocol-Oriented Transport | ✅ N/A | No device communication |
+| IV. Structured Logging | ✅ N/A | Bash script; uses `echo` to stdout/stderr (appropriate for CLI) |
+| V. Protobuf Contract Fidelity | ✅ N/A | No proto changes |
+| VI. Lint-Clean Commits | ✅ Pass | No Swift code introduced; bash script should pass `shellcheck` |
+| VII. Platform Parity | ✅ N/A | Script targets macOS only (dev tool, not app code) |
+| VIII. Design Standards | ✅ N/A | No UI changes |
+| Docs Workflow | ✅ Pass | Constitution mandates `--beta` for development; this script adds the authorized release-time exception |
+
+**Gate result**: PASS — no violations. Proceed to Phase 0.
+
+**Post-design re-check**: PASS — confirmed no new Swift, UI, or persistence changes required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-docs-release-versioning/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── script-contract.md     # Phase 1 output
+│   └── workflow-contract.md   # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+scripts/
+└── cut-release-docs.sh            # NEW — release doc build, verify, commit, tag
+
+.github/workflows/
+└── docs-release-gate.yml          # NEW — advisory banner check on v*.*.* tag push
+
+# Existing files called but NOT modified:
+scripts/build-docs.sh
+scripts/copy-snapshots.sh
+Meshtastic.xcodeproj/project.pbxproj  (read-only by the script)
+Meshtastic/Resources/docs/            (written by build-docs.sh via the script)
+```
+
+**Structure Decision**: Single-project layout. Two new standalone files at repo root
+level. No new directories in the app source tree.

--- a/specs/013-docs-release-versioning/quickstart.md
+++ b/specs/013-docs-release-versioning/quickstart.md
@@ -1,0 +1,142 @@
+# Quickstart: Cutting a Docs Release
+
+**Phase 1 output for plan.md**  
+**Date**: 2026-06-05
+
+---
+
+## Prerequisites
+
+- `cmark-gfm` installed: `brew install cmark-gfm`
+- `MARKETING_VERSION` already updated in Xcode project and committed (this is done
+  when the build entered TestFlight, weeks before App Store submission)
+- Snapshot tests have been run recently (ideally on CI) — see warning note below
+- Working tree has no uncommitted changes to `docs/`, `Meshtastic/Resources/docs/`,
+  or `scripts/`
+
+---
+
+## The release-cut workflow
+
+### Step 1 — Verify you are on the correct branch
+
+```bash
+git branch          # must NOT be main
+git log --oneline -3
+```
+
+Typically you will run this on a release branch (e.g., `2.7.14-release`) or on
+a dedicated commit just before tagging. The script does not enforce which branch
+you are on.
+
+### Step 2 — Run the release docs script
+
+```bash
+bash scripts/cut-release-docs.sh 2.7.14
+```
+
+Replace `2.7.14` with the actual version matching `MARKETING_VERSION` in Xcode.
+
+**What the script does**:
+1. Verifies version format and that it matches `MARKETING_VERSION` in `project.pbxproj`
+2. Verifies the git tag `v2.7.14` does not already exist
+3. Checks that `docs/`, `Meshtastic/Resources/docs/`, and `scripts/` are clean
+4. Rebuilds all bundled HTML **without** the pre-release banner
+5. Copies current doc-referenced screenshots
+6. Warns (non-blocking) if any screenshots appear stale
+7. Creates a git commit: `docs: rebuild for v2.7.14 release`
+8. Creates an annotated git tag: `v2.7.14`
+
+**Example output**:
+```
+✓ Rebuilt in-app docs without pre-release banner
+✓ 24 files changed in commit a3f9e21
+✓ Tag v2.7.14 created → a3f9e21
+
+Next steps:
+  git push origin <branch>
+  git push origin v2.7.14
+```
+
+### Step 3 — Push the commit and tag
+
+```bash
+git push origin <your-branch>
+git push origin v2.7.14
+```
+
+Pushing the tag triggers:
+- `docs-release-gate.yml` — advisory banner check (should pass after step 2)
+- `docs-release.yml` — deploys the Jekyll site to GitHub Pages
+
+### Step 4 — Submit to App Store via Xcode Cloud
+
+Xcode Cloud picks up the tag commit for the App Store submission as normal.
+The in-app HTML in that build will not contain the pre-release banner.
+
+---
+
+## Handling errors
+
+### "does not match MARKETING_VERSION"
+
+The version you passed to the script does not match what is in `project.pbxproj`.
+
+```
+error: argument '2.7.14' does not match MARKETING_VERSION '2.7.13'
+```
+
+Fix: Either update `MARKETING_VERSION` in Xcode and commit first, or correct
+the version argument.
+
+### "tag 'v2.7.14' already exists"
+
+A tag with this name was already created. If you need to recut it:
+
+```bash
+git tag -d v2.7.14          # delete local tag
+# optionally: git push origin :refs/tags/v2.7.14  (deletes remote)
+bash scripts/cut-release-docs.sh 2.7.14
+```
+
+### "docs-related paths have uncommitted changes"
+
+You have unstaged or staged changes in `docs/`, `Meshtastic/Resources/docs/`,
+or `scripts/`. Commit or stash them first:
+
+```bash
+git status -- docs/ Meshtastic/Resources/docs/ scripts/
+# commit or stash the relevant changes, then re-run
+bash scripts/cut-release-docs.sh 2.7.14
+```
+
+### Stale screenshot warning
+
+```
+warning: some doc screenshots may be stale (newest .md is newer than <file>)
+```
+
+This is non-blocking. The release script continues. To resolve before shipping:
+1. Run the Xcode snapshot test suite: `MeshtasticTests/SwiftUIViewSnapshotTests`
+2. The screenshots are updated automatically on the next `docs-deploy.yml` CI run
+
+---
+
+## After the release: returning to pre-release state
+
+After the tag is pushed, the next doc change committed to `main` will be built by
+the existing `docs-deploy.yml` workflow using `--beta`, restoring the pre-release
+banner automatically. No manual action required.
+
+---
+
+## Notes for reviewers
+
+- The commit created by this script (`docs: rebuild for v<version> release`) should
+  be the **last** commit before the App Store build is submitted from Xcode Cloud.
+- The script is idempotent for the file changes (re-running with the same version
+  after deleting the tag produces the same HTML output); only the commit and tag
+  are non-idempotent.
+- The `Meshtastic/Resources/docs/` HTML files are committed to the repo and bundled
+  via the Xcode Copy Files build phase — they are not generated at Xcode Cloud
+  build time. The script ensures they are in the correct state before the tag.

--- a/specs/013-docs-release-versioning/research.md
+++ b/specs/013-docs-release-versioning/research.md
@@ -1,0 +1,160 @@
+# Research: Docs Release Versioning
+
+**Phase 0 output for plan.md**  
+**Date**: 2026-06-05
+
+---
+
+## R-001: Extracting MARKETING_VERSION from project.pbxproj
+
+**Decision**: Use `grep` + `sort -u` to extract all distinct values, then assert
+exactly one unique value that matches the version argument.
+
+**Rationale**: `project.pbxproj` is a plain-text file with multiple
+`MARKETING_VERSION = X.Y.Z;` entries (one per build configuration × target).
+For a correctly-prepared release all entries will be identical, so deduplicating
+with `sort -u` produces exactly one line. The script can then compare that single
+value to the argument. If `sort -u` yields more than one value, the project is in
+an inconsistent state and the script should fail with a clear message showing all
+found values.
+
+**Implementation pattern**:
+```bash
+mapfile -t versions < <(grep -E 'MARKETING_VERSION = [0-9]' \
+    Meshtastic.xcodeproj/project.pbxproj \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)
+
+if [[ ${#versions[@]} -ne 1 ]]; then
+    echo "error: inconsistent MARKETING_VERSION values: ${versions[*]}" >&2
+    exit 1
+fi
+if [[ "${versions[0]}" != "$VERSION" ]]; then
+    echo "error: argument '$VERSION' does not match MARKETING_VERSION '${versions[0]}'" >&2
+    exit 1
+fi
+```
+
+**Alternatives considered**:
+- `PlistBuddy` — only works on `.plist` files, not `.pbxproj`
+- `xcodebuild -showBuildSettings` — slow (~5s) and requires a full Xcode build
+  environment; overkill for a version string read
+- `agvtool mktg-version` — depends on `agvtool` being installed; same overhead
+
+---
+
+## R-002: Detecting dirty docs-related paths in git
+
+**Decision**: Use `git status --porcelain` filtered to the three relevant path
+prefixes (`docs/`, `Meshtastic/Resources/docs/`, `scripts/`). Any non-empty
+output = dirty.
+
+**Rationale**: `git diff --quiet` checks the index vs. working tree but misses
+staged changes. `git status --porcelain` covers both staged and unstaged changes
+in a single call. Filtering to the three prefixes avoids blocking developers who
+have unrelated Swift files modified — consistent with clarification Q2.
+
+**Implementation pattern**:
+```bash
+dirty=$(git status --porcelain -- docs/ Meshtastic/Resources/docs/ scripts/ \
+    | grep -v '^?' || true)
+if [[ -n "$dirty" ]]; then
+    echo "error: docs-related paths have uncommitted changes:" >&2
+    echo "$dirty" >&2
+    exit 1
+fi
+```
+
+Note: `grep -v '^?'` excludes untracked files (the spec only references
+"uncommitted changes"; untracked files outside the docs tree are benign).
+
+**Alternatives considered**:
+- `git diff --quiet HEAD -- <paths>` — misses staged-but-not-committed changes
+- Checking the entire working tree — too strict per clarification Q2
+
+---
+
+## R-003: Stale PNG detection
+
+**Decision**: Compare the modification time of the newest `.md` file under `docs/`
+against the oldest doc-referenced PNG under
+`Meshtastic/Resources/docs/assets/screenshots/`. If the oldest PNG is older than
+the newest `.md`, emit a warning.
+
+**Rationale**: The script should not block on stale PNGs (clarification Q3 — warn
+only). The comparison is a `find` + `stat` operation that runs in <1s and gives
+the developer actionable information.
+
+**Implementation pattern**:
+```bash
+newest_md=$(find docs -name '*.md' -newer /dev/null -print0 \
+    | xargs -0 stat -f '%m %N' 2>/dev/null | sort -rn | head -1 | awk '{print $2}')
+oldest_png=$(find Meshtastic/Resources/docs/assets/screenshots -name '*.png' \
+    -print0 | xargs -0 stat -f '%m %N' 2>/dev/null | sort -n | head -1 | awk '{print $2}')
+
+if [[ -n "$oldest_png" && "$newest_md" -nt "$oldest_png" ]]; then
+    echo "warning: some doc screenshots may be stale (newest .md is newer than $oldest_png)" >&2
+    echo "warning: run snapshot tests and copy-snapshots.sh before submitting to App Store" >&2
+fi
+```
+
+Note: `stat -f` is macOS-specific syntax (GNU `stat -c` on Linux).
+The warning path in the script is macOS-only (the script is a dev tool — FR-010).
+
+**Alternatives considered**:
+- Date-threshold (e.g., >7 days) — arbitrary and fragile for repos with infrequent
+  doc changes; file-relative comparison is more meaningful
+- Blocking — rejected per clarification Q3
+
+---
+
+## R-004: Relationship between docs-release.yml and docs-release-gate.yml
+
+**Decision**: Keep the two workflows fully independent. `docs-release.yml` (existing)
+deploys the Jekyll/GitHub Pages site. The new `docs-release-gate.yml` checks bundled
+HTML. They both trigger on `v*.*.*` tags but have no dependency on each other.
+
+**Rationale**: The Jekyll site build does not use `--beta` and is therefore always
+clean — no gate needed for it. The gate is specifically for the in-app HTML that
+is committed to the repo. Since the gate is advisory (clarification Q4), there
+is no workflow-level dependency to establish.
+
+**Alternatives considered**:
+- Adding the gate as a job inside `docs-release.yml` — would couple the two concerns;
+  harder to disable independently
+- Using `workflow_run` trigger — unnecessary complexity for an advisory check
+
+---
+
+## R-005: copy-snapshots.sh calls cleanup-screenshots.sh — release impact
+
+**Decision**: The `cleanup-screenshots.sh` call at the end of `copy-snapshots.sh`
+is safe to run during a release cut. It only removes orphaned PNGs from the source
+`docs/assets/screenshots/` directory (files not referenced by any `.md`). It does
+not touch `Meshtastic/Resources/docs/assets/screenshots/`.
+
+**Rationale**: Reviewed `copy-snapshots.sh` lines 44-47 — `cleanup-screenshots.sh`
+receives no arguments and operates on `docs/assets/screenshots/` (the source
+directory), not the output directory. Any files it removes would be orphaned
+screenshots that are already not referenced. No risk to release content.
+
+**Alternatives considered**: Skipping `copy-snapshots.sh` for release — rejected
+because FR-004 requires it; screenshots must be current in the release bundle.
+
+---
+
+## R-006: Atomic commit strategy
+
+**Decision**: Stage only `Meshtastic/Resources/docs/` with `git add` before
+committing. Use `set -euo pipefail` throughout the script so any failure before
+the `git commit` call leaves the working tree modified but uncommitted — no partial
+state is persisted to history. The developer can simply re-run the script after
+fixing the issue.
+
+**Rationale**: The script's dirty-check (FR-002) runs before any files are modified,
+so the only way the working tree becomes dirty mid-run is from `build-docs.sh` or
+`copy-snapshots.sh` themselves. `set -e` ensures the script exits before `git add`
+if those tools fail.
+
+**Alternatives considered**:
+- `git stash` / restore on failure — overly complex; not needed given `set -e` ordering
+- A separate `--dry-run` flag — nice-to-have but out of scope for v1

--- a/specs/013-docs-release-versioning/spec.md
+++ b/specs/013-docs-release-versioning/spec.md
@@ -1,0 +1,192 @@
+# Feature Specification: Docs Release Versioning
+
+**Feature Branch**: `013-docs-release-versioning`  
+**Created**: 2026-06-05  
+**Status**: Draft
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Cut a release and ship docs without the pre-release banner (Priority: P1)
+
+A developer (or CI) is ready to submit a new App Store release. They run a single
+script (or trigger a single action) that rebuilds all in-app HTML docs without the
+`--beta` flag, commits those files, and tags the resulting commit with the version
+number. The tagged commit is what gets submitted to App Store.
+
+**Why this priority**: Every App Store release currently ships the "⚠️ Pre-release —
+subject to change" banner to real users. That is the primary user-visible bug this
+feature fixes.
+
+**Independent Test**: Run the script for a fake version (e.g. `2.7.14-test`). Verify
+the committed HTML files contain no `pre-release-banner` div. Verify the git tag
+exists. No App Store submission required to validate this story.
+
+**Acceptance Scenarios**:
+
+1. **Given** the current branch is `main` with no uncommitted changes, **When** the
+   developer runs `bash scripts/cut-release-docs.sh 2.7.14`, **Then** the script runs
+   `build-docs.sh` without `--beta`, commits the updated HTML with message
+   `docs: rebuild for v2.7.14 release`, and creates an annotated git tag `v2.7.14`.
+
+2. **Given** the script has completed, **When** any bundled HTML doc page is opened
+   in the app, **Then** no element with class `pre-release-banner` is present in the
+   HTML.
+
+3. **Given** `main` has uncommitted changes, **When** the script is run, **Then** it
+   exits with a non-zero code and a clear error message without modifying anything.
+
+---
+
+### User Story 2 — GitHub Action validates in-app docs are not in pre-release state on a tag push (Priority: P2)
+
+When a `v*.*.*` tag is pushed, a GitHub Action confirms that the bundled HTML files
+do not contain the pre-release banner. If they do, the workflow fails visibly so the
+release can be corrected before App Store submission.
+
+**Why this priority**: Prevents accidentally shipping the beta banner to the App Store
+even if the script in Story 1 was not run (e.g., the tag was pushed manually).
+
+**Independent Test**: Push a test tag on a branch where HTML still has the banner;
+confirm the workflow reports a failure. Push a tag after running the release script;
+confirm the workflow passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `v*.*.*` tag is pushed where bundled HTML contains `pre-release-banner`,
+   **When** the validation workflow runs, **Then** the workflow fails with a message
+   identifying which HTML files still contain the banner.
+
+2. **Given** a `v*.*.*` tag is pushed after `cut-release-docs.sh` was run, **When**
+   the validation workflow runs, **Then** the workflow passes with a green check.
+
+---
+
+### User Story 3 — Return to pre-release state after a release tag (Priority: P3)
+
+After a release tag is cut, the next development cycle should immediately restore the
+`--beta` flag so that docs commits on `main` go back to the pre-release state. This
+is automatic and requires no manual step.
+
+**Why this priority**: Prevents a window where in-progress post-release changes are
+incorrectly presented as stable in TestFlight builds.
+
+**Independent Test**: After tagging, merge one doc change to `main` (triggering the
+existing `docs-deploy.yml` action). Confirm the updated HTML contains the
+`pre-release-banner` div again.
+
+**Acceptance Scenarios**:
+
+1. **Given** a release tag has been created, **When** a subsequent doc change is
+   committed and built on `main` via the normal `build-docs.sh --beta` call,
+   **Then** the committed HTML contains the pre-release banner.
+
+---
+
+### Edge Cases
+
+- What if the version argument does not match `MARKETING_VERSION` in `project.pbxproj`?
+  → Script exits with a clear mismatch error showing both values before touching anything.
+- What if the version argument is missing or malformed (e.g. not `X.Y.Z`)?
+  → Script exits with a usage error before modifying anything.
+- What if the git tag already exists?
+  → Script exits with an error rather than force-overwriting an existing tag.
+- What if `build-docs.sh` or `copy-snapshots.sh` fails mid-run?
+  → Script exits immediately (`set -e`); no partial commit is created.
+- What if the working tree is dirty (uncommitted changes)?
+  → Script detects this and exits before touching any files.
+- What about the Jekyll/GitHub Pages site — does it also need to drop the banner?
+  → The existing `docs-release.yml` already builds the Jekyll site on tag push.
+  The script just needs to ensure the in-app HTML (bundled with the app binary) is
+  also rebuilt. The Jekyll build is independent and does not use `--beta`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A script `scripts/cut-release-docs.sh` MUST accept a single positional
+  argument: the release version string (e.g. `2.7.14`).
+- **FR-002**: The script MUST refuse to run if `docs/`, `Meshtastic/Resources/docs/`,
+  or `scripts/` contain staged or unstaged **tracked** changes. Untracked files and
+  changes to other paths (e.g., Swift source files) do not block the script.
+- **FR-003**: The script MUST rebuild the in-app docs by calling
+  `bash scripts/build-docs.sh --output Meshtastic/Resources/docs` **without** the
+  `--beta` flag.
+- **FR-004**: The script MUST call `bash scripts/copy-snapshots.sh` after rebuilding
+  so that doc-referenced screenshots are up to date.
+- **FR-004a**: After copying, the script MUST check whether any doc-referenced PNG
+  under `Meshtastic/Resources/docs/assets/screenshots/` is older than the newest
+  `.md` file under `docs/`. If so, it MUST print a **warning** (non-blocking) listing
+  the stale files and advising the developer to regenerate snapshots before shipping.
+- **FR-005**: The script MUST `git add` only the `Meshtastic/Resources/docs/` subtree
+  and commit with a deterministic message: `docs: rebuild for v<version> release`.
+- **FR-006**: The script MUST create an annotated git tag `v<version>` (using
+  `git tag -a`, not GPG/SSH-signed) pointing at the new commit, with a tag message
+  `Release v<version>`.
+- **FR-007**: A GitHub Actions workflow (`docs-release-gate.yml`) MUST trigger on
+  `push: tags: v*.*.*` and scan every `*.html` file under `Meshtastic/Resources/docs/`
+  for the string `pre-release-banner`. The workflow MUST fail if any match is found.
+  This is an **advisory check** — it does not block the tag push or App Store
+  submission pipeline; it alerts the developer to recut the tag.
+- **FR-008**: The validation workflow MUST report which files still contain the banner
+  so the developer can act on the output without guessing.
+- **FR-009**: The script MUST print a summary of what it did (files changed, commit
+  hash, tag name) on success.
+- **FR-010**: The script MUST be runnable on macOS (the developer's machine) without
+  additional dependencies beyond what is already required by `build-docs.sh`
+  (i.e., `cmark-gfm` via Homebrew).
+- **FR-011**: Before rebuilding docs, the script MUST extract every `MARKETING_VERSION`
+  value from `Meshtastic.xcodeproj/project.pbxproj`. It MUST fail if:
+  (a) the values are not all identical (inconsistent project state), or
+  (b) the single resolved value does not match the version argument.
+  In both cases it MUST exit non-zero with a message showing the found values and
+  the argument, and no files are modified.
+
+### Key Entities
+
+- **`scripts/cut-release-docs.sh`**: New shell script that orchestrates the release
+  doc build, commit, and tag.
+- **`.github/workflows/docs-release-gate.yml`**: New GitHub Actions workflow that
+  validates no pre-release banner exists in bundled HTML when a version tag is pushed.
+- **`Meshtastic/Resources/docs/` (HTML files)**: In-app bundled docs. These are the
+  artefacts whose state changes between beta and release builds.
+- **`scripts/build-docs.sh` (existing)**: Already supports `--beta` / no-`--beta`.
+  No changes needed to this script.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: App Store builds of `v2.7.14` and later contain zero instances of the
+  string `pre-release-banner` in any bundled HTML file.
+- **SC-002**: The entire release-cut process (script + tag) completes in under
+  60 seconds on a developer machine with an already-built snapshot cache.
+- **SC-003**: The validation workflow catches a banner-present tag push 100% of the
+  time before the build reaches App Store Connect.
+- **SC-004**: Zero additional manual steps are required beyond running
+  `bash scripts/cut-release-docs.sh <version>`.
+
+## Clarifications
+
+### Session 2026-06-05
+
+- Q: Should the git tag be GPG/SSH-signed or annotated only? → A: Annotated only (`git tag -a`); no signing key required.
+- Q: Should the dirty-tree check block on any uncommitted file or only docs-related paths? → A: Block only on changes within `docs/`, `Meshtastic/Resources/docs/`, or `scripts/`.
+- Q: Should stale doc screenshots block the release script or just warn? → A: Warn (non-blocking); list stale PNGs but do not exit non-zero.
+- Q: Should `docs-release-gate.yml` be a required status check or advisory? → A: Advisory only; workflow fails loudly but does not block the tag push pipeline.
+- Q: Should the script update or verify MARKETING_VERSION? → A: Verify only — the version arg must match the pre-existing MARKETING_VERSION in project.pbxproj; fail if mismatched. All MARKETING_VERSION entries in project.pbxproj will be identical for a valid release.
+
+## Assumptions
+
+- `cmark-gfm` is already installed on the developer's machine (required by
+  `build-docs.sh`).
+- The release version string matches the `MARKETING_VERSION` in the Xcode project.
+  The script verifies this match and fails fast if they differ. `MARKETING_VERSION`
+  will have been updated in a prior commit (often weeks earlier, while the build
+  was in TestFlight).
+- Snapshot images under `Meshtastic/Resources/docs/assets/screenshots/` are already
+  current (generated by a prior snapshot test run); the script calls
+  `copy-snapshots.sh` to ensure they are in place but does not regenerate them.
+- GitHub Pages (Jekyll) docs versioning is out of scope — the existing
+  `docs-release.yml` workflow already handles that correctly on tag push.
+- Only the in-app bundled HTML (`Meshtastic/Resources/docs/*.html`) requires the
+  beta/release distinction; the markdown source files under `docs/` are unaffected.

--- a/specs/013-docs-release-versioning/tasks.md
+++ b/specs/013-docs-release-versioning/tasks.md
@@ -1,0 +1,121 @@
+# Tasks: Docs Release Versioning
+
+**Input**: Design documents from `specs/013-docs-release-versioning/`  
+**Prerequisites**: [plan.md](plan.md) · [spec.md](spec.md) · [research.md](research.md) · [data-model.md](data-model.md) · [contracts/](contracts/)
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel with other [P]-marked tasks in the same phase
+- **[Story]**: User story this task belongs to (US1 / US2 / US3)
+- Exact file paths are included in every task description
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Environment sanity check before writing any code
+
+- [x] T001 Confirm `bash scripts/build-docs.sh --output /tmp/test-docs-013 && grep -r 'pre-release-banner' /tmp/test-docs-013 --include='*.html' && echo FAIL || echo PASS` exits PASS (no `--beta` omits the banner from HTML files; CSS always contains the class selector — scope to `*.html` only); clean up temp dir. Time the run to confirm it completes well under 60s (SC-002 — design-time guarantee; this script only calls fast bash tools)
+
+**Checkpoint**: `build-docs.sh` confirmed to work without `--beta`
+
+---
+
+## Phase 2: Foundational (Script Scaffold)
+
+**Purpose**: Create the script skeleton that all US1 tasks build on
+
+**⚠️ CRITICAL**: US1 pre-flight and build tasks cannot begin until this phase is complete
+
+- [x] T002 Create `scripts/cut-release-docs.sh` with shebang `#!/usr/bin/env bash`, `set -euo pipefail`, and three output helpers: `info()` (green), `warn()` (yellow stderr), `error()` (red stderr + exit 1), plus a `usage()` function that prints synopsis and exits 1
+- [x] T003 Add positional argument parsing: accept exactly one arg `VERSION`, validate it matches `^[0-9]+\.[0-9]+\.[0-9]+$`; call `usage` with error message on mismatch or missing arg (FR-001, contracts/script-contract.md §Arguments)
+
+**Checkpoint**: Script scaffold is complete — US1 implementation and US2 (independent) can now proceed in parallel
+
+---
+
+## Phase 3: User Story 1 — Pre-flight Checks & Release Build (Priority: P1) 🎯 MVP
+
+**Goal**: `bash scripts/cut-release-docs.sh 2.7.14` verifies the environment, rebuilds in-app HTML without the pre-release banner, commits, and tags
+
+**Independent Test**: Run `bash scripts/cut-release-docs.sh <MARKETING_VERSION>` on a clean branch. Verify: (1) no `pre-release-banner` in any `Meshtastic/Resources/docs/*.html`, (2) `git log --oneline -1` shows `docs: rebuild for v<version> release`, (3) `git tag -l v<version>` returns the tag
+
+- [x] T004 [US1] Add `check_marketing_version()` function: extract all `MARKETING_VERSION = X.Y.Z` values from `Meshtastic.xcodeproj/project.pbxproj` via `grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`; pipe to `sort -u`; fail if result has >1 unique value (inconsistent project) or the single value ≠ `$VERSION` (FR-011, research.md §R-001)
+- [x] T005 [P] [US1] Add `check_tag_available()` function: run `git tag -l "v$VERSION"`; if output is non-empty call `error` with message `tag 'v$VERSION' already exists` (FR-006, contracts/script-contract.md §Pre-conditions check 4)
+- [x] T006 [US1] Add `check_docs_clean()` function: run `git status --porcelain -- docs/ Meshtastic/Resources/docs/ scripts/`; if output is non-empty call `error` listing the dirty paths (FR-002, research.md §R-002)
+- [x] T007 [US1] In `main()`: call pre-flight functions in order — `check_marketing_version`, `check_tag_available`, `check_docs_clean` — then `info "All pre-flight checks passed"` (contracts/script-contract.md §Execution steps 1–5)
+- [x] T008 [US1] Add build step in `main()`: call `bash scripts/build-docs.sh --output Meshtastic/Resources/docs` (no `--beta`); propagation via `set -e` handles failures automatically (FR-003)
+- [x] T009 [US1] Add snapshot copy step in `main()`: call `bash scripts/copy-snapshots.sh --output Meshtastic/Resources/docs/assets/screenshots` (FR-004)
+- [x] T010 [US1] Add stale PNG check after copy: find newest `.md` under `docs/` and oldest PNG under `Meshtastic/Resources/docs/assets/screenshots/`; if oldest PNG is older than newest `.md`, call `warn` listing **all** stale PNG file names and regeneration advice (FR-004a, research.md §R-003)
+- [x] T011 [US1] Add commit step: `git add Meshtastic/Resources/docs/` then `git commit -m "docs: rebuild for v${VERSION} release"`; capture short SHA for summary (FR-005)
+- [x] T012 [US1] Add tag step: `git tag -a "v${VERSION}" -m "Release v${VERSION}"` (FR-006, clarification Q1: annotated only)
+- [x] T013 [US1] Add success summary: count changed HTML files, print `info` lines for rebuild confirmation, files-changed count, commit SHA, and tag name; print plain-text next-step push commands (FR-009, contracts/script-contract.md §Stdout)
+
+**Checkpoint**: US1 fully functional — `bash scripts/cut-release-docs.sh <version>` should pass all acceptance scenarios from spec.md §User Story 1
+
+---
+
+## Phase 4: User Story 2 — Advisory Gate Workflow (Priority: P2)
+
+**Goal**: Pushing a `v*.*.*` tag triggers a GitHub Actions workflow that fails and lists any bundled HTML files containing `pre-release-banner`
+
+**Independent Test**: On a branch where `Meshtastic/Resources/docs/` HTML still contains `pre-release-banner`, push a test tag (e.g. `v99.99.99`); confirm the workflow job fails and lists the offending files in the step output
+
+> **Note**: This entire phase is [P] with Phase 3 — `.github/workflows/docs-release-gate.yml` is a separate file with no dependency on `scripts/cut-release-docs.sh`
+
+- [x] T014 [P] [US2] Create `.github/workflows/docs-release-gate.yml`: set `name: Release Docs Gate`, trigger on `push: tags: v*.*.*`, one job `validate` on `ubuntu-latest`, `permissions: contents: read`, concurrency group `docs-gate-${{ github.ref }}` with `cancel-in-progress: false`; add `actions/checkout@v4` step (contracts/workflow-contract.md §Trigger, §Runner)
+- [x] T015 [US2] Add scan step to `validate` job: run `grep -rl "pre-release-banner" Meshtastic/Resources/docs/ --include="*.html" > /tmp/banner_files.txt 2>&1 || true`; count matches; capture file list for reporting. **Note**: must scope to `*.html` — `docs.css` always contains `.pre-release-banner` as a class selector (contracts/workflow-contract.md §Steps)
+- [x] T016 [US2] Add result-reporting step: if `/tmp/banner_files.txt` is non-empty, print `✗ pre-release-banner found in:` followed by the file list and recovery instructions (`bash scripts/cut-release-docs.sh <version>`) then `exit 1`; if empty, print `✓ No pre-release-banner found — scanned N HTML files` (contracts/workflow-contract.md §Outputs)
+
+**Checkpoint**: US2 fully functional — workflow file exists, triggers on tag push, passes/fails correctly per contracts/workflow-contract.md
+
+---
+
+## Phase 5: User Story 3 — Verify Post-Release Pre-release Restoration (Priority: P3)
+
+**Goal**: Confirm that the existing `docs-deploy.yml` workflow already handles the automatic return to pre-release state after a release tag
+
+**Independent Test**: Open `.github/workflows/docs-deploy.yml` and confirm `build-docs.sh` is called with `--beta`; no code changes required for this story to pass
+
+- [x] T017 [P] [US3] Verify `.github/workflows/docs-deploy.yml` line 86 calls `bash scripts/build-docs.sh --output Meshtastic/Resources/docs --beta`; if `--beta` is absent (it is present as of the plan date), add it (spec.md §User Story 3 acceptance scenario 1)
+
+**Checkpoint**: US3 satisfied with zero or one line change — existing workflow already correct
+
+---
+
+## Phase 6: Polish & Cross-cutting Concerns
+
+- [x] T018 [P] Run `shellcheck scripts/cut-release-docs.sh` and fix any reported warnings; run `chmod +x scripts/cut-release-docs.sh` and stage the executable bit
+- [x] T019 [P] Update `RELEASING.md`: insert a "Docs release step" section documenting `bash scripts/cut-release-docs.sh <version>` as a required step before pushing the release tag, with a cross-reference to `specs/013-docs-release-versioning/quickstart.md` (SC-004)
+
+---
+
+## Dependencies
+
+```
+T001 → T002 → T003 → T004 → T007 → T008 → T009 → T010 → T011 → T012 → T013
+                    ↗ T005 ↗
+               (T005 parallel with T004 — both read-only pre-flight, different functions)
+
+T003 → T014 → T015 → T016   (Phase 4 fully parallel with Phase 3 after T003 — different files)
+
+T017, T018, T019 — independent, parallel with each other, begin after Phase 3+4 complete
+```
+
+> **[P] marker note**: Within a phase, [P] means parallel with adjacent [P] tasks in the
+> same phase (e.g., T004 ∥ T005). Across phases, [P] on a phase header (Phase 4) means
+> the entire phase runs concurrently with Phase 3.
+
+## Parallel Execution Examples
+
+**Developer A** (US1 — script logic): T001 → T002 → T003 → T004 + T005 (parallel) → T006 → T007 → T008 → T009 → T010 → T011 → T012 → T013  
+**Developer B** (US2 — workflow): waits for T003, then T014 → T015 → T016 (runs concurrently with Developer A's T004–T013)  
+**Developer C** (Polish): T017 + T018 + T019 (parallel, after Developers A and B complete)
+
+## Implementation Strategy
+
+**MVP (User Story 1 only)**: Complete Phases 1–3. This directly fixes the App Store
+pre-release banner bug and is the highest-value deliverable. US2 and US3 are safety
+nets, not prerequisites for shipping.
+
+**Full delivery order**: Phase 1 → Phase 2 → Phase 3 + Phase 4 in parallel → Phase 5 → Phase 6


### PR DESCRIPTION
## What changed

Adds two new files:

- `scripts/cut-release-docs.sh` — developer tool to cut a docs release: verifies `MARKETING_VERSION` matches the version argument, rebuilds all in-app HTML **without** the pre-release banner, commits, and creates an annotated tag.
- `.github/workflows/docs-release-gate.yml` — advisory CI check that fires on `v*.*.*` tag pushes and fails if any bundled HTML still contains the pre-release banner.

Also updates `RELEASING.md` with a new **Docs Release Step** section.

## Why it changed

Every App Store release currently ships the `⚠️ Pre-release — subject to change` banner to real users because `build-docs.sh` is always invoked with `--beta`. This feature adds the release-time workflow that strips the banner before tagging.

## How to use

```sh
bash scripts/cut-release-docs.sh 2.7.14
git push origin <branch>
git push origin v2.7.14
```

See `specs/013-docs-release-versioning/quickstart.md` for full details and error recovery.

## How it was tested

- `shellcheck scripts/cut-release-docs.sh` — 0 warnings
- Manual run of `build-docs.sh` without `--beta` confirmed zero `pre-release-banner` occurrences in output HTML (`grep --include='*.html'` scoping verified necessary to avoid false-positive from CSS)
- Pre-flight checks (version mismatch, existing tag, dirty tree) verified by code review against contracts

## Notes

- `Meshtastic/Resources/docs/` HTML files are **not** modified by this PR — the script is a dev tool run at release time
- The gate workflow scopes `grep` to `*.html` only; `docs.css` always contains the class selector and would cause false positives without this scope
- Spec: `specs/013-docs-release-versioning/`