### PR TITLE
fix: stop Local Mesh Discovery hanging on the first preset (#1952)

### DIFF
--- a/Meshtastic/Services/DiscoveryScanEngine.swift
+++ b/Meshtastic/Services/DiscoveryScanEngine.swift
@@ -54,6 +54,10 @@ final class DiscoveryScanEngine {
 	var dwellDuration: TimeInterval = 900 // 15 minutes default
 	var session: DiscoverySessionEntity?
 	var errorMessage: String?
+	/// Non-blocking advisory shown when the device's LoRa setup means discovery can't land on
+	/// the public frequency for every preset — e.g. a manually-set frequency slot, which the
+	/// firmware can't auto-translate across presets. The scan still runs. See #1952.
+	var configurationWarning: String?
 
 	// MARK: Internal State
 
@@ -123,8 +127,9 @@ final class DiscoveryScanEngine {
 			return
 		}
 
-		// Clear any previous error
+		// Clear any previous error/advisory
 		errorMessage = nil
+		configurationWarning = nil
 
 		// Record home preset from current LoRa config
 		let connectedNodeNum = Int64(UserDefaults.preferredPeripheralNum)
@@ -134,6 +139,18 @@ final class DiscoveryScanEngine {
 			// Snapshot the complete config so restore puts back the frequency slot and all
 			// other LoRa settings exactly — not just the modem preset (#1952).
 			homeLoRaConfig = loRaConfigProto(from: loraConfig, presetOverride: nil)
+
+			// Discovery relies on the firmware auto-deriving each preset's frequency from the
+			// primary channel (Frequency Slot 0). A manually-set frequency slot can't be
+			// translated across presets, so non-home presets may scan a different frequency than
+			// the public mesh and find nothing. Warn rather than silently mislead (#1952 item 1).
+			if loraConfig.channelNum != 0 {
+				configurationWarning = String(
+					format: "This device uses a manual Frequency Slot (%d). Local Mesh Discovery assumes the public/default channel as primary with automatic frequency (Slot 0); results for presets other than your current one may be incomplete.".localized,
+					Int(loraConfig.channelNum)
+				)
+				Logger.discovery.warning("📡 [Discovery] Manual frequency slot \(loraConfig.channelNum) — discovery results may be incomplete for non-home presets")
+			}
 		}
 
 		// Create session
@@ -350,17 +367,56 @@ final class DiscoveryScanEngine {
 		}
 	}
 
+	/// Seconds to wait for the device to reboot before we stop requiring an observed BLE
+	/// disconnect (see `awaitingDisconnect`). A reboot+reconnect normally completes within this.
+	private static let reconnectGraceSeconds = 30
+	/// Hard cap on the whole reconnect wait before giving up.
+	private static let reconnectTimeoutSeconds = 120
+
+	/// Once the post-preset-change reconnect window elapses, decide where a still-`.reconnecting`
+	/// scan should go: connected & subscribed → resume dwelling (covers a missed disconnect edge
+	/// or a recovered link); otherwise the link is genuinely down → pause. Pure for testability.
+	nonisolated static func reconnectTimeoutResolution(isConnected: Bool, isSubscribed: Bool) -> DiscoveryScanState {
+		(isConnected && isSubscribed) ? .dwell : .paused
+	}
+
 	private func startReconnectTimeout() {
 		reconnectTimeoutTask?.cancel()
 		reconnectTimeoutTask = Task { [weak self] in
-			do {
-				try await Task.sleep(for: .seconds(120))
-				guard let self, self.currentState == .reconnecting else { return }
-				Logger.discovery.warning("📡 [Discovery] Reconnect timeout (120s) → Paused")
-				self.transitionTo(.paused)
-			} catch {
-				// Cancelled — expected when reconnection succeeds
+			// Grace period: give the device time to reboot and BLE to cycle. If we never observe
+			// the disconnect edge (missed event, or a reconnect faster than the observer can see
+			// it), stop requiring it — otherwise the scan hangs on this preset forever and never
+			// rotates (#1952 item 3).
+			do { try await Task.sleep(for: .seconds(Self.reconnectGraceSeconds)) } catch { return }
+			guard let self, self.currentState == .reconnecting else { return }
+
+			if self.awaitingDisconnect {
+				self.awaitingDisconnect = false
+				Logger.discovery.warning("📡 [Discovery] No disconnect observed \(Self.reconnectGraceSeconds)s after preset change — no longer requiring one")
+				// Already back? Proceed to dwell now rather than waiting out the full timeout.
+				let connected = self.accessoryManager?.isConnected ?? false
+				let subscribed = self.accessoryManager.map { $0.state == .subscribed } ?? false
+				if connected && subscribed {
+					Logger.discovery.info("📡 [Discovery] Connected & subscribed → Dwell")
+					self.transitionTo(.dwell)
+					self.startDwellTimer()
+					return
+				}
 			}
+
+			// Still not back: wait out the remaining window. With `awaitingDisconnect` now clear,
+			// the connection observer will advance us to dwell the instant we reconnect. If the
+			// window fully elapses, recover if we're somehow connected, else pause.
+			let remaining = Self.reconnectTimeoutSeconds - Self.reconnectGraceSeconds
+			do { try await Task.sleep(for: .seconds(remaining)) } catch { return }
+			guard self.currentState == .reconnecting else { return }
+			let resolution = Self.reconnectTimeoutResolution(
+				isConnected: self.accessoryManager?.isConnected ?? false,
+				isSubscribed: self.accessoryManager.map { $0.state == .subscribed } ?? false
+			)
+			Logger.discovery.warning("📡 [Discovery] Reconnect window elapsed (\(Self.reconnectTimeoutSeconds)s) → \(resolution)")
+			self.transitionTo(resolution)
+			if resolution == .dwell { self.startDwellTimer() }
 		}
 	}
 

--- a/Meshtastic/Services/DiscoveryScanEngine.swift
+++ b/Meshtastic/Services/DiscoveryScanEngine.swift
@@ -145,9 +145,11 @@ final class DiscoveryScanEngine {
 			// translated across presets, so non-home presets may scan a different frequency than
 			// the public mesh and find nothing. Warn rather than silently mislead (#1952 item 1).
 			if loraConfig.channelNum != 0 {
-				configurationWarning = String(
-					format: "This device uses a manual Frequency Slot (%d). Local Mesh Discovery assumes the public/default channel as primary with automatic frequency (Slot 0); results for presets other than your current one may be incomplete.".localized,
-					Int(loraConfig.channelNum)
+				// `channelNum` is Int32 (matches %d's expected C int); use localizedStringWithFormat
+				// for locale-aware number formatting, matching the rest of the app.
+				configurationWarning = String.localizedStringWithFormat(
+					"This device uses a manual Frequency Slot (%d). Local Mesh Discovery assumes the public/default channel as primary with automatic frequency (Slot 0); results for presets other than your current one may be incomplete.".localized,
+					loraConfig.channelNum
 				)
 				Logger.discovery.warning("📡 [Discovery] Manual frequency slot \(loraConfig.channelNum) — discovery results may be incomplete for non-home presets")
 			}
@@ -390,18 +392,23 @@ final class DiscoveryScanEngine {
 			do { try await Task.sleep(for: .seconds(Self.reconnectGraceSeconds)) } catch { return }
 			guard let self, self.currentState == .reconnecting else { return }
 
+			// After the grace period we no longer require an observed disconnect edge.
 			if self.awaitingDisconnect {
 				self.awaitingDisconnect = false
 				Logger.discovery.warning("📡 [Discovery] No disconnect observed \(Self.reconnectGraceSeconds)s after preset change — no longer requiring one")
-				// Already back? Proceed to dwell now rather than waiting out the full timeout.
-				let connected = self.accessoryManager?.isConnected ?? false
-				let subscribed = self.accessoryManager.map { $0.state == .subscribed } ?? false
-				if connected && subscribed {
-					Logger.discovery.info("📡 [Discovery] Connected & subscribed → Dwell")
-					self.transitionTo(.dwell)
-					self.startDwellTimer()
-					return
-				}
+			}
+			// If the device is back — whether or not we ever saw the disconnect, and whether or
+			// not the observer's subscribe edge fired — proceed to dwell now rather than waiting
+			// out the full timeout. (Checked regardless of awaitingDisconnect: the observer
+			// clears it on the disconnect edge, so gating this on it would skip the fast path in
+			// exactly the missed-subscribe-edge case it exists to handle.)
+			let connected = self.accessoryManager?.isConnected ?? false
+			let subscribed = self.accessoryManager.map { $0.state == .subscribed } ?? false
+			if connected && subscribed {
+				Logger.discovery.info("📡 [Discovery] Connected & subscribed after grace → Dwell")
+				self.transitionTo(.dwell)
+				self.startDwellTimer()
+				return
 			}
 
 			// Still not back: wait out the remaining window. With `awaitingDisconnect` now clear,

--- a/Meshtastic/Views/Settings/Discovery/DiscoveryScanView.swift
+++ b/Meshtastic/Views/Settings/Discovery/DiscoveryScanView.swift
@@ -103,6 +103,14 @@ struct DiscoveryScanView: View {
 							.foregroundStyle(.red)
 					}
 				}
+
+				if let configurationWarning = engine.configurationWarning {
+					Section {
+						Label(configurationWarning, systemImage: "exclamationmark.triangle")
+							.foregroundStyle(.orange)
+							.font(.callout)
+					}
+				}
 			}
 		}
 		.navigationTitle("Local Mesh Discovery")

--- a/MeshtasticTests/DiscoveryScanEngineTests.swift
+++ b/MeshtasticTests/DiscoveryScanEngineTests.swift
@@ -89,6 +89,18 @@ struct DiscoveryScanEngineTests {
 			#expect(!scanning, "Expected isScanning=false for state \(state)")
 		}
 	}
+
+	// MARK: - Reconnect timeout resolution (#1952 item 3)
+
+	@Test func reconnectTimeoutResolvesToDwellOnlyWhenConnectedAndSubscribed() {
+		// Connected & subscribed → resume dwelling (covers a missed disconnect edge that
+		// previously left the scan hung on one preset and never rotating).
+		#expect(DiscoveryScanEngine.reconnectTimeoutResolution(isConnected: true, isSubscribed: true) == .dwell)
+		// Anything short of fully connected → pause (link genuinely down).
+		#expect(DiscoveryScanEngine.reconnectTimeoutResolution(isConnected: false, isSubscribed: false) == .paused)
+		#expect(DiscoveryScanEngine.reconnectTimeoutResolution(isConnected: true, isSubscribed: false) == .paused)
+		#expect(DiscoveryScanEngine.reconnectTimeoutResolution(isConnected: false, isSubscribed: true) == .paused)
+	}
 }
 
 // MARK: - LoRa config preservation (#1952)


### PR DESCRIPTION
## What changed?

Two parts of #1952:

**Item #3 — scan hangs on the first preset and never rotates.** Made the post-preset-change reconnect handling staged and recovery-oriented in `DiscoveryScanEngine`:
- After a grace period, the engine stops requiring an *observed* BLE disconnect; if the device is already connected & subscribed, it resumes dwelling immediately.
- When the full window elapses, it resolves on connection state (connected & subscribed → dwell, else pause) instead of always pausing.
- The decision is extracted into a pure `reconnectTimeoutResolution(isConnected:isSubscribed:)` and unit-tested.

**Item #1 (safe guard) — non-blocking advisory.** When the device uses a manual Frequency Slot (`channelNum != 0`), the scan now shows a warning that results for presets other than the current one may be incomplete, rather than silently misleading the user.

## Why did it change?

When a preset change is sent, the device reboots and BLE drops/reconnects. The engine only left `.reconnecting` once it observed the disconnect edge (`awaitingDisconnect`). If that edge was missed — or the reconnect beat the connection observer — `awaitingDisconnect` never cleared, the reconnect→dwell transition never fired, and after the 120s timeout the scan went to `.paused` and stayed there. The first preset (which skips the config change when it equals the current preset) dwelled fine, so the symptom was "tests the first preset, then hangs until the timer runs out."

For item #1: discovery relies on the firmware auto-deriving each preset's frequency from the primary channel (Frequency Slot 0). A *manually-set* frequency slot can't be translated across presets, so for "private primary, public secondary" setups the scan can sit on the wrong frequency. Correctly computing the public slot per preset would require porting the firmware's region band table + channel-name hash + per-preset bandwidth (none of which exist in the app) and is regulatory-sensitive, so that full fix is intentionally **out of scope**; this PR adds an honest advisory instead.

## How is this tested?

- New unit test for `reconnectTimeoutResolution` covering all connection/subscription combinations.
- Existing `DiscoveryScanEngineTests` state-machine suite still passes (10/10) on the iOS 18.2 simulator.
- The live reconnect timing path itself is device/BLE-timing dependent and isn't unit-tested (consistent with the rest of the engine's reconnection logic); the recovery decision it relies on is covered by the pure helper test.

## Screenshots/Videos (when applicable)

The advisory renders as an orange warning row on the discovery screen when a manual frequency slot is detected.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. This is an internal bug fix with no documented-behavior change, so no doc update is needed (`skip-docs-check`).
- [x] I have tested the change to ensure that it works as intended.

> Note: lightly overlaps #1956 (both read the connected node's LoRa config at scan start); a trivial conflict to resolve if both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Code review pass

Ran a high-effort code review (`/code-review high --fix`). Two fixes it surfaced: (1) the 30s reconnect grace fast-path ("connected & subscribed → resume dwelling") was nested inside `if awaitingDisconnect`, but the connection observer clears that flag on the disconnect edge — so the fast path was skipped in exactly the missed-subscribe-edge case it exists for, stalling ~90s; itʼs now evaluated unconditionally after the grace. (2) The manual-frequency-slot warning now uses `String.localizedStringWithFormat` (the appʼs convention, locale-aware) and passes the `Int32` `channelNum` directly to `%d` instead of a widened 64-bit `Int`. (A warning-lifecycle finding was left as-is to stay consistent with `errorMessage`.) Tests pass (10).
