### PR TITLE
fix: drop map overlays while backgrounded to stop the foreground CPU spin

### DIFF
--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -88,8 +88,14 @@ struct MeshMap: View {
 
 	/// Keep the detached map window fully populated while still starving the
 	/// main tabbed Mesh Map when it is off-screen.
+	///
+	/// Also drop all map content while the app is backgrounded (both the tab and the detached
+	/// window). Otherwise the per-node `MapCircle` overlays stay live and MapKit/VectorKit
+	/// re-invalidates the whole overlay layer on `willEnterForeground`, which can spin at ~100%
+	/// CPU. The map repopulates on the next foreground.
 	private var isMapVisible: Bool {
-		showOpenWindowButton ? router.selectedTab == .map : true
+		guard !accessoryManager.isInBackground else { return false }
+		return showOpenWindowButton ? router.selectedTab == .map : true
 	}
 
 	/// Positions actually passed to the map — empty when the tab is off-screen
@@ -358,6 +364,11 @@ struct MeshMap: View {
 			}
 			.onChange(of: accessoryManager.activeDeviceNum) {
 				filters.fallbackLocation = activeDeviceCoordinate
+			}
+			.onChange(of: accessoryManager.isInBackground) {
+				// Foreground/background flips isMapVisible; refresh so the overlay-bearing
+				// snapshots are dropped when backgrounded and rebuilt when foregrounded.
+				refreshVisiblePositionSnapshots(from: positionState.positions)
 			}
 			.onAppear {
 				UIApplication.shared.isIdleTimerDisabled = true


### PR DESCRIPTION
## Summary

Fixes the ~100% CPU / multi-GB RAM runaway seen when the app sits backgrounded (overnight) on the Map and then returns to the foreground.

A `sample` of the wedged process showed the hot path entirely in MapKit/VectorKit overlay invalidation:

```
md::OverlayLayerDataSource::invalidate → _updateNonTileOverlays → geo::TaskQueue::queueAsyncTask  (tight dispatch loop)
```
with CPU dominated by lock contention (`__ulock_wait2`) inside the debug GCD backtrace-recording hook. The "overlays" are the **per-node reduced-precision `MapCircle`s** (every `MapCircle`/`MapPolygon`/`MapPolyline` is a MapKit overlay) — not GeoJSON overlays, which are already gated off.

## Root cause

`isMapVisible` only checked the **tab** (and returned `true` unconditionally for the detached window) — never the app's **background** state:

```swift
showOpenWindowButton ? router.selectedTab == .map : true
```

So a backgrounded map kept all those circle-overlays live, and `willEnterForeground` re-invalidated the whole set at once → the loop.

## Fix

- Gate `isMapVisible` on `!accessoryManager.isInBackground`, so both the tabbed map and the detached window empty `positionSnapshots` (and thus emit **no overlays**) while backgrounded, and rebuild on the next foreground.
- Add `.onChange(of: accessoryManager.isInBackground)` to force the snapshot refresh on the transition.

## Test plan

- [ ] Open the Map tab, background the app a while, foreground it — confirm no CPU spike / beachball; map repopulates normally
- [ ] Same with a detached Mesh Map window open
- [ ] Normal foreground map use (pan/zoom, node updates, reduced-precision circles) is unaffected
- [ ] Distance-filter device-position fallback still works (it shares these handlers)

> Builds clean for the iOS Simulator. Much of the *severity* was the debug build's GCD backtrace-recording amplification; Release would burn less, but the underlying overlay churn is real, so gating it is the right call.