### PR TITLE
fix: prevent SwiftData unique-num crash when creating stub nodes (top 2.7.13 crash)

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -446,7 +446,7 @@ extension AccessoryManager {
 			for (index, node) in routingMessage.route.enumerated() {
 				var hopNode = getNodeInfo(id: Int64(node), context: context)
 				if hopNode == nil && hopNode?.num ?? 0 > 0 && node != 4294967295 {
-					hopNode = createNodeInfo(num: Int64(node), context: context)
+					hopNode = findOrCreateNode(num: Int64(node), context: context)
 				}
 				let traceRouteHop = TraceRouteHopEntity()
 				context.insert(traceRouteHop)
@@ -510,7 +510,7 @@ extension AccessoryManager {
 				for (index, node) in routingMessage.routeBack.enumerated() {
 					var hopNode = getNodeInfo(id: Int64(node), context: context)
 					if hopNode == nil && hopNode?.num ?? 0 > 0 && node != 4294967295 {
-						hopNode = createNodeInfo(num: Int64(node), context: context)
+						hopNode = findOrCreateNode(num: Int64(node), context: context)
 					}
 					let traceRouteHop = TraceRouteHopEntity()
 					context.insert(traceRouteHop)

--- a/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
@@ -299,3 +299,28 @@ func createNodeInfo(num: Int64, context: ModelContext) -> NodeInfoEntity {
 	context.insert(newUser)
 	return newNode
 }
+
+/// Returns the `NodeInfoEntity` for `num`, creating and inserting a stub only when none exists yet.
+///
+/// `NodeInfoEntity.num` is `@Attribute(.unique)`. SwiftData resolves unique collisions against the
+/// **saved** store only — it does NOT dedup against un-saved inserts pending in the same context.
+/// So a plain `fetch`-then-`insert` can leave two pending rows with the same `num` (e.g. a POSITION
+/// packet creates a stub before the matching NodeInfo packet arrives, or two packets for a new node
+/// arrive back-to-back before a save), which then traps at insert/save time with a SwiftData
+/// assertion (`_assertionFailure`, "…remapped to a temporary identifier… fatal logic error in
+/// DefaultStore"). Routing every node creation through this helper — which checks pending inserts in
+/// addition to the store — guarantees exactly one node per `num`.
+func findOrCreateNode(num: Int64, context: ModelContext) -> NodeInfoEntity {
+	var descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate<NodeInfoEntity> { $0.num == num })
+	descriptor.fetchLimit = 1
+	if let existing = (try? context.fetch(descriptor))?.first {
+		return existing
+	}
+	// `fetch` only sees saved rows; an un-saved insert for this `num` won't appear above.
+	if let pending = context.insertedModelsArray.lazy
+		.compactMap({ $0 as? NodeInfoEntity })
+		.first(where: { $0.num == num }) {
+		return pending
+	}
+	return createNodeInfo(num: num, context: context)
+}

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -391,7 +391,7 @@ actor MeshPackets {
 					}
 				} else {
 					if fromNum > 0 {
-						let newNode = createNodeInfo(num: Int64(fromNum), context: modelContext)
+						let newNode = findOrCreateNode(num: Int64(fromNum), context: modelContext)
 						newNode.metadata = newMetadata
 					}
 				}

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -583,7 +583,7 @@ extension MeshPackets {
 					var fetchedNode = try modelContext.fetch(fetchNodePositionRequest)
 					// Create a stub node if one doesn't exist yet — it will be updated when the NodeInfo packet arrives
 					if fetchedNode.isEmpty {
-						let newNode = createNodeInfo(num: Int64(packet.from), context: modelContext)
+						let newNode = findOrCreateNode(num: Int64(packet.from), context: modelContext)
 						newNode.lastHeard = Date()
 						fetchedNode = [newNode]
 						Logger.data.debug("📍 [Position] created stub node for: \(packet.from.toHex(), privacy: .public)")

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -94,6 +94,57 @@ struct CreateNodeInfoTests {
 	}
 }
 
+// MARK: - findOrCreateNode Tests
+//
+// NodeInfoEntity.num is @Attribute(.unique). SwiftData resolves unique collisions against the saved
+// store only — not against un-saved inserts pending in the same context — so a plain fetch-then-
+// insert can leave two pending rows with the same num and trap at save. That was the top 2.7.13
+// crash (issue 4fb84588: createNodeInfo from upsertPositionPacket on a POSITION packet that arrives
+// before the node's NodeInfo). findOrCreateNode dedups against pending inserts too.
+
+@Suite("findOrCreateNode")
+struct FindOrCreateNodeTests {
+
+	/// A fresh context over the shared container isolates this test's pending inserts from others.
+	@MainActor private func freshContext() -> ModelContext {
+		ModelContext(sharedModelContainer)
+	}
+
+	@Test @MainActor func dedupesPendingInsertBeforeSave() throws {
+		let context = freshContext()
+		let num: Int64 = 0x1A2B_3C40
+
+		let first = findOrCreateNode(num: num, context: context)
+		// Not saved yet: a plain fetch wouldn't see it, but findOrCreateNode checks pending inserts.
+		let second = findOrCreateNode(num: num, context: context)
+
+		#expect(first === second)
+		let pending = context.insertedModelsArray.compactMap { $0 as? NodeInfoEntity }.filter { $0.num == num }
+		#expect(pending.count == 1)
+
+		// The original bug trapped here — saving two pending rows with the same unique `num`.
+		try context.save()
+		var descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+		descriptor.fetchLimit = 2
+		#expect(try context.fetch(descriptor).count == 1)
+	}
+
+	@Test @MainActor func returnsExistingSavedNode() throws {
+		let context = freshContext()
+		let num: Int64 = 0x0BAD_F00D
+
+		let created = findOrCreateNode(num: num, context: context)
+		try context.save()
+
+		let again = findOrCreateNode(num: num, context: context)
+		#expect(created.num == again.num)
+
+		var descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+		descriptor.fetchLimit = 2
+		#expect(try context.fetch(descriptor).count == 1)
+	}
+}
+
 // MARK: - UserEntity.hardwareImage Tests
 
 @Suite("UserEntity hardwareImage", .serialized)


### PR DESCRIPTION
## Summary

Fixes the **#1 crash on 2.7.13 App Store** — issue `4fb84588`, ~220 crashes in 7 days. Symbolicated crashed thread:

```
createNodeInfo(num:context:)
← MeshPackets.upsertPositionPacket   UpdateSwiftData.swift:586
← AccessoryManager.processFromRadio   [async, MeshPackets actor]
→ SwiftData …destroy_boxed_opaque_existential → _assertionFailure   (SIGTRAP)
```

### Root cause

A POSITION_APP packet from a node we haven't seen yet creates a **stub** `NodeInfoEntity` via `createNodeInfo`. `NodeInfoEntity.num` is `@Attribute(.unique)`, and SwiftData resolves unique collisions **only against the saved store** — not against un-saved inserts pending in the same `ModelContext`. The MeshPackets actor batches writes (debounced save), so a plain `fetch`-then-`insert` can leave two pending rows with the same `num` and trap at insert/save (`_assertionFailure`, the "PersistentIdentifier … remapped to a temporary identifier … fatal logic error in DefaultStore" we also saw in the clear-data logs).

The trigger is extremely common: hearing a **position before the NodeInfo** for a new node — `upsertPositionPacket` creates a stub, then `nodeInfoPacket` (and two trace-route hop loops) also call `createNodeInfo` for the same `num`. Four call sites all blind-insert on a unique key.

## Fix

- Add `findOrCreateNode(num:context:)` which checks `context.insertedModelsArray` (pending inserts) in addition to the saved store, so it returns the existing/pending node instead of inserting a duplicate.
- Route all four `createNodeInfo` call sites through it (position, admin/metadata, two trace-route hop loops).
- `createNodeInfo` remains the raw insert that the helper wraps.

## Test

`EntityTests.swift` → `@Suite("findOrCreateNode")`:
- `dedupesPendingInsertBeforeSave` — reproduces the crash condition (two pending inserts of the same unique `num`, then `save()`); asserts a single instance and that the save no longer traps.
- `returnsExistingSavedNode` — after save, returns the existing node, no duplicate.

Both pass; full app + test target builds.

## Note
Distinct from the other open crash PRs (#1948 clear-app-data reset, #1944 view faulted objects) — this is on the packet-ingestion write path.