### PR TITLE
Reduce redundant list refresh work

### DIFF
--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -129,7 +129,7 @@ private struct FilteredUserList: View {
 		let dateFormatString = (localeDateFormat ?? "MM/dd/YY")
 		let activeDeviceNum = Int64(accessoryManager.activeDeviceNum ?? 0)
 		let visibleUsers = users.filter { $0.num != activeDeviceNum }
-		let summaryUsers = allUsers.filter { $0.num != activeDeviceNum && $0.lastMessage != nil }
+		let summaryUsers = visibleUsers.filter { $0.lastMessage != nil }
 		let summaryRefreshKey = directMessageSummaryRefreshKey(for: summaryUsers)
 		let currentDay = Calendar.current.dateComponents([.day], from: Date()).day ?? 0
 

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -318,6 +318,20 @@ private struct FilteredNodeList: View {
 		return nodes.map { NodeListEntry(id: $0.num, node: $0) }
 	}
 
+	private func replaceDisplayedNodesIfNeeded(with newNodes: [NodeListEntry]) {
+		guard displayedNodeIDsDiffer(from: newNodes) else { return }
+		displayedNodes = newNodes
+	}
+
+	private func displayedNodeIDsDiffer(from newNodes: [NodeListEntry]) -> Bool {
+		guard displayedNodes.count == newNodes.count else { return true }
+		for (currentNode, newNode) in zip(displayedNodes, newNodes)
+			where currentNode.id != newNode.id || currentNode.node !== newNode.node {
+			return true
+		}
+		return false
+	}
+
 	// The body of the view
 	var body: some View {
 		List(displayedNodes, selection: $selectedNodeNum) { entry in
@@ -352,7 +366,7 @@ private struct FilteredNodeList: View {
 			// displayNodes (a scan over the whole node set) per write pegged the main thread
 			// on reconnect with a large DB. ~3/sec is imperceptible and keeps CPU sane.
 			while !Task.isCancelled {
-				displayedNodes = displayNodes(activeNodeNum: accessoryManager.activeDeviceNum)
+				replaceDisplayedNodesIfNeeded(with: displayNodes(activeNodeNum: accessoryManager.activeDeviceNum))
 				try? await Task.sleep(for: .milliseconds(350))
 			}
 		}


### PR DESCRIPTION
## Summary
- Avoid reassigning the throttled node-list snapshot when the visible node IDs, order, and SwiftData model instances are unchanged.
- Refresh direct-message summaries only for contacts that are currently visible after filtering.

## Reasoning
This keeps the existing throttled recompute behavior, but avoids extra SwiftUI list invalidation during live packet ingestion when the visible node set has not actually changed. The contact-list change narrows summary refresh work to rows that can be displayed, while leaving the existing message fetch semantics intact.

## Verification
- `git diff --check`
- `xcodebuild -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,id=DE3343B3-1E9D-4C2D-9AFE-B50AC465BEBA' -derivedDataPath /tmp/meshtastic-round2-derived -skipPackagePluginValidation -skipMacroValidation build`
- Installed and launched the simulator app with `--meshtastic-perf-seed --meshtastic-perf-reset` and `MESHTASTIC_PERF_SEED_NODES=1000`; captured a smoke screenshot showing the seeded Nodes list rendering normally.

No screenshot attached because this PR has no intended visual change.