### PR TITLE
fix: prevent SwiftData faulted-object SIGTRAP crashes in NodeList, MeshMap, and NodeMapSwiftUI

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
@@ -64,21 +64,21 @@ struct NodeMapSwiftUI: View {
 	@State private var mapRegion = MKCoordinateRegion.init()
 
 	var body: some View {
-		Group {
-			if totalPositionCount > 0 {
-				mapWithNavigation
-			} else {
-				ContentUnavailableView("No Positions", systemImage: "mappin.slash")
+		if node.modelContext != nil {
+			Group {
+				if totalPositionCount > 0 {
+					mapWithNavigation
+				} else {
+					ContentUnavailableView("No Positions", systemImage: "mappin.slash")
+				}
 			}
-		}
-		.onChange(of: node) {
-			handleNodeChange()
-		}
-		.onChange(of: node.lastHeard) {
-			refreshPositions()
-		}
-		.onAppear {
-			handleAppear()
+			.onChange(of: node) {
+				handleNodeChange()
+				refreshPositions()
+			}
+			.onAppear {
+				handleAppear()
+			}
 		}
 	}
 

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -130,13 +130,13 @@ struct MeshMap: View {
 		}
 		combine(&key, filterRefreshKey)
 		for position in positions.prefix(64) {
-			combine(&key, position.nodePosition?.num ?? 0)
+			combine(&key, Int64(truncatingIfNeeded: position.persistentModelID.hashValue))
 			combine(&key, Int64(position.latitudeI))
 			combine(&key, Int64(position.longitudeI))
 			combine(&key, Int64(position.precisionBits))
 		}
 		if let last = positions.last {
-			combine(&key, last.nodePosition?.num ?? 0)
+			combine(&key, Int64(truncatingIfNeeded: last.persistentModelID.hashValue))
 			combine(&key, Int64(last.latitudeI))
 				combine(&key, Int64(last.longitudeI))
 			}

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -306,26 +306,28 @@ private struct FilteredNodeList: View {
 	// The body of the view
 	var body: some View {
 		List(displayedNodes, selection: $selectedNodeNum) { entry in
-			NavigationLink(value: entry.id) {
-				switch nodeListDensity {
-				case .compact:
-					NodeListItemCompact(
+			if entry.node.modelContext != nil {
+				NavigationLink(value: entry.id) {
+					switch nodeListDensity {
+					case .compact:
+						NodeListItemCompact(
+							node: entry.node,
+							isDirectlyConnected: entry.id == accessoryManager.activeDeviceNum,
+							connectedNode: accessoryManager.activeConnection?.device.num ?? -1)
+					case .standard:
+						NodeListItem(
+							node: entry.node,
+							isDirectlyConnected: entry.id == accessoryManager.activeDeviceNum,
+							connectedNode: accessoryManager.activeConnection?.device.num ?? -1
+						)
+					}
+				}
+				.contextMenu {
+					contextMenuActions(
 						node: entry.node,
-						isDirectlyConnected: entry.id == accessoryManager.activeDeviceNum,
-						connectedNode: accessoryManager.activeConnection?.device.num ?? -1)
-				case .standard:
-					NodeListItem(
-						node: entry.node,
-						isDirectlyConnected: entry.id == accessoryManager.activeDeviceNum,
-						connectedNode: accessoryManager.activeConnection?.device.num ?? -1
+						connectedNode: connectedNode
 					)
 				}
-			}
-			.contextMenu {
-				contextMenuActions(
-					node: entry.node,
-					connectedNode: connectedNode
-				)
 			}
 		}
 		.navigationTitle(String.localizedStringWithFormat("Nodes (%@)".localized, String(displayedNodes.count)))

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -184,6 +184,14 @@ struct NodeList: View {
 //  FilteredNodeList.swift
 //  Meshtastic
 //
+/// Wraps a NodeInfoEntity with a pre-extracted stable identity so that List/ForEach never
+/// reads a key path on a live SwiftData object during diffing. If the backing object is
+/// faulted between snapshot and render, the identity comparison still works safely.
+private struct NodeListEntry: Identifiable {
+	let id: Int64
+	let node: NodeInfoEntity
+}
+
 private struct FilteredNodeList: View {
 	@EnvironmentObject var accessoryManager: AccessoryManager
 	@EnvironmentObject var router: Router
@@ -193,7 +201,7 @@ private struct FilteredNodeList: View {
 	/// Throttled snapshot of the filtered/sorted nodes actually shown. Recomputed on a gentle
 	/// cadence (see `.task`) instead of in `body`, so the full-node-set scan in `displayNodes`
 	/// doesn't run on every SwiftData write — which pegged the CPU on reconnect with a large DB.
-	@State private var displayedNodes: [NodeInfoEntity] = []
+	@State private var displayedNodes: [NodeListEntry] = []
 
 	var connectedNode: NodeInfoEntity?
 	@Binding var isPresentingDeleteNodeAlert: Bool
@@ -250,7 +258,7 @@ private struct FilteredNodeList: View {
 		)
 	}
 
-	private func displayNodes(activeNodeNum: Int64?) -> [NodeInfoEntity] {
+	private func displayNodes(activeNodeNum: Int64?) -> [NodeListEntry] {
 		let searchText = filters.searchText.lowercased()
 		let onlineThreshold = filters.isOnline ? Date().addingTimeInterval(-7_200) : nil
 		let distanceBounds = filters.currentDistanceBounds
@@ -292,30 +300,30 @@ private struct FilteredNodeList: View {
 		}
 		nodes.append(contentsOf: favoriteNodes)
 		nodes.append(contentsOf: regularNodes)
-		return nodes
+		return nodes.map { NodeListEntry(id: $0.num, node: $0) }
 	}
 
 	// The body of the view
 	var body: some View {
-		List(displayedNodes, id: \.num, selection: $selectedNodeNum) { node in
-			NavigationLink(value: node.num) {
+		List(displayedNodes, selection: $selectedNodeNum) { entry in
+			NavigationLink(value: entry.id) {
 				switch nodeListDensity {
 				case .compact:
 					NodeListItemCompact(
-						node: node,
-						isDirectlyConnected: node.num == accessoryManager.activeDeviceNum,
+						node: entry.node,
+						isDirectlyConnected: entry.id == accessoryManager.activeDeviceNum,
 						connectedNode: accessoryManager.activeConnection?.device.num ?? -1)
 				case .standard:
 					NodeListItem(
-						node: node,
-						isDirectlyConnected: node.num == accessoryManager.activeDeviceNum,
+						node: entry.node,
+						isDirectlyConnected: entry.id == accessoryManager.activeDeviceNum,
 						connectedNode: accessoryManager.activeConnection?.device.num ?? -1
 					)
 				}
 			}
 			.contextMenu {
 				contextMenuActions(
-					node: node,
+					node: entry.node,
 					connectedNode: connectedNode
 				)
 			}


### PR DESCRIPTION
## Summary

Three commits addressing a class of crash where accessing `@Attribute` or `@Relationship` properties on a deleted/faulted SwiftData `@Model` object fires `_SD_get_faulting_backingdata_tsd` → `_assertionFailure` → SIGTRAP. Identified from Datadog RUM crash data for build 2045 (App Store) — 43+ SIGTRAP events and 3 SIGABRT events across 2 days.

- **NodeList** (dominant crash, 34+ events, issue `565990b0`): `List(displayedNodes, id: \.num)` read `.num` via the SwiftData key-path getter during ForEach diffing on every render. A 350ms snapshot window means nodes can be deleted between snapshot and render. Fixed by wrapping each node in a `NodeListEntry` struct that pre-extracts `id: Int64`, then guarding the cell body with `entry.node.modelContext != nil` so `NodeListItem` never accesses backing-store properties on a faulted object.
- **MeshMap** (issue `ab285602`): `visiblePositionState` key computation traversed `position.nodePosition?.num` — a `@Relationship` that can be faulted. Replaced with `Int64(truncatingIfNeeded: position.persistentModelID.hashValue)`, which is safe metadata with no persistent-store fetch.
- **NodeMapSwiftUI**: `body` accessed `node.num`, `node.favorite`, `node.user?.shortName`, and `node.lastHeard` directly. Wrapped the entire body in `if node.modelContext != nil` and merged the two `onChange` handlers to eliminate the unsafe `node.lastHeard` read at modifier-evaluation time.

## Test plan

- [ ] Build and run on device with a large node database, trigger rapid BLE reconnects to stress the snapshot window
- [ ] Verify node list renders correctly after connect/disconnect cycles
- [ ] Verify MeshMap loads and updates positions normally
- [ ] Verify NodeMapSwiftUI shows node map and responds to node changes
- [ ] Monitor Datadog RUM for build after merge — SIGTRAP rate for issue `565990b0` should drop to zero