### PR TITLE
fix: stop auto-reconnect after a user-initiated TCP disconnect

### DIFF
--- a/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
+++ b/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
@@ -98,6 +98,14 @@ actor TCPConnection: Connection {
 						Logger.transport.debug("🌐 [TCP] startReader: EOF while waiting for length")
 					}
 				} catch {
+					// An intentional teardown cancels this task (and the NWConnection), which surfaces
+					// here as a receive error. Do NOT treat that as a reconnectable failure — the
+					// explicit `disconnect(shouldReconnect:)` call that cancelled us already yielded the
+					// correct event. Emitting `.error(shouldReconnect: true)` here races that intent and
+					// can trigger an auto-reconnect right after a user-initiated disconnect (the timing
+					// varies by OS — observed on iOS 18). Only a genuine, un-cancelled read error should
+					// request a reconnect.
+					if Task.isCancelled { break }
 					Logger.transport.error("🌐 [TCP] startReader: Error reading from TCP: \(error, privacy: .public)")
 					try? await self.disconnect(withError: error, shouldReconnect: true)
 					break


### PR DESCRIPTION
## Summary

After a manual disconnect on a TCP connection, the app could automatically reconnect. Reproduced on the iOS 18 simulator; not seen on iOS 26.

### Root cause (confirmed from a live iOS 18 sim log)

`AccessoryManager.disconnect()` correctly requests no reconnect — `connection.disconnect(withError: nil, shouldReconnect: false)` — and the discovery auto-reconnect gate is blocked by `userRequestedConnectionCancellation`.

But `disconnect()` cancels the `NWConnection` while the TCP **reader task is still running**. The cancelled socket surfaces in the reader's `receive` as an error (`"Error while receiving data"`), and the reader's `catch` unconditionally called `disconnect(withError: error, shouldReconnect: true)`. That emits a spurious `.error(shouldReconnect: true)` event which **races** the intentional `.disconnected(shouldReconnect: false)`. The `.error` handler sets `shouldAutomaticallyConnectToPreferredPeripheralAfterError = true`; depending on event ordering / an in-flight `connectionStepper`, that can win and auto-reconnect. The race resolution is OS-timing-dependent (the Network-framework `cancel()` → `receive` completion timing differs iOS 18 vs 26).

Captured on iOS 18 immediately on a manual disconnect:
```
08:57:52.145  E  🌐 [TCP] startReader: Error reading from TCP: …disconnected("Error while receiving data")   ← spurious shouldReconnect:true
08:57:52.173  I  [Accessory] Connection reported user-initiated disconnect.                                  ← the intended event
```

## Fix

Guard the reader's `catch` with `Task.isCancelled`. An intentional teardown cancels the reader task, so a cancellation-driven read error must not request a reconnect — the explicit `disconnect(shouldReconnect:)` that cancelled it already yielded the correct event. Only a genuine, un-cancelled read error reconnects. This makes disconnect deterministic on every iOS version.

```swift
} catch {
    if Task.isCancelled { break }   // intentional teardown — not a reconnectable failure
    Logger.transport.error("🌐 [TCP] startReader: Error reading from TCP: …")
    try? await self.disconnect(withError: error, shouldReconnect: true)
    break
}
```

### Other transports
- **Serial** already handles this: its read-source cancel handler is gated by `shouldHandleReadSourceCancellation()` (`!isDisconnecting && isOpen`), and `disconnect()` sets `isDisconnecting` + finishes the stream before cancelling the source. No change needed.
- **BLE** uses a separate disconnect path.

## Test plan

- [x] `xcodebuild build` succeeds for the iOS Simulator.
- [ ] On the iOS 18 simulator (TCP connection to a node), tap Disconnect and confirm it stays disconnected (no auto-reconnect) across repeated attempts.
- [ ] Pull the cable / drop the network on a real TCP link and confirm a *genuine* drop still auto-reconnects.
- [ ] Confirm BLE and Serial disconnect/reconnect behavior is unchanged.