### PR TITLE
fix: reflect message ACK delivery status live in open conversations

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		DD00001BINTCVRTST0000001 /* IntentConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001BINTCVRTST0000000 /* IntentConverterTests.swift */; };
 		DD00001CMAPDATTST0000001 /* MapDataModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001CMAPDATTST0000000 /* MapDataModelTests.swift */; };
 		DD00001DCDENTTST00000001 /* EntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001DCDENTTST00000000 /* EntityTests.swift */; };
+		DD000031ACKXCTXTST000001 /* AckCrossContextRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000031ACKXCTXTST000000 /* AckCrossContextRefreshTests.swift */; };
 		DD00001EURLDETTST0000001 /* URLExtensionDetailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001EURLDETTST0000000 /* URLExtensionDetailedTests.swift */; };
 		DD00001FFWVMERRTST000001 /* FirmwareViewModelErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001FFWVMERRTST000000 /* FirmwareViewModelErrorTests.swift */; };
 		DD000020TAKBRDTST0000001 /* TAKBridgeDetailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000020TAKBRDTST0000000 /* TAKBridgeDetailedTests.swift */; };
@@ -830,6 +831,7 @@
 		DD00001BINTCVRTST0000000 /* IntentConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentConverterTests.swift; sourceTree = "<group>"; };
 		DD00001CMAPDATTST0000000 /* MapDataModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapDataModelTests.swift; sourceTree = "<group>"; };
 		DD00001DCDENTTST00000000 /* EntityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityTests.swift; sourceTree = "<group>"; };
+		DD000031ACKXCTXTST000000 /* AckCrossContextRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AckCrossContextRefreshTests.swift; sourceTree = "<group>"; };
 		DD00001EURLDETTST0000000 /* URLExtensionDetailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtensionDetailedTests.swift; sourceTree = "<group>"; };
 		DD00001FFWVMERRTST000000 /* FirmwareViewModelErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareViewModelErrorTests.swift; sourceTree = "<group>"; };
 		DD000020TAKBRDTST0000000 /* TAKBridgeDetailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAKBridgeDetailedTests.swift; sourceTree = "<group>"; };
@@ -1576,6 +1578,7 @@
 				AA009MCT0000001000000001 /* MarkdownConverterTests.swift */,
 				AA003DOC0000001000000008 /* DocTranslationTests.swift */,
 				DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */,
+				DD000031ACKXCTXTST000000 /* AckCrossContextRefreshTests.swift */,
 			);
 			path = MeshtasticTests;
 			sourceTree = "<group>";
@@ -2640,6 +2643,7 @@
 				DD00001BINTCVRTST0000001 /* IntentConverterTests.swift in Sources */,
 				DD00001CMAPDATTST0000001 /* MapDataModelTests.swift in Sources */,
 				DD00001DCDENTTST00000001 /* EntityTests.swift in Sources */,
+				DD000031ACKXCTXTST000001 /* AckCrossContextRefreshTests.swift in Sources */,
 				DD00001EURLDETTST0000001 /* URLExtensionDetailedTests.swift in Sources */,
 				DD00001FFWVMERRTST000001 /* FirmwareViewModelErrorTests.swift in Sources */,
 				DD000020TAKBRDTST0000001 /* TAKBridgeDetailedTests.swift in Sources */,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -691,9 +691,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 						Logger.mesh.error("🕸️ No active connection. Unable to determine connectedNodeNum for routingPacket.")
 						return
 					}
-					await MeshPackets.shared.routingPacket(packet: packet, connectedNodeNum: deviceNum)
+					await MeshPackets.shared.routingPacket(packet: packet, connectedNodeNum: deviceNum, appState: appState)
 				case .adminApp:
-					await MeshPackets.shared.adminAppPacket(packet: packet)
+					await MeshPackets.shared.adminAppPacket(packet: packet, appState: appState)
 				case .replyApp:
 					Logger.mesh.info("[Reply] packet received from \(packet.from.toHex(), privacy: .public)")
 					guard let deviceNum = activeConnection?.device.num else {

--- a/Meshtastic/AppState.swift
+++ b/Meshtastic/AppState.swift
@@ -12,6 +12,12 @@ class AppState: ObservableObject {
 	/// refetch, so they drop objects cached from the previous node's database. Applied
 	/// as `.id(appState.databaseResetID)` on the root content view.
 	@Published var databaseResetID = UUID()
+	/// Bumped whenever a routing ACK (delivery receipt) is persisted for a sent message.
+	/// Open message conversations observe this to refresh their delivery indicators
+	/// immediately, instead of waiting for the periodic poll. ACK writes happen in
+	/// MeshPackets' isolated ModelActor context, so the already-loaded message objects
+	/// don't observe the change on their own.
+	@Published var messageAckUpdate = 0
 
 	var totalUnreadMessages: Int {
 		unreadChannelMessages + unreadDirectMessages

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -115,6 +115,14 @@ actor MeshPackets {
 		}
 	}
 
+	/// Commit a delivery-ACK write immediately and nudge open conversations to refresh.
+	/// Shared by every ACK-writing path (routing ACKs and admin-response ACKs) so the
+	/// live delivery-indicator update never depends on which path delivered the receipt.
+	func saveAck(appState: AppState?, caller: String) {
+		savePendingChanges(caller: caller)
+		Task { @MainActor in appState?.messageAckUpdate += 1 }
+	}
+
 	// MARK: - Debounced Save for High-Frequency Packets
 
 	/// Timer task for debounced saves (position/telemetry).
@@ -647,7 +655,7 @@ actor MeshPackets {
 		return nil
 	}
 
-	func adminAppPacket (packet: MeshPacket) {
+	func adminAppPacket (packet: MeshPacket, appState: AppState?) {
 		if let adminMessage = try? AdminMessage(serializedBytes: packet.decoded.payload) {
 
 			if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getCannedMessageModuleMessagesResponse(adminMessage.getCannedMessageModuleMessagesResponse) {
@@ -735,11 +743,11 @@ actor MeshPackets {
 				Logger.admin.error("🕸️ MESH PACKET received Admin App UNHANDLED \((try? packet.decoded.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
 			}
 			// Save an ack for the admin message log for each admin message response received as we stopped sending acks if there is also a response to reduce airtime.
-			self.adminResponseAck(packet: packet)
+			self.adminResponseAck(packet: packet, appState: appState)
 		}
 	}
 
-	private func adminResponseAck (packet: MeshPacket) {
+	private func adminResponseAck (packet: MeshPacket, appState: AppState?) {
 		let requestID = Int64(packet.decoded.requestID)
 		let fetchDescriptor = FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.messageId == requestID })
 		do {
@@ -752,7 +760,7 @@ actor MeshPackets {
 				fetchedMessage[0].relayNode = Int64(packet.relayNode)
 				fetchedMessage[0].ackSNR = packet.rxSnr
 
-				savePendingChanges()
+				saveAck(appState: appState, caller: "adminResponseAck")
 			}
 		} catch {
 			Logger.data.error("Failed to fetch admin message by requestID: \(error.localizedDescription, privacy: .public)")
@@ -791,7 +799,7 @@ actor MeshPackets {
 		}
 	}
 
-	func routingPacket (packet: MeshPacket, connectedNodeNum: Int64) {
+	func routingPacket (packet: MeshPacket, connectedNodeNum: Int64, appState: AppState?) {
 		if let routingMessage = try? Routing(serializedBytes: packet.decoded.payload) {
 
 			let routingError = RoutingError(rawValue: routingMessage.errorReason.rawValue)
@@ -829,8 +837,13 @@ actor MeshPackets {
 				} else {
 					return
 				}
-				scheduleDebouncedSave()
-				Logger.data.debug("💾 ACK buffered for Message: \(packet.decoded.requestID, privacy: .public)")
+				// Persist the ACK right away (rather than via the debounced batch) so the
+				// open conversation's reload below reads the committed state, then signal the
+				// UI. ACKs are low-frequency, so flushing the shared context here — which also
+				// matches the existing adminResponseAck path — is an acceptable trade-off
+				// against the position/telemetry debounce.
+				saveAck(appState: appState, caller: "routingPacket-ack")
+				Logger.data.debug("💾 ACK saved for Message: \(packet.decoded.requestID, privacy: .public)")
 			} catch {
 				let nsError = error as NSError
 				Logger.data.error("Error Saving ACK for message: \(packet.id, privacy: .public) Error: \(nsError, privacy: .public)")

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -369,6 +369,13 @@ struct ChannelMessageList: View {
 			.onChange(of: appState.unreadChannelMessages) {
 				refreshIfNeeded()
 			}
+			// A routing/admin ACK for a sent message bumps appState.messageAckUpdate. Reload
+			// directly (rather than the token-gated refreshIfNeeded) so any ACK-field change
+			// — receivedACK, realACK, or a later ackError/NAK on an already-acked message —
+			// surfaces immediately instead of waiting for the 5s poll or re-entry.
+			.onChange(of: appState.messageAckUpdate) {
+				loadMessages(markReadAfterLoad: routerIsShowingThisChannel())
+			}
 			.onChange(of: messageFieldFocused) {
 				if messageFieldFocused {
 					DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -440,6 +440,13 @@ struct UserMessageList: View {
 				.onChange(of: appState.unreadDirectMessages) {
 					refreshIfNeeded()
 				}
+				// A routing/admin ACK for a sent message bumps appState.messageAckUpdate. Reload
+				// directly (rather than the token-gated refreshIfNeeded) so any ACK-field change
+				// — receivedACK, realACK, or a later ackError/NAK on an already-acked message —
+				// surfaces immediately instead of waiting for the 5s poll or re-entry.
+				.onChange(of: appState.messageAckUpdate) {
+					loadMessages(markReadAfterLoad: routerIsShowingThisUser())
+				}
 				.onChange(of: messageFieldFocused) {
 					if messageFieldFocused {
 						DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/MeshtasticTests/AckCrossContextRefreshTests.swift
+++ b/MeshtasticTests/AckCrossContextRefreshTests.swift
@@ -1,0 +1,106 @@
+// AckCrossContextRefreshTests.swift
+// MeshtasticTests
+//
+// Verifies the central assumption behind the "instant delivery indicator" fix:
+// a delivery ACK is written by MeshPackets' OWN ModelContext (it is a @ModelActor),
+// but the message lists read through the view's main @Environment ModelContext.
+// The fix only works if a fresh fetch on the main context — what loadMessages() does —
+// sees the ACK fields the actor committed on its separate context.
+//
+// This test drives the real routingPacket() path on a second context sharing the
+// shared test container, then refetches on the main context and asserts the ACK is
+// visible. If this fails, the in-place reload cannot surface the ACK and the fix
+// needs an object-dropping fallback (e.g. an .id() rebuild) instead.
+
+import Testing
+import Foundation
+import SwiftData
+import MeshtasticProtobufs
+@testable import Meshtastic
+
+@Suite("ACK cross-context refresh")
+struct AckCrossContextRefreshTests {
+
+	@MainActor
+	private func fetchMessage(_ messageId: Int64, _ context: ModelContext) throws -> MessageEntity? {
+		var descriptor = FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.messageId == messageId })
+		descriptor.fetchLimit = 1
+		return try context.fetch(descriptor).first
+	}
+
+	/// Builds a routing-ACK MeshPacket (errorReason == .none) for the given sent-message id,
+	/// mirroring how the app constructs MeshPacket/DataMessage protobufs.
+	private func makeRoutingAck(requestID: UInt32, to: Int64, from: Int64) throws -> MeshPacket {
+		var routing = Routing()
+		routing.errorReason = .none
+
+		var data = DataMessage()
+		data.portnum = .routingApp
+		data.requestID = requestID
+		data.payload = try routing.serializedData()
+
+		var packet = MeshPacket()
+		packet.to = UInt32(truncatingIfNeeded: to)
+		packet.from = UInt32(truncatingIfNeeded: from)   // to != from → counts as a real ACK from the recipient
+		packet.decoded = data
+		packet.rxSnr = 5.0
+		packet.rxTime = UInt32(Date().timeIntervalSince1970)
+		packet.relayNode = 0
+		return packet
+	}
+
+	@Test @MainActor
+	func routingAck_isVisibleToMainContextRefetch() async throws {
+		let container = sharedModelContainer
+		let context = container.mainContext
+
+		let messageId: Int64 = 0x7FAC_0001
+		let connectedNodeNum: Int64 = 0x1111_1111
+		let remoteNodeNum: Int64 = 0x2222_2222
+
+		// Clean any residue from a prior run on the shared (process-lifetime) container.
+		if let stale = try fetchMessage(messageId, context) {
+			context.delete(stale)
+			try context.save()
+		}
+
+		// A sent DM awaiting an ACK: toUser set, not yet acknowledged.
+		let recipient = try createUser(num: remoteNodeNum, context: context)
+		let message = MessageEntity()
+		message.messageId = messageId
+		message.toUser = recipient
+		message.messagePayload = "ping"
+		message.messageTimestamp = Int32(Date().timeIntervalSince1970)
+		message.receivedACK = false
+		message.realACK = false
+		context.insert(message)
+		try context.save()
+
+		// Simulate the open conversation holding the fetched object in its @State array.
+		let held = try fetchMessage(messageId, context)
+		#expect(held?.receivedACK == false)
+
+		// Drive the REAL routing-ACK path on a separate ModelContext, exactly as production
+		// does (MeshPackets is a @ModelActor with its own context on the same container).
+		let actor = MeshPackets(modelContainer: container)
+		let packet = try makeRoutingAck(requestID: UInt32(messageId), to: connectedNodeNum, from: remoteNodeNum)
+		await actor.routingPacket(packet: packet, connectedNodeNum: connectedNodeNum, appState: nil)
+
+		// THE CRUX — what loadMessages() does: a fresh fetch on the view's main context.
+		let refetched = try fetchMessage(messageId, context)
+		#expect(refetched?.receivedACK == true,
+			"main-context refetch must see the ACK the actor context committed — the fix depends on this")
+		#expect(refetched?.realACK == true)
+		#expect(refetched?.ackError == Int32(RoutingError.none.rawValue))
+
+		// Informational: does the originally-held instance also reflect the change (the pure
+		// @Bindable live path)? Printed, not asserted — the fix reloads via fetch regardless.
+		print("ℹ️ held instance after ACK: receivedACK=\(held?.receivedACK == true), realACK=\(held?.realACK == true)")
+
+		// Cleanup so reruns on the shared container start clean.
+		if let toDelete = try fetchMessage(messageId, context) {
+			context.delete(toDelete)
+			try context.save()
+		}
+	}
+}


### PR DESCRIPTION
## What changed?

Message **delivery-receipt (ACK) status now updates live** in an open Direct Message or Channel conversation, instead of only appearing after the user leaves and re-enters the conversation.

- Added `AppState.messageAckUpdate`, a signal bumped whenever a delivery ACK is persisted.
- Factored a shared `MeshPackets.saveAck(appState:caller:)` helper that commits the ACK and fires the signal, used by **both** ACK-writing paths — `routingPacket` (routing ACKs) and `adminResponseAck` (admin-response ACKs) — so the live update never depends on which path delivered the receipt.
- `UserMessageList` and `ChannelMessageList` observe the signal and reload, so any ACK-field change — `receivedACK`, `realACK`, or a later `ackError`/NAK on an already-acked message — surfaces immediately.
- The ACK write is committed synchronously so the reload reads the fresh state.

## Why did it change?

Since the message lists moved from `@Query` to a manually-fetched `@State` snapshot array + 5s poll (#1901), they only reload when their change token (latest cursor + message count) moves. An incoming ACK changes neither, and ACK fields are written on `MeshPackets`' isolated `@ModelActor` context — so the on-screen rows kept their stale "sent" state until a full re-fetch happened on re-entry. This restores the live delivery indicator users expect.

## How is this tested?

- Added `AckCrossContextRefreshTests`, which drives the **real** `routingPacket()` path on a separate `ModelContext` (exactly as the production `@ModelActor` does) and asserts that a fresh fetch on the view's **main context** — what `loadMessages()` does — sees the committed `receivedACK`/`realACK`/`ackError`. This proves the cross-context refresh the fix depends on, and runs in CI.
- `xcodebuild test` passes on the iOS 18 simulator; full app build succeeds.
- Note: not yet exercised against a live LoRa ACK round-trip (requires two physical nodes), but the data-layer mechanism it relies on is verified.

## Screenshots/Videos (when applicable)

N/A — delivery-indicator timing change; covered by the automated test above.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. No user-facing view → doc mapping changes; requesting the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
