### PR TITLE
fix: add Copy button for public key on Security Config (#1943)

### DIFF
--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -54,7 +54,23 @@ struct SecurityConfig: View {
 				.font(.title3)
 			Section(header: Text("Direct Message Key")) {
 				VStack(alignment: .leading) {
-					Label("Public Key", systemImage: "key")
+					HStack(alignment: .firstTextBaseline) {
+						Label("Public Key", systemImage: "key")
+						Spacer()
+						// Explicit copy action. On Mac Catalyst `.textSelection(.enabled)` on a
+						// Text inside a Form does not reliably offer a right-click "Copy", so the
+						// selection-only approach left macOS users unable to copy their key (#1943).
+						Button {
+							UIPasteboard.general.string = publicKey
+						} label: {
+							Image(systemName: "doc.on.doc")
+							Text("Copy")
+						}
+						.buttonStyle(.bordered)
+						.buttonBorderShape(.capsule)
+						.controlSize(.small)
+						.disabled(publicKey.isEmpty)
+					}
 					Text(publicKey)
 						.font(idiom == .phone ? .caption : .callout)
 						.allowsTightening(true)

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -78,6 +78,9 @@ struct SecurityConfig: View {
 						.keyboardType(.alphabet)
 						.foregroundStyle(.tertiary)
 						.disableAutocorrection(true)
+						// Retained as the iOS copy path (long-press to select); the Copy button
+						// above is the reliable path on Mac Catalyst, where this doesn't offer
+						// a right-click "Copy" inside a Form (#1943).
 						.textSelection(.enabled)
 						.background(
 							RoundedRectangle(cornerRadius: 10.0)


### PR DESCRIPTION
## What changed?

Added an explicit **Copy** button next to the Public Key on the Security Config page. It writes the key to `UIPasteboard.general`, mirroring the pattern already used for the same key in `NodeDetail`. `.textSelection(.enabled)` is kept for iOS, and the button is disabled when there is no key to copy.

Fixes #1943.

## Why did it change?

On the macOS app you could not copy your public key from the Security Config page (right-click did nothing); it works on iOS. The app is a **Mac Catalyst** build (`SUPPORTS_MACCATALYST = YES`), and the key's only copy affordance was `.textSelection(.enabled)`. On Catalyst, `.textSelection(.enabled)` on a `Text` inside a `Form`/`List` does not reliably wire up the right-click → Copy menu; iOS works because selection is driven by a long-press gesture SwiftUI does hook up. An explicit Copy button works on every platform regardless of selection support.

## How is this tested?

- Builds clean for the iOS Simulator and for **Mac Catalyst** (the affected platform).
- One-line UI affordance using the same `UIPasteboard` pattern already proven in `NodeDetail`; there is no extractable logic to unit-test, and the repo has no interaction/UI-test harness for this view (the equivalent `NodeDetail` Copy button has no behavioral test either).

## Screenshots/Videos (when applicable)

A capsule **Copy** button appears to the right of the "Public Key" label, matching the styling of the existing Backup/Restore/Regenerate buttons on the same screen.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. The Security page docs describe the feature at a high level and do not enumerate UI buttons, so no doc update is needed (`skip-docs-check`).
- [x] I have tested the change to ensure that it works as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Code review pass

Ran a high-effort code review (`/code-review high --fix`). The production change was clean; added a one-line comment clarifying that `.textSelection(.enabled)` is intentionally retained as the iOS (long-press) copy path, distinct from the Copy button which is the reliable Mac Catalyst path — so a future reader doesnʼt remove it as redundant. (A "silent copy / no confirmation" suggestion was considered and skipped to stay consistent with the existing `NodeDetail` copy button.)
