### PR TITLE
fix: restore favorited nodes to the top of the admin/configuration node picker

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0516B3FE2F68892000D0FC40 /* NodeFilterParametersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */; };
+		05A1B2C32F70000100D0FC40 /* SettingsNodeSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */; };
 		0B9642EC0DB1B971CB26E8AE /* RadarSweepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E06A9BCC789BD452DFA9CFB /* RadarSweepView.swift */; };
 		102B5EAB2E172F41003D191E /* DatadogCore in Frameworks */ = {isa = PBXBuildFile; productRef = 102B5EAA2E172F41003D191E /* DatadogCore */; };
 		102B5EAD2E172F41003D191E /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 102B5EAC2E172F41003D191E /* DatadogCrashReporting */; };
@@ -558,6 +559,7 @@
 /* Begin PBXFileReference section */
 		01028778B8BFD81F7A039593 /* TAKConnection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKConnection.swift; sourceTree = "<group>"; };
 		05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeFilterParametersTests.swift; sourceTree = "<group>"; };
+		05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNodeSortTests.swift; sourceTree = "<group>"; };
 		05E0BD1A81CF4F6A90D56CE3 /* MeshtasticSchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshtasticSchemaV1.swift; sourceTree = "<group>"; };
 		0618E6D0DF90B74EE32E6C06 /* TAKServerConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKServerConfig.swift; sourceTree = "<group>"; };
 		09936BEBD6D82479B2360FDC /* TAKCertificateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKCertificateManager.swift; sourceTree = "<group>"; };
@@ -1524,6 +1526,7 @@
 				DD9C70112E9F2A0000029299 /* DeviceOnboardingTests.swift */,
 				25F5D5D02C4375DF008036E3 /* RouterTests.swift */,
 				05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */,
+				05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */,
 				AA0120250000000000000C02 /* PacketStreamModelTests.swift */,
 				AA000301CPTST000000000001 /* CarPlayTests.swift */,
 				DD000001NODNAVTST00000000 /* NodeNavigationTests.swift */,
@@ -2614,6 +2617,7 @@
 				DD9C70102E9F2A0000029299 /* DeviceOnboardingTests.swift in Sources */,
 				25F5D5D12C4375DF008036E3 /* RouterTests.swift in Sources */,
 				0516B3FE2F68892000D0FC40 /* NodeFilterParametersTests.swift in Sources */,
+				05A1B2C32F70000100D0FC40 /* SettingsNodeSortTests.swift in Sources */,
 				AA0120250000000000000C01 /* PacketStreamModelTests.swift in Sources */,
 				AA000301CPTST000000000002 /* CarPlayTests.swift in Sources */,
 				DD000001NODNAVTST00000001 /* NodeNavigationTests.swift in Sources */,

--- a/Meshtastic/Model/NodeInfoEntity.swift
+++ b/Meshtastic/Model/NodeInfoEntity.swift
@@ -133,3 +133,25 @@ final class NodeInfoEntity {
 
 	init() {}
 }
+
+extension NodeInfoEntity {
+	/// Orders nodes for the admin / configuration node picker in `Settings.swift`:
+	/// favorited nodes first, then non-favorites, with each group keeping the input's
+	/// relative order. This restores the favorite-on-top behavior of the legacy
+	/// CoreData `@FetchRequest` sort, which was lost in the SwiftData conversion
+	/// (PR #1668).
+	///
+	/// `nodes` is expected to already be sorted by `lastHeard` descending — as the
+	/// Settings `@Query` provides — so the partition yields favorites (most-recent
+	/// first) ahead of non-favorites (most-recent first). It's a `Bool`-keyed
+	/// partition rather than a SwiftData `@Query` sort because `favorite` is a
+	/// `Bool`, and `Bool` is not `Comparable`, so it cannot be a `SortDescriptor`
+	/// key on a non-`NSObject` `@Model`.
+	///
+	/// Implemented as a stable O(n) partition (rather than an O(n log n) re-sort) so
+	/// it is cheap to call per render, and deterministic across re-renders as long as
+	/// the input order is stable.
+	static func adminPickerOrder(_ nodes: [NodeInfoEntity]) -> [NodeInfoEntity] {
+		nodes.filter(\.favorite) + nodes.filter { !$0.favorite }
+	}
+}

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -18,6 +18,16 @@ struct Settings: View {
 	@Query(sort: \NodeInfoEntity.lastHeard, order: .reverse)
 	private var nodes: [NodeInfoEntity]
 
+	/// Nodes for the admin / configuration picker, ordered favorites-first while
+	/// preserving the `@Query`'s `lastHeard`-descending order within each group. The
+	/// favorite-on-top behavior can't be expressed as a SwiftData `@Query` sort
+	/// because `favorite` is a `Bool` and `Bool` isn't `Comparable` (so it's not a
+	/// valid `SortDescriptor` key); it's applied here as a cheap stable partition.
+	/// See `NodeInfoEntity.adminPickerOrder`.
+	private var sortedNodes: [NodeInfoEntity] {
+		NodeInfoEntity.adminPickerOrder(nodes)
+	}
+
 	@State private var selectedNode: Int = 0
 	@State private var preferredNodeNum: Int = 0
 
@@ -531,7 +541,7 @@ struct Settings: View {
 									if selectedNode == 0 {
 										Text("Connect to a Node").tag(0)
 									}
-									ForEach(nodes) { node in
+									ForEach(sortedNodes) { node in
 										/// Connected Node
 										if node.num == accessoryManager.activeDeviceNum ?? 0 {
 											Label {

--- a/MeshtasticTests/SettingsNodeSortTests.swift
+++ b/MeshtasticTests/SettingsNodeSortTests.swift
@@ -1,0 +1,110 @@
+//
+//  SettingsNodeSortTests.swift
+//  Meshtastic
+//
+//  Regression coverage for the admin / configuration node Picker ordering in
+//  `Settings.swift`. The CoreData→SwiftData conversion (PR #1668) collapsed a
+//  multi-key `@FetchRequest` sort down to `@Query(sort: \.lastHeard, .reverse)`,
+//  which dropped `favorite` as a sort key — favorited nodes stopped appearing at
+//  the top of the list.
+//
+//  Favorite-on-top can't be a SwiftData `SortDescriptor` key (`favorite` is a
+//  `Bool`, and `Bool` isn't `Comparable`), so the view restores it in memory via
+//  `NodeInfoEntity.adminPickerOrder(_:)`: a stable favorites-first partition over
+//  the `@Query`'s already-`lastHeard`-descending results. These tests feed that
+//  helper inputs ordered the way the `@Query` delivers them (recency descending)
+//  and assert favorites are hoisted while recency order is preserved within each
+//  group.
+//
+
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@MainActor
+@Suite("Settings admin node sort")
+struct SettingsNodeSortTests {
+
+	/// Builds a node with the given favorite flag. `lastHeard` is set for realism but
+	/// the partition helper relies on input order, not the value itself.
+	private func makeNode(num: Int64, favorite: Bool, lastHeard: Date? = nil) -> NodeInfoEntity {
+		let node = NodeInfoEntity()
+		node.num = num
+		node.id = num
+		node.favorite = favorite
+		node.lastHeard = lastHeard
+		return node
+	}
+
+	/// Applies the production ordering helper and returns the resulting `num` order.
+	private func orderedNums(_ nodes: [NodeInfoEntity]) -> [Int64] {
+		NodeInfoEntity.adminPickerOrder(nodes).map(\.num)
+	}
+
+	// MARK: - Tests
+
+	@Test("Favorites are hoisted above non-favorites regardless of recency")
+	func favoritesAboveNonFavorites() {
+		// As the @Query delivers them: most-recent first. The favorite is the *older*
+		// node, so a plain recency order would bury it — the partition must hoist it.
+		// This is the exact regression.
+		let freshPlain = makeNode(num: 7_700_002, favorite: false)
+		let staleFavorite = makeNode(num: 7_700_001, favorite: true)
+
+		#expect(orderedNums([freshPlain, staleFavorite]) == [7_700_001, 7_700_002])
+	}
+
+	@Test("Recency order is preserved within the favorites group")
+	func recencyPreservedAmongFavorites() {
+		// Input is already recency-descending (newer first), as the @Query provides.
+		let newerFavorite = makeNode(num: 7_710_002, favorite: true)
+		let olderFavorite = makeNode(num: 7_710_001, favorite: true)
+
+		#expect(orderedNums([newerFavorite, olderFavorite]) == [7_710_002, 7_710_001])
+	}
+
+	@Test("Recency order is preserved within the non-favorites group")
+	func recencyPreservedAmongNonFavorites() {
+		let newerPlain = makeNode(num: 7_720_002, favorite: false)
+		let olderPlain = makeNode(num: 7_720_001, favorite: false)
+
+		#expect(orderedNums([newerPlain, olderPlain]) == [7_720_002, 7_720_001])
+	}
+
+	@Test("Full ordering: favorites first (recency preserved), then non-favorites (recency preserved)")
+	func combinedOrdering() {
+		// Interleaved and recency-descending within each favorite state, as the
+		// @Query delivers: favNew, plainNew, favOld, plainOld.
+		let favNew = makeNode(num: 7_730_002, favorite: true)
+		let plainNew = makeNode(num: 7_730_004, favorite: false)
+		let favOld = makeNode(num: 7_730_001, favorite: true)
+		let plainOld = makeNode(num: 7_730_003, favorite: false)
+
+		let order = orderedNums([favNew, plainNew, favOld, plainOld])
+		#expect(order == [7_730_002, 7_730_001, 7_730_004, 7_730_003])
+	}
+
+	@Test("A never-heard favorite still sorts above a recently-heard non-favorite")
+	func favoriteNeverHeardStillFirst() {
+		// The @Query orders nil lastHeard last, so a never-heard favorite arrives
+		// after the fresh non-favorite; the partition must still hoist it.
+		let freshPlain = makeNode(num: 7_740_002, favorite: false, lastHeard: Date(timeIntervalSince1970: 1_700_000_000))
+		let favoriteNeverHeard = makeNode(num: 7_740_001, favorite: true, lastHeard: nil)
+
+		#expect(orderedNums([freshPlain, favoriteNeverHeard]) == [7_740_001, 7_740_002])
+	}
+
+	@Test("Ordering is a no-op when nodes are already favorites-first")
+	func alreadyOrderedIsStable() {
+		let fav = makeNode(num: 7_750_001, favorite: true)
+		let plain = makeNode(num: 7_750_002, favorite: false)
+
+		#expect(orderedNums([fav, plain]) == [7_750_001, 7_750_002])
+	}
+
+	@Test("Empty input yields empty output")
+	func emptyInput() {
+		#expect(orderedNums([]) == [])
+	}
+}


### PR DESCRIPTION
## What changed?

Favorited nodes are once again listed at the top of the **Remote Admin / Configuration** node picker (`Settings.swift`), above non-favorites. Within each group, the existing most-recently-heard order is preserved.

The ordering is applied via a new helper, `NodeInfoEntity.adminPickerOrder(_:)`, a stable favorites-first partition over the picker's `@Query` results. The picker's `ForEach` now iterates a `sortedNodes` computed property instead of the raw `@Query`.

## Why did it change?

The CoreData→SwiftData conversion (#1668) replaced the picker's multi-key `@FetchRequest` sort with `@Query(sort: \.lastHeard, .reverse)`, which silently dropped `favorite` as a sort key. As a result, favorited nodes were no longer surfaced at the top of the list — they landed wherever their last-heard time placed them.

Favorite-on-top can't be expressed as a SwiftData `SortDescriptor` because `favorite` is a `Bool` and `Bool` isn't `Comparable` (so it's not a valid `SortDescriptor` key on a non-`NSObject` `@Model`). It's restored in memory instead, as a stable **O(n)** partition over the `@Query`'s already-`lastHeard`-descending results — rather than an O(n log n) re-sort — so it stays cheap to evaluate per render and deterministic across re-renders.

## How is this tested?

Adds `SettingsNodeSortTests` (Swift Testing, 7 cases) exercising `NodeInfoEntity.adminPickerOrder(_:)`:

- favorites hoisted above non-favorites regardless of recency (the regression itself),
- recency order preserved within both the favorites and non-favorites groups,
- combined/interleaved ordering,
- a never-heard (`lastHeard == nil`) favorite still sorts above a recently-heard non-favorite,
- already-ordered and empty-input edge cases.

All 7 pass locally (iPhone 16, iOS 18 simulator).

## Screenshots/Videos (when applicable)

N/A — ordering change in the existing admin node picker; no UI structure change.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. No doc update needed (no documented behavior changes) — please apply the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.