### PR TITLE
build: make download_images.py emit a deterministic (sorted) image_manifest.json

### DIFF
--- a/Meshtastic/Resources/images/image_manifest.json
+++ b/Meshtastic/Resources/images/image_manifest.json
@@ -1,215 +1,215 @@
 {
+  "api_hash": "73ebeda095e6bdfc84abc6526d7c471dcca2dbc4a0145da34c5d9754b090bcf1",
   "files": {
-    "thinknode_m4.svg": {
-      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
-    },
-    "m5stack_cardputer.svg": {
-      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
-    },
-    "tlora-t3s3-epaper.svg": {
-      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
+    "crowpanel_2_4.svg": {
+      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
     },
     "crowpanel_2_8.svg": {
       "etag": "\"78955180f4e0b1a4bfc1efe8d6b953ad\""
     },
-    "seeed-sensecap-indicator.svg": {
-      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
-    },
-    "station-g2.svg": {
-      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
-    },
-    "rak-wismeshtap.svg": {
-      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
-    },
-    "thinknode_m1.svg": {
-      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
-    },
-    "tracker-t1000-e.svg": {
-      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
-    },
-    "diy.svg": {
-      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
-    },
-    "t5s3_epaper.svg": {
-      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
-    },
-    "muzi_base.svg": {
-      "etag": "\"be887c289c63af434835279b75f0879e\""
-    },
-    "seeed_xiao_nrf52_kit.svg": {
-      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
-    },
-    "pico.svg": {
-      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
-    },
-    "lilygo-tlora-pager.svg": {
-      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
-    },
-    "seeed-xiao-s3.svg": {
-      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
-    },
-    "heltec-v3-case.svg": {
-      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
-    },
-    "crowpanel_2_4.svg": {
-      "etag": "\"29194e5a415e5aee034b2d4a3ba2e398\""
-    },
-    "rak-wismesh-tap-v2.svg": {
-      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
-    },
-    "heltec-mesh-node-t114-case.svg": {
-      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
-    },
-    "heltec-wsl-v3.svg": {
-      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
-    },
-    "rak3401.svg": {
-      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
-    },
-    "rak_wismesh_tag.svg": {
-      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
-    },
-    "techo_lite.svg": {
-      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
-    },
     "crowpanel_3_5.svg": {
       "etag": "\"59675dc1a08a4c485becd29a3e8d9db8\""
-    },
-    "wio_tracker_l1_case.svg": {
-      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
-    },
-    "tbeam.svg": {
-      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
-    },
-    "heltec-vision-master-e290.svg": {
-      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
     },
     "crowpanel_5_0.svg": {
       "etag": "\"9e4795bf9f644fc071d78f291f6ff510\""
     },
-    "meteor_pro.svg": {
-      "etag": "\"db5044328b825421851b963479fab9ca\""
-    },
-    "heltec_wireless_tracker_v2.svg": {
-      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
-    },
-    "promicro.svg": {
-      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
-    },
-    "tbeam-1w.svg": {
-      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
-    },
-    "heltec-mesh-node-t114.svg": {
-      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
-    },
     "crowpanel_7_0.svg": {
       "etag": "\"d41e7b3abca1955c6e7038517a0d9623\""
     },
-    "t-watch-s3.svg": {
-      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
-    },
-    "t-echo.svg": {
-      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
-    },
-    "m5_c6l.svg": {
-      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
-    },
-    "heltec_mesh_pocket.svg": {
-      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
-    },
-    "rak_3312.svg": {
-      "etag": "\"8db94664189df83d099b726cd21045b4\""
-    },
-    "heltec-wireless-tracker.svg": {
-      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
-    },
-    "tlora-v2-1-1_6.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "rak11310.svg": {
-      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
-    },
-    "heltec-vision-master-t190.svg": {
-      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
-    },
-    "t-echo_plus.svg": {
-      "etag": "\"62d23557949092b77fd24a94abe16678\""
-    },
-    "wio_tracker_l1_eink.svg": {
-      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
-    },
-    "tbeam-s3-core.svg": {
-      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
-    },
-    "tlora-v2-1-1_8.svg": {
-      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
-    },
-    "rak2560.svg": {
-      "etag": "\"e425adc49058399a2a7f8517093192f0\""
-    },
-    "rpipicow.svg": {
-      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
+    "diy.svg": {
+      "etag": "\"c06a4d66579f4c69c5f362918cd36da5\""
     },
     "heltec-ht62-esp32c3-sx1262.svg": {
       "etag": "\"e71d389dc4571952283b1d2e69f1fc54\""
     },
-    "heltec-v3.svg": {
-      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
+    "heltec-mesh-node-t114-case.svg": {
+      "etag": "\"3d7eae010a7cd6fdd25e83c6abfec91c\""
     },
-    "rak11200.svg": {
-      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
-    },
-    "seeed_solar.svg": {
-      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
-    },
-    "rak4631.svg": {
-      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
-    },
-    "heltec-wireless-paper.svg": {
-      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
-    },
-    "thinknode_m6.svg": {
-      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
-    },
-    "thinknode_m2.svg": {
-      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
-    },
-    "t-deck.svg": {
-      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
-    },
-    "tdeck_pro.svg": {
-      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
-    },
-    "heltec-vision-master-e213.svg": {
-      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    "heltec-mesh-node-t114.svg": {
+      "etag": "\"5a183e933a9886ed38b258c7923b3105\""
     },
     "heltec-mesh-solar.svg": {
       "etag": "\"80ee3e192cc4aeb6f6ec4bf54deebbce\""
     },
-    "nano-g2-ultra.svg": {
-      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    "heltec-t096.svg": {
+      "etag": "\"686fe6ac17fea4e6ff34aca78ca610f9\""
     },
-    "muzi_r1_neo.svg": {
-      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
+    "heltec-v3-case.svg": {
+      "etag": "\"5319a951380495a93daab78d33ebc9a1\""
+    },
+    "heltec-v3.svg": {
+      "etag": "\"98fd45f8aed4f3cf9c59037755309362\""
+    },
+    "heltec-vision-master-e213.svg": {
+      "etag": "\"48c2615afa32e5236ded7dea74aa0a66\""
+    },
+    "heltec-vision-master-e290.svg": {
+      "etag": "\"50a5e52466ea3a5ef3ff6c87ff6b5b24\""
+    },
+    "heltec-vision-master-t190.svg": {
+      "etag": "\"9b85f16d85e5589816d45f1b865f7132\""
+    },
+    "heltec-wireless-paper.svg": {
+      "etag": "\"09dff671cae6a64033c5160c62b1a6cb\""
+    },
+    "heltec-wireless-tracker.svg": {
+      "etag": "\"cc8148848b4097c555396bb0794a2cd2\""
+    },
+    "heltec-wsl-v3.svg": {
+      "etag": "\"676b33b3d89eb109f5ff984db6041605\""
+    },
+    "heltec_mesh_pocket.svg": {
+      "etag": "\"4a7af4be3e7a829cd83017f05fa11f9a\""
     },
     "heltec_v4.svg": {
       "etag": "\"57666cd119ac01e74716bef5f785e2df\""
     },
-    "wio-tracker-wm1110.svg": {
-      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    "heltec_wireless_tracker_v2.svg": {
+      "etag": "\"7a6b4a5c152ec91cc9f746da978bdfbc\""
+    },
+    "lilygo-tlora-pager.svg": {
+      "etag": "\"ea8a22cd8e3436caebd4cc1ea981d6d6\""
+    },
+    "m5_c6l.svg": {
+      "etag": "\"e84fff6641461d595b2f180ddeaeeaa6\""
+    },
+    "m5stack_cardputer.svg": {
+      "etag": "\"3b483e95371895fbaf5d22a289a9a48e\""
+    },
+    "meteor_pro.svg": {
+      "etag": "\"db5044328b825421851b963479fab9ca\""
+    },
+    "muzi_base.svg": {
+      "etag": "\"be887c289c63af434835279b75f0879e\""
+    },
+    "muzi_r1_neo.svg": {
+      "etag": "\"bb4bbf8fb998eb671d61c5a7796581ba\""
+    },
+    "nano-g2-ultra.svg": {
+      "etag": "\"c655b6154835204b5b60e947c64a3c43\""
+    },
+    "pico.svg": {
+      "etag": "\"25eaff431def69b7bf838a2e312c1032\""
+    },
+    "promicro.svg": {
+      "etag": "\"c54c8757f3c95185d2243fdf3da84992\""
+    },
+    "rak-wismesh-tap-v2.svg": {
+      "etag": "\"0f5bdd7e2d770dc19fe6caa64051f9d6\""
+    },
+    "rak-wismeshtap.svg": {
+      "etag": "\"d808e95fe31048bdfc3fbb0b574c9dc6\""
+    },
+    "rak11200.svg": {
+      "etag": "\"7d2051c84c073becece5a6fada9a4cfc\""
+    },
+    "rak11310.svg": {
+      "etag": "\"ddbea703ff2b2481a46c1b56ebbd0b44\""
+    },
+    "rak2560.svg": {
+      "etag": "\"e425adc49058399a2a7f8517093192f0\""
+    },
+    "rak3401.svg": {
+      "etag": "\"d05f088f4b14eb7235678c5d84c1dde8\""
+    },
+    "rak4631.svg": {
+      "etag": "\"cd9d48fd9e38ccb769268681547339e8\""
     },
     "rak4631_case.svg": {
       "etag": "\"fdb5ee0ba5fb97d3f2c45ebec1629af2\""
     },
-    "heltec-t096.svg": {
-      "etag": "\"686fe6ac17fea4e6ff34aca78ca610f9\""
+    "rak_3312.svg": {
+      "etag": "\"8db94664189df83d099b726cd21045b4\""
+    },
+    "rak_wismesh_tag.svg": {
+      "etag": "\"d0fe0072bdfd0c3671ed8be8339708fa\""
+    },
+    "rpipicow.svg": {
+      "etag": "\"63d5265a14db854a409aa8d2c02b6df7\""
+    },
+    "seeed-sensecap-indicator.svg": {
+      "etag": "\"26a69d9484d3c5f39c96e8c6081f1829\""
+    },
+    "seeed-xiao-s3.svg": {
+      "etag": "\"6475faad5c2459af8d133bf4956e8ba4\""
+    },
+    "seeed_solar.svg": {
+      "etag": "\"1b517a452f66e0e5b1b7323dfce89fbc\""
+    },
+    "seeed_xiao_nrf52_kit.svg": {
+      "etag": "\"c73c0f939e9f6ad244a36d4a3e3da289\""
+    },
+    "station-g2.svg": {
+      "etag": "\"5527898bfd96b94c05251f8c8876dbec\""
+    },
+    "t-deck.svg": {
+      "etag": "\"8b10a3d59ee362ea0190b6612c9e695e\""
+    },
+    "t-echo.svg": {
+      "etag": "\"aaa20e725876f408d28ba4dd1c632ebc\""
+    },
+    "t-echo_plus.svg": {
+      "etag": "\"62d23557949092b77fd24a94abe16678\""
+    },
+    "t-watch-s3.svg": {
+      "etag": "\"b2c26bdc010a6f78855a1fb1905c9397\""
+    },
+    "t5s3_epaper.svg": {
+      "etag": "\"423640c486cc7c4480f194bc02481ea5\""
+    },
+    "tbeam-1w.svg": {
+      "etag": "\"ffb9d18fb8c98f231a610c58a1d1e865\""
+    },
+    "tbeam-s3-core.svg": {
+      "etag": "\"d233dcce52944ab5fb01410c5d58a4ae\""
+    },
+    "tbeam.svg": {
+      "etag": "\"df4f996aed77c59eb57d1ae0edeed549\""
+    },
+    "tdeck_pro.svg": {
+      "etag": "\"b55287ed57a297631de99e024c8e4ab2\""
+    },
+    "techo_lite.svg": {
+      "etag": "\"c8218fb723d7e92b71cf38c17b1118c8\""
+    },
+    "thinknode_m1.svg": {
+      "etag": "\"4f1ffbb8c2cbd39ef57660a2b227003e\""
+    },
+    "thinknode_m2.svg": {
+      "etag": "\"fa007f18567fb18c9d137dae88350a4a\""
+    },
+    "thinknode_m3.svg": {
+      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    },
+    "thinknode_m4.svg": {
+      "etag": "\"9e9d7390e3ee50ef5fbb0e9670252ec3\""
+    },
+    "thinknode_m6.svg": {
+      "etag": "\"d2cc380005e0d8ea839cc32104b14813\""
+    },
+    "tlora-t3s3-epaper.svg": {
+      "etag": "\"7aa92389d32074449bf4ce92b8ea5fad\""
     },
     "tlora-t3s3-v1.svg": {
       "etag": "\"bbf44e526676ad298698d1387af57c15\""
     },
-    "thinknode_m3.svg": {
-      "etag": "\"85966b6aae7d961c9b390f2a4d1e8b0c\""
+    "tlora-v2-1-1_6.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "tlora-v2-1-1_8.svg": {
+      "etag": "\"31b910b6a06249a6850cd2485617fb1a\""
+    },
+    "tracker-t1000-e.svg": {
+      "etag": "\"f04f6744865fcc7aab2527b2eb31d57c\""
+    },
+    "wio-tracker-wm1110.svg": {
+      "etag": "\"97e3dea651a4f60f08ded179035ac8dd\""
+    },
+    "wio_tracker_l1_case.svg": {
+      "etag": "\"0b7c6f0940dc247e407937a81525e5cf\""
+    },
+    "wio_tracker_l1_eink.svg": {
+      "etag": "\"87446ec40a3c65f81a28e5c3309f4067\""
     }
-  },
-  "api_hash": "6dfff9f4d6c1950d193cb0ed1cc4369c68aae266951a4ac22789f8c6de4ca9c9"
+  }
 }

--- a/scripts/download_images.py
+++ b/scripts/download_images.py
@@ -45,8 +45,13 @@ def load_manifest(manifest_path, log_warning):
         return {}
 
 def save_manifest(data, manifest_path):
+    # sort_keys makes the output deterministic. The 'files' map is populated in
+    # thread-completion order (ThreadPoolExecutor / as_completed), which varies run to
+    # run; without sorting, identical data serializes in a different key order each time,
+    # producing noisy "sort-only" diffs. Sorting keys yields a stable, reorder-free file.
     with open(manifest_path, 'w') as f:
-        json.dump(data, f, indent=2)
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write('\n')
 
 def download_image(url, local_path, log_warning):
     """


### PR DESCRIPTION
## Problem
`image_manifest.json` keeps showing up in diffs with **sort-only changes** — same data, reordered keys — creating noise on builds.

## Cause
In `scripts/download_images.py`, the `files` map is built inside `for future in as_completed(future_to_image)`, so entries are inserted in **thread-completion order** across the 16-worker pool (nondeterministic). `save_manifest` then did `json.dump(..., indent=2)` with **no `sort_keys`**, serializing that dict in insertion order — a different order on every run.

## Fix
- `save_manifest` now uses `json.dump(..., indent=2, sort_keys=True)` (+ trailing newline), so output depends only on content. Sorts the top-level keys (`api_hash`, `files`) and the filenames within `files`.
- Re-sorted the committed `Meshtastic/Resources/images/image_manifest.json` to match, so the churn ends now rather than on the next regen (verified sorted + idempotent).

## Scope
Left the legacy `Devices.xcassets/image_manifest.json` untouched — the build only runs `--output-dir` mode, so it's never regenerated and can't churn. `DeviceHardware.json` (raw API list) is unaffected; `sort_keys` doesn't reorder a JSON array.