### PR TITLE
Support additional relays provided by the node

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1115,6 +1115,30 @@ actor MeshPackets {
 				Logger.mesh.info("\(messageLabel, privacy: .public) packet received from \(packet.from.toHex(), privacy: .public) — \(messageDetail, privacy: .public)")
 				let toNum = Int64(packet.to)
 				let fromNum = Int64(packet.from)
+				// A second copy of a message we already stored (same packet id) means another node also
+				// relayed it to us. Update the relay tracking on the existing message and stop here — do not
+				// insert a duplicate or fire a second notification. (SwiftData's unique constraint on
+				// messageId upserts the existing row on save, which would otherwise re-trigger the
+				// notification below.)
+				let packetMessageId = Int64(packet.id)
+				let dupeDescriptor = FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.messageId == packetMessageId })
+				if let existingMessage = try? modelContext.fetch(dupeDescriptor).first {
+					if packet.relayNode != 0 {
+						if existingMessage.relayNode == 0 {
+							// First relayer we've seen for this message: pin it as the named relay.
+							existingMessage.relayNode = Int64(packet.relayNode)
+						} else {
+							// A further node also relayed this copy: count it as an additional relay.
+							// relayNode stays pinned to the first relayer; the display shows it as "(+N)".
+							existingMessage.relays = existingMessage.relays &+ 1
+						}
+					}
+					if modelContext.hasChanges {
+						try? modelContext.save()
+					}
+					Logger.mesh.info("📡 Additional relayer for message \(packetMessageId, privacy: .public); extra relays now \(Int(existingMessage.relays), privacy: .public)")
+					return
+				}
 				let fetchDescriptor = FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == toNum || $0.num == fromNum })
 				do {
 					let fetchedUsers = try modelContext.fetch(fetchDescriptor)


### PR DESCRIPTION
## What changed?

Adds support for receiving additional relay info about the same packet from the firmware.

## Why did it change?

meshtastic/firmware#10767 provides multiple notices of the same packet for each overheard transmission of the packet. This causes duplicate push notifications for the packet as each repeat is heard.

## How is this tested?

I connected the current app (2.7.14 2062) to a node running the changed firmware, and observed the duplicate notifications. I built and installed the iOS app onto an iPhone 16 Pro (iOS 18) and connected it to the node to confirm it does not show duplicates now, and correctly counts the relays.

## Screenshots/Videos (when applicable)

<img width="300" alt="IMG_3059" src="https://github.com/user-attachments/assets/d21a71e3-9e00-42b4-8469-44c3a37aeb6e" />

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.

