### PR TITLE
Add LoRa coding rate preset override controls

### DIFF
--- a/Meshtastic/Enums/LoraConfigEnums.swift
+++ b/Meshtastic/Enums/LoraConfigEnums.swift
@@ -587,7 +587,7 @@ enum CodingRates {
 			return Array(validRange)
 		}
 		let defaultCodingRate = modemPreset?.defaultCodingRate ?? ModemPresets.longFast.defaultCodingRate
-		return [0] + validRange.filter { $0 >= defaultCodingRate }
+		return [0] + validRange.filter { $0 > defaultCodingRate }
 	}
 
 	static func normalized(_ codingRate: Int, usePreset: Bool, modemPreset: ModemPresets?) -> Int {

--- a/Meshtastic/Enums/LoraConfigEnums.swift
+++ b/Meshtastic/Enums/LoraConfigEnums.swift
@@ -504,6 +504,16 @@ enum ModemPresets: Int, CaseIterable, Identifiable {
 			return "NarrowSlow"
 		}
 	}
+	var defaultCodingRate: Int {
+		switch self {
+		case .longTurbo, .longModerate, .longSlow:
+			return 8
+		case .narrowFast, .narrowSlow:
+			return 6
+		default:
+			return 5
+		}
+	}
 	func snrLimit() -> Float {
 		switch self {
 		case .longFast:
@@ -566,6 +576,37 @@ enum ModemPresets: Int, CaseIterable, Identifiable {
 		case .narrowSlow:
 			return Config.LoRaConfig.ModemPreset.narrowSlow
 		}
+	}
+}
+
+enum CodingRates {
+	static let validRange = 5...8
+
+	static func options(usePreset: Bool, modemPreset: ModemPresets?) -> [Int] {
+		guard usePreset else {
+			return Array(validRange)
+		}
+		let defaultCodingRate = modemPreset?.defaultCodingRate ?? ModemPresets.longFast.defaultCodingRate
+		return [0] + validRange.filter { $0 >= defaultCodingRate }
+	}
+
+	static func normalized(_ codingRate: Int, usePreset: Bool, modemPreset: ModemPresets?) -> Int {
+		let options = options(usePreset: usePreset, modemPreset: modemPreset)
+		if options.contains(codingRate) {
+			return codingRate
+		}
+		if usePreset {
+			return 0
+		}
+		return validRange.lowerBound
+	}
+
+	static func description(for codingRate: Int, modemPreset: ModemPresets?) -> String {
+		if codingRate == 0 {
+			let defaultCodingRate = modemPreset?.defaultCodingRate ?? ModemPresets.longFast.defaultCodingRate
+			return String.localizedStringWithFormat("Preset Default (4/%d)".localized, defaultCodingRate)
+		}
+		return "4/\(codingRate)"
 	}
 }
 

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -31,6 +31,18 @@ struct LoRaConfig: View {
 
 	let node: NodeInfoEntity?
 
+	private var selectedModemPreset: ModemPresets {
+		ModemPresets(rawValue: modemPreset) ?? .longFast
+	}
+
+	private var codingRateOptions: [Int] {
+		CodingRates.options(usePreset: usePreset, modemPreset: selectedModemPreset)
+	}
+
+	private var normalizedCodingRate: Int {
+		CodingRates.normalized(codingRate, usePreset: usePreset, modemPreset: selectedModemPreset)
+	}
+
 	@State var hasChanges = false
 	@State var region: Int = 0
 	@State var modemPreset = 0
@@ -126,15 +138,24 @@ struct LoRaConfig: View {
 							 }
 						 }
 					 }
-					 HStack {
-						 Picker("Coding Rate", selection: $codingRate) {
-							 ForEach(5..<9) {
-								 Text("\($0)")
-									 .tag($0)
-							 }
-						 }
-					 }
 				}
+
+				VStack(alignment: .leading) {
+					Picker("Coding Rate", selection: $codingRate) {
+						ForEach(codingRateOptions, id: \.self) { rate in
+							Text(CodingRates.description(for: rate, modemPreset: selectedModemPreset))
+								.tag(rate)
+						}
+					}
+					Text(
+						usePreset
+						? "Power user option. Leave this on Preset Default unless you understand the airtime tradeoff. Higher values add redundancy for noisy links but slow every transmission. Preset mode only allows the preset default or a higher, more robust coding rate."
+						: "Power user option. Coding rate controls error-correction redundancy. Higher values can help noisy links but reduce throughput and increase airtime, so beginners should keep the default 4/5."
+					)
+					.foregroundColor(.gray)
+					.font(.callout)
+				}
+
 				VStack(alignment: .leading) {
 					Picker("Number of hops", selection: $hopLimit) {
 						ForEach(0..<8) {
@@ -203,7 +224,7 @@ struct LoRaConfig: View {
 					lc.txPower = Int32(txPower)
 					lc.channelNum = UInt32(channelNum)
 					lc.bandwidth = UInt32(bandwidth)
-					lc.codingRate = UInt32(codingRate)
+					lc.codingRate = UInt32(normalizedCodingRate)
 					lc.spreadFactor = UInt32(spreadFactor)
 					lc.sx126XRxBoostedGain = rxBoostedGain
 					lc.overrideFrequency = overrideFrequency
@@ -238,9 +259,11 @@ struct LoRaConfig: View {
 			if newRegion != node?.loRaConfig?.regionCode ?? -1 { hasChanges = true }
 		}
 		.onChange(of: usePreset) { _, newPreset in
+			codingRate = CodingRates.normalized(codingRate, usePreset: newPreset, modemPreset: selectedModemPreset)
 			if newPreset != node?.loRaConfig?.usePreset { hasChanges = true }
 		}
 		.onChange(of: modemPreset) { _, newModemPreset in
+			codingRate = CodingRates.normalized(codingRate, usePreset: usePreset, modemPreset: ModemPresets(rawValue: newModemPreset) ?? .longFast)
 			if newModemPreset != node?.loRaConfig?.modemPreset ?? -1 { hasChanges = true }
 		}
 		.onChange(of: hopLimit) { _, newHopLimit in
@@ -253,7 +276,11 @@ struct LoRaConfig: View {
 			if newBandwidth != node?.loRaConfig?.bandwidth ?? -1 { hasChanges = true }
 		}
 		.onChange(of: codingRate) { _, newCodingRate in
-			if newCodingRate != node?.loRaConfig?.codingRate ?? -1 { hasChanges = true }
+			let normalizedNewCodingRate = CodingRates.normalized(newCodingRate, usePreset: usePreset, modemPreset: selectedModemPreset)
+			if normalizedNewCodingRate != newCodingRate {
+				codingRate = normalizedNewCodingRate
+			}
+			if normalizedNewCodingRate != node?.loRaConfig?.codingRate ?? -1 { hasChanges = true }
 		}
 		.onChange(of: spreadFactor) { _, newSpreadFactor in
 			if newSpreadFactor != node?.loRaConfig?.spreadFactor ?? -1 { hasChanges = true }
@@ -290,7 +317,11 @@ struct LoRaConfig: View {
 		self.channelNum = Int(node?.loRaConfig?.channelNum ?? 0)
 		self.bandwidth = Int(node?.loRaConfig?.bandwidth ?? 0)
 		let loadedCodingRate = Int(node?.loRaConfig?.codingRate ?? 0)
-		self.codingRate = loadedCodingRate == 0 ? 5 : loadedCodingRate
+		self.codingRate = CodingRates.normalized(
+			loadedCodingRate,
+			usePreset: self.usePreset,
+			modemPreset: ModemPresets(rawValue: self.modemPreset) ?? .longFast
+		)
 		self.spreadFactor = Int(node?.loRaConfig?.spreadFactor ?? 0)
 		self.rxBoostedGain = node?.loRaConfig?.sx126xRxBoostedGain ?? false
 		self.overrideFrequency = node?.loRaConfig?.overrideFrequency ?? 0.0

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -35,12 +35,54 @@ struct LoRaConfig: View {
 		ModemPresets(rawValue: modemPreset) ?? .longFast
 	}
 
-	private var codingRateOptions: [Int] {
-		CodingRates.options(usePreset: usePreset, modemPreset: selectedModemPreset)
-	}
-
 	private var normalizedCodingRate: Int {
 		CodingRates.normalized(codingRate, usePreset: usePreset, modemPreset: selectedModemPreset)
+	}
+
+	private var defaultCodingRate: Int {
+		selectedModemPreset.defaultCodingRate
+	}
+
+	private var canOverridePresetCodingRate: Bool {
+		defaultCodingRate < CodingRates.validRange.upperBound
+	}
+
+	private var usePresetCodingRate: Binding<Bool> {
+		Binding(
+			get: { normalizedCodingRate == 0 },
+			set: { useDefault in
+				if useDefault || !canOverridePresetCodingRate {
+					codingRate = 0
+				} else {
+					codingRate = defaultCodingRate + 1
+				}
+			}
+		)
+	}
+
+	private var presetCodingRateSliderValue: Binding<Double> {
+		Binding(
+			get: {
+				let firstOverride = defaultCodingRate + 1
+				return Double(max(normalizedCodingRate, firstOverride))
+			},
+			set: { newValue in
+				codingRate = Int(newValue.rounded())
+			}
+		)
+	}
+
+	private var customCodingRateSliderValue: Binding<Double> {
+		Binding(
+			get: { Double(normalizedCodingRate) },
+			set: { newValue in
+				codingRate = CodingRates.normalized(
+					Int(newValue.rounded()),
+					usePreset: false,
+					modemPreset: selectedModemPreset
+				)
+			}
+		)
 	}
 
 	@State var hasChanges = false
@@ -140,20 +182,56 @@ struct LoRaConfig: View {
 					 }
 				}
 
-				VStack(alignment: .leading) {
-					Picker("Coding Rate", selection: $codingRate) {
-						ForEach(codingRateOptions, id: \.self) { rate in
-							Text(CodingRates.description(for: rate, modemPreset: selectedModemPreset))
-								.tag(rate)
-						}
+				VStack(alignment: .leading, spacing: 8) {
+					HStack {
+						Text("Coding Rate")
+						Spacer()
+						Text(CodingRates.description(for: normalizedCodingRate, modemPreset: selectedModemPreset))
+							.foregroundColor(.secondary)
 					}
-					Text(
-						usePreset
-						? "Power user option. Leave this on Preset Default unless you understand the airtime tradeoff. Higher values add redundancy for noisy links but slow every transmission. Preset mode only allows the preset default or a higher, more robust coding rate."
-						: "Power user option. Coding rate controls error-correction redundancy. Higher values can help noisy links but reduce throughput and increase airtime, so beginners should keep the default 4/5."
-					)
-					.foregroundColor(.gray)
-					.font(.callout)
+					if usePreset {
+						Toggle("Follow Preset Coding Rate", isOn: usePresetCodingRate)
+							.tint(.accentColor)
+						if !canOverridePresetCodingRate {
+							Text("This preset already uses 4/\(defaultCodingRate), the highest redundancy available.")
+								.foregroundColor(.gray)
+								.font(.callout)
+						} else if normalizedCodingRate == 0 {
+							Text("Uses \(selectedModemPreset.description)'s 4/\(defaultCodingRate) coding rate. Turn this off only when nearby nodes use the same preset and you want extra error correction on noisy links.")
+								.foregroundColor(.gray)
+								.font(.callout)
+						} else {
+							Slider(
+								value: presetCodingRateSliderValue,
+								in: Double(defaultCodingRate + 1)...Double(CodingRates.validRange.upperBound),
+								step: 1
+							) {
+								Text("Coding Rate")
+							} minimumValueLabel: {
+								Text("4/\(defaultCodingRate + 1)")
+							} maximumValueLabel: {
+								Text("4/\(CodingRates.validRange.upperBound)")
+							}
+							Text("Uses 4/\(normalizedCodingRate) while keeping the \(selectedModemPreset.description) bandwidth and spread factor. Higher values add error correction, but each packet uses more airtime and has less throughput.")
+								.foregroundColor(.gray)
+								.font(.callout)
+						}
+					} else {
+						Slider(
+							value: customCodingRateSliderValue,
+							in: Double(CodingRates.validRange.lowerBound)...Double(CodingRates.validRange.upperBound),
+							step: 1
+						) {
+							Text("Coding Rate")
+						} minimumValueLabel: {
+							Text("4/\(CodingRates.validRange.lowerBound)")
+						} maximumValueLabel: {
+							Text("4/\(CodingRates.validRange.upperBound)")
+						}
+						Text("Coding rate controls error-correction redundancy. Higher values can help noisy links, but reduce throughput and increase airtime. Keep 4/5 unless your channel plan calls for a different value.")
+							.foregroundColor(.gray)
+							.font(.callout)
+					}
 				}
 
 				VStack(alignment: .leading) {

--- a/MeshtasticTests/LoraDeviceEnumTests.swift
+++ b/MeshtasticTests/LoraDeviceEnumTests.swift
@@ -105,8 +105,44 @@ struct ModemPresetsTests {
 		#expect(ModemPresets.shortTurbo.snrLimit() == -7.5)
 	}
 
+	@Test func defaultCodingRate_matchesPresetParams() {
+		#expect(ModemPresets.longFast.defaultCodingRate == 5)
+		#expect(ModemPresets.longSlow.defaultCodingRate == 8)
+		#expect(ModemPresets.longModerate.defaultCodingRate == 8)
+		#expect(ModemPresets.longTurbo.defaultCodingRate == 8)
+		#expect(ModemPresets.narrowFast.defaultCodingRate == 6)
+		#expect(ModemPresets.narrowSlow.defaultCodingRate == 6)
+	}
+
 	@Test func totalCaseCount() {
 		#expect(ModemPresets.allCases.count == 13)
+	}
+}
+
+// MARK: - CodingRates
+
+@Suite("CodingRates")
+struct CodingRatesTests {
+
+	@Test func customMode_allowsExplicitCodingRatesOnly() {
+		#expect(CodingRates.options(usePreset: false, modemPreset: .longFast) == [5, 6, 7, 8])
+	}
+
+	@Test func presetMode_allowsAutoAndHigherRedundancyOnly() {
+		#expect(CodingRates.options(usePreset: true, modemPreset: .longFast) == [0, 5, 6, 7, 8])
+		#expect(CodingRates.options(usePreset: true, modemPreset: .narrowFast) == [0, 6, 7, 8])
+		#expect(CodingRates.options(usePreset: true, modemPreset: .longSlow) == [0, 8])
+	}
+
+	@Test func presetMode_normalizesInvalidValuesToAuto() {
+		#expect(CodingRates.normalized(0, usePreset: true, modemPreset: .longFast) == 0)
+		#expect(CodingRates.normalized(5, usePreset: true, modemPreset: .longSlow) == 0)
+		#expect(CodingRates.normalized(9, usePreset: true, modemPreset: .longFast) == 0)
+	}
+
+	@Test func customMode_normalizesInvalidValuesToLowestCodingRate() {
+		#expect(CodingRates.normalized(0, usePreset: false, modemPreset: .longFast) == 5)
+		#expect(CodingRates.normalized(9, usePreset: false, modemPreset: .longFast) == 5)
 	}
 }
 

--- a/MeshtasticTests/LoraDeviceEnumTests.swift
+++ b/MeshtasticTests/LoraDeviceEnumTests.swift
@@ -129,14 +129,16 @@ struct CodingRatesTests {
 	}
 
 	@Test func presetMode_allowsAutoAndHigherRedundancyOnly() {
-		#expect(CodingRates.options(usePreset: true, modemPreset: .longFast) == [0, 5, 6, 7, 8])
-		#expect(CodingRates.options(usePreset: true, modemPreset: .narrowFast) == [0, 6, 7, 8])
-		#expect(CodingRates.options(usePreset: true, modemPreset: .longSlow) == [0, 8])
+		#expect(CodingRates.options(usePreset: true, modemPreset: .longFast) == [0, 6, 7, 8])
+		#expect(CodingRates.options(usePreset: true, modemPreset: .narrowFast) == [0, 7, 8])
+		#expect(CodingRates.options(usePreset: true, modemPreset: .longSlow) == [0])
 	}
 
 	@Test func presetMode_normalizesInvalidValuesToAuto() {
 		#expect(CodingRates.normalized(0, usePreset: true, modemPreset: .longFast) == 0)
+		#expect(CodingRates.normalized(5, usePreset: true, modemPreset: .longFast) == 0)
 		#expect(CodingRates.normalized(5, usePreset: true, modemPreset: .longSlow) == 0)
+		#expect(CodingRates.normalized(8, usePreset: true, modemPreset: .longSlow) == 0)
 		#expect(CodingRates.normalized(9, usePreset: true, modemPreset: .longFast) == 0)
 	}
 


### PR DESCRIPTION
## Summary
- Adds a LoRa coding-rate control to the LoRa config screen.
- Keeps preset mode on preset bandwidth/spreading factor while allowing only firmware-valid higher coding-rate overrides.
- Uses a default toggle plus stepped slider so users can see when they are following the preset and when they are adding redundancy.
- Preserves protobuf default behavior by saving `coding_rate = 0` for preset-default CR instead of writing an explicit equal-to-default value.

## Reasoning
Firmware now allows `config.lora.coding_rate` to override a preset only when the value is a valid higher/more redundant CR. Equal or lower values should fall back to the preset CR. The UI mirrors that rule by filtering preset-mode choices to `0` or strictly higher values, while custom mode still exposes explicit `4/5...4/8` values.

## Screenshot
<img src="https://raw.githubusercontent.com/RCGV1/Meshtastic-Apple-Fork/codex-pr-assets-lora-coding-rate/pr-assets/lora-coding-rate-pr-screenshot.png" alt="LoRa coding rate override slider in preset mode" width="360">

## Verification
- `git diff --check` passed.
- Built for Benjamin's iPhone with:
  `xcodebuild -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS,id=00008130-000578880102001C' -derivedDataPath /tmp/meshtastic-device-derived -skipPackagePluginValidation -skipMacroValidation build`
- Initial device build hit a codesign internal error while disk was nearly full; after clearing this branch's derived-data caches, the same build succeeded.
- Installed the built app to the iPhone successfully. Launch was denied because the phone was locked.
- Focused test compile was attempted earlier, but the test bundle hit the same local code-signing/disk-space issue rather than a source failure.
