### PR TITLE
fix: recreate the SwiftData container on data clear to end the ModelContext.reset crash

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -127,6 +127,26 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	lazy var context = PersistenceController.shared.context
 	let mqttManager = MqttClientProxyManager.shared
 
+	// MARK: - Database reset
+
+	/// Call after a full data clear (clear app data / device reset / node switch). Reopens the
+	/// SwiftData container fresh and repoints the MeshPackets actor and this manager's cached
+	/// `context` at it, so no long-lived context keeps stale objects that would trap
+	/// ("destroyed by ModelContext.reset") when a reconnect reuses freed SQLite rowids.
+	func repointToFreshContainer() {
+		PersistenceController.shared.recreateContainer()
+		MeshPackets.recreateShared()
+		context = PersistenceController.shared.context
+	}
+
+	/// `repointToFreshContainer()` plus a UI refresh: bumps `databaseResetID` so @Query-backed
+	/// views rebind to the recreated container. Use at clear sites with no follow-up reconnect;
+	/// the node-switch flow repoints first and refreshes the UI itself after its restore.
+	func resetDatabaseAfterClear() {
+		repointToFreshContainer()
+		appState?.databaseResetID = UUID()
+	}
+
 	// Published Stuff
 	@Published var mqttProxyConnected: Bool = false
 	@Published var devices: [Device] = []

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -73,9 +73,13 @@ actor MeshPackets {
 		let metricsType: Int32
 	}
 
-	private static let _container: ModelContainer = {
+	/// Always the current shared container. Computed (not cached) so that after a data clear
+	/// recreates the container, the next `recreateShared()` rebuilds the actor on the new one
+	/// rather than a stale, torn-down container. Only read on the main actor (recreateShared and
+	/// the initial `_shared` are both reached from @MainActor code).
+	private static var _container: ModelContainer {
 		MainActor.assumeIsolated { PersistenceController.shared.container }
-	}()
+	}
 
 	/// The current shared instance. Access via `MeshPackets.shared`.
 	/// Periodically recreated to release accumulated ModelContext memory.

--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -30,8 +30,37 @@ class PersistenceController {
 
 	private(set) var container: ModelContainer
 
+	/// Remembered so the store can be reopened in a fresh container — see `recreateContainer()`.
+	private let storeName: String
+	private let inMemory: Bool
+
 	var context: ModelContext {
 		container.mainContext
+	}
+
+	/// Reopen the (already-migrated) store in a brand-new `ModelContainer`, replacing `container`.
+	///
+	/// Used after a full data clear so every context — the main context and any actor contexts
+	/// built from the container — starts with no stale object registrations. Without this, a
+	/// long-lived context keeps the pre-clear objects registered; on reconnect SQLite reuses the
+	/// freed rowids, so a fetch/relationship access returns a dead instance and SwiftData traps
+	/// with "This model instance was destroyed by calling ModelContext.reset".
+	func recreateContainer() {
+		let schema = Schema(versionedSchema: MeshtasticSchema.current)
+		let config = ModelConfiguration(
+			storeName,
+			schema: schema,
+			isStoredInMemoryOnly: inMemory,
+			allowsSave: true
+		)
+		do {
+			let fresh = try ModelContainer(for: schema, configurations: config)
+			fresh.mainContext.autosaveEnabled = false
+			container = fresh
+			Logger.data.info("💾 SwiftData container recreated after data clear")
+		} catch {
+			Logger.data.error("💾 Failed to recreate SwiftData container: \(error.localizedDescription, privacy: .public)")
+		}
 	}
 
 	private static func removeStoreFiles(at storeURL: URL) {
@@ -52,6 +81,8 @@ class PersistenceController {
 	}
 
 	init(inMemory: Bool = false, storeName: String = "Meshtastic") {
+		self.storeName = storeName
+		self.inMemory = inMemory
 		let isTestEnvironment = NSClassFromString("XCTestCase") != nil || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
 		let schema = Schema(versionedSchema: MeshtasticSchema.current)
 

--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -54,7 +54,14 @@ class PersistenceController {
 			allowsSave: true
 		)
 		do {
-			let fresh = try ModelContainer(for: schema, configurations: config)
+			// Mirror init()'s open logic: on-disk stores go through the migration plan so a
+			// reopen behaves identically to launch if a schema migration ever applies here.
+			let fresh: ModelContainer
+			if inMemory {
+				fresh = try ModelContainer(for: schema, configurations: config)
+			} else {
+				fresh = try ModelContainer(for: schema, migrationPlan: MeshtasticMigrationPlan.self, configurations: config)
+			}
 			fresh.mainContext.autosaveEnabled = false
 			container = fresh
 			Logger.data.info("💾 SwiftData container recreated after data clear")

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -787,8 +787,10 @@ func backupCurrentAndRestoreDatabase(
 
 	await MeshPackets.shared.flushDebouncedSaves()
 	await MeshPackets.shared.clearDatabase(includeRoutes: false)
-	MeshPackets.recreateShared()
-	Logger.backup.info("💾 Database cleared and MeshPackets recreated")
+	// Repoint at a fresh container so the restore below (and the post-restore UI refresh) operate
+	// on a context with no stale registrations. The databaseResetID bump stays after the restore.
+	accessoryManager.repointToFreshContainer()
+	Logger.backup.info("💾 Database cleared and container recreated")
 
 	let restoreResult = await NodeBackupManager.shared.restoreFromBackup(
 		forNode: targetNodeNum,

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -207,7 +207,7 @@ struct AppSettings: View {
 								}
 								await MeshPackets.shared.flushDebouncedSaves()
 								await MeshPackets.shared.clearDatabase(includeRoutes: true)
-								MeshPackets.recreateShared()
+								AccessoryManager.shared.resetDatabaseAfterClear()
 								clearNotifications()
 								// Repopulate device catalog immediately — no reconnect happens after a full reset.
 								try? await MeshtasticAPI.shared.refreshBundledDevicesData()

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -191,7 +191,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .milliseconds(500))
 										await MeshPackets.shared.flushDebouncedSaves()
 										await MeshPackets.shared.clearDatabase(includeRoutes: false, preserveFavorites: true)
-										MeshPackets.recreateShared()
+										AccessoryManager.shared.resetDatabaseAfterClear()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("NodeDB Reset Failed")
@@ -213,7 +213,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .milliseconds(500))
 										await MeshPackets.shared.flushDebouncedSaves()
 										await MeshPackets.shared.clearDatabase(includeRoutes: false)
-										MeshPackets.recreateShared()
+										AccessoryManager.shared.resetDatabaseAfterClear()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("NodeDB Reset Failed")
@@ -247,7 +247,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .milliseconds(500))
 										await MeshPackets.shared.flushDebouncedSaves()
 										await MeshPackets.shared.clearDatabase(includeRoutes: false)
-										MeshPackets.recreateShared()
+										AccessoryManager.shared.resetDatabaseAfterClear()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("Factory Reset Failed")
@@ -267,7 +267,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .milliseconds(500))
 										await MeshPackets.shared.flushDebouncedSaves()
 										await MeshPackets.shared.clearDatabase(includeRoutes: false)
-										MeshPackets.recreateShared()
+										AccessoryManager.shared.resetDatabaseAfterClear()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("Factory Reset Failed")


### PR DESCRIPTION
## Summary

Durable fix for the recurring crash:

```
Fatal error: This model instance was destroyed by calling ModelContext.reset and is no longer usable. (MyInfoEntity/p58)
```

Reproduced by **reconnecting to a node after "Clear App Data"** (and on node switch, which also clears).

## Why it kept happening

A full clear empties the store and recreates the **MeshPackets** actor context, but the long-lived **main context** — `AccessoryManager.context` (a cached `lazy var`) and the UI's `@Query` — is never refreshed. It keeps the pre-clear objects registered; on reconnect SQLite reuses the freed rowids, so a `fetch`/relationship access on the main context returns a **dead instance** and SwiftData traps.

This isn't fixable at the model level — `"destroyed by ModelContext.reset"` is an uncatchable Core Data trap, not a Swift `throw`. And it isn't one site: earlier point-fixes (#1918 resolved two `model(for:)` reads on a fresh context) didn't cover `tryClearExistingChannels`, the MQTT setup, etc. — each reads through the same stale main context. So this fixes it **at the source** instead of chasing every read.

## Change

- `PersistenceController.recreateContainer()` — reopens the (already-migrated) store in a brand-new `ModelContainer`, so every derived context starts with **no stale registrations**.
- `MeshPackets._container` is now computed (not cached), so `recreateShared()` rebuilds the actor on the current container.
- `AccessoryManager`:
  - `repointToFreshContainer()` — recreate container + recreate the actor + refresh its cached `context`.
  - `resetDatabaseAfterClear()` — the above plus a `databaseResetID` bump so `@Query` views rebind to the new container.
- All clear/reset sites call `resetDatabaseAfterClear()`: **Clear App Data** (AppSettings) and the **four device resets** (DeviceConfig). The **node-switch** flow repoints before its restore and keeps its existing post-restore UI refresh. The connect-time `recreateShared()` (a memory optimization, not a clear) is unchanged.

Net effect: after any clear, no long-lived context holds objects from the old store, so rowid reuse on reconnect can't surface a dead instance.

## Test plan (needs on-device — the rowid-reuse race is runtime-only)

- [ ] Settings → **Clear App Data**, then reconnect to a node — no `ModelContext.reset` crash
- [ ] **Reset node database** (both variants) and **Factory reset** (both variants), then reconnect — no crash, UI shows empty then repopulates
- [ ] **Switch** between two nodes repeatedly — no crash; the previous node's data clears (the #1916 behavior still holds)
- [ ] Normal launch + connect (no clear) still works; the connect-time memory `recreateShared()` is unaffected
- [ ] Confirm the UI repopulates after each clear (no blank/stuck lists)

> Builds clean for the iOS Simulator. This touches core data plumbing (container lifecycle, the MeshPackets `@ModelActor` container, AccessoryManager's cached context) and the race is only reproducible at runtime, so it needs the on-device checks above before merge.