### PR TITLE
fix: prevent ModelContext.reset crash when clearing app data

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -142,7 +142,20 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// `repointToFreshContainer()` plus a UI refresh: bumps `databaseResetID` so @Query-backed
 	/// views rebind to the recreated container. Use at clear sites with no follow-up reconnect;
 	/// the node-switch flow repoints first and refreshes the UI itself after its restore.
-	func resetDatabaseAfterClear() {
+	///
+	/// Pops every tab to its root and yields *before* recreating the container. Detail views such
+	/// as `ChannelMessageList` bind a `@Bindable ChannelEntity` directly; if one is still mounted
+	/// when the container is torn down, reading that now-invalid object traps with "This model
+	/// instance was destroyed by calling ModelContext.reset". Popping + yielding lets SwiftUI
+	/// unmount those views first. Mirrors the node-switch flow in `restoreNodeFromBackup`.
+	func resetDatabaseAfterClear() async {
+		if let router = appState?.router {
+			router.popToRoot(tab: .messages)
+			router.popToRoot(tab: .nodes)
+			router.popToRoot(tab: .map)
+			router.popToRoot(tab: .settings)
+		}
+		await Task.yield()
 		repointToFreshContainer()
 		appState?.databaseResetID = UUID()
 	}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -147,17 +147,27 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// as `ChannelMessageList` bind a `@Bindable ChannelEntity` directly; if one is still mounted
 	/// when the container is torn down, reading that now-invalid object traps with "This model
 	/// instance was destroyed by calling ModelContext.reset". Popping + yielding lets SwiftUI
-	/// unmount those views first. Mirrors the node-switch flow in `restoreNodeFromBackup`.
+	/// unmount those views first. Mirrors the node-switch flow in `backupCurrentAndRestoreDatabase`
+	/// (Views/Connect/Connect.swift).
 	func resetDatabaseAfterClear() async {
-		if let router = appState?.router {
-			router.popToRoot(tab: .messages)
-			router.popToRoot(tab: .nodes)
-			router.popToRoot(tab: .map)
-			router.popToRoot(tab: .settings)
+		// `appState` (and its `router`) are wired up at launch and are required for the safety
+		// guarantee here. Bail loudly rather than recreating the container without first popping the
+		// detail views: a half-done reset (container torn down, views still mounted) would
+		// reintroduce the exact ModelContext.reset crash this method exists to prevent. The data was
+		// already cleared by the preceding `clearDatabase`, so skipping the container swap is the
+		// safe degradation.
+		guard let appState else {
+			Logger.data.error("💾 [Database] resetDatabaseAfterClear skipped: appState is nil — cannot pop views before recreating the container")
+			return
 		}
+		let router = appState.router
+		router.popToRoot(tab: .messages)
+		router.popToRoot(tab: .nodes)
+		router.popToRoot(tab: .map)
+		router.popToRoot(tab: .settings)
 		await Task.yield()
 		repointToFreshContainer()
-		appState?.databaseResetID = UUID()
+		appState.databaseResetID = UUID()
 	}
 
 	// Published Stuff

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -147,9 +147,19 @@ extension MeshPackets {
 	}
 	
 	public func clearDatabase(includeRoutes: Bool, preserveFavorites: Bool = false) {
-		// Delete entities that are on the inverse side of many-to-many
-		// relationships first to avoid constraint trigger violations.
+		// Delete entities that are on the inverse side of many-to-many relationships first to avoid
+		// constraint trigger violations. A batch `delete(model:)` alone trips the mandatory MTM
+		// nullify inverse between DeviceHardwareEntity.tags and DeviceHardwareTagEntity.devices, so
+		// first sever the relationship from the owning side and save before deleting the tag/image
+		// entities. Mirrors PersistenceController.clearDatabase.
 		do {
+			let hardwareDevices = try modelContext.fetch(FetchDescriptor<DeviceHardwareEntity>())
+			for device in hardwareDevices {
+				device.tags.removeAll()
+			}
+			if modelContext.hasChanges {
+				try modelContext.save()
+			}
 			try modelContext.delete(model: DeviceHardwareTagEntity.self)
 			try modelContext.delete(model: DeviceHardwareImageEntity.self)
 		} catch {

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -207,7 +207,7 @@ struct AppSettings: View {
 								}
 								await MeshPackets.shared.flushDebouncedSaves()
 								await MeshPackets.shared.clearDatabase(includeRoutes: true)
-								AccessoryManager.shared.resetDatabaseAfterClear()
+								await AccessoryManager.shared.resetDatabaseAfterClear()
 								clearNotifications()
 								// Repopulate device catalog immediately — no reconnect happens after a full reset.
 								try? await MeshtasticAPI.shared.refreshBundledDevicesData()

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -191,7 +191,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .milliseconds(500))
 										await MeshPackets.shared.flushDebouncedSaves()
 										await MeshPackets.shared.clearDatabase(includeRoutes: false, preserveFavorites: true)
-										AccessoryManager.shared.resetDatabaseAfterClear()
+										await AccessoryManager.shared.resetDatabaseAfterClear()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("NodeDB Reset Failed")
@@ -213,7 +213,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .milliseconds(500))
 										await MeshPackets.shared.flushDebouncedSaves()
 										await MeshPackets.shared.clearDatabase(includeRoutes: false)
-										AccessoryManager.shared.resetDatabaseAfterClear()
+										await AccessoryManager.shared.resetDatabaseAfterClear()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("NodeDB Reset Failed")
@@ -247,7 +247,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .milliseconds(500))
 										await MeshPackets.shared.flushDebouncedSaves()
 										await MeshPackets.shared.clearDatabase(includeRoutes: false)
-										AccessoryManager.shared.resetDatabaseAfterClear()
+										await AccessoryManager.shared.resetDatabaseAfterClear()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("Factory Reset Failed")
@@ -267,7 +267,7 @@ struct DeviceConfig: View {
 										try await Task.sleep(for: .milliseconds(500))
 										await MeshPackets.shared.flushDebouncedSaves()
 										await MeshPackets.shared.clearDatabase(includeRoutes: false)
-										AccessoryManager.shared.resetDatabaseAfterClear()
+										await AccessoryManager.shared.resetDatabaseAfterClear()
 										clearNotifications()
 									} catch {
 										Logger.mesh.error("Factory Reset Failed")


### PR DESCRIPTION
## Summary

Fixes a SIGTRAP crash (`SwiftData/BackingData.swift: Fatal error: This model instance was destroyed by calling ModelContext.reset and is no longer usable`) that occurs when using **Settings → Clear App Data** (and the device-reset flows).

### Root cause

The clear flow recreates the SwiftData container (`repointToFreshContainer()`), but detail views such as `ChannelMessageList` bind a `@Bindable ChannelEntity` **directly**. If such a view is still mounted (e.g. on the Messages tab's navigation stack) when the container is torn down, that model object becomes invalid and the next access traps.

The node-switch restore flow (`restoreNodeFromBackup` in `Connect.swift`) already avoids this by popping every tab to root and `await Task.yield()`-ing before recreating the container. The clear-app-data path was missing that step.

Observed crash tail:
```
SwiftData/BackingData.swift:835: Fatal error: This model instance was destroyed by
calling ModelContext.reset and is no longer usable.
PersistentIdentifier(... ChannelEntity/p371 ...)
```

## Changes

**1. The crash (`resetDatabaseAfterClear`)**
- Pop messages/nodes/map/settings to root and `await Task.yield()` so SwiftUI unmounts entity-holding detail views *before* the container is recreated, then recreate + bump `databaseResetID`.
- Made the method `async`; all five callers (Clear App Data + four DeviceConfig reset flows) now `await`.

**2. M2M constraint-violation cleanup (`UpdateSwiftData.clearDatabase`)**
- The log also showed repeated `Constraint trigger violation: Batch delete failed due to mandatory MTM nullify inverse on DeviceHardwareTagEntity/devices` errors. The batch delete of the tag/image entities trips the mandatory many-to-many inverse with `DeviceHardwareEntity.tags`.
- Sever the relationship from the owning side first (clear each device's `tags` and save) before the batch delete, mirroring `PersistenceController.clearDatabase`. Not the crash, but the same broken flow — it was leaving hardware rows behind and spamming errors.

## Test plan

- [x] `xcodebuild build` succeeds for the iOS Simulator.
- [x] With a channel message thread open (pushed on the Messages stack), trigger **Clear App Data** and confirm no crash.
- [x] Confirm the `Constraint trigger violation … DeviceHardwareTagEntity/devices` errors no longer appear, and hardware data is actually cleared.
- [x] Repeat for the DeviceConfig NodeDB reset / Factory reset flows.