### PR TITLE
fix: remove duplicate NodeFilterParameters init that broke compilation

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
@@ -289,10 +289,4 @@ final class NodeFilterParameters: ObservableObject {
 
 		return true
 	}
-
-	init() {
-		if let storedRoles = UserDefaults.standard.array(forKey: "nodeFilter.deviceRoles") as? [Int] {
-			self.deviceRoles = Set(storedRoles)
-		}
-	}
 }


### PR DESCRIPTION
## Summary

`main` currently does **not compile**. `NodeFilterParameters.swift` (merged via #1625) has a leftover no-argument `init()` — introduced during the PR's rebase conflict resolution — that returns without initializing the non-optional stored filter properties (`isOnline`, `isPkiEncrypted`, etc.):

```swift
init() {
    if let storedRoles = UserDefaults.standard.array(forKey: "nodeFilter.deviceRoles") as? [Int] {
        self.deviceRoles = Set(storedRoles)
    }
}
```

This fails with `error: return from initializer without initializing all stored properties`, breaking the whole target.

The designated `init(store: UserDefaults = .standard)` already loads persisted `deviceRoles`, so this trailing init is both dead and broken. This PR removes it.

## Test plan

- [x] `xcodebuild` builds the `Meshtastic` scheme + test target successfully (it did not before this change)
- [x] `MeshtasticTests` snapshot suite runs green against the fixed target