### PR TITLE
ci: fail the build when an archive can't upload dSYMs

### DIFF
--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -15,8 +15,10 @@ fi
 DSYM_DIR="$CI_ARCHIVE_PATH/dSYMs"
 
 if [ ! -d "$DSYM_DIR" ]; then
-	echo "No dSYMs directory found at $DSYM_DIR — skipping upload."
-	exit 0
+	echo "❌ ERROR: this is an archive ($CI_ARCHIVE_PATH) but there is no dSYMs directory at $DSYM_DIR."
+	echo "   Crashes from this build would be unsymbolicated. Failing the build so it is caught now."
+	echo "   Check the Release config uses DEBUG_INFORMATION_FORMAT = dwarf-with-dsym."
+	exit 1
 fi
 
 DSYM_COUNT=$(find "$DSYM_DIR" -name "*.dSYM" -type d | wc -l | tr -d ' ')
@@ -26,14 +28,17 @@ find "$DSYM_DIR" -name "*.dSYM" -type d | while read -r dsym; do
 done
 
 if [ "$DSYM_COUNT" -eq 0 ]; then
-	echo "No dSYM files to upload."
-	exit 0
+	echo "❌ ERROR: this is an archive but found 0 dSYM bundles in $DSYM_DIR."
+	echo "   Crashes from this build would be unsymbolicated. Failing the build so it is caught now."
+	exit 1
 fi
 
 if [ -z "$DATADOG_API_KEY" ]; then
-	echo "WARNING: DATADOG_API_KEY is not set — skipping dSYM upload."
-	echo "Configure it as a secret in Xcode Cloud workflow environment variables."
-	exit 0
+	echo "❌ ERROR: DATADOG_API_KEY is not set, but this is an archive build with $DSYM_COUNT dSYM bundle(s)."
+	echo "   dSYMs will NOT upload and crashes will be unsymbolicated. Failing the build so it is caught now."
+	echo "   Fix: add a secret named exactly DATADOG_API_KEY to the Xcode Cloud workflow"
+	echo "   (App Store Connect → Xcode Cloud → Workflow → Environment), and ensure it is available to the Archive action."
+	exit 1
 fi
 
 # Install datadog-ci if not already present.


### PR DESCRIPTION
## Summary

The Xcode Cloud dSYM-upload step (`ci_scripts/ci_post_xcodebuild.sh`) was `exit 0`-ing (green build) whenever it *couldn't* upload — missing `DATADOG_API_KEY`, missing `dSYMs` directory, or zero dSYM bundles. So a misconfigured archive shipped to TestFlight with **unsymbolicated crashes** and nothing flagged it.

This is exactly why **2.7.13's top crash (issue `565990b0`, 96 SIGTRAP) has no symbols** — the upload almost certainly took one of those silent skip paths (most likely the `DATADOG_API_KEY` check).

## Change

Once `CI_ARCHIVE_PATH` confirms this is an **archive action**, the three failure cases now `exit 1` with a loud, actionable message instead of skipping:

| Condition | Before | After |
|---|---|---|
| Not an archive (`CI_ARCHIVE_PATH` unset) | `exit 0` skip | `exit 0` skip (unchanged — PR/test workflows unaffected) |
| Archive, no `dSYMs` dir | `exit 0` | **`exit 1`** + hint to check `DEBUG_INFORMATION_FORMAT=dwarf-with-dsym` |
| Archive, 0 dSYM bundles | `exit 0` | **`exit 1`** |
| Archive, `DATADOG_API_KEY` unset | `exit 0` (warning) | **`exit 1`** + how to add the secret |

So a green archive build now *guarantees* dSYMs were uploaded; a misconfiguration blocks the build until fixed rather than silently shipping unsymbolicated.

## Before merging — verify the secret

This will **start failing archive builds** if `DATADOG_API_KEY` isn't actually configured. So first confirm the Xcode Cloud workflow has a secret named exactly **`DATADOG_API_KEY`** (App Store Connect → Xcode Cloud → Workflow → Environment), available to the Archive action. The build's "POST-Xcode Build" log will also show which path it took historically.

## Test plan
- [ ] Archive build with the key set → logs `dSYM upload succeeded`, build passes
- [ ] Archive build with the key unset → build **fails** with the `DATADOG_API_KEY is not set` error (intended)
- [ ] PR/test (non-archive) build → still skips cleanly (`CI_ARCHIVE_PATH is not set`), passes

> `sh -n` clean. Can't exercise Xcode Cloud from here, so the archive-path behavior needs a real CI run to confirm.