### PR TITLE
fix: clear stale TextEditor selection on programmatic edits to stop send crash (#1976)

### DIFF
--- a/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
@@ -214,9 +214,19 @@ private struct FormattingComposeArea: View {
 					.contentShape(RoundedRectangle(cornerRadius: 20))
 					.onChange(of: typingMessage) { _, value in
 						totalBytes = value.utf8.count
+						// A programmatic text change (send empties the field; the byte-limit
+						// truncation below shortens it) leaves `textSelection` holding a UTF-16
+						// range into the *old* string. The next layout pass in
+						// UIKitTextEditorCoordinator maps that stale range onto the new string
+						// and traps in String.UTF16View._offsetRange. Drop the selection so the
+						// coordinator never sees an out-of-range index. (#1976)
+						if value.isEmpty {
+							textSelection = nil
+						}
 						while totalBytes > maxbytes {
 							typingMessage = String(typingMessage.dropLast())
 							totalBytes = typingMessage.utf8.count
+							textSelection = nil
 						}
 					}
 					.keyboardType(.default)
@@ -224,7 +234,7 @@ private struct FormattingComposeArea: View {
 					.multilineTextAlignment(.leading)
 					.foregroundColor(.primary)
 				if !typingMessage.isEmpty {
-					Button(action: onSend) {
+					Button(action: send) {
 						Image(systemName: "arrow.up.circle.fill")
 							.font(.largeTitle)
 							.foregroundColor(.accentColor)
@@ -265,10 +275,29 @@ private struct FormattingComposeArea: View {
 			if keyPress.modifiers.contains(.shift) {
 				return .ignored
 			}
-			onSend()
+			send()
 			return .handled
 		}
 		#endif
+	}
+
+	// Clear any active selection before invoking the parent handlers, which mutate
+	// `typingMessage` programmatically (send empties it; position/alert replace or
+	// append). Doing this first means the TextEditor coordinator never updates with a
+	// text/selection pair where the selection's UTF-16 range is out of bounds. (#1976)
+	private func send() {
+		textSelection = nil
+		onSend()
+	}
+
+	private func alert() {
+		textSelection = nil
+		onAlert()
+	}
+
+	private func requestPosition() {
+		textSelection = nil
+		onRequestPosition()
 	}
 
 	private var toolbarContent: some View {
@@ -290,8 +319,8 @@ private struct FormattingComposeArea: View {
 						Image(systemName: "face.smiling")
 					}
 					#endif
-					AlertButton(action: onAlert, compact: true)
-					RequestPositionButton(action: onRequestPosition, compact: true)
+					AlertButton(action: alert, compact: true)
+					RequestPositionButton(action: requestPosition, compact: true)
 				}
 			}
 			Spacer()


### PR DESCRIPTION
## Problem

Closes #1976. On iOS 18+, sending a message crashes with `EXC_BREAKPOINT (SIGTRAP)` in `UIKitTextEditorCoordinator.update` → `String.UTF16View._offsetRange(for:from:)`.

The iOS 18+ compose area (`FormattingComposeArea`) binds `TextEditor`'s selection to a `TextSelection?` holding a UTF-16 range into the *current* string. Sending a message clears the field (`typingMessage = ""`), and the byte-limit guard truncates it — both programmatic mutations that leave the selection pointing into the old, longer string. On the next layout pass the coordinator maps that stale `NSRange` onto the shorter string and traps, so it crashes on every send.

The pre-iOS-18 path uses a plain `TextField` with no selection binding, which is why the crash is iOS-18-only and predates 2.7.14 (it landed with the formatting compose area).

## Fix

Drop the selection whenever the text changes programmatically:

- **Reactive** — in `onChange(of: typingMessage)`, set `textSelection = nil` when the field is emptied or truncated.
- **Proactive** — new `send()` / `alert()` / `requestPosition()` wrappers null the selection *before* the parent handlers mutate the text, so the coordinator never updates with an out-of-range selection.

Normal typing/deletion is untouched (UIKit drives text and selection together); only programmatic edits clear the selection. Builds clean for the iOS simulator.