### PR TITLE
fix: don't capture SwiftData models across the notification Task (switch-device crash)

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1263,69 +1263,86 @@ actor MeshPackets {
 								}
 							}
 							if !(newMessage.fromUser?.mute ?? false) && newMessage.isEmoji == false {
-								// Create an iOS Notification for the received DM message
+								// Build the notification from the model objects now, while this context is valid,
+								// and capture only the resulting value — a deferred Task must not hold `newMessage`
+								// (a context-bound model), since a device switch can reset this context first
+								// ("destroyed by ModelContext.reset").
+								let senderName = newMessage.fromUser?.longName ?? "Unknown".localized
+								var dmNotification = Notification(
+									id: ("notification.id.\(newMessage.messageId)"),
+									title: "\(senderName)",
+									subtitle: "AKA \(newMessage.fromUser?.shortName ?? "?")",
+									content: messageText!,
+									target: "messages",
+									path: "meshtastic:///messages?userNum=\(newMessage.fromUser?.num ?? 0)&messageId=\(newMessage.isEmoji ? newMessage.replyID : newMessage.messageId)",
+									messageId: newMessage.messageId,
+									channel: newMessage.channel,
+									userNum: Int64(packet.from),
+									critical: critical
+								)
+								#if os(iOS)
+								dmNotification.senderIntent = CarPlayIntentDonation.incomingMessageIntent(from: newMessage)
+								#endif
+								let notification = dmNotification
 								Task {@MainActor in
 									let manager = LocalNotificationManager()
-									var dmNotification = Notification(
-										id: ("notification.id.\(newMessage.messageId)"),
-										title: "\(newMessage.fromUser?.longName ?? "Unknown".localized)",
-										subtitle: "AKA \(newMessage.fromUser?.shortName ?? "?")",
-										content: messageText!,
-										target: "messages",
-										path: "meshtastic:///messages?userNum=\(newMessage.fromUser?.num ?? 0)&messageId=\(newMessage.isEmoji ? newMessage.replyID : newMessage.messageId)",
-										messageId: newMessage.messageId,
-										channel: newMessage.channel,
-										userNum: Int64(packet.from),
-										critical: critical
-									)
-									#if os(iOS)
-									dmNotification.senderIntent = CarPlayIntentDonation.incomingMessageIntent(from: newMessage)
-									#endif
-									manager.notifications = [dmNotification]
+									manager.notifications = [notification]
 									manager.schedule()
-
-									Logger.services.debug("iOS Notification Scheduled for text message from \(newMessage.fromUser?.longName ?? "Unknown".localized, privacy: .public)")
+									Logger.services.debug("iOS Notification Scheduled for text message from \(senderName, privacy: .public)")
 								}
 							}
 						} else if newMessage.fromUser != nil && newMessage.toUser == nil {
 							let myInfoFetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == connectedNode })
 							do {
 								let fetchedMyInfo = try modelContext.fetch(myInfoFetchDescriptor)
-								if !fetchedMyInfo.isEmpty {
-									let ctx = modelContext
-									// unreadMessages is O(unread); recomputing it for the badge on every
-									// incoming channel message is quadratic over a burst and stalls slower
-									// devices. Throttle to ~1/sec — the badge tolerates brief lag and also
-									// resyncs on app-active and on read (refreshBadgeCount). Notifications
-									// below still fire per message.
+								if let myInfo = fetchedMyInfo.first {
+									// Snapshot everything off this context NOW, synchronously, and capture only
+									// plain values into the deferred Task. The entity (and `newMessage`) must not
+									// cross the hop: a device switch can reset this context before the Task runs,
+									// which traps with "destroyed by ModelContext.reset" on access.
+									//
+									// unreadMessages is O(unread); recomputing it for the badge on every incoming
+									// channel message is quadratic over a burst and stalls slower devices. Throttle
+									// to ~1/sec — the badge tolerates brief lag and resyncs on app-active and on read.
 									let recountUnread = shouldRecomputeChannelUnread()
+									let connectedNodeNum = connectedNode
+									let shouldNotify = UserDefaults.channelMessageNotifications && newMessage.isEmoji == false && myInfo.channels.contains(where: { $0.index == newMessage.channel && !$0.mute })
+									var channelNotification: Notification?
+									if shouldNotify {
+										var chNotification = Notification(
+											id: ("notification.id.\(newMessage.messageId)"),
+											title: "\(newMessage.fromUser?.longName ?? "Unknown".localized)",
+											subtitle: "AKA \(newMessage.fromUser?.shortName ?? "?")",
+											content: messageText!,
+											target: "messages",
+											path: "meshtastic:///messages?channelId=\(newMessage.channel)&messageId=\(newMessage.isEmoji ? newMessage.replyID : newMessage.messageId)",
+											messageId: newMessage.messageId,
+											channel: newMessage.channel,
+											userNum: Int64(newMessage.fromUser?.userId ?? "0"),
+											critical: critical
+										)
+										#if os(iOS)
+										chNotification.senderIntent = CarPlayIntentDonation.incomingMessageIntent(from: newMessage)
+										#endif
+										channelNotification = chNotification
+									}
+									let notification = channelNotification
 									Task {@MainActor in
 										if recountUnread {
-											appState?.unreadChannelMessages = fetchedMyInfo[0].unreadMessages(context: ctx)
-										}
-										for channel in fetchedMyInfo[0].channels {
-											if channel.index == newMessage.channel && !channel.mute && UserDefaults.channelMessageNotifications && newMessage.isEmoji == false {
-												// Create an iOS Notification for the received channel message
-												let manager = LocalNotificationManager()
-												var chNotification = Notification(
-													id: ("notification.id.\(newMessage.messageId)"),
-													title: "\(newMessage.fromUser?.longName ?? "Unknown".localized)",
-													subtitle: "AKA \(newMessage.fromUser?.shortName ?? "?")",
-													content: messageText!,
-													target: "messages",
-													path: "meshtastic:///messages?channelId=\(newMessage.channel)&messageId=\(newMessage.isEmoji ? newMessage.replyID : newMessage.messageId)",
-													messageId: newMessage.messageId,
-													channel: newMessage.channel,
-													userNum: Int64(newMessage.fromUser?.userId ?? "0"),
-													critical: critical
-												)
-												#if os(iOS)
-												chNotification.senderIntent = CarPlayIntentDonation.incomingMessageIntent(from: newMessage)
-												#endif
-												manager.notifications = [chNotification]
-												manager.schedule()
-												Logger.services.debug("iOS Notification Scheduled for text message from \(newMessage.fromUser?.longName ?? "Unknown".localized, privacy: .public)")
+											// Recompute the badge against a freshly re-fetched, live main-context
+											// entity (unreadMessages is @MainActor); never touch the captured
+											// MeshPackets entity, which a device switch may have invalidated.
+											let mainContext = PersistenceController.shared.context
+											let liveDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == connectedNodeNum })
+											if let liveMyInfo = try? mainContext.fetch(liveDescriptor).first {
+												appState?.unreadChannelMessages = liveMyInfo.unreadMessages(context: mainContext)
 											}
+										}
+										if let notification {
+											let manager = LocalNotificationManager()
+											manager.notifications = [notification]
+											manager.schedule()
+											Logger.services.debug("iOS Notification Scheduled for channel text message")
 										}
 									}
 								}


### PR DESCRIPTION
## Summary

Backtrace-confirmed fix for the recurring crash when **switching devices**:

```
Fatal error: This model instance was destroyed by calling ModelContext.reset and is no longer usable. (MyInfoEntity/p65)
  frame #7  MyInfoEntity.channels.getter()
  frame #8  closure #11 in MeshPackets.textMessageAppPacket(...)  MeshPackets.swift:1310
```

## Root cause (from the backtrace)

On an incoming text message, `textMessageAppPacket` deferred its notification/badge work to a `Task { @MainActor in … }` that **captured context-bound model objects** — the fetched `MyInfoEntity` and `newMessage` — and read them (`.channels`, `.unreadMessages`, `newMessage.*`) when it ran. A device switch recreates/resets the MeshPackets `ModelContext` between the capture and the Task firing, so by the time the Task executes those objects belong to a torn-down context and any access traps.

This is why it was intermittent (depends on a message in flight around the switch) and why the container/context fixes (#1918, #1922) didn't catch it — the bug is the cross-`Task` capture, not the clear path.

## Fix

Snapshot everything the Task needs **before** the hop; capture no model objects:

- **Channel branch:** the channel mute-check runs synchronously while the context is alive; the `Notification` (and CarPlay intent) is pre-built; only plain values cross into the Task. The badge recompute (`unreadMessages` is `@MainActor`) re-fetches a **fresh, live main-context** `MyInfoEntity` inside the Task instead of touching the captured one.
- **DM branch:** the `Notification` is built before the Task and only the resulting value is captured.

## Relationship to the other open PRs

- **#1918** (resolve myInfo/nodeInfo on a fresh context) and **#1922** (recreate the container on clear) are complementary hardening; this PR fixes the specific capture that the backtrace points at. They don't conflict.

## Test plan (on-device — the race is timing-dependent)

- [ ] Switch between two nodes repeatedly while channel/DM traffic is arriving — no `ModelContext.reset` crash
- [ ] Clear App Data → reconnect with traffic — no crash
- [ ] Confirm incoming channel + DM notifications still fire, and the unread badge still updates (throttled ~1/sec)
- [ ] Confirm CarPlay sender intent still attaches (iOS)

> Builds clean for the iOS Simulator. The crash only reproduces at runtime under a switch with a message in flight, so it needs the on-device checks above.