### PR TITLE
fix: preserve full LoRa config during Local Mesh Discovery (#1952)

### DIFF
--- a/Meshtastic/Services/DiscoveryScanEngine.swift
+++ b/Meshtastic/Services/DiscoveryScanEngine.swift
@@ -58,6 +58,9 @@ final class DiscoveryScanEngine {
 	// MARK: Internal State
 
 	private var homePreset: ModemPresets?
+	/// Full snapshot of the LoRa config as it was before the scan started, so every field
+	/// (frequency slot, overrides, MQTT flags, …) can be restored exactly afterward (#1952).
+	private var homeLoRaConfig: Config.LoRaConfig?
 	private var presetQueue: [ModemPresets] = []
 	private var currentPresetResult: DiscoveryPresetResultEntity?
 	private var dwellTask: Task<Void, Never>?
@@ -126,8 +129,11 @@ final class DiscoveryScanEngine {
 		// Record home preset from current LoRa config
 		let connectedNodeNum = Int64(UserDefaults.preferredPeripheralNum)
 		let connectedNode = getNodeInfo(id: connectedNodeNum, context: context)
-		if let loraConfig = connectedNode?.loRaConfig {
+		if let loraConfig = connectedNode?.loRaConfig, !loraConfig.isDeleted {
 			homePreset = ModemPresets(rawValue: Int(loraConfig.modemPreset))
+			// Snapshot the complete config so restore puts back the frequency slot and all
+			// other LoRa settings exactly — not just the modem preset (#1952).
+			homeLoRaConfig = loRaConfigProto(from: loraConfig, presetOverride: nil)
 		}
 
 		// Create session
@@ -206,6 +212,41 @@ final class DiscoveryScanEngine {
 		await sendPresetChange(nextPreset)
 	}
 
+	// MARK: - LoRa Config Helper
+
+	/// Builds a complete `Config.LoRaConfig` proto from the stored entity, preserving every
+	/// field. `saveLoRaConfig` replaces the device's entire LoRa config, so any field left at
+	/// its proto default is written as 0/false on the radio — e.g. `channelNum` (frequency
+	/// slot) → 0, which silently moves the radio off the user's frequency and wipes their
+	/// settings. The discovery scan only needs to change the modem preset, so everything else
+	/// must be carried through (#1952).
+	/// - Parameter presetOverride: when set, replaces the modem preset (used while shifting
+	///   presets); when `nil`, the entity's own preset is used (used to snapshot/restore home).
+	///
+	/// Internal (not private) so the field-preservation guarantee can be unit-tested.
+	func loRaConfigProto(from entity: LoRaConfigEntity, presetOverride: ModemPresets?) -> Config.LoRaConfig {
+		var config = Config.LoRaConfig()
+		if let resolvedPreset = presetOverride ?? ModemPresets(rawValue: Int(entity.modemPreset)) {
+			config.modemPreset = resolvedPreset.protoEnumValue()
+		}
+		config.region = Config.LoRaConfig.RegionCode(rawValue: Int(entity.regionCode)) ?? .unset
+		config.usePreset = entity.usePreset
+		config.hopLimit = UInt32(entity.hopLimit)
+		config.txEnabled = entity.txEnabled
+		config.txPower = entity.txPower
+		config.channelNum = UInt32(entity.channelNum)
+		config.bandwidth = UInt32(entity.bandwidth)
+		config.codingRate = UInt32(entity.codingRate)
+		config.spreadFactor = UInt32(entity.spreadFactor)
+		config.frequencyOffset = entity.frequencyOffset
+		config.overrideFrequency = entity.overrideFrequency
+		config.overrideDutyCycle = entity.overrideDutyCycle
+		config.sx126XRxBoostedGain = entity.sx126xRxBoostedGain
+		config.ignoreMqtt = entity.ignoreMqtt
+		config.configOkToMqtt = entity.okToMqtt
+		return config
+	}
+
 	// MARK: - Send Preset Change
 
 	private func sendPresetChange(_ preset: ModemPresets) async {
@@ -219,16 +260,18 @@ final class DiscoveryScanEngine {
 			return
 		}
 
-		var loraConfig = Config.LoRaConfig()
-		loraConfig.modemPreset = preset.protoEnumValue()
-
-		// Copy existing config values if available
+		// Carry through EVERY existing LoRa field, changing only the modem preset. The device
+		// applies the whole config, so building a partial one zeroes the omitted fields —
+		// notably channelNum (frequency slot) → 0, which moves the radio off the user's
+		// frequency and breaks the scan for non-default-primary setups (#1952).
+		let loraConfig: Config.LoRaConfig
 		if let existingConfig = connectedNode.loRaConfig, !existingConfig.isDeleted {
-			loraConfig.region = Config.LoRaConfig.RegionCode(rawValue: Int(existingConfig.regionCode)) ?? .unset
-			loraConfig.hopLimit = UInt32(existingConfig.hopLimit)
-			loraConfig.txEnabled = existingConfig.txEnabled
-			loraConfig.txPower = existingConfig.txPower
-			loraConfig.usePreset = existingConfig.usePreset
+			loraConfig = loRaConfigProto(from: existingConfig, presetOverride: preset)
+		} else {
+			var minimal = Config.LoRaConfig()
+			minimal.modemPreset = preset.protoEnumValue()
+			loraConfig = minimal
+			Logger.discovery.warning("📡 [Discovery] No existing LoRa config to copy — sending preset-only config")
 		}
 
 		do {
@@ -575,8 +618,11 @@ extension DiscoveryScanEngine {
 	// MARK: - Restore Home Preset
 
 	func restoreHomePreset() async {
-		guard let homePreset, let accessoryManager, let context = modelContext else {
-			Logger.discovery.info("📡 [Discovery] No home preset to restore → Idle")
+		// Restore the full config snapshot captured at scan start — preset, frequency slot,
+		// overrides and all — rather than rebuilding a partial config that would drop the
+		// user's frequency slot and other settings (#1952).
+		guard let homeLoRaConfig, let accessoryManager, let context = modelContext else {
+			Logger.discovery.info("📡 [Discovery] No home config to restore → Idle")
 			cleanupAndIdle()
 			return
 		}
@@ -585,27 +631,16 @@ extension DiscoveryScanEngine {
 		guard let connectedNode = getNodeInfo(id: connectedNodeNum, context: context),
 			  let fromUser = connectedNode.user,
 			  let toUser = connectedNode.user else {
-			Logger.discovery.error("📡 [Discovery] Cannot restore home preset — no connected node")
+			Logger.discovery.error("📡 [Discovery] Cannot restore home config — no connected node")
 			cleanupAndIdle()
 			return
 		}
 
-		var loraConfig = Config.LoRaConfig()
-		loraConfig.modemPreset = homePreset.protoEnumValue()
-
-		if let existingConfig = connectedNode.loRaConfig, !existingConfig.isDeleted {
-			loraConfig.region = Config.LoRaConfig.RegionCode(rawValue: Int(existingConfig.regionCode)) ?? .unset
-			loraConfig.hopLimit = UInt32(existingConfig.hopLimit)
-			loraConfig.txEnabled = existingConfig.txEnabled
-			loraConfig.txPower = existingConfig.txPower
-			loraConfig.usePreset = existingConfig.usePreset
-		}
-
 		do {
-			_ = try await accessoryManager.saveLoRaConfig(config: loraConfig, fromUser: fromUser, toUser: toUser)
-			Logger.discovery.info("📡 [Discovery] Restored home preset: \(homePreset.name)")
+			_ = try await accessoryManager.saveLoRaConfig(config: homeLoRaConfig, fromUser: fromUser, toUser: toUser)
+			Logger.discovery.info("📡 [Discovery] Restored home LoRa config — preset: \(self.homePreset?.name ?? "unknown"), frequency slot: \(homeLoRaConfig.channelNum)")
 		} catch {
-			Logger.discovery.error("📡 [Discovery] Failed to restore home preset: \(error.localizedDescription)")
+			Logger.discovery.error("📡 [Discovery] Failed to restore home config: \(error.localizedDescription)")
 		}
 
 		cleanupAndIdle()
@@ -712,6 +747,7 @@ extension DiscoveryScanEngine {
 		deviceMetricsHistory = [:]
 		awaitingDisconnect = false
 		interruptedDwellRemaining = nil
+		homeLoRaConfig = nil
 		transitionTo(.idle)
 	}
 

--- a/Meshtastic/Services/DiscoveryScanEngine.swift
+++ b/Meshtastic/Services/DiscoveryScanEngine.swift
@@ -747,6 +747,9 @@ extension DiscoveryScanEngine {
 		deviceMetricsHistory = [:]
 		awaitingDisconnect = false
 		interruptedDwellRemaining = nil
+		// Clear both home snapshots together so a later scan that starts without a readable
+		// LoRa config doesn't inherit a stale preset/config from a previous scan (#1952).
+		homePreset = nil
 		homeLoRaConfig = nil
 		transitionTo(.idle)
 	}

--- a/MeshtasticTests/DiscoveryScanEngineTests.swift
+++ b/MeshtasticTests/DiscoveryScanEngineTests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import Testing
+import MeshtasticProtobufs
 
 @testable import Meshtastic
 
@@ -87,5 +88,72 @@ struct DiscoveryScanEngineTests {
 			let scanning = await engine.isScanning
 			#expect(!scanning, "Expected isScanning=false for state \(state)")
 		}
+	}
+}
+
+// MARK: - LoRa config preservation (#1952)
+
+/// The scan changes only the modem preset; it must carry through every other LoRa field.
+/// Building a partial config previously zeroed omitted fields on the device — notably
+/// `channelNum` (frequency slot) → 0 — moving the radio off the user's frequency and wiping
+/// their settings, and never restoring them. These lock in that `loRaConfigProto` preserves
+/// the full config.
+@MainActor
+@Suite("DiscoveryScanEngine LoRa config preservation (#1952)")
+struct DiscoveryScanEngineLoRaConfigTests {
+
+	/// A config entity with distinctive non-default values in every field.
+	private func makeEntity() -> LoRaConfigEntity {
+		let entity = LoRaConfigEntity()
+		entity.modemPreset = Int32(ModemPresets.longFast.rawValue)
+		entity.regionCode = 1 // US
+		entity.usePreset = true
+		entity.hopLimit = 5
+		entity.txEnabled = true
+		entity.txPower = 27
+		entity.channelNum = 20
+		entity.bandwidth = 250
+		entity.codingRate = 8
+		entity.spreadFactor = 11
+		entity.frequencyOffset = 1.5
+		entity.overrideFrequency = 915.0
+		entity.overrideDutyCycle = true
+		entity.sx126xRxBoostedGain = true
+		entity.ignoreMqtt = true
+		entity.okToMqtt = true
+		return entity
+	}
+
+	@Test("Preset change preserves the frequency slot and every other LoRa field")
+	func presetChangePreservesAllFields() {
+		let engine = DiscoveryScanEngine()
+		let config = engine.loRaConfigProto(from: makeEntity(), presetOverride: .longSlow)
+
+		// Only the modem preset changes.
+		#expect(config.modemPreset == ModemPresets.longSlow.protoEnumValue())
+		// Everything else is carried through (the #1952 bug zeroed these).
+		#expect(config.channelNum == 20)
+		#expect(config.region.rawValue == 1)
+		#expect(config.usePreset)
+		#expect(config.hopLimit == 5)
+		#expect(config.txEnabled)
+		#expect(config.txPower == 27)
+		#expect(config.bandwidth == 250)
+		#expect(config.codingRate == 8)
+		#expect(config.spreadFactor == 11)
+		#expect(config.frequencyOffset == 1.5)
+		#expect(config.overrideFrequency == 915.0)
+		#expect(config.overrideDutyCycle)
+		#expect(config.sx126XRxBoostedGain)
+		#expect(config.ignoreMqtt)
+		#expect(config.configOkToMqtt)
+	}
+
+	@Test("Home snapshot (no override) keeps the entity's own preset and frequency slot")
+	func homeSnapshotKeepsPresetAndSlot() {
+		let engine = DiscoveryScanEngine()
+		let config = engine.loRaConfigProto(from: makeEntity(), presetOverride: nil)
+		#expect(config.modemPreset == ModemPresets.longFast.protoEnumValue())
+		#expect(config.channelNum == 20)
 	}
 }


### PR DESCRIPTION
## What changed?

Local Mesh Discovery now changes **only** the modem preset when shifting presets and restores the user's **complete** LoRa config afterward, instead of rebuilding a partial config that dropped most fields.

- Added `DiscoveryScanEngine.loRaConfigProto(from:presetOverride:)`, which copies every field from the stored config entity (frequency slot, override frequency, manual SF/BW/CR, duty-cycle/MQTT flags, region, hop limit, tx settings) and changes only the modem preset.
- The full config is snapshotted at scan start and restored wholesale when the scan completes/stops.

Addresses items #1 and #2 of #1952.

## Why did it change?

`sendPresetChange` and `restoreHomePreset` built a `Config.LoRaConfig` that copied only `region`, `hopLimit`, `txEnabled`, `txPower`, `usePreset`. `AccessoryManager.saveLoRaConfig` sets `adminPacket.setConfig.lora = config`, which **replaces the device's entire LoRa config** — so every omitted field was written back as `0`/`false`, most importantly **`channelNum` (frequency slot) → 0**.

With `channelNum = 0` the firmware auto-derives the frequency from a hash of the **primary (slot 0)** channel name. For the reporter's "private primary, public secondary" setup, that lands the radio on the *private* channel's frequency, so discovery never sits on the public mesh frequency for the preset being scanned (item #1). The same partial config was used to restore, and the home snapshot captured only the modem preset — so the user's manually-set frequency slot (and `overrideFrequency`, manual SF/BW/CR, MQTT flags) were **permanently wiped** by running a scan and never restored (item #2).

> Scope note: this PR covers items #1 and #2 (config preservation/restore). Item #3 (scan not rotating past the first preset — a separate reconnection-detection race) and computing the correct *public* frequency slot per preset for non-default-primary setups are larger and intentionally out of scope here.

## How is this tested?

- New Swift Testing suite `DiscoveryScanEngineLoRaConfigTests` asserts `loRaConfigProto` preserves the frequency slot **and every other LoRa field** across a preset change, and that the home snapshot keeps the entity's own preset + slot.
- The existing `DiscoveryScanEngineTests` state-machine suite still passes (11/11 total) on the iOS 18.2 simulator.

## Screenshots/Videos (when applicable)

N/A — radio-config behavior, no UI change.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. This is an internal bug fix with no user-facing doc impact, so no doc update is needed (`skip-docs-check`).
- [x] I have tested the change to ensure that it works as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Code review pass

Ran a high-effort code review (`/code-review high --fix`). Fixed one issue it surfaced: `cleanupAndIdle` cleared `homeLoRaConfig` but left `homePreset` set, so a later scan that starts when the connected nodeʼs LoRa config isnʼt readable could inherit the previous scanʼs preset — mislabeling `session.homePreset` and the restore log. Both home snapshots are now cleared together. (Two further findings — unguarded `UInt32(...)` conversions and the node-lookup-fails restore path — were verified to match existing convention / be pre-existing, and left as-is.) Tests pass (11).
