### PR TITLE
fix: MQTT client proxy — per-channel subscriptions, zero-hop injection, security hardening

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
@@ -55,11 +55,12 @@ extension AccessoryManager {
 	func onMqttConnected() {
 		mqttProxyConnected = true
 		mqttError = ""
-		if mqttManager.shouldSubscribe {
-			Logger.services.info("📲 [MQTT Client Proxy] onMqttConnected now subscribing to \(self.mqttManager.topic, privacy: .public).")
-			mqttManager.mqttClientProxy?.subscribe(mqttManager.topic)
-		} else {
-			Logger.services.info("📲 [MQTT Client Proxy] onMqttConnected not subscribing since downlink is not on")
+		for topic in mqttManager.topics {
+			Logger.services.info("📲 [MQTT Client Proxy] onMqttConnected subscribing to \(topic, privacy: .public).")
+			mqttManager.mqttClientProxy?.subscribe(topic, qos: .qos1)
+		}
+		if mqttManager.topics.isEmpty {
+			Logger.services.info("📲 [MQTT Client Proxy] onMqttConnected - no topics to subscribe to")
 		}
 	}
 
@@ -72,13 +73,27 @@ extension AccessoryManager {
 		if message.topic.contains("/stat/") {
 			return
 		}
+
+		// Clamp hop_limit to 0 on downlink ServiceEnvelopes before forwarding to
+		// the device. Packets with hop_limit > 0 would be re-broadcast over RF,
+		// flooding the mesh with traffic that arrived via MQTT. hop_start is
+		// preserved so receivers can still compute how far the packet travelled.
+		let rawData = Data(message.payload)
+		let forwardData: Data
+		if var envelope = try? ServiceEnvelope(serializedData: rawData),
+		   envelope.hasPacket, envelope.packet.hopLimit > 0 {
+			envelope.packet.hopLimit = 0
+			forwardData = (try? envelope.serializedData()) ?? rawData
+		} else {
+			forwardData = rawData
+		}
+
 		var proxyMessage = MqttClientProxyMessage()
 		proxyMessage.topic = message.topic
-		proxyMessage.data = Data(message.payload)
+		proxyMessage.data = forwardData
 		proxyMessage.retained = message.retained
 
-		var toRadio: ToRadio!
-		toRadio = ToRadio()
+		var toRadio = ToRadio()
 		toRadio.mqttClientProxyMessage = proxyMessage
 		Task {
 			try? await self.send(toRadio)

--- a/Meshtastic/Helpers/Mqtt/MqttClientProxyManager.swift
+++ b/Meshtastic/Helpers/Mqtt/MqttClientProxyManager.swift
@@ -23,9 +23,11 @@ class MqttClientProxyManager {
 	private static let defaultKeepAliveInterval: Int32 = 60
 	weak var delegate: MqttClientProxyManagerDelegate?
 	var mqttClientProxy: CocoaMQTT?
-	var topic = "msh"
+	/// Per-channel subscription topics built in `connectFromConfigSettings`.
+	/// Mirrors Android: one `prefix/2/e/<channelName>/+` per downlink-enabled channel,
+	/// plus `prefix/2/e/PKI/+` which is always subscribed.
+	var topics: [String] = []
 	var debugLog = false
-	var shouldSubscribe = true
 	func connectFromConfigSettings(node: NodeInfoEntity) {
 		let originalAddress = node.mqttConfig?.address ?? "mqtt.meshtastic.org"
 		let defaultServerAddress = "mqtt.meshtastic.org"
@@ -44,24 +46,34 @@ class MqttClientProxyManager {
 		let port = defaultServerPort
 		let root = node.mqttConfig?.root?.count ?? 0 > 0 ? node.mqttConfig?.root : "msh"
 		let prefix = root!
-		let hasAnyDownlinkEnabled = node.myInfo?.channels.contains { $0.downlinkEnabled } ?? false
-		
-		shouldSubscribe = hasAnyDownlinkEnabled
-		
-		topic = prefix + "/2/e" + "/#"
+
+		// Build per-channel subscription topics (mirrors Android MQTTRepositoryImpl):
+		// - one topic per downlink-enabled channel: prefix/2/e/<channelName>/+
+		// - PKI channel is always subscribed regardless of downlink settings
+		var newTopics: [String] = []
+		for channel in node.myInfo?.channels ?? [] {
+			if channel.downlinkEnabled, let name = channel.name, !name.isEmpty {
+				newTopics.append(prefix + "/2/e/" + name + "/+")
+			}
+		}
+		newTopics.append(prefix + "/2/e/PKI/+")
+		topics = newTopics
+
 		// Require opt in to map report terms to connect
 		if node.mqttConfig?.mapReportingEnabled ?? false && UserDefaults.mapReportingOptIn || !(node.mqttConfig?.mapReportingEnabled ?? false) {
-			connect(host: host, port: port, useSsl: useSsl, topic: topic, node: node)
+			connect(host: host, port: port, useSsl: useSsl, node: node)
 		} else {
 			delegate?.onMqttError(message: "MQTT Map Reporting Terms need to be accepted.")
 		}
 	}
-	func connect(host: String, port: Int, useSsl: Bool, topic: String?, node: NodeInfoEntity) {
+	func connect(host: String, port: Int, useSsl: Bool, node: NodeInfoEntity) {
 		guard !host.isEmpty else {
 			delegate?.onMqttDisconnected()
 			return
 		}
-		let clientId = "MeshtasticAppleMqttProxy-" + (node.user?.userId ?? String(ProcessInfo().processIdentifier))
+		// UUID suffix prevents SESSION_TAKEN_OVER when multiple clients share the same node ID
+		// (mirrors Android: "MeshtasticAndroidMqttProxy-<nodeId>-<uuid>")
+		let clientId = "MeshtasticAppleMqttProxy-" + (node.user?.userId ?? String(ProcessInfo().processIdentifier)) + "-" + UUID().uuidString
 		mqttClientProxy = CocoaMQTT(clientID: clientId, host: host, port: UInt16(port))
 		if let mqttClient = mqttClientProxy {
 			mqttClient.enableSSL = useSsl

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -395,7 +395,7 @@ struct Connect: View {
 						deviceConnected: accessoryManager.isConnected,
 						name: accessoryManager.activeConnection?.device.shortName ?? "?",
 						mqttProxyConnected: accessoryManager.mqttProxyConnected,
-						mqttTopic: accessoryManager.mqttManager.topic
+						mqttTopic: accessoryManager.mqttManager.topics.first ?? ""
 					)
 				}
 			}

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -420,7 +420,7 @@ struct ChannelMessageList: View {
 						mqttProxyConnected: accessoryManager.mqttProxyConnected && (channel.uplinkEnabled || channel.downlinkEnabled),
 						mqttUplinkEnabled: channel.uplinkEnabled,
 						mqttDownlinkEnabled: channel.downlinkEnabled,
-						mqttTopic: accessoryManager.mqttManager.topic
+						mqttTopic: accessoryManager.mqttManager.topics.first(where: { $0.contains("/2/e/\(channel.name ?? "")") }) ?? accessoryManager.mqttManager.topics.first ?? ""
 					)
 				}
 			}

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -24,8 +24,8 @@ struct MQTTConfig: View {
 	@State var username = ""
 	@State var password = ""
 	@State var encryptionEnabled = true
-	@State var jsonEnabled = false
 	@State var tlsEnabled = false
+	@State private var showPassword = false
 	@State var root = "msh"
 	@State var selectedTopic = ""
 	@State var mqttConnected: Bool = false
@@ -83,14 +83,6 @@ struct MQTTConfig: View {
 						Label("Encryption Enabled", systemImage: "lock.icloud")
 					}
 					.tint(.accentColor)
-					
-					if !proxyToClientEnabled {
-						Toggle(isOn: $jsonEnabled) {
-							Label("JSON Enabled", systemImage: "ellipsis.curlybraces")
-							Text("JSON mode is a limited, unencrypted MQTT output for locally integrating with home assistant")
-						}
-						.tint(.accentColor)
-					}
 				}
 				
 				Section(header: Text("Map Report")) {
@@ -213,19 +205,30 @@ struct MQTTConfig: View {
 						.keyboardType(.default)
 						HStack {
 							Label("Password", systemImage: "wallet.pass")
-							TextField("Password", text: $password)
-								.foregroundColor(.gray)
-								.autocapitalization(.none)
-								.disableAutocorrection(true)
-								.onChange(of: password) {
-									var totalBytes = password.utf8.count
-									// Only mess with the value if it is too big
-									while totalBytes > 31 {
-										password = String(password.dropLast())
-										totalBytes = password.utf8.count
-									}
+							Group {
+								if showPassword {
+									TextField("Password", text: $password)
+								} else {
+									SecureField("Password", text: $password)
 								}
-								.foregroundColor(.gray)
+							}
+							.foregroundColor(.gray)
+							.autocapitalization(.none)
+							.disableAutocorrection(true)
+							.onChange(of: password) {
+								var totalBytes = password.utf8.count
+								while totalBytes > 31 {
+									password = String(password.dropLast())
+									totalBytes = password.utf8.count
+								}
+							}
+							Button {
+								showPassword.toggle()
+							} label: {
+								Image(systemName: showPassword ? "eye.slash" : "eye")
+									.foregroundColor(.secondary)
+							}
+							.buttonStyle(.plain)
 						}
 						.keyboardType(.default)
 						.listRowSeparator(/*@START_MENU_TOKEN@*/.visible/*@END_MENU_TOKEN@*/)
@@ -270,7 +273,6 @@ struct MQTTConfig: View {
 						mqtt.password = self.password
 						mqtt.root = self.root
 						mqtt.encryptionEnabled = self.encryptionEnabled
-						mqtt.jsonEnabled = self.jsonEnabled
 						mqtt.tlsEnabled = self.tlsEnabled
 						mqtt.mapReportingEnabled = self.mapReportingEnabled
 						mqtt.mapReportSettings.shouldReportLocation = UserDefaults.mapReportingOptIn
@@ -284,9 +286,6 @@ struct MQTTConfig: View {
 				if oldEnabled != newEnabled && newEnabled != node?.mqttConfig?.enabled { hasChanges = true }
 			}
 			.onChange(of: proxyToClientEnabled) { oldProxy, newProxyToClientEnabled in
-				if newProxyToClientEnabled {
-					jsonEnabled = false
-				}
 				if oldProxy != newProxyToClientEnabled && newProxyToClientEnabled != node?.mqttConfig?.proxyToClientEnabled { hasChanges = true }
 			}
 			.onChange(of: address) { oldAddress, newAddress in
@@ -316,12 +315,6 @@ struct MQTTConfig: View {
 			}
 			.onChange(of: encryptionEnabled) { oldEncryption, newEncryptionEnabled in
 				if oldEncryption != newEncryptionEnabled && newEncryptionEnabled != node?.mqttConfig?.encryptionEnabled { hasChanges = true }
-			}
-			.onChange(of: jsonEnabled) { oldJson, newJsonEnabled in
-				if newJsonEnabled {
-					proxyToClientEnabled = false
-				}
-				if oldJson != newJsonEnabled && newJsonEnabled != node?.mqttConfig?.jsonEnabled { hasChanges = true }
 			}
 			.onChange(of: tlsEnabled) { oldTls, newTlsEnabled in
 				if defaultServer && accessoryManager.checkIsVersionSupported(forVersion: "2.7.3") {
@@ -363,10 +356,14 @@ struct MQTTConfig: View {
 				request: accessoryManager.requestMqttModuleConfig
 			)
 		}
+		.onChange(of: accessoryManager.mqttProxyConnected) { _, connected in
+			mqttConnected = connected
+		}
 	}
-	
+}
+
+private extension MQTTConfig {
 	func setMqttValues() {
-		
 		nearbyTopics = []
 		let geocoder = CLGeocoder()
 		if LocationsHandler.shared.locationsArray.count > 0 {
@@ -377,52 +374,34 @@ struct MQTTConfig: View {
 					Logger.services.error("Failed to reverse geocode location: \(error.localizedDescription, privacy: .public)")
 					return
 				}
-				
 				if let placemarks = placemarks, let placemark = placemarks.first {
-					/// Country Topic unless your region is a country
 					if !(region?.isCountry ?? false) {
 						let countryTopic = defaultTopic + "/" + (placemark.isoCountryCode ?? "")
-						if !countryTopic.isEmpty {
-							nearbyTopics.append(countryTopic)
-						}
+						if !countryTopic.isEmpty { nearbyTopics.append(countryTopic) }
 					}
 					let stateTopic = defaultTopic + "/" + (placemark.administrativeArea ?? "")
-					if !stateTopic.isEmpty {
-						nearbyTopics.append(stateTopic)
-					}
+					if !stateTopic.isEmpty { nearbyTopics.append(stateTopic) }
 					let countyTopic = defaultTopic + "/" + (placemark.administrativeArea ?? "") + "/" + (placemark.subAdministrativeArea?.lowercased().replacingOccurrences(of: " ", with: "") ?? "")
-					if !countyTopic.isEmpty {
-						nearbyTopics.append(countyTopic)
-					}
+					if !countyTopic.isEmpty { nearbyTopics.append(countyTopic) }
 					let cityTopic = defaultTopic + "/" + (placemark.administrativeArea ?? "") + "/" + (placemark.locality?.lowercased().replacingOccurrences(of: " ", with: "") ?? "")
-					if !cityTopic.isEmpty {
-						nearbyTopics.append(cityTopic)
-					}
-					let neightborhoodTopic = defaultTopic + "/" + (placemark.administrativeArea ?? "") + "/" + (placemark.subLocality?.lowercased()
+					if !cityTopic.isEmpty { nearbyTopics.append(cityTopic) }
+					let neighborhoodTopic = defaultTopic + "/" + (placemark.administrativeArea ?? "") + "/" + (placemark.subLocality?.lowercased()
 						.replacingOccurrences(of: " ", with: "")
 						.replacingOccurrences(of: "'", with: "") ?? "")
-					if !neightborhoodTopic.isEmpty {
-						nearbyTopics.append(neightborhoodTopic)
-					}
+					if !neighborhoodTopic.isEmpty { nearbyTopics.append(neighborhoodTopic) }
 				} else {
 					Logger.services.debug("No Location")
 				}
 			})
 		}
-		
 		self.enabled = node?.mqttConfig?.enabled ?? false
 		self.proxyToClientEnabled = node?.mqttConfig?.proxyToClientEnabled ?? false
 		self.address = node?.mqttConfig?.address ?? ""
-		if address.lowercased().contains("mqtt.meshtastic.org") {
-			defaultServer = true
-		} else {
-			defaultServer = false
-		}
+		defaultServer = address.lowercased().contains("mqtt.meshtastic.org")
 		self.username = node?.mqttConfig?.username ?? ""
 		self.password = node?.mqttConfig?.password ?? ""
 		self.root = node?.mqttConfig?.root ?? "msh"
 		self.encryptionEnabled = node?.mqttConfig?.encryptionEnabled ?? false
-		self.jsonEnabled = node?.mqttConfig?.jsonEnabled ?? false
 		if defaultServer && accessoryManager.checkIsVersionSupported(forVersion: "2.7.3") {
 			self.tlsEnabled = true
 		} else {
@@ -430,16 +409,10 @@ struct MQTTConfig: View {
 		}
 		self.mqttConnected = accessoryManager.mqttProxyConnected
 		self.mapReportingEnabled = node?.mqttConfig?.mapReportingEnabled ?? false
-		if node?.mqttConfig?.mapPublishIntervalSecs ?? 0 < 3600 {
-			self.mapPublishIntervalSecs = UpdateInterval(from: 3600)
-		} else {
-			self.mapPublishIntervalSecs = UpdateInterval(from: Int(node?.mqttConfig?.mapPublishIntervalSecs ?? 3600))
-		}
+		self.mapPublishIntervalSecs = UpdateInterval(from: max(3600, Int(node?.mqttConfig?.mapPublishIntervalSecs ?? 3600)))
 		self.mapPositionPrecision = Double(node?.mqttConfig?.mapPositionPrecision ?? 14)
 		self.mapReportingOptIn = UserDefaults.mapReportingOptIn
-		if mapPositionPrecision < 11 || mapPositionPrecision > 14 {
-			self.mapPositionPrecision = 14
-		}
+		if mapPositionPrecision < 11 || mapPositionPrecision > 14 { self.mapPositionPrecision = 14 }
 		self.hasChanges = false
 	}
 }


### PR DESCRIPTION
## Summary

- **Per-channel subscriptions**: replaced the broad `msh/2/e/#` wildcard with one subscription per downlink-enabled channel (`prefix/2/e/<channelName>/+`), plus the PKI channel which is always subscribed — matching Android behavior
- **Zero-hop injection**: clamp `hop_limit` to 0 on all downlink `ServiceEnvelope` packets before forwarding to the connected device; prevents MQTT-bridged packets from being re-broadcast over RF (`hop_start` is preserved so receivers can still compute travel distance)
- **Session takeover fix**: append a random UUID suffix to the MQTT client ID to prevent `SESSION_TAKEN_OVER` disconnections when multiple clients connect with the same node ID
- **Password field**: replaced plaintext `TextField` with `SecureField` + show/hide eye toggle
- **Remove JSON mode toggle**: firmware marks `json_enabled` deprecated and ignores it; removed from UI and save path
- **Reactive connected toggle**: the "Connect via Proxy" toggle now observes `mqttProxyConnected` so it reflects external disconnects without requiring a screen dismiss/reappear

## Test plan

- [ ] Connect to `mqtt.meshtastic.org` with a node that has a downlink-enabled channel — verify subscription appears in logs as `msh/2/e/LongFast/+` and `msh/2/e/PKI/+` (not `#`)
- [ ] Receive a packet via MQTT downlink — verify it arrives on the device with `hop_limit = 0` in device logs
- [ ] Verify own-device published packets are NOT zero-hopped (they go through the uplink path, not `onMqttMessageReceived`)
- [ ] Confirm password is masked by default; eye button reveals/hides it
- [ ] Drop MQTT connection externally — verify the "Connect via Proxy" toggle turns off without navigating away
- [ ] Confirm JSON mode toggle is gone; saving config no longer sends `json_enabled`