### PR TITLE
fix: stop SIGTRAP converting Int32 local-stats counters to UInt32 for Live Activity

### DIFF
--- a/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
+++ b/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
@@ -731,17 +731,17 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 		let timerSeconds = 900 // 15 minute local stats interval
 		let future = Date(timeIntervalSinceNow: Double(timerSeconds))
 		let initialState = MeshActivityAttributes.ContentState(
-			uptimeSeconds: UInt32(mostRecent?.uptimeSeconds ?? 0),
+			uptimeSeconds: UInt32(bitPattern: mostRecent?.uptimeSeconds ?? 0),
 			channelUtilization: mostRecent?.channelUtilization ?? 0.0,
 			airtime: mostRecent?.airUtilTx ?? 0.0,
-			sentPackets: UInt32(mostRecent?.numPacketsTx ?? 0),
-			receivedPackets: UInt32(mostRecent?.numPacketsRx ?? 0),
-			badReceivedPackets: UInt32(mostRecent?.numPacketsRxBad ?? 0),
-			dupeReceivedPackets: UInt32(mostRecent?.numRxDupe ?? 0),
-			packetsSentRelay: UInt32(mostRecent?.numTxRelay ?? 0),
-			packetsCanceledRelay: UInt32(mostRecent?.numTxRelayCanceled ?? 0),
-			nodesOnline: UInt32(mostRecent?.numOnlineNodes ?? 0),
-			totalNodes: UInt32(mostRecent?.numTotalNodes ?? 0),
+			sentPackets: UInt32(bitPattern: mostRecent?.numPacketsTx ?? 0),
+			receivedPackets: UInt32(bitPattern: mostRecent?.numPacketsRx ?? 0),
+			badReceivedPackets: UInt32(bitPattern: mostRecent?.numPacketsRxBad ?? 0),
+			dupeReceivedPackets: UInt32(bitPattern: mostRecent?.numRxDupe ?? 0),
+			packetsSentRelay: UInt32(bitPattern: mostRecent?.numTxRelay ?? 0),
+			packetsCanceledRelay: UInt32(bitPattern: mostRecent?.numTxRelayCanceled ?? 0),
+			nodesOnline: UInt32(bitPattern: mostRecent?.numOnlineNodes ?? 0),
+			totalNodes: UInt32(bitPattern: mostRecent?.numTotalNodes ?? 0),
 			timerRange: Date.now...future
 		)
 

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1025,17 +1025,17 @@ actor MeshPackets {
 
 						let fifteenMinutesLater = Calendar.current.date(byAdding: .minute, value: (Int(15) ), to: Date())!
 						let date = Date.now...fifteenMinutesLater
-						let updatedMeshStatus = MeshActivityAttributes.MeshActivityStatus(uptimeSeconds: telemetry.uptimeSeconds.map { UInt32($0) },
+						let updatedMeshStatus = MeshActivityAttributes.MeshActivityStatus(uptimeSeconds: telemetry.uptimeSeconds.map { UInt32(bitPattern: $0) },
 																						  channelUtilization: telemetry.channelUtilization,
 																						  airtime: telemetry.airUtilTx,
-																						  sentPackets: UInt32(telemetry.numPacketsTx),
-																						  receivedPackets: UInt32(telemetry.numPacketsRx),
-																						  badReceivedPackets: UInt32(telemetry.numPacketsRxBad),
-																						  dupeReceivedPackets: UInt32(telemetry.numRxDupe),
-																						  packetsSentRelay: UInt32(telemetry.numTxRelay),
-																						  packetsCanceledRelay: UInt32(telemetry.numTxRelayCanceled),
-																						  nodesOnline: UInt32(telemetry.numOnlineNodes),
-																						  totalNodes: UInt32(telemetry.numTotalNodes),
+																						  sentPackets: UInt32(bitPattern: telemetry.numPacketsTx),
+																						  receivedPackets: UInt32(bitPattern: telemetry.numPacketsRx),
+																						  badReceivedPackets: UInt32(bitPattern: telemetry.numPacketsRxBad),
+																						  dupeReceivedPackets: UInt32(bitPattern: telemetry.numRxDupe),
+																						  packetsSentRelay: UInt32(bitPattern: telemetry.numTxRelay),
+																						  packetsCanceledRelay: UInt32(bitPattern: telemetry.numTxRelayCanceled),
+																						  nodesOnline: UInt32(bitPattern: telemetry.numOnlineNodes),
+																						  totalNodes: UInt32(bitPattern: telemetry.numTotalNodes),
 																						  timerRange: date)
 
 						let alertConfiguration = AlertConfiguration(title: "Mesh activity update", body: "Updated Node Stats Data.", sound: .default)

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -518,17 +518,17 @@ struct Connect: View {
 		let activityAttributes = MeshActivityAttributes(nodeNum: Int(node?.num ?? 0), name: node?.user?.longName?.addingVariationSelectors ?? "unknown", shortName: node?.user?.shortName ?? "?")
 		
 		let future = Date(timeIntervalSinceNow: Double(timerSeconds))
-		let initialContentState = MeshActivityAttributes.ContentState(uptimeSeconds: UInt32(mostRecent?.uptimeSeconds ?? 0),
+		let initialContentState = MeshActivityAttributes.ContentState(uptimeSeconds: UInt32(bitPattern: mostRecent?.uptimeSeconds ?? 0),
 																	  channelUtilization: mostRecent?.channelUtilization ?? 0.0,
 																	  airtime: mostRecent?.airUtilTx ?? 0.0,
-																	  sentPackets: UInt32(mostRecent?.numPacketsTx ?? 0),
-																	  receivedPackets: UInt32(mostRecent?.numPacketsRx ?? 0),
-																	  badReceivedPackets: UInt32(mostRecent?.numPacketsRxBad ?? 0),
-																	  dupeReceivedPackets: UInt32(mostRecent?.numRxDupe ?? 0),
-																	  packetsSentRelay: UInt32(mostRecent?.numTxRelay ?? 0),
-																	  packetsCanceledRelay: UInt32(mostRecent?.numTxRelayCanceled ?? 0),
-																	  nodesOnline: UInt32(mostRecent?.numOnlineNodes ?? 0),
-																	  totalNodes: UInt32(mostRecent?.numTotalNodes ?? 0),
+																	  sentPackets: UInt32(bitPattern: mostRecent?.numPacketsTx ?? 0),
+																	  receivedPackets: UInt32(bitPattern: mostRecent?.numPacketsRx ?? 0),
+																	  badReceivedPackets: UInt32(bitPattern: mostRecent?.numPacketsRxBad ?? 0),
+																	  dupeReceivedPackets: UInt32(bitPattern: mostRecent?.numRxDupe ?? 0),
+																	  packetsSentRelay: UInt32(bitPattern: mostRecent?.numTxRelay ?? 0),
+																	  packetsCanceledRelay: UInt32(bitPattern: mostRecent?.numTxRelayCanceled ?? 0),
+																	  nodesOnline: UInt32(bitPattern: mostRecent?.numOnlineNodes ?? 0),
+																	  totalNodes: UInt32(bitPattern: mostRecent?.numTotalNodes ?? 0),
 																	  timerRange: Date.now...future)
 		
 		let activityContent = ActivityContent(state: initialContentState, staleDate: Calendar.current.date(byAdding: .minute, value: 15, to: Date())!)


### PR DESCRIPTION
## Summary

Fixes a `SIGTRAP` crash on 2.7.13 App Store (issue `212e3554`) in `MeshPackets.telemetryPacket` (MeshPackets.swift:1032), confirmed from a symbolicated report:

```
MeshPackets.telemetryPacket(packet:connectedNode:)   MeshPackets.swift:1032
→ TelemetryEntity.numPacketsRx.getter
→ SIGTRAP   [async MeshPackets actor]
```

### Root cause

Local-stats counters (`numPacketsRx`/`Tx`/`RxBad`, `numRxDupe`, `numTxRelay`/`Canceled`, `numOnlineNodes`, `numTotalNodes`, `uptimeSeconds`) are firmware **`uint32`** values stored into **`Int32`** entity fields via `Int32(truncatingIfNeeded:)` (MeshPackets.swift:935-942). Any value above `Int32.max` is therefore stored as a **negative** `Int32`.

The Live Activity (`MeshActivityStatus`) build then read them back with the **trapping** `UInt32(_:)` initializer. `UInt32(negativeValue)` traps with *"Negative value is not representable in type 'UInt32'"* → `SIGTRAP`. A long-running node whose packet counters exceed `Int32.max` (~2.1B — common on routers/base nodes) crash-loops on every local-stats telemetry packet.

This is distinct from #1951 (unique-insert) — it's an integer-conversion bug.

## Fix

Use `UInt32(bitPattern:)`, the exact inverse of the `Int32(truncatingIfNeeded:)` storage, so the original firmware `uint32` value round-trips correctly. Applied to all three sites that build `MeshActivityStatus`, which would all crash identically:

- `Meshtastic/Helpers/MeshPackets.swift` — live update (the crash site)
- `Meshtastic/Views/Connect/Connect.swift` — initial Live Activity state
- `Meshtastic/CarPlay/CarPlaySceneDelegate.swift` — initial Live Activity state

27 conversions total (9 per site).

## Test plan

- [x] `xcodebuild build` succeeds for the iOS Simulator.
- [x] Connect to / simulate a node whose local-stats counters exceed `Int32.max` (negative when stored) and confirm the Live Activity updates without crashing.
- [x] Confirm the displayed counters show the correct large value (round-tripped), not a wrapped/negative number.