### PR TITLE
ci: publish a version-pinned docs bundle on release tags

### DIFF
--- a/.github/workflows/docs-release-bundle.yml
+++ b/.github/workflows/docs-release-bundle.yml
@@ -1,0 +1,67 @@
+name: Release Docs Bundle
+
+# On every release tag, publish a GitHub Release whose asset is a version-pinned
+# bundle of the canonical English docs. This gives meshtastic.org's sync-apple-docs
+# job a stable artifact to pull from, so the website's Apple docs only change when a
+# new app version is tagged — not on every docs commit to main.
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write # create the GitHub Release and upload the bundle asset
+
+concurrency:
+  group: docs-release-bundle-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (at the release tag)
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Bundle canonical English docs
+        id: bundle
+        run: |
+          set -euo pipefail
+          archive="meshtastic-apple-docs-${{ steps.version.outputs.version }}.tar.gz"
+          # User + developer guides and their screenshots, preserving the repo's
+          # docs/ layout so the consumer reads the same paths it does today.
+          # Jekyll machinery (_config.yml, _data, _includes, Gemfile) is excluded.
+          tar -czf "$archive" \
+            docs/index.md \
+            docs/user.md \
+            docs/developer.md \
+            docs/user \
+            docs/developer \
+            docs/assets/screenshots
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+          echo "Bundled $(tar -tzf "$archive" | wc -l | tr -d ' ') entries into $archive"
+
+      - name: Create or update the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="$GITHUB_REF_NAME"
+          archive="${{ steps.bundle.outputs.archive }}"
+          printf '%s\n' \
+            "Documentation bundle for ${tag}." \
+            "" \
+            "Canonical English user & developer guides (markdown + screenshots) frozen at this" \
+            "release, for syncing into meshtastic.org. Point the \`sync-apple-docs\` job at this" \
+            "release asset (\`${archive}\`) instead of the \`main\` branch so the site's Apple docs" \
+            "only change when a new app version is tagged." > release-notes.md
+          # Idempotent: a re-run (or a tag re-push) updates the existing release/asset.
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" "$archive" --clobber
+          else
+            gh release create "$tag" "$archive" --title "$tag" --notes-file release-notes.md
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,7 +8,8 @@ This document outlines the process for preparing and making a release for Meshta
 2. [Preparing for a Release](#preparing-for-a-release)
 3. [Creating a Release Branch](#creating-a-release-branch)
 4. [Docs Release Step](#docs-release-step)
-5. [Finalizing the Release](#finalizing-the-release)
+5. [Documentation Publishing & Website Sync](#documentation-publishing--website-sync)
+6. [Finalizing the Release](#finalizing-the-release)
 
 ## Branching Strategy
 
@@ -54,6 +55,29 @@ without the “Pre-release — subject to change” warning.
 
 For full details and error recovery, see
 [`specs/013-docs-release-versioning/quickstart.md`](specs/013-docs-release-versioning/quickstart.md).
+
+## Documentation Publishing & Website Sync
+
+Documentation publishes **only at a tagged release** — never from day-to-day commits
+to `main`. Pushing the `vX.YY.ZZ` tag (step 3 above) runs three GitHub Actions
+workflows:
+
+| Workflow | What it does |
+|---|---|
+| [`docs-release-gate.yml`](.github/workflows/docs-release-gate.yml) | Fails the release if any bundled HTML still carries the pre-release banner. If it fails, re-run `scripts/cut-release-docs.sh X.YY.ZZ` and re-push the tag. |
+| [`docs-release.yml`](.github/workflows/docs-release.yml) | Builds and deploys this repo's GitHub Pages docs site (production, no beta banner). |
+| [`docs-release-bundle.yml`](.github/workflows/docs-release-bundle.yml) | Creates the GitHub **Release** for the tag and attaches `meshtastic-apple-docs-<version>.tar.gz` — the canonical English user/developer guides and screenshots, in the repo's `docs/` layout. |
+
+**Website (meshtastic.org) sync.** The main docs site pulls Apple docs from this repo
+via its `sync-apple-docs` job. That job downloads the **latest Meshtastic-Apple
+release** asset (`meshtastic-apple-docs-*.tar.gz`) and runs `sync-apple-docs.js`
+against it — it does **not** clone `main`. So the published Apple docs are pegged to
+the released app version and only change when a new `vX.YY.ZZ` tag is cut, not on
+every docs commit to `main`.
+
+> The website sync runs on a weekly schedule (and on demand). The first sync after a
+> release picks up the new bundle automatically; to publish sooner, manually run the
+> `Sync Apple App Documentation` workflow in the `meshtastic/meshtastic` repo.
 
 ## Finalizing the Release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,7 +64,7 @@ workflows:
 
 | Workflow | What it does |
 |---|---|
-| [`docs-release-gate.yml`](.github/workflows/docs-release-gate.yml) | Fails the release if any bundled HTML still carries the pre-release banner. If it fails, re-run `scripts/cut-release-docs.sh X.YY.ZZ` and re-push the tag. |
+| [`docs-release-gate.yml`](.github/workflows/docs-release-gate.yml) | Fails the release if any bundled HTML still carries the pre-release banner. If it fails, re-run `scripts/cut-release-docs.sh X.YY.ZZ`, then **delete and recreate the tag** — re-running the script makes a new commit, so a plain re-push won't move the existing tag. The workflow prints the exact recovery commands (`git tag -d vX.YY.ZZ && git push origin :refs/tags/vX.YY.ZZ`, then re-tag and push `vX.YY.ZZ`). |
 | [`docs-release.yml`](.github/workflows/docs-release.yml) | Builds and deploys this repo's GitHub Pages docs site (production, no beta banner). |
 | [`docs-release-bundle.yml`](.github/workflows/docs-release-bundle.yml) | Creates the GitHub **Release** for the tag and attaches `meshtastic-apple-docs-<version>.tar.gz` — the canonical English user/developer guides and screenshots, in the repo's `docs/` layout. |
 
@@ -84,10 +84,14 @@ every docs commit to `main`.
 1. Perform final testing and quality checks on the `X.YY.ZZ-release` branch.
     a. If any hotfix changes are required, merge those changes into `X.YY.ZZ-release`.
     b. After merging these changes into the release branch, cherry-pick the changes onto `main`.
-2. Once everything is ready, create a final tag for the release:
+2. Once everything is ready, push the final release tag. Use the **`v`-prefixed**
+   form — this is the same `vX.YY.ZZ` tag created by the Docs Release Step, and the
+   docs release workflows only trigger on `v*.*.*` (a bare `X.YY.ZZ` tag would never
+   publish the docs bundle or Pages). See
+   [Documentation Publishing & Website Sync](#documentation-publishing--website-sync).
    ```sh
-   git tag -a X.YY.ZZ -m "Release version X.Y.Z"
-   git push origin X.YY.ZZ
+   git tag -a vX.YY.ZZ -m "Release vX.YY.ZZ"
+   git push origin vX.YY.ZZ
    ```
 
 Thank you for following the release process and helping to ensure the stability and quality of Meshtastic!


### PR DESCRIPTION
## Summary

Pegs the meshtastic.org Apple-docs sync to a **release**, fixing the concern that the website's docs update on every docs commit to `main` rather than only when an app version ships.

Today the website's [`sync-apple-docs`](https://github.com/meshtastic/meshtastic/blob/wip-docs-sync/.github/workflows/sync-apple-docs.yml) job does:

```yaml
git clone --depth=1 --branch main https://github.com/meshtastic/Meshtastic-Apple.git /tmp/Meshtastic-Apple
node scripts/sync-apple-docs.js /tmp/Meshtastic-Apple --convert-webp
```

…so it always pulls live `main`. The script reads `SRC_DOCS_DIR = <repo>/docs`.

## What this adds

A new workflow, `docs-release-bundle.yml`, triggered on `v*.*.*` tags. It:
1. Checks out at the tag (the release-final docs produced by `scripts/cut-release-docs.sh`).
2. Bundles `meshtastic-apple-docs-<version>.tar.gz` — `docs/index.md`, `docs/user.md`, `docs/developer.md`, `docs/user/`, `docs/developer/`, `docs/assets/screenshots/` (preserving the `docs/` layout the sync script reads; Jekyll machinery excluded).
3. Creates (or idempotently updates) the GitHub Release for the tag with that asset.

This complements the existing tag workflows (`docs-release.yml` publishes this repo's Pages; `docs-release-gate.yml` validates no beta banner).

## Required companion change (other repo — not in this PR)

In meshtastic/meshtastic, point the sync at the release instead of `main` — replace the clone step with:

```yaml
- name: Fetch latest Meshtastic-Apple docs release
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    mkdir -p /tmp/Meshtastic-Apple
    gh release download --repo meshtastic/Meshtastic-Apple \
      --pattern 'meshtastic-apple-docs-*.tar.gz' --dir /tmp
    tar -xzf /tmp/meshtastic-apple-docs-*.tar.gz -C /tmp/Meshtastic-Apple
```

The existing `node scripts/sync-apple-docs.js /tmp/Meshtastic-Apple --convert-webp` step then reads `/tmp/Meshtastic-Apple/docs` unchanged. The weekly schedule can stay — it'll just pull the latest release, which only changes when a new app version is tagged.

## Test plan

- [ ] Tag a release (`scripts/cut-release-docs.sh <version>` → push tag) and confirm a GitHub Release appears with `meshtastic-apple-docs-<version>.tar.gz`
- [ ] Download the asset, `tar -tzf` it, confirm `docs/user/*.md`, `docs/developer/*.md`, and `docs/assets/screenshots/*` are present and no `_config.yml`/`Gemfile`
- [ ] Run the website sync against the extracted bundle and confirm `pnpm build` passes with no broken links

> Note: tag-triggered, so it can't be exercised on a PR. The bundle command and YAML were validated locally; the `gh release` step uses the built-in `GITHUB_TOKEN` (`contents: write`).