### PR TITLE
feat: distance filter device-position fallback + no-position passthrough

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
@@ -111,14 +111,19 @@ final class NodeFilterParameters: ObservableObject {
 		(viaLora && !viaMqtt) || (!viaLora && viaMqtt)
 	}
 
+	/// Fallback origin for distance filtering when the phone's location services are
+	/// unavailable. Set by the owning view to the connected device's last known position.
+	@Published var fallbackLocation: CLLocationCoordinate2D?
+
 	var currentDistanceBounds: NodeDistanceFilterBounds? {
-		guard distanceFilter,
-			  let pointOfInterest = LocationsHandler.currentLocation,
-			  pointOfInterest.latitude != LocationsHandler.DefaultLocation.latitude,
-			  pointOfInterest.longitude != LocationsHandler.DefaultLocation.longitude else {
+		guard distanceFilter else { return nil }
+		let center = LocationsHandler.currentLocation ?? fallbackLocation
+		guard let center,
+			  center.latitude != LocationsHandler.DefaultLocation.latitude,
+			  center.longitude != LocationsHandler.DefaultLocation.longitude else {
 			return nil
 		}
-		return NodeDistanceFilterBounds(center: pointOfInterest, maxDistance: maxDistance)
+		return NodeDistanceFilterBounds(center: center, maxDistance: maxDistance)
 	}
 
 	var currentPreciseDistanceBounds: NodeDistanceFilterBounds? {

--- a/Meshtastic/Views/Nodes/Helpers/NodeListFilter.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListFilter.swift
@@ -66,15 +66,20 @@ struct NodeListFilter: View {
 						Label("Distance", systemImage: "map")
 					}
 					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
-					.disabled(LocationsHandler.currentPreciseLocation == nil)
+					.disabled(LocationsHandler.currentLocation == nil && filters.fallbackLocation == nil)
 					.listRowSeparator(filters.distanceFilter ? .hidden : .visible)
 
 					if filters.distanceFilter {
-						if LocationsHandler.currentPreciseLocation == nil {
+						if LocationsHandler.currentLocation == nil && filters.fallbackLocation == nil {
 							Text("Requires a precise GPS fix from your phone")
 								.font(.caption)
 								.foregroundStyle(.secondary)
 						} else {
+							if LocationsHandler.currentLocation == nil {
+								Text("Using your connected device's position")
+									.font(.caption)
+									.foregroundStyle(.secondary)
+							}
 							HStack {
 								Label("Show nodes", systemImage: "lines.measurement.horizontal")
 								Picker("", selection: $filters.maxDistance) {

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -59,6 +59,13 @@ struct MeshMap: View {
 	/// Track whether a detached Mesh Map window is currently open.
 	@State private var isMapWindowOpen = false
 
+	/// The connected device's latest coordinate, used as a fallback origin
+	/// for distance filtering when the phone's location services are unavailable.
+	private var activeDeviceCoordinate: CLLocationCoordinate2D? {
+		guard let num = accessoryManager.activeDeviceNum else { return nil }
+		return getNodeInfo(id: num, context: context)?.latestPosition?.nodeCoordinate
+	}
+
 	@Query(filter: #Predicate<PositionEntity> { $0.nodePosition != nil && $0.latest == true && $0.nodePosition?.ignored != true })
 	private var allLatestPositions: [PositionEntity]
 
@@ -344,9 +351,17 @@ struct MeshMap: View {
 		}
 			.onChange(of: positionState.key) {
 				refreshVisiblePositionSnapshots(from: positionState.positions)
+				filters.fallbackLocation = activeDeviceCoordinate
+			}
+			.onChange(of: allLatestPositions) {
+				filters.fallbackLocation = activeDeviceCoordinate
+			}
+			.onChange(of: accessoryManager.activeDeviceNum) {
+				filters.fallbackLocation = activeDeviceCoordinate
 			}
 			.onAppear {
 				UIApplication.shared.isIdleTimerDisabled = true
+				filters.fallbackLocation = activeDeviceCoordinate
 				refreshMapWindowOpenState()
 			// Initialize enabled overlay configs with all active files
 			let activeFiles = GeoJSONOverlayManager.shared.getUploadedFilesWithState().filter { $0.isActive }
@@ -371,6 +386,7 @@ struct MeshMap: View {
 		})
 		.onChange(of: router.selectedTab) { _, newTab in
 			if newTab == .map {
+				filters.fallbackLocation = activeDeviceCoordinate
 				refreshMapWindowOpenState()
 				UIApplication.shared.isIdleTimerDisabled = true
 				refreshVisiblePositionSnapshots()

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -49,6 +49,12 @@ struct NodeList: View {
 			}
 		}
 		.navigationSplitViewStyle(.balanced)
+		.onAppear {
+			filters.fallbackLocation = connectedNode?.latestPosition?.nodeCoordinate
+		}
+		.onChange(of: accessoryManager.activeDeviceNum) {
+			filters.fallbackLocation = connectedNode?.latestPosition?.nodeCoordinate
+		}
 	}
 
 	// MARK: - Sidebar
@@ -361,6 +367,10 @@ private struct FilteredNodeList: View {
 private struct NodeListFilterLookup {
 	private let environmentNodeNums: Set<Int64>?
 	private let distanceNodeNums: Set<Int64>?
+	/// Node nums that have at least one `latest` PositionEntity. Used by `isWithinDistance`
+	/// so that nodes with no position data pass through the distance filter rather than
+	/// being silently excluded.
+	private let positionedNodeNums: Set<Int64>?
 
 	init(
 		nodes: [NodeInfoEntity],
@@ -373,6 +383,7 @@ private struct NodeListFilterLookup {
 		guard needsEnvironment || distanceBounds != nil else {
 			self.environmentNodeNums = nil
 			self.distanceNodeNums = nil
+			self.positionedNodeNums = nil
 			return
 		}
 		let nodeNums = Array(Set(nodes.map(\.num)))
@@ -382,9 +393,12 @@ private struct NodeListFilterLookup {
 			self.environmentNodeNums = nil
 		}
 		if let distanceBounds {
-			self.distanceNodeNums = Self.fetchDistanceNodeNums(nodeNums: nodeNums, bounds: distanceBounds, context: context)
+			let (within, positioned) = Self.fetchDistanceNodeNums(nodeNums: nodeNums, bounds: distanceBounds, context: context)
+			self.distanceNodeNums = within
+			self.positionedNodeNums = positioned
 		} else {
 			self.distanceNodeNums = nil
+			self.positionedNodeNums = nil
 		}
 	}
 
@@ -393,7 +407,10 @@ private struct NodeListFilterLookup {
 	}
 
 	func isWithinDistance(_ node: NodeInfoEntity) -> Bool {
-		distanceNodeNums?.contains(node.num) ?? false
+		guard let distanceNodeNums else { return true }
+		// Nodes with no known position are not excluded by the distance filter.
+		guard positionedNodeNums?.contains(node.num) == true else { return true }
+		return distanceNodeNums.contains(node.num)
 	}
 
 	private static func fetchEnvironmentNodeNums(nodeNums: [Int64], context: ModelContext) -> Set<Int64> {
@@ -414,8 +431,8 @@ private struct NodeListFilterLookup {
 		nodeNums: [Int64],
 		bounds: NodeDistanceFilterBounds,
 		context: ModelContext
-	) -> Set<Int64> {
-		guard !nodeNums.isEmpty else { return [] }
+	) -> (withinBounds: Set<Int64>, withAnyPosition: Set<Int64>) {
+		guard !nodeNums.isEmpty else { return ([], []) }
 		let descriptor = FetchDescriptor<PositionEntity>(
 			predicate: #Predicate<PositionEntity> {
 				$0.latest == true
@@ -424,10 +441,16 @@ private struct NodeListFilterLookup {
 			}
 		)
 		let positions = (try? context.fetch(descriptor)) ?? []
-		return Set(positions.compactMap { position in
-			guard bounds.contains(position) else { return nil }
-			return position.nodePosition?.num
-		})
+		var withinBounds = Set<Int64>()
+		var withAnyPosition = Set<Int64>()
+		for position in positions {
+			guard let num = position.nodePosition?.num else { continue }
+			withAnyPosition.insert(num)
+			if bounds.contains(position) {
+				withinBounds.insert(num)
+			}
+		}
+		return (withinBounds, withAnyPosition)
 	}
 }
 

--- a/Meshtastic/Views/Settings/Logs/PacketStreamModel.swift
+++ b/Meshtastic/Views/Settings/Logs/PacketStreamModel.swift
@@ -27,10 +27,10 @@ final class PacketStreamModel: ObservableObject {
 
 	// MARK: - Tuning
 
-	/// ~4 entries/sec readable cadence (FR-021). Each tick also drives a view re-render and
-	/// auto-scroll, so a slightly longer interval meaningfully cuts main-actor churn under load
-	/// while staying readable (the adaptive per-tick count keeps overall throughput up).
-	private let revealIntervalNanos: UInt64 = 250_000_000
+	/// ≈2 entries/sec at calm and ≈6 entries/sec under load (SC-008). The 500ms tick
+	/// keeps main-actor churn low; the adaptive per-tick count catches up a backlog without
+	/// the stream becoming unreadable.
+	private let revealIntervalNanos: UInt64 = 500_000_000
 	/// Poll cadence for new entries (well under the 5s visibility target, SC-001).
 	private let pollIntervalNanos: UInt64 = 1_000_000_000
 
@@ -162,9 +162,9 @@ final class PacketStreamModel: ObservableObject {
 		let perTick: Int
 		switch buffer.pending.count {
 		case 0:       perTick = 0
-		case 1...10:  perTick = 1    // ~6/sec  — calm, fully readable
-		case 11...40: perTick = 4    // ~24/sec — busy mesh
-		default:      perTick = 12   // ~72/sec — drain a firehose / fast replay quickly
+		case 1...10:  perTick = 1    // ~2/sec  — calm, easy to read
+		case 11...40: perTick = 3    // ~6/sec  — spec target SC-008
+		default:      perTick = 6    // ~12/sec — drain backlog quickly
 		}
 		if perTick > 0, buffer.reveal(perTick) > 0 { syncFromBuffer() }
 	}


### PR DESCRIPTION
## Summary

Split out of #1915 (mesh-map-route-lines) so the distance-filter improvements and bugfixes can land independently of the topology/route-lines feature. **Code-only** — the topology lines, map legend, Topology Lines toggle, and docs stay on `feature/mesh-map-route-lines` (#1915).

## Changes

- **Device-position fallback:** the distance filter falls back to the connected device's last known position when the phone's own location services are unavailable. `NodeFilterParameters` gains a `fallbackLocation` that the Mesh Map and Node List set to the connected device's coordinate; `currentDistanceBounds` uses it when phone location is `nil`.
- **Looser gating:** the Distance toggle is enabled (with a "Using your connected device's position" hint) whenever *either* location source is available, instead of requiring a precise phone fix.
- **Bugfix — no-position passthrough:** nodes with no position data are no longer silently hidden by the distance filter. Only nodes that have a position *and* fall outside the radius are excluded (`fetchDistanceNodeNums` now returns both within-bounds and has-any-position sets).
- **PacketStreamModel tuning:** calmer reveal cadence (500ms tick, lower per-tick counts) to cut main-actor churn while staying readable (spec SC-008).

## Notes

- After this merges, `feature/mesh-map-route-lines` (#1915) can be rebased onto `main`; these distance-filter commits drop out automatically, leaving #1915 as a clean route-lines-only PR.

## Test plan

- [ ] With phone location OFF but a node connected, enable the Distance filter — confirm it's selectable, shows "Using your connected device's position", and filters around the device's location
- [ ] With phone location ON, distance filter still centers on the phone
- [ ] Nodes with no position remain visible when the distance filter is active
- [ ] Nodes with a position outside the radius are hidden; inside are shown
- [ ] Packet Stream reveal feels readable under load