### PR TITLE
fix: correct IPv4 byte order in Network Config (display + write)

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		BD7B1A838F8245A0B6BE56C5 /* WatchSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CCF00CDD3D48C9B9DCA554 /* WatchSessionManager.swift */; };
 		C1B995B38DC97D13D90D9C1A /* DiscoverySummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B6FB13C4D4E03503BB1DF8 /* DiscoverySummaryView.swift */; };
 		C54AC9F4DA920A4F718CE21A /* DiscoveryScanEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD14FA280F0A130730DEB93 /* DiscoveryScanEngineTests.swift */; };
+		FDAF8808342245C4817C93EC /* NetworkConfigIPConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18295AFE686247778632C6DE /* NetworkConfigIPConversionTests.swift */; };
 		C79BFC99EDCC89DD45082753 /* DiscoveryScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CA8BAC814CF82E127EEABF /* DiscoveryScanView.swift */; };
 		D02589957BD040969FCB8663 /* PositionEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97241903A924144A3EEB679 /* PositionEntity.swift */; };
 		D748D59A3AF3253FFCDEF8BF /* DiscoveryMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D942B763789DEA044C5EBD6 /* DiscoveryMapView.swift */; };
@@ -754,6 +755,7 @@
 		AA10D0002D00000000000001 /* DiscoverySummaryPDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverySummaryPDF.swift; sourceTree = "<group>"; };
 		AA11223344556677AABB0002 /* DiscoveryTips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryTips.swift; sourceTree = "<group>"; };
 		AAD14FA280F0A130730DEB93 /* DiscoveryScanEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryScanEngineTests.swift; sourceTree = "<group>"; };
+		18295AFE686247778632C6DE /* NetworkConfigIPConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConfigIPConversionTests.swift; sourceTree = "<group>"; };
 		AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeListItemCompact.swift; sourceTree = "<group>"; };
 		AB6E72752E3FC85A00639328 /* LayoutEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutEnums.swift; sourceTree = "<group>"; };
 		ABA8E63F2E2F2A2300E27791 /* AppIconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconButton.swift; sourceTree = "<group>"; };
@@ -1532,6 +1534,7 @@
 				DD000006GEOTST0000000000 /* GeoExtensionTests.swift */,
 				DD000007LORATST000000000 /* LoraDeviceEnumTests.swift */,
 				AAD14FA280F0A130730DEB93 /* DiscoveryScanEngineTests.swift */,
+				18295AFE686247778632C6DE /* NetworkConfigIPConversionTests.swift */,
 				64C6057F9508D4356DAF411F /* DiscoveryModelTests.swift */,
 				AA003DOC0000001000000005 /* DocBundleTests.swift */,
 				DD000008APPSTST000000000 /* AppSettingsEnumTests.swift */,
@@ -2601,6 +2604,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C54AC9F4DA920A4F718CE21A /* DiscoveryScanEngineTests.swift in Sources */,
+				FDAF8808342245C4817C93EC /* NetworkConfigIPConversionTests.swift in Sources */,
 				1396606FC903D7DA662B6326 /* DiscoveryModelTests.swift in Sources */,
 				AA003DOC0000002000000005 /* DocBundleTests.swift in Sources */,
 				AA003DOC0000002000000008 /* DocTranslationTests.swift in Sources */,

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -304,18 +304,21 @@ struct NetworkConfig: View {
 		self.hasChanges = false
 	}
 
+	// Firmware stores IPv4 addresses little-endian (first octet = least-significant
+	// byte), matching the Arduino IPAddress / Android convention. Encode and decode
+	// must use the same order or addresses display and write byte-reversed.
 	func ipStringToUInt32(_ ipString: String) -> UInt32 {
 		let parts = ipString.split(separator: ".").compactMap { UInt32($0) }
 		guard parts.count == 4, parts.allSatisfy({ $0 <= 255 }) else { return 0 }
-		return (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]
+		return parts[0] | (parts[1] << 8) | (parts[2] << 16) | (parts[3] << 24)
 	}
 
 	func uint32ToIpString(_ value: UInt32) -> String {
 		if value == 0 { return "" }
-		let a = (value >> 24) & 0xFF
-		let b = (value >> 16) & 0xFF
-		let c = (value >> 8) & 0xFF
-		let d = value & 0xFF
+		let a = value & 0xFF
+		let b = (value >> 8) & 0xFF
+		let c = (value >> 16) & 0xFF
+		let d = (value >> 24) & 0xFF
 		return "\(a).\(b).\(c).\(d)"
 	}
 }

--- a/MeshtasticTests/NetworkConfigIPConversionTests.swift
+++ b/MeshtasticTests/NetworkConfigIPConversionTests.swift
@@ -1,0 +1,79 @@
+// MARK: NetworkConfigIPConversionTests
+
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+/// Verifies the IPv4 <-> UInt32 conversion in `NetworkConfig` uses little-endian
+/// octet order (first octet = least-significant byte), matching the firmware's
+/// Arduino IPAddress storage and the Meshtastic Android app. A big-endian
+/// implementation would display and write addresses byte-reversed.
+@Suite("NetworkConfig IPv4 conversion")
+struct NetworkConfigIPConversionTests {
+
+	private let view = NetworkConfig(node: nil)
+
+	// MARK: - Known little-endian mapping
+
+	@Test func stringToUInt32IsLittleEndian() {
+		// 192.168.1.1 -> 192 | 168<<8 | 1<<16 | 1<<24 == 0x0101A8C0
+		#expect(view.ipStringToUInt32("192.168.1.1") == 0x0101_A8C0)
+	}
+
+	@Test func uint32ToStringIsLittleEndian() {
+		#expect(view.uint32ToIpString(0x0101_A8C0) == "192.168.1.1")
+	}
+
+	@Test func octetOrderIsNotReversed() {
+		// Asymmetric address catches an accidental byte swap that a palindrome wouldn't.
+		let value = view.ipStringToUInt32("10.20.30.40")
+		#expect(view.uint32ToIpString(value) == "10.20.30.40")
+		#expect(value == (10 | (20 << 8) | (30 << 16) | (40 << 24)))
+	}
+
+	// MARK: - Round trips
+
+	@Test(arguments: [
+		"0.0.0.1",
+		"1.2.3.4",
+		"10.0.0.138",
+		"172.16.254.1",
+		"192.168.50.100",
+		"255.255.255.0",
+		"255.255.255.255"
+	])
+	func roundTripsPreserveAddress(_ address: String) {
+		let value = view.ipStringToUInt32(address)
+		#expect(view.uint32ToIpString(value) == address)
+	}
+
+	@Test func subnetMaskRoundTrips() {
+		let value = view.ipStringToUInt32("255.255.255.0")
+		#expect(view.uint32ToIpString(value) == "255.255.255.0")
+		// Each octet maps to a distinct byte; 0 only in the high byte.
+		#expect(value == 0x00FF_FFFF)
+	}
+
+	// MARK: - Edge cases
+
+	@Test func zeroValueMapsToEmptyString() {
+		#expect(view.uint32ToIpString(0) == "")
+	}
+
+	@Test func emptyAndUnsetAddressesMapToZero() {
+		#expect(view.ipStringToUInt32("") == 0)
+		#expect(view.ipStringToUInt32("0.0.0.0") == 0)
+	}
+
+	@Test(arguments: [
+		"192.168.1",         // too few octets
+		"192.168.1.1.1",     // too many octets
+		"192.168.1.256",     // octet out of range
+		"192.168.1.x",       // non-numeric octet
+		"not an ip"
+	])
+	func malformedAddressesMapToZero(_ address: String) {
+		#expect(view.ipStringToUInt32(address) == 0)
+	}
+}


### PR DESCRIPTION
## What changed?
Corrected the IPv4 ⇄ `UInt32` byte order in the static-IP helpers in `NetworkConfig.swift`. Both `ipStringToUInt32` and `uint32ToIpString` now use **little-endian** octet order (first octet = least-significant byte) instead of big-endian, and a Swift Testing suite (`NetworkConfigIPConversionTests`) was added to pin the byte order.

## Why did it change?
The helpers packed octets big-endian, but the firmware (Arduino `IPAddress`) and the Meshtastic Android app store them little-endian. This caused two problems:

- **Display:** static/DHCP IPv4 addresses read back from the device rendered byte-reversed in the iOS/macOS app (e.g. `192.168.1.1` shown as `1.1.168.192`).
- **Write:** a static IP typed into the app would have been written to the device byte-reversed.

The little-endian convention is confirmed by the Android reference implementation:

```kotlin
// formatIpAddress — first octet from the LOW byte
"${(ipAddress) and 0xFF}.${(ipAddress shr 8) and 0xFF}.${(ipAddress shr 16) and 0xFF}.${(ipAddress shr 24) and 0xFF}"

// convertIpAddressToInt
.split(".").map { it.toIntOrNull() }
.reversed() // little-endian byte order
.fold(0) { total, next -> total shl 8 or next }
```

No data migration is required: stored values are the firmware's raw `uint32` (kept verbatim in `UpdateSwiftData.swift`); only the display/encode order changed, so existing addresses now render correctly.

## How is this tested?
Added `MeshtasticTests/NetworkConfigIPConversionTests.swift` (Swift Testing):

- Known-value mapping in both directions (`192.168.1.1 ↔ 0x0101A8C0`)
- Asymmetric case (`10.20.30.40`) that catches any accidental byte swap a palindrome wouldn't
- 7 parameterized round-trips + subnet-mask check
- Edge cases: `0 → ""`, empty/`0.0.0.0 → 0`, and 5 malformed inputs → `0`

Suite passes on the iOS 18 simulator (`xcodebuild test -only-testing:MeshtasticTests/NetworkConfigIPConversionTests`).

> Note / follow-up: `ipStringToUInt32` still returns `0` for malformed input, so a typo in a static field saves as `0.0.0.0` with no validation feedback. This is pre-existing and out of scope for this byte-order fix; tracking input validation separately.

## Screenshots/Videos (when applicable)
N/A — addressing values are not easily shown without a networked device; covered by unit tests instead.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. No user-facing doc change needed (bugfix to existing field behavior) — please apply the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.