### PR TITLE
fix: stop NodeList LazyVStack-in-List recursive layout-loop crash (565990b0)

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -164,7 +164,12 @@ struct NodeListItem: View {
 		let cachedHasDetectionSensorMetrics = rowSummary?.hasDetectionSensorMetrics ?? false
 		let cachedHasTraceRoutes = rowSummary?.hasTraceRoutes ?? false
 		let cachedHasLogs = cachedHasPositions || cachedHasEnvironmentMetrics || cachedHasDetectionSensorMetrics || cachedHasTraceRoutes
-		LazyVStack(alignment: .leading) {
+		// A plain VStack — NOT LazyVStack. A LazyVStack reports inconsistent self-sized
+		// heights when measured inside a List cell (it sizes lazily from a scroll viewport),
+		// which sends UICollectionViewCompositionalLayout into a recursive layout loop and
+		// traps on iOS 18+/26 (_UICollectionViewFeedbackLoopDebugger). The laziness was also
+		// pointless here — it wrapped a single HStack.
+		VStack(alignment: .leading) {
 			HStack {
 				VStack(alignment: .center) {
 					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 70)

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -173,7 +173,10 @@ struct NodeListItemCompact: View {
 		let cachedHasEnvironmentMetrics = shouldShowTelemetry ? rowSummary?.hasEnvironmentMetrics ?? false : false
 		let cachedHasDetectionSensorMetrics = shouldShowTelemetry ? rowSummary?.hasDetectionSensorMetrics ?? false : false
 		let cachedHasTraceRoutes = shouldShowTelemetry ? rowSummary?.hasTraceRoutes ?? false : false
-		LazyVStack(alignment: .leading) {
+		// Plain VStack, not LazyVStack: a LazyVStack inside a List cell returns inconsistent
+		// self-sized heights and trips UICollectionViewCompositionalLayout's recursive
+		// layout-loop trap on iOS 18+/26. See NodeListItem for the full explanation.
+		VStack(alignment: .leading) {
 			HStack {
 				// First Column
 				VStack(alignment: .center) {

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -336,7 +336,9 @@ private struct BuildTestNodeStandardRow: View {
 	private var modemPreset: ModemPresets { ModemPresets(rawValue: UserDefaults.modemPreset) ?? .longFast }
 
 	var body: some View {
-		LazyVStack(alignment: .leading) {
+		// Plain VStack, not LazyVStack: a LazyVStack inside a List cell returns inconsistent
+		// self-sized heights and trips the recursive layout-loop trap on iOS 18+/26.
+		VStack(alignment: .leading) {
 			HStack {
 				VStack(alignment: .center) {
 					CircleText(text: node.shortName, color: Color(UIColor(hex: 0x76A5AF)), circleSize: 70)
@@ -402,7 +404,9 @@ private struct BuildTestNodeCompactRow: View {
 	let node: BuildTestNodeSnapshot
 
 	var body: some View {
-		LazyVStack(alignment: .leading) {
+		// Plain VStack, not LazyVStack: a LazyVStack inside a List cell returns inconsistent
+		// self-sized heights and trips the recursive layout-loop trap on iOS 18+/26.
+		VStack(alignment: .leading) {
 			HStack {
 				VStack(alignment: .center) {
 					CircleText(text: node.shortName, color: Color(UIColor(hex: 0x76A5AF)), circleSize: 42)


### PR DESCRIPTION
## Problem
Top open crash in 2.7.13 (Datadog issue `565990b0`): a SIGTRAP from a SwiftUI `List` recursive layout loop, hitting iPhone (iOS 26) and iPad (iPadOS 18). Symbolicated stack bottoms out in `UICollectionViewCompositionalLayout` (`_updateVisibleCellsNow:` recursing ~97 deep → `_UICollectionViewFeedbackLoopDebugger` fatalError).

## Root cause
`NodeListItem` and `NodeListItemCompact` wrap their row content in a **`LazyVStack`**. Inside a self-sizing `List` cell, a `LazyVStack` returns **inconsistent heights across measurement passes** (it sizes lazily from a scroll viewport), so adjacent rows ping-pong their preferred height (observed **170 ↔ 164pt**) every layout pass until UIKit's recursive-layout guard traps.

Latent since 2023, but only *crashes* on iOS 18+/26 — which added the fatal recursive-layout-loop guard (older OSes merely spun the CPU). Surfaces on relayout (foreground / rotation), matching the field split across iPadOS 18 + iOS 26.

## Fix
`LazyVStack` → `VStack` in `NodeListItem`, `NodeListItemCompact`, and the two `BuildTestNode…Row` preview rows in `AppSettings` (same pattern, also inside a `List`). The laziness bought nothing — each wrapped a single `HStack`.

## Verification
Reproduced locally on a seeded Simulator by rotating during list churn — crashed at ~9 rotations every time, with Apple's `UICollectionViewFeedbackLoopDebugger` naming the two oscillating NodeList rows. After the fix the same scenario **survived 60 rotations** with zero feedback-loop errors.