### PR TITLE
fix: resolve myInfo/nodeInfo on a fresh context to stop post-clear connect crash

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -92,8 +92,15 @@ extension AccessoryManager {
 
 		updateDevice(key: \.num, value: Int64(myNodeInfo.myNodeNum))
 
+		// Resolve on a throwaway context, NOT the long-lived main context. After a database clear
+		// (manual reset, or the clear inside a device switch) the main context can still hold an
+		// invalidated instance registered under a rowid that SwiftData then reuses for the
+		// freshly-inserted row — model(for:) would hand that dead instance back and accessing it
+		// traps with "destroyed by ModelContext.reset". A fresh context has no such registrations,
+		// so it faults the current row from the store.
+		let myInfoResolveContext = ModelContext(context.container)
 		if let myInfoId = await MeshPackets.shared.myInfoPacket(myInfo: myNodeInfo, peripheralId: connectedDeviceId),
-		   let myInfo = try? context.model(for: myInfoId) as? MyInfoEntity {
+		   let myInfo = try? myInfoResolveContext.model(for: myInfoId) as? MyInfoEntity {
 			if let bleName = myInfo.bleName {
 				updateDevice(key: \.name, value: bleName)
 				updateDevice(key: \.longName, value: bleName)
@@ -155,8 +162,12 @@ extension AccessoryManager {
 		
 		// TODO: nodeInfoPacket's channel: parameter is not used
 		// deferSave hard coded: No need to defer save when nodeInfoPacket is now happening off the main thread
+		// Resolve on a throwaway context (see handleMyInfo): the long-lived main context can return
+		// a stale instance registered under a rowid reused after a database clear, which traps with
+		// "destroyed by ModelContext.reset". A fresh context faults the current row from the store.
+		let nodeInfoResolveContext = ModelContext(context.container)
 		if let nodeInfoId = await MeshPackets.shared.nodeInfoPacket(nodeInfo: nodeInfo, channel: 0, deferSave: false),
-		   let nodeInfo = try? context.model(for: nodeInfoId) as? NodeInfoEntity {
+		   let nodeInfo = try? nodeInfoResolveContext.model(for: nodeInfoId) as? NodeInfoEntity {
 			if let activeDevice = activeConnection?.device, activeDevice.num == nodeInfo.num {
 				if let user = nodeInfo.user {
 					updateDevice(deviceId: activeDevice.id, key: \.shortName, value: user.shortName ?? "?")


### PR DESCRIPTION
## Summary

Fixes a crash when connecting **after a database clear** — either a manual app-data reset or the clear performed during a device switch:

```
Fatal error: This model instance was destroyed by calling ModelContext.reset and is no longer usable.
PersistentIdentifier(... MyInfoEntity/p53)
```

A normal connect (no prior clear) does **not** crash — confirmed by the repro: it only happens after a clear/switch.

## Root cause

`clearDatabase` empties the store with a batch delete, but the long-lived **main context** keeps its pre-clear objects registered. On reconnect the store starts fresh and SwiftData **reuses low rowids** (`p53`). So when [handleMyInfo](Meshtastic/Accessory/Accessory%20Manager/AccessoryManager+FromRadio.swift#L96) resolves the freshly-saved myInfo via `context.model(for:)` against the main context, SwiftData's uniquing returns the **stale instance** registered under that reused id — whose backing was invalidated by the clear — and accessing it traps. The same fragile pattern exists for nodeInfo.

`model(for:)` returns a registered instance **without refreshing** it from the store, which is why the stale object surfaces. (Normal connects don't collide because the rowids already exist and aren't reused.)

## Fix

Resolve `myInfoId`/`nodeInfoId` on a throwaway `ModelContext(context.container)` instead of the long-lived main context. A fresh context has no stale registrations, so `model(for:)` faults the current row from the store. Both blocks only read scalars/relationships (no mutate-and-save), so a short-lived context is safe.

**Why `@Query` views are unaffected:** they fetch (which refreshes object data from the store), unlike `model(for:)`, which hands back the registered instance as-is — so the crash is specific to these two resolve sites.

## Test plan

- [ ] Clear app data, then connect to the DEFCON simulated TCP node — confirm no `ModelContext.reset` crash
- [ ] Switch from one node to the DEFCON node — confirm no crash
- [ ] Normal connect (no clear) still works
- [ ] After connect, the connected node's name/details populate correctly (the resolved values are still read correctly from the fresh context)

> Builds clean for the iOS Simulator. Needs on-device validation against the simulated node, since the rowid-reuse race only manifests at runtime.