### PR TITLE
ci: fix Release Docs Jekyll build by pointing bundler at docs/Gemfile

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           JEKYLL_ENV: production
           DOCS_VERSION: ${{ steps.version.outputs.version }}
+          # The Gemfile lives in docs/ (where setup-ruby installed the bundle), but this
+          # step runs from the repo root — point bundler at it so `bundle exec` resolves.
+          BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
The **Release Docs** workflow (GitHub Pages deploy, on `v*.*.*` tags) has been failing at the *Build with Jekyll* step with `Could not locate Gemfile or .bundle/ directory` — on both `v2.7.13` and `v2.7.14`.

`setup-ruby` is scoped with `working-directory: docs` (where `docs/Gemfile` lives), but the *Build with Jekyll* step runs `bundle exec jekyll build` from the repo **root** with no `BUNDLE_GEMFILE`, so bundler can't find the Gemfile.

Fix: set `BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile` on the build step so `bundle exec` resolves the docs/ bundle.

Already applied on the `2.7.14-release` branch and the `v2.7.14` tag was re-pointed to it; this PR brings the same one-line fix to `main` so future releases' Pages deploy works. No app/runtime changes.