### PR TITLE
fix: defer post-restore UI refresh until after reconnect to stop node-switch crash

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -795,14 +795,12 @@ func backupCurrentAndRestoreDatabase(
 		into: PersistenceController.shared.container
 	)
 
-	// The clear ran on the MeshPackets context and the restore imported through a separate
-	// liveContext, neither of which the UI's main context observes — and a batch delete sends
-	// no change notification, so the existing @Query views keep their previously-fetched
-	// results (the previous node's nodes/pins linger; e.g. switching back to a local node
-	// still shows the other node's map pins). Bumping databaseResetID re-identifies the root
-	// view, forcing every @Query to re-execute its fetch and return only the restored data.
-	appState.databaseResetID = UUID()
-
+	// NOTE: the UI refresh (bumping appState.databaseResetID) is intentionally NOT done here.
+	// Callers must trigger it only once the database is settled — for switchToDevice that means
+	// AFTER the reconnect completes. Refreshing here, mid-switch, forces every @Query to
+	// re-fetch and re-run its .task during the volatile connect window (DB retrieval + the
+	// connect-flow MeshPackets.recreateShared() teardown), which crashes accessing a model
+	// instance whose context was torn down ("destroyed by ModelContext.reset").
 	return restoreResult
 }
 
@@ -870,6 +868,12 @@ func switchToDevice(
 	} catch {
 		Logger.backup.error("💾 Failed to connect to target: \(error.localizedDescription, privacy: .public)")
 	}
+
+	// Now that the clear/restore AND the reconnect (with its DB retrieval and the connect-flow
+	// MeshPackets.recreateShared() teardown) have settled, refresh the UI. This re-identifies the
+	// root view so every @Query re-executes and drops objects cached from the previous node —
+	// done here, after the volatile connect window, to avoid the use-after-teardown crash.
+	appState.databaseResetID = UUID()
 }
 
 // MARK: - Nymea (mPWRD-OS) discovery row

--- a/Meshtastic/Views/Settings/BackupManagement/BackupManagement.swift
+++ b/Meshtastic/Views/Settings/BackupManagement/BackupManagement.swift
@@ -199,6 +199,11 @@ struct BackupManagement: View {
 			disconnectCurrentDevice: true
 		)
 
+		// Refresh the UI so @Query views drop the previous database's objects. Safe to do here:
+		// this path disconnects and does not reconnect, so there is no active connect window to
+		// race with (unlike switchToDevice, which must defer this until after its reconnect).
+		accessoryManager.appState.databaseResetID = UUID()
+
 		switch restoreResult {
 		case .success:
 			refreshBackups()


### PR DESCRIPTION
## Summary

Fixes a crash when switching nodes (reported connecting to the DEFCON simulated TCP node):

```
Fatal error: This model instance was destroyed by calling ModelContext.reset and is no longer usable.
PersistentIdentifier(... MyInfoEntity/p53)
```

## Root cause

The node-switch UI refresh from #1916 bumped `appState.databaseResetID` **inside** `backupCurrentAndRestoreDatabase`, which runs *before* `switchToDevice` reconnects. That re-identifies the root view (`.id(appState.databaseResetID)`) mid-switch, forcing every `@Query` to re-fetch and re-run its `.task` during the volatile connect window: DB retrieval plus the connect-flow `MeshPackets.recreateShared()` teardown ([AccessoryManager+Connect.swift Step 7](Meshtastic/Accessory/Accessory%20Manager/AccessoryManager+Connect.swift)). Re-querying then can touch a model instance whose `ModelContext` was just torn down → trap.

Before #1916 the stale `@Query` views simply kept their previous result arrays and never re-fetched, so the teardown was never observed — hence this surfaced only after that fix landed. The underlying `recreateShared()` lifetime fragility is older (perf PR #1774); this change removes the trigger.

## Fix

Move the refresh to each caller's **settled** point instead of the shared helper:

- **`switchToDevice`** — bump `databaseResetID` after `accessoryManager.connect()` returns, once DB retrieval and the `recreateShared()` teardown have completed.
- **`BackupManagement` restore** — bump right after the restore; that path disconnects and never reconnects, so there is no connect window to race with.

The stale-data fix from #1916 is preserved — the UI still rebuilds and drops the previous node's objects — it just happens once the database is settled.

## Test plan

- [ ] Switch from a local node to the DEFCON simulated TCP node; confirm no `ModelContext.reset` crash
- [ ] After the switch completes, confirm the previous node's nodes/pins are gone (stale-data fix still works)
- [ ] Switch back and forth a few times; confirm stability
- [ ] Manually restore a backup from Backup Management; confirm UI refreshes and no crash

> Note: builds clean for the iOS Simulator. Reproducing requires switching between two physical/simulated nodes, so this needs on-device validation. This removes the crash trigger; a deeper hardening of `recreateShared()`'s context lifetime would be a separate, reproduction-driven change.