### PR TITLE
fix: resolve Messages node from live context to stop ModelContext.reset crash (fac7c8f6)

### DIFF
--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -17,14 +17,33 @@ struct Messages: View {
 	@ObservedObject	var router: Router
 	@Binding var unreadChannelMessages: Int
 	@Binding var unreadDirectMessages: Int
-	@State var node: NodeInfoEntity?
+	/// Store the connected node's `num`, NOT the `NodeInfoEntity` itself, and resolve the object
+	/// from the live context every render (see `node`). Caching the SwiftData model here traps
+	/// ("destroyed by ModelContext.reset") when the container is recreated (data clear / node
+	/// switch) while this view still reads `node?.myInfo`; a fresh fetch returns nil safely.
+	@State private var nodeNum: Int64?
 	@State private var userSelection: UserEntity? // Nothing selected by default.
 	@State private var channelSelection: ChannelEntity? // Nothing selected by default.
 
 	@State private var columnVisibility = NavigationSplitViewVisibility.all
 
+	/// Resolves the connected node from the current context on each access. Never cached, so it
+	/// can't outlive a container recreation. `getNodeInfo` is a `try?` fetch and returns nil if
+	/// the store is mid-reset.
+	private var node: NodeInfoEntity? {
+		guard let nodeNum else { return nil }
+		return getNodeInfo(id: nodeNum, context: context)
+	}
+
 	var body: some View {
-		NavigationSplitView(columnVisibility: $columnVisibility) {
+		// Resolve once per render and hand children a binding backed by the node's `num`, so no
+		// view holds a NodeInfoEntity across a container recreation.
+		let node = node
+		let nodeBinding = Binding<NodeInfoEntity?>(
+			get: { node },
+			set: { nodeNum = $0?.num }
+		)
+		return NavigationSplitView(columnVisibility: $columnVisibility) {
 			List(selection: $router.messagesState) {
 				NavigationLink(value: MessagesNavigationState.channels()) {
 					Spacer()
@@ -80,11 +99,11 @@ struct Messages: View {
 		} content: {
 			switch router.messagesState {
 			case .channels:
-				ChannelList(node: $node, channelSelection: $channelSelection)
+				ChannelList(node: nodeBinding, channelSelection: $channelSelection)
 					// Removed navigationTitle and navigationBarTitleDisplayMode here.
 					// ChannelList.swift now handles this within its own NavigationStack.
 			case .directMessages:
-				UserList(node: $node, userSelection: $userSelection)
+				UserList(node: nodeBinding, userSelection: $userSelection)
 					// Removed navigationTitle here. UserList will handle this.
 			case nil:
 				Text("Select a conversation type")
@@ -117,8 +136,8 @@ struct Messages: View {
 
 	private func setupNavigationState() {
 		let nodeId = Int64(UserDefaults.preferredPeripheralNum)
-		if nodeId > 0 && node == nil {
-			node = getNodeInfo(id: nodeId, context: context)
+		if nodeId > 0 && nodeNum == nil {
+			nodeNum = nodeId
 		}
 
 		guard let state = router.messagesState else {

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -35,15 +35,15 @@ struct Messages: View {
 		return getNodeInfo(id: nodeNum, context: context)
 	}
 
+	/// Binding handed to ChannelList/UserList. The getter resolves `node` from the live context on
+	/// every read (never a captured/cached object), so the retained closure can't read a reset
+	/// NodeInfoEntity if a container recreation happens before this view re-renders.
+	private var nodeBinding: Binding<NodeInfoEntity?> {
+		Binding(get: { self.node }, set: { self.nodeNum = $0?.num })
+	}
+
 	var body: some View {
-		// Resolve once per render and hand children a binding backed by the node's `num`, so no
-		// view holds a NodeInfoEntity across a container recreation.
-		let node = node
-		let nodeBinding = Binding<NodeInfoEntity?>(
-			get: { node },
-			set: { nodeNum = $0?.num }
-		)
-		return NavigationSplitView(columnVisibility: $columnVisibility) {
+		NavigationSplitView(columnVisibility: $columnVisibility) {
 			List(selection: $router.messagesState) {
 				NavigationLink(value: MessagesNavigationState.channels()) {
 					Spacer()


### PR DESCRIPTION
## Crash
Datadog issue `fac7c8f6` (build 2034, TestFlight): SIGTRAP in the generated `NodeInfoEntity.myInfo` getter, called from a SwiftUI body update inside the Messages `NavigationStack<AnyView>`. First seen 2026-06-12 — i.e. once the container-recreation work reached TestFlight.

## Root cause
`Messages` cached the connected node as `@State var node: NodeInfoEntity?` and read `node?.myInfo` in its body/detail. When the SwiftData container is recreated (data clear / node switch via `repointToFreshContainer`), every object held from the old container is reset.

The **node-switch** flow is the trigger: it recreates the container, then runs an `await` restore, and only bumps `databaseResetID` (which rebuilds the root via `.id(databaseResetID)`) **afterward**. During that restore window the cached `@State` node is stale, and any re-render reading `node?.myInfo` traps. (The clear-data path doesn't crash because it bumps `databaseResetID` atomically with the repoint.)

## Fix (durable)
Store the node's `num`, not the model object, and resolve the `NodeInfoEntity` from the **current context every render** via `getNodeInfo` — a `try?` fetch that returns `nil` if the store is mid-reset. Nothing holds a node across a container recreation, so the trap is gone for this view generically (not just patched for one reset path).

`ChannelList`/`UserList` keep their `Binding<NodeInfoEntity?>` interface, now backed by the live resolution; both only **read** the binding, so there's no behavior change.

## Verify
Builds clean (Debug, iOS Simulator). Behavior unchanged in normal use; the difference is only at container-recreation time, where a fresh fetch now returns a valid (or nil) node instead of a reset object.