### PR TITLE
fix: stop heartbeat timer reset/cancel log spam on busy TCP/serial links

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -201,6 +201,11 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	
 	var heartbeatTimer: ResettableTimer?
 	var heartbeatResponseTimer: ResettableTimer?
+	/// How long a TCP/serial connection may sit idle (no data or log packets) before we send a
+	/// keep-alive heartbeat. The timer is resettable, so an active link never sends one — heartbeats
+	/// only fire after this much silence. BLE does not use this at all (Core Bluetooth manages the
+	/// link); see `Transport.requiresPeriodicHeartbeat`.
+	static let heartbeatInterval: TimeInterval = 15.0
 	private var isClosingConnection = false
 
 	init(transports: [any Transport] = [BLETransport(), TCPTransport()]) {
@@ -471,7 +476,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			await self.processFromRadio(fromRadio)
 			Task {
 				await self.heartbeatResponseTimer?.cancel(withReason: "Data packet received")
-				await self.heartbeatTimer?.reset(delay: .seconds(15.0))
+				await self.heartbeatTimer?.reset(delay: .seconds(Self.heartbeatInterval))
 			}
 
 		case .logMessage(let message):
@@ -482,7 +487,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			self.didReceiveLog(message: message)
 			Task {
 				await self.heartbeatResponseTimer?.cancel(withReason: "Log message packet received")
-				await self.heartbeatTimer?.reset(delay: .seconds(15.0))
+				await self.heartbeatTimer?.reset(delay: .seconds(Self.heartbeatInterval))
 			}
 		
 		case .rssiUpdate(let rssi):
@@ -928,7 +933,10 @@ extension AccessoryManager {
 			self.heartbeatTimer = nil
 		}
 		
-		self.heartbeatTimer = ResettableTimer(isRepeating: true, debugName: Bundle.main.isDebug ? "Send Heartbeat" : nil) {
+		// No debugName: this timer is reset on every received data/log packet, so a per-reset debug
+		// line would flood the log on busy TCP/serial links. The meaningful "heartbeat sent" log
+		// below still fires only when a heartbeat is actually sent (i.e. after an idle interval).
+		self.heartbeatTimer = ResettableTimer(isRepeating: true) {
 			Logger.transport.debug("💓 [Heartbeat] Sending periodic heartbeat")
 			try? await self.sendHeartbeat()
 		}
@@ -936,7 +944,10 @@ extension AccessoryManager {
 		// We can send heartbeats for older versions just fine, but only 2.7.4 and up will respond with
 		// a definite queueStatus packet.
 		if self.checkIsVersionSupported(forVersion: "2.7.4") {
-			self.heartbeatResponseTimer = ResettableTimer(isRepeating: false, debugName: Bundle.main.isDebug ? "Heartbeat Timeout" : nil) { @MainActor in
+			// No debugName: this timer is cancelled on every received data/log packet, so a per-cancel
+			// debug line would flood the log on busy links. The timeout error below still fires if a
+			// heartbeat truly goes unanswered.
+			self.heartbeatResponseTimer = ResettableTimer(isRepeating: false) { @MainActor in
 				Logger.transport.error("💓 [Heartbeat] Connection Timeout: Did not receive a packet after heartbeat.")
 				// If we're in the middle of a connection cancel it.
 				await self.connectionStepper?.cancel()
@@ -950,7 +961,7 @@ extension AccessoryManager {
 				}
 			}
 		}
-		await self.heartbeatTimer?.reset(delay: .seconds(15.0))
+		await self.heartbeatTimer?.reset(delay: .seconds(Self.heartbeatInterval))
 	}
 }
 


### PR DESCRIPTION
## Summary

On busy TCP/serial connections (e.g. a load test) the log fills with `⏱️ [Send Heartbeat] Resettable timer reset…` and `⏱️ [Heartbeat Timeout] …cancelled…` lines.

Root cause: the keep-alive heartbeat timer is **reset**, and the response-timeout timer **cancelled**, on *every received data/log packet* (`AccessoryManager` `didReceive` for `.data` / `.logMessage`). Both timers were constructed with a `debugName`, and `ResettableTimer` emits a debug line on every `reset()`/`cancel()` when a `debugName` is set — so the log gets one or two lines per packet under load.

This is purely log noise, not a behavior problem: the 15s interval is correct for TCP/serial, and BLE never runs heartbeats at all (Core Bluetooth manages that link).

## Changes

- Drop the `debugName` on both heartbeat timers so the per-packet `⏱️` reset/cancel lines stop. The meaningful `💓` logs are in the timer action closures and are unaffected:
  - `💓 [Heartbeat] Sending periodic heartbeat` — only when one actually fires (after an idle interval)
  - `💓 [Heartbeat] Connection Timeout: …` — only if a heartbeat truly goes unanswered
- Factor the duplicated `15.0` interval into a single named constant `AccessoryManager.heartbeatInterval` (used by the setup and the two per-packet resets).

## Not changed

- **Interval stays 15s** for TCP/serial.
- **BLE** still never runs periodic heartbeats — gated by `Transport.requiresPeriodicHeartbeat` (`false` for BLE).

## Test plan

- [ ] On a TCP connection under heavy traffic, confirm the `⏱️` heartbeat reset/cancel lines no longer appear.
- [ ] Let a TCP/serial link go idle ~15s and confirm a single `💓 Sending periodic heartbeat` still logs.
- [ ] Confirm a dropped/unanswered link still surfaces `💓 Connection Timeout` and reconnects.