### PR TITLE
fix: guard faulted SwiftData node reads in Connect and NodeDetail (565990b0)

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -51,7 +51,21 @@ struct Connect: View {
 			return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
 		}
 	}
-	
+
+	/// The connected node, but only while it's still a live SwiftData object.
+	///
+	/// `node` is cached in `@State` and survives across connection state changes, so after a
+	/// disconnect/reconnect or node switch — which recreate the ModelContext/container — the
+	/// cached reference can become faulted or detached. Reading any real attribute on a faulted
+	/// `@Model` traps (`_SD_get_faulting_backingdata` → `SIGTRAP`), and because the Connect tab
+	/// is always mounted and re-renders on `accessoryManager` state changes, that trap fires
+	/// during render. `modelContext` is safe metadata (nil on a detached/deleted object), so
+	/// gating every read through this accessor prevents the crash. (Same guard pattern as #1944.)
+	private var safeNode: NodeInfoEntity? {
+		guard let node, node.modelContext != nil else { return nil }
+		return node
+	}
+
 	var body: some View {
 		NavigationStack {
 			VStack(spacing: 0) {
@@ -66,7 +80,7 @@ struct Connect: View {
 							VStack(alignment: .leading) {
 								HStack {
 									VStack(alignment: .center) {
-										CircleText(text: node?.user?.shortName?.addingVariationSelectors ?? "?", color: Color(UIColor(hex: UInt32(node?.num ?? 0))), circleSize: 90)
+										CircleText(text: safeNode?.user?.shortName?.addingVariationSelectors ?? "?", color: Color(UIColor(hex: UInt32(safeNode?.num ?? 0))), circleSize: 90)
 											.padding(.trailing, 5)
 										if let batteryLevel = connectedBatteryLevel {
 											BatteryCompact(batteryLevel: batteryLevel, font: .caption, iconFont: .callout, color: .accentColor)
@@ -75,7 +89,7 @@ struct Connect: View {
 									}
 									.padding(.trailing)
 									VStack(alignment: .leading) {
-										if node != nil {
+										if safeNode != nil {
 											HStack {
 												Text(connectedDevice.longName?.addingVariationSelectors ?? "Unknown".localized).font(.title2)
 												if connectedDevice.wasRestored {
@@ -95,8 +109,8 @@ struct Connect: View {
 											Spacer()
 										}
 										.padding(0)
-										if node != nil {
-											Text("Firmware Version").font(.callout)+Text(": \(node?.metadata?.firmwareVersion ?? "Unknown".localized)")
+										if safeNode != nil {
+											Text("Firmware Version").font(.callout)+Text(": \(safeNode?.metadata?.firmwareVersion ?? "Unknown".localized)")
 												.font(.callout).foregroundColor(Color.gray)
 										}
 										if accessoryManager.firmwareEdition.isEvent {
@@ -176,8 +190,8 @@ struct Connect: View {
 							}
 							.contextMenu {
 								
-								if node != nil {
-									Label("\(String(node!.num))", systemImage: "number")
+								if let node = safeNode {
+									Label("\(String(node.num))", systemImage: "number")
 #if !targetEnvironment(macCatalyst)
 									if accessoryManager.state == .subscribed {
 										Button {
@@ -210,7 +224,9 @@ struct Connect: View {
 										Button(role: .destructive) {
 											Task {
 												do {
-													try await accessoryManager.sendShutdown(fromUser: node!.user!, toUser: node!.user!)
+													if let user = node.user {
+														try await accessoryManager.sendShutdown(fromUser: user, toUser: user)
+													}
 												} catch {
 													Logger.mesh.error("Shutdown Failed: \(error)")
 												}
@@ -225,7 +241,7 @@ struct Connect: View {
 							if isUnsetRegion {
 								HStack {
 									NavigationLink {
-										LoRaConfig(node: node)
+										LoRaConfig(node: safeNode)
 									} label: {
 										Label("Set LoRa Region", systemImage: "globe.americas.fill")
 											.foregroundColor(.red)
@@ -461,7 +477,7 @@ struct Connect: View {
 		.onChange(of: scenePhase) { _, _ in updateNymeaDiscovery() }
 		.onChange(of: accessoryManager.isConnected) { _, _ in updateNymeaDiscovery() }
 		.onChange(of: accessoryManager.isConnecting) { _, _ in updateNymeaDiscovery() }
-		.task(id: node?.num) {
+		.task(id: safeNode?.num) {
 			// Refresh the connected node's battery on an interval instead of fetching in
 			// `body` (which re-ran the TelemetryEntity query on every render — costly while
 			// ingestion churns the node @Query). Battery changes slowly, so 15s is plenty.

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -63,28 +63,35 @@ struct NodeDetail: View {
 	@State var showingCompassSheet = false
 	
 	var body: some View {
-		ScrollViewReader { scrollView in
-			Color.clear
-				.frame(height: 0) // Ensure it has no height
-				.id("topOfList")
-				nodeDetailList
-				.sheet(isPresented: $showingCompassSheet) {
-					CompassView(waypointLocation: latestPosition?.nodeCoordinate ?? nil, waypointLongName: node.user?.longName ?? nil, waypointShortName: node.user?.shortName ?? nil, color: Color(UIColor(hex: UInt32(node.num))))
+		if node.modelContext != nil {
+			ScrollViewReader { scrollView in
+				Color.clear
+					.frame(height: 0) // Ensure it has no height
+					.id("topOfList")
+					nodeDetailList
+					.sheet(isPresented: $showingCompassSheet) {
+						CompassView(waypointLocation: latestPosition?.nodeCoordinate ?? nil, waypointLongName: node.user?.longName ?? nil, waypointShortName: node.user?.shortName ?? nil, color: Color(UIColor(hex: UInt32(node.num))))
+							}
+					.onAppear {
+						refreshNodeSummary()
+						scrollView.scrollTo("topOfList", anchor: .top)
+					}
+						.onChange(of: node.lastHeard) {
+							refreshNodeSummary()
 						}
-				.onAppear {
-					refreshNodeSummary()
-					scrollView.scrollTo("topOfList", anchor: .top)
-				}
-					.onChange(of: node.lastHeard) {
-						refreshNodeSummary()
-					}
-					.onReceive(NotificationCenter.default.publisher(for: .nodeLogAvailabilityDidChange)) { notification in
-						guard notification.object as? Int64 == node.num else { return }
-						refreshNodeSummary()
-					}
-					.contentMargins(.top, 0, for: .scrollContent)
-				.navigationTitle(String(node.user?.longName?.addingVariationSelectors ?? "Unknown".localized))
-				.navigationBarTitleDisplayMode(.inline)
+						.onReceive(NotificationCenter.default.publisher(for: .nodeLogAvailabilityDidChange)) { notification in
+							guard notification.object as? Int64 == node.num else { return }
+							refreshNodeSummary()
+						}
+						.contentMargins(.top, 0, for: .scrollContent)
+					.navigationTitle(String(node.user?.longName?.addingVariationSelectors ?? "Unknown".localized))
+					.navigationBarTitleDisplayMode(.inline)
+			}
+		} else {
+			// Node was deleted or detached (e.g. after a database reset / node switch).
+			// Reading any attribute on a faulted @Model traps during render, so render
+			// nothing — the navigation stack pops this detail as its data source updates.
+			Color.clear
 		}
 	}
 


### PR DESCRIPTION
## Problem

The dominant unguarded iOS render-time crash on 2.7.13/2.7.14 (Datadog `565990b0`) is a Swift-runtime `SIGTRAP` fired inside SwiftUI/AttributeGraph during view-body evaluation, with a Foundation/CoreData frame in the trap path — the signature of a **faulted/detached SwiftData `@Model` read during render**. It correlates with switching/disconnecting the connected node (#1967), which recreates the SwiftData `ModelContext`/container via `repointToFreshContainer()`.

PR #1944 guarded `NodeList` / `MeshMap` / `NodeMapSwiftUI`, but **`Connect` was never guarded** — and it's the one always-mounted root tab that caches the connected node in `@State` (`NodeInfoEntity?`) rather than resolving it live. It reads that cached object directly in `body`, including two force-unwraps (`node!.num`, `node!.user!`). Because `Connect` re-renders on `accessoryManager` `@Published` state changes, a disconnect/reconnect/node-switch can leave the cached reference faulted; reading any attribute then traps during render.

## Fix

- Add a `safeNode` accessor that returns the node only while `node.modelContext != nil` (safe metadata — nil on a detached/deleted object) and route every `body` read through it, removing both force-unwraps.
- Fold in `NodeDetail` (`@Bindable node` read throughout its body/modifiers): wrap the body in `if node.modelContext != nil { … } else { Color.clear }` so a faulted node renders nothing and pops as its data source updates.

Same guard pattern as #1944. Builds clean for the iOS simulator.

## Notes

This is a code-level identification (no symbolicated frame was available locally; the trap's single app frame resolves to the SwiftUI root). Confidence is high given the trigger/stack/anti-pattern alignment, and the change is low-risk — it only suppresses reads of objects that are already invalid.

Fixes the render path behind #1967.