### PR TITLE
fix: refresh UI after node-switch restore so previous node's data clears

### DIFF
--- a/Meshtastic/AppState.swift
+++ b/Meshtastic/AppState.swift
@@ -8,6 +8,10 @@ class AppState: ObservableObject {
 	@Published var router: Router
 	@Published var unreadChannelMessages: Int
 	@Published var unreadDirectMessages: Int
+	/// Bumped after a node-switch restore to force @Query-backed views to rebuild and
+	/// refetch, so they drop objects cached from the previous node's database. Applied
+	/// as `.id(appState.databaseResetID)` on the root content view.
+	@Published var databaseResetID = UUID()
 
 	var totalUnreadMessages: Int {
 		unreadChannelMessages + unreadDirectMessages

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -170,6 +170,9 @@ struct MeshtasticAppleApp: App {
 					appState: appState,
 					router: appState.router
 				)
+				// Rebuild the whole view tree (and re-run every @Query) after a node-switch
+				// restore so views drop the previous node's cached objects. See AppState.databaseResetID.
+				.id(appState.databaseResetID)
 				.sheet(item: $saveChannelLink
 				) { link in
 					SaveChannelQRCode(
@@ -265,6 +268,7 @@ struct MeshtasticAppleApp: App {
 		WindowGroup("Mesh Map", id: "meshmap-window") {
 			if !Self.isRunningTests {
 				MapWindow()
+					.id(appState.databaseResetID)
 					.modelContainer(persistenceController!.container)
 					.environmentObject(appState)
 					.environmentObject(accessoryManager)

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -794,6 +794,15 @@ func backupCurrentAndRestoreDatabase(
 		forNode: targetNodeNum,
 		into: PersistenceController.shared.container
 	)
+
+	// The clear ran on the MeshPackets context and the restore imported through a separate
+	// liveContext, neither of which the UI's main context observes — and a batch delete sends
+	// no change notification, so the existing @Query views keep their previously-fetched
+	// results (the previous node's nodes/pins linger; e.g. switching back to a local node
+	// still shows the other node's map pins). Bumping databaseResetID re-identifies the root
+	// view, forcing every @Query to re-execute its fetch and return only the restored data.
+	appState.databaseResetID = UUID()
+
 	return restoreResult
 }
 


### PR DESCRIPTION
## Summary

Switching nodes (and manual backup restore) left the previous node's nodes/pins on screen — e.g. switching back to a local node still showed another node's map pins.

## Root cause

The restore path clears the database on the **MeshPackets** context and imports the backup through a separate **liveContext** ([NodeBackupManager.restoreFromBackup](Meshtastic/Persistence/NodeBackupManager.swift)), neither of which the UI's **main context** observes. Because `clearDatabase` uses batch `delete(model:)` — which sends no change notification — the live `@Query` views never re-execute and keep showing their previously-fetched results. The flow's own doc comment promised a "Step 7: trigger UI reset" that was never implemented (`onRestoreComplete` only flips a loading spinner).

This is **not** caused by the recent save-debounce work (#1914): the device is disconnected before the clear, and every clear/restore path already flushes the debouncer.

## Fix

- Add `AppState.databaseResetID` and bump it after the restore completes in `backupCurrentAndRestoreDatabase` (covers both the node-switch and the manual-restore-from-BackupManagement callers).
- Apply `.id(appState.databaseResetID)` to the root `ContentView` and the detached Mesh Map window.

Re-identifying those views tears down and rebuilds the tree, forcing every `@Query` to re-run its fetch and return only the restored data. The orphaned objects cached in the main context are never in fresh fetch results, so they drop out. (`ModelContext` exposes no `reset()` — only `rollback()`, which wouldn't evict batch-deleted objects — hence the view-layer approach.)

## Test plan

- [ ] Switch from node A to node B, then back to A; confirm A's view no longer shows any of B's nodes/pins
- [ ] Manually restore a backup from Backup Management; confirm the UI reflects the restored DB immediately (no relaunch)
- [ ] Confirm normal navigation still works after a switch (the `.id()` rebuild resets navigation/scroll/map camera, which is expected during a switch)

> Note: builds clean for the iOS Simulator. Reproducing the bug requires switching between two physical nodes, so this needs on-device validation before merge.