### PR TITLE
Fix list text wrapping after performance row caps

### DIFF
--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -110,6 +110,7 @@ struct ChannelList: View {
 						Text(LocalizedStringKey(mostRecent?.messagePayload ?? " "))
 							.font(.footnote)
 							.foregroundColor(.onSurfaceVariant)
+							.fixedSize(horizontal: false, vertical: true)
 					}
 				}
 			}
@@ -126,7 +127,7 @@ struct ChannelList: View {
 			.alignmentGuide(.listRowSeparatorLeading) {
 				$0[.leading]
 			}
-			.frame(height: 62)
+			.frame(minHeight: 62, alignment: .center)
 			.contextMenu {
 				if hasMessages {
 					Button(role: .destructive) {

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -294,6 +294,7 @@ private struct DirectMessageUserRow: View {
 					Text(user.longName ?? "Unknown".localized)
 						.font(.headline)
 						.allowsTightening(true)
+						.fixedSize(horizontal: false, vertical: true)
 					Spacer()
 					if user.userNode?.favorite ?? false {
 						Image(systemName: "star.fill")
@@ -309,11 +310,12 @@ private struct DirectMessageUserRow: View {
 						Text(LocalizedStringKey(summary.payload))
 							.font(.footnote)
 							.foregroundColor(.onSurfaceVariant)
+							.fixedSize(horizontal: false, vertical: true)
 					}
 				}
 			}
 		}
-		.frame(height: 62)
+		.frame(minHeight: 62, alignment: .center)
 		.alignmentGuide(.listRowSeparatorLeading) {
 			$0[.leading]
 		}

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -338,6 +338,7 @@ struct IconAndText: View {
 				.font(UIDevice.current.userInterfaceIdiom == .phone ? .callout : .caption)
 				.foregroundColor(textColor)
 				.allowsTightening(true)
+				.fixedSize(horizontal: false, vertical: true)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Let channel and direct-message preview rows grow past their old 62pt fixed height when text wraps.
- Let the shared node `IconAndText` label report its vertical size instead of being visually capped by list row measurement.
- Preserve the existing performance caching and deliberate one-line compact controls.

## Reasoning
I checked the current upstream tree and recent performance history for a global `lineLimit` / text cap. There is no app-wide text limiter in the latest code; the practical regression points are fixed-height list rows and shared row text that could not claim vertical space when wrapping.

## Verification
- `git diff --check`
- `xcodebuild -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,id=DE3343B3-1E9D-4C2D-9AFE-B50AC465BEBA' -derivedDataPath /tmp/meshtastic-textlimit-derived -skipPackagePluginValidation -skipMacroValidation build` succeeded.
- Installed/launched the built app on the iPhone 16e simulator with `--meshtastic-perf-seed --meshtastic-perf-reset`; seeded Nodes list rendered successfully.
