### PR TITLE
fix: persist environment metrics table and chart config (#1615)

### DIFF
--- a/Meshtastic/Model/Metrics Visualization/MetricsColumnList.swift
+++ b/Meshtastic/Model/Metrics Visualization/MetricsColumnList.swift
@@ -10,8 +10,17 @@ class MetricsColumnList: ObservableObject, RandomAccessCollection, RangeReplacea
 
 	@Published var columns: [MetricsTableColumn]
 
-	init(columns: [MetricsTableColumn]) {
+	/// Namespace under which each column's `visible` flag is persisted. When `nil`, visibility is
+	/// not saved (the default for the collection-conformance initializers).
+	private let persistenceKey: String?
+	/// Backing store for persisted visibility. Defaults to `.standard`; tests inject an isolated suite.
+	private let store: UserDefaults
+
+	init(persistenceKey: String? = nil, columns: [MetricsTableColumn], store: UserDefaults = .standard) {
 		self.columns = columns
+		self.persistenceKey = persistenceKey
+		self.store = store
+		applyPersistedVisibility()
 	}
 
 	var visible: [MetricsTableColumn] {
@@ -22,7 +31,33 @@ class MetricsColumnList: ObservableObject, RandomAccessCollection, RangeReplacea
 		if columns.contains(column) {
 			self.objectWillChange.send()
 			column.visible.toggle()
+			persistVisibility()
 		}
+	}
+
+	private var storageKey: String? {
+		persistenceKey.map { "metricsColumnVisibility.\($0)" }
+	}
+
+	/// Restores each column's `visible` flag from the store. Columns absent from the saved map
+	/// (e.g. added in a later app version) keep their default visibility.
+	private func applyPersistedVisibility() {
+		guard let storageKey, let stored = store.dictionary(forKey: storageKey) as? [String: Bool] else { return }
+		for column in columns {
+			if let isVisible = stored[column.id] {
+				column.visible = isVisible
+			}
+		}
+	}
+
+	/// Persists the current visibility of every column so it survives the view being recreated.
+	private func persistVisibility() {
+		guard let storageKey else { return }
+		var map: [String: Bool] = [:]
+		for column in columns {
+			map[column.id] = column.visible
+		}
+		store.set(map, forKey: storageKey)
 	}
 
 	var gridItems: [GridItem] {
@@ -52,9 +87,15 @@ class MetricsColumnList: ObservableObject, RandomAccessCollection, RangeReplacea
 	typealias Element = MetricsTableColumn
 	typealias SubSequence = ArraySlice<Element>
 
-	required init() { columns = [] }
+	required init() {
+		columns = []
+		persistenceKey = nil
+		store = .standard
+	}
 	required init<S: Sequence>(_ columns: S) where S.Element == Element {
 		self.columns = Array(columns)
+		persistenceKey = nil
+		store = .standard
 	}
 
 	var startIndex: Int { columns.startIndex }

--- a/Meshtastic/Model/Metrics Visualization/MetricsColumnList.swift
+++ b/Meshtastic/Model/Metrics Visualization/MetricsColumnList.swift
@@ -39,25 +39,14 @@ class MetricsColumnList: ObservableObject, RandomAccessCollection, RangeReplacea
 		persistenceKey.map { "metricsColumnVisibility.\($0)" }
 	}
 
-	/// Restores each column's `visible` flag from the store. Columns absent from the saved map
-	/// (e.g. added in a later app version) keep their default visibility.
 	private func applyPersistedVisibility() {
-		guard let storageKey, let stored = store.dictionary(forKey: storageKey) as? [String: Bool] else { return }
-		for column in columns {
-			if let isVisible = stored[column.id] {
-				column.visible = isVisible
-			}
-		}
+		MetricsVisibilityPersistence.restore(columns, key: storageKey, store: store,
+			id: { $0.id }, setVisible: { $0.visible = $1 })
 	}
 
-	/// Persists the current visibility of every column so it survives the view being recreated.
 	private func persistVisibility() {
-		guard let storageKey else { return }
-		var map: [String: Bool] = [:]
-		for column in columns {
-			map[column.id] = column.visible
-		}
-		store.set(map, forKey: storageKey)
+		MetricsVisibilityPersistence.persist(columns, key: storageKey, store: store,
+			id: { $0.id }, isVisible: { $0.visible })
 	}
 
 	var gridItems: [GridItem] {
@@ -135,5 +124,44 @@ class MetricsColumnList: ObservableObject, RandomAccessCollection, RangeReplacea
 	func insert(_ newElement: Element, at index: Int) {
 		objectWillChange.send()
 		columns.insert(newElement, at: index)
+	}
+}
+
+/// Persists a per-element `visible` flag under a namespaced `UserDefaults` key. Shared by
+/// `MetricsColumnList` and `MetricsSeriesList`, whose elements both expose a `String` id and a
+/// mutable `visible` flag, so the read/cast/loop logic lives here once instead of in each class.
+enum MetricsVisibilityPersistence {
+
+	/// Restores each element's `visible` flag from the store. Elements absent from the saved map
+	/// (e.g. added in a later app version) keep their current (default) visibility.
+	static func restore<Element>(
+		_ elements: [Element],
+		key: String?,
+		store: UserDefaults,
+		id: (Element) -> String,
+		setVisible: (Element, Bool) -> Void
+	) {
+		guard let key, let stored = store.dictionary(forKey: key) as? [String: Bool] else { return }
+		for element in elements {
+			if let isVisible = stored[id(element)] {
+				setVisible(element, isVisible)
+			}
+		}
+	}
+
+	/// Persists the current visibility of every element so it survives the view being recreated.
+	static func persist<Element>(
+		_ elements: [Element],
+		key: String?,
+		store: UserDefaults,
+		id: (Element) -> String,
+		isVisible: (Element) -> Bool
+	) {
+		guard let key else { return }
+		var map: [String: Bool] = [:]
+		for element in elements {
+			map[id(element)] = isVisible(element)
+		}
+		store.set(map, forKey: key)
 	}
 }

--- a/Meshtastic/Model/Metrics Visualization/MetricsSeriesList.swift
+++ b/Meshtastic/Model/Metrics Visualization/MetricsSeriesList.swift
@@ -41,25 +41,14 @@ class MetricsSeriesList: ObservableObject, RandomAccessCollection, RangeReplacea
 		persistenceKey.map { "metricsSeriesVisibility.\($0)" }
 	}
 
-	/// Restores each series' `visible` flag from the store. Series absent from the saved map
-	/// (e.g. added in a later app version) keep their default visibility.
 	private func applyPersistedVisibility() {
-		guard let storageKey, let stored = store.dictionary(forKey: storageKey) as? [String: Bool] else { return }
-		for aSeries in series {
-			if let isVisible = stored[aSeries.id] {
-				aSeries.visible = isVisible
-			}
-		}
+		MetricsVisibilityPersistence.restore(series, key: storageKey, store: store,
+			id: { $0.id }, setVisible: { $0.visible = $1 })
 	}
 
-	/// Persists the current visibility of every series so it survives the view being recreated.
 	private func persistVisibility() {
-		guard let storageKey else { return }
-		var map: [String: Bool] = [:]
-		for aSeries in series {
-			map[aSeries.id] = aSeries.visible
-		}
-		store.set(map, forKey: storageKey)
+		MetricsVisibilityPersistence.persist(series, key: storageKey, store: store,
+			id: { $0.id }, isVisible: { $0.visible })
 	}
 
 	func foregroundStyle<T>(forName: String, chartRange: ClosedRange<T>? = nil) -> AnyShapeStyle? where T: BinaryFloatingPoint {

--- a/Meshtastic/Model/Metrics Visualization/MetricsSeriesList.swift
+++ b/Meshtastic/Model/Metrics Visualization/MetricsSeriesList.swift
@@ -12,6 +12,19 @@ class MetricsSeriesList: ObservableObject, RandomAccessCollection, RangeReplacea
 
 	@Published var series: [MetricsChartSeries]
 
+	/// Namespace under which each series' `visible` flag is persisted. When `nil`, visibility is
+	/// not saved (the default for the collection-conformance initializers).
+	private let persistenceKey: String?
+	/// Backing store for persisted visibility. Defaults to `.standard`; tests inject an isolated suite.
+	private let store: UserDefaults
+
+	init(persistenceKey: String? = nil, series: [MetricsChartSeries], store: UserDefaults = .standard) {
+		self.series = series
+		self.persistenceKey = persistenceKey
+		self.store = store
+		applyPersistedVisibility()
+	}
+
 	var visible: [MetricsChartSeries] {
 		return series.filter { $0.visible }
 	}
@@ -20,7 +33,33 @@ class MetricsSeriesList: ObservableObject, RandomAccessCollection, RangeReplacea
 		if series.contains(aSeries) {
 			self.objectWillChange.send()
 			aSeries.visible.toggle()
+			persistVisibility()
 		}
+	}
+
+	private var storageKey: String? {
+		persistenceKey.map { "metricsSeriesVisibility.\($0)" }
+	}
+
+	/// Restores each series' `visible` flag from the store. Series absent from the saved map
+	/// (e.g. added in a later app version) keep their default visibility.
+	private func applyPersistedVisibility() {
+		guard let storageKey, let stored = store.dictionary(forKey: storageKey) as? [String: Bool] else { return }
+		for aSeries in series {
+			if let isVisible = stored[aSeries.id] {
+				aSeries.visible = isVisible
+			}
+		}
+	}
+
+	/// Persists the current visibility of every series so it survives the view being recreated.
+	private func persistVisibility() {
+		guard let storageKey else { return }
+		var map: [String: Bool] = [:]
+		for aSeries in series {
+			map[aSeries.id] = aSeries.visible
+		}
+		store.set(map, forKey: storageKey)
 	}
 
 	func foregroundStyle<T>(forName: String, chartRange: ClosedRange<T>? = nil) -> AnyShapeStyle? where T: BinaryFloatingPoint {
@@ -122,9 +161,15 @@ class MetricsSeriesList: ObservableObject, RandomAccessCollection, RangeReplacea
 	typealias Element = MetricsChartSeries
 	typealias SubSequence = ArraySlice<Element>
 
-	required init() { series = [] }
+	required init() {
+		series = []
+		persistenceKey = nil
+		store = .standard
+	}
 	required init<S: Sequence>(_ series: S) where S.Element == Element {
 		self.series = Array(series)
+		persistenceKey = nil
+		store = .standard
 	}
 
 	var startIndex: Int { series.startIndex }

--- a/Meshtastic/Views/Nodes/Helpers/Metrics Columns/EnvironmentDefaultColumns.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Metrics Columns/EnvironmentDefaultColumns.swift
@@ -12,7 +12,7 @@ import SwiftUI
 // This is the default configuration used by the EnvironmentMetricsLog view for the table
 extension MetricsColumnList {
 	static var environmentDefaultColumns: MetricsColumnList {
-		MetricsColumnList(columns: [
+		MetricsColumnList(persistenceKey: "environment", columns: [
 			// Temperature Series Configuration
 			MetricsTableColumn(
 				id: "temperature",

--- a/Meshtastic/Views/Nodes/Helpers/Metrics Columns/EnvironmentDefaultSeries.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Metrics Columns/EnvironmentDefaultSeries.swift
@@ -12,7 +12,7 @@ import SwiftUI
 // This is the default configuration used by the EnvironmentMetricsLog view for the chart
 extension MetricsSeriesList {
 	static var environmentDefaultChartSeries: MetricsSeriesList {
-		MetricsSeriesList([
+		MetricsSeriesList(persistenceKey: "environment", series: [
 			// Temperature Series Configuration
 			MetricsChartSeries(
 				id: "temperature",

--- a/MeshtasticTests/MetricsVisualizationTests.swift
+++ b/MeshtasticTests/MetricsVisualizationTests.swift
@@ -280,6 +280,125 @@ struct MetricsTableColumnPropertyTests {
 	}
 }
 
+// MARK: - Visibility Persistence
+
+/// Tests that column/series visibility selections survive the view being recreated (the bug from
+/// issue #1615). Each test injects an isolated `UserDefaults` suite so it neither reads nor clobbers
+/// `UserDefaults.standard`.
+@Suite("Metrics visibility persistence", .serialized)
+struct MetricsVisibilityPersistenceTests {
+
+	private func makeDefaults(_ suiteName: String) -> UserDefaults {
+		let defaults = UserDefaults(suiteName: suiteName)!
+		defaults.removePersistentDomain(forName: suiteName)
+		return defaults
+	}
+
+	private func makeColumn(id: String, visible: Bool = true) -> MetricsTableColumn {
+		MetricsTableColumn(
+			id: id,
+			keyPath: \TelemetryEntity.batteryLevel,
+			name: id,
+			abbreviatedName: id,
+			visible: visible
+		) { _, _ in EmptyView() }
+	}
+
+	private func makeSeries(id: String, visible: Bool = true) -> MetricsChartSeries {
+		MetricsChartSeries(
+			id: id,
+			keyPath: \TelemetryEntity.batteryLevel,
+			name: id,
+			abbreviatedName: id,
+			visible: visible,
+			foregroundStyle: { _ in Color(red: 0.0, green: 0.0, blue: 1.0) }
+		) { _, _, time, value in
+			LineMark(x: .value("Time", time), y: .value("Value", Int(value ?? 0)))
+		}
+	}
+
+	// MARK: Columns
+
+	@Test("Column visibility persists across new instances with the same key")
+	func columnVisibilityPersists() {
+		let defaults = makeDefaults("MetricsVisibility.columns.persist")
+		let list = MetricsColumnList(persistenceKey: "env", columns: [
+			makeColumn(id: "temp", visible: true),
+			makeColumn(id: "lux", visible: false)
+		], store: defaults)
+
+		list.toggleVisibity(for: list.column(withId: "temp")!)   // true -> false
+		list.toggleVisibity(for: list.column(withId: "lux")!)    // false -> true
+
+		// A freshly built list (as happens when the view is recreated) restores the selections.
+		let restored = MetricsColumnList(persistenceKey: "env", columns: [
+			makeColumn(id: "temp", visible: true),
+			makeColumn(id: "lux", visible: false)
+		], store: defaults)
+
+		#expect(restored.column(withId: "temp")?.visible == false)
+		#expect(restored.column(withId: "lux")?.visible == true)
+	}
+
+	@Test("Columns absent from saved state keep their default visibility")
+	func columnForwardCompatibility() {
+		let defaults = makeDefaults("MetricsVisibility.columns.forward")
+		let list = MetricsColumnList(persistenceKey: "env", columns: [makeColumn(id: "temp", visible: true)], store: defaults)
+		list.toggleVisibity(for: list.column(withId: "temp")!) // persists { temp: false }
+
+		// A later app version adds a column that isn't in the saved map.
+		let restored = MetricsColumnList(persistenceKey: "env", columns: [
+			makeColumn(id: "temp", visible: true),
+			makeColumn(id: "newColumn", visible: true)
+		], store: defaults)
+
+		#expect(restored.column(withId: "temp")?.visible == false)     // restored from storage
+		#expect(restored.column(withId: "newColumn")?.visible == true) // default preserved
+	}
+
+	@Test("Without a persistence key, column visibility is not saved")
+	func columnNoKeyNoPersistence() {
+		let defaults = makeDefaults("MetricsVisibility.columns.nokey")
+		let list = MetricsColumnList(columns: [makeColumn(id: "temp", visible: true)], store: defaults)
+		list.toggleVisibity(for: list[0]) // true -> false, but nothing is persisted
+
+		let restored = MetricsColumnList(columns: [makeColumn(id: "temp", visible: true)], store: defaults)
+		#expect(restored.column(withId: "temp")?.visible == true)
+	}
+
+	// MARK: Series
+
+	@Test("Series visibility persists across new instances with the same key")
+	func seriesVisibilityPersists() {
+		let defaults = makeDefaults("MetricsVisibility.series.persist")
+		let list = MetricsSeriesList(persistenceKey: "env", series: [
+			makeSeries(id: "temp", visible: true),
+			makeSeries(id: "humidity", visible: false)
+		], store: defaults)
+
+		list.toggleVisibity(for: list.series.first { $0.id == "temp" }!)     // true -> false
+		list.toggleVisibity(for: list.series.first { $0.id == "humidity" }!) // false -> true
+
+		let restored = MetricsSeriesList(persistenceKey: "env", series: [
+			makeSeries(id: "temp", visible: true),
+			makeSeries(id: "humidity", visible: false)
+		], store: defaults)
+
+		#expect(restored.series.first { $0.id == "temp" }?.visible == false)
+		#expect(restored.series.first { $0.id == "humidity" }?.visible == true)
+	}
+
+	@Test("Without a persistence key, series visibility is not saved")
+	func seriesNoKeyNoPersistence() {
+		let defaults = makeDefaults("MetricsVisibility.series.nokey")
+		let list = MetricsSeriesList(persistenceKey: nil, series: [makeSeries(id: "temp", visible: true)], store: defaults)
+		list.toggleVisibity(for: list.series[0]) // true -> false, but nothing is persisted
+
+		let restored = MetricsSeriesList(persistenceKey: nil, series: [makeSeries(id: "temp", visible: true)], store: defaults)
+		#expect(restored.series.first { $0.id == "temp" }?.visible == true)
+	}
+}
+
 // MARK: - Plottable floatValue extension
 
 @Suite("Plottable floatValue")


### PR DESCRIPTION
## What changed?

`MetricsColumnList` and `MetricsSeriesList` now persist each column/series `visible` flag instead of holding it only in memory. The change is opt-in:

- Added a `persistenceKey` namespace and an injectable `UserDefaults` store to both model classes.
- Visibility is mirrored to `UserDefaults` (an `[id: Bool]` map) through the single `toggleVisibity()` chokepoint that all UI toggling already routes through, and restored on construction.
- The environment defaults factories opt in with `persistenceKey: "environment"`. All other (collection-conformance) initializers default to no key, so their behavior is unchanged.
- Forward-compatible: columns/series absent from the saved map keep their coded default visibility, so adding new metrics in a later build won't get silently hidden.

These list types are currently consumed only by `EnvironmentMetricsLog`, so that's the only screen affected; the mechanism is reusable if other metric logs gain configuration later.

## Why did it change?

Fixes #385. Fixes #1615 — the Environment Metrics Log on iPad/Mac (and iPhone) forgot its table/chart column selections every time you navigated away and back.

Root cause: `MetricsColumnList` and `MetricsSeriesList` stored each column/series `visible` flag only in memory. `EnvironmentMetricsLog` holds them as `@StateObject`s, so recreating the view rebuilt fresh default instances and discarded the user's configuration.

## How is this tested?

Added a `Metrics visibility persistence` suite (Swift Testing, isolated `UserDefaults` suites):

- Round-trip persistence for columns and series across new instances.
- Forward-compatibility with a newly-added column/series.
- The no-key (non-persisting) path.

Verification:

- `** BUILD SUCCEEDED **` (iPhone 17 Pro simulator, Debug).
- All 23 metrics tests pass (5 new persistence + 18 existing collection tests).

## Screenshots/Videos (when applicable)

N/A — behavior-only change (persisted view configuration); no visual change beyond selections being retained across navigation.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
