### PR TITLE
Use native MapKit user location control

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -63,6 +63,7 @@ struct MeshMapContent: MapContent {
 	
 	/// Pre-filtered, pre-extracted positions passed in from the parent view.
 	var positionSnapshots: [MeshMapPositionSnapshot]
+	var isMapVisible: Bool
 
 	@Query(sort: \WaypointEntity.name, order: .reverse)
 	var waypoints: [WaypointEntity]
@@ -275,6 +276,9 @@ struct MeshMapContent: MapContent {
 	
 	@MapContentBuilder
 	var body: some MapContent {
+		if showUserLocation && isMapVisible {
+			UserAnnotation()
+		}
 		meshMap
 	}
 }

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -17,34 +17,6 @@ private struct MeshMapVisiblePositionState {
 	let key: Int64
 }
 
-private enum MeshMapUserTrackingMode {
-	case none
-	case centered
-	case followingHeading
-
-	var systemImage: String {
-		switch self {
-		case .none:
-			"location.circle"
-		case .centered:
-			"location.circle.fill"
-		case .followingHeading:
-			"location.north.circle.fill"
-		}
-	}
-
-	var accessibilityLabel: Text {
-		switch self {
-		case .none:
-			Text("Center on me")
-		case .centered:
-			Text("Map centered on me")
-		case .followingHeading:
-			Text("Map following my heading")
-		}
-	}
-}
-
 struct MeshMap: View {
 	private let denseMapPositionLimit = 700
 
@@ -65,16 +37,11 @@ struct MeshMap: View {
 	@AppStorage("mapLayer") private var selectedMapLayer: MapLayer = .standard
 	/// Map overlay configs
 	@State private var enabledOverlayConfigs: Set<UUID> = []
-	// Map Configuration
-	@Namespace var mapScope
 	@AppStorage("meshMapDistance") private var meshMapDistance: Double = 800000
 	@State var mapStyle: MapStyle = MapStyle.standard(elevation: .flat, emphasis: MapStyle.StandardEmphasis.muted, pointsOfInterest: .excludingAll, showsTraffic: false)
 	@State var position = MapCameraPosition.automatic
 	@State private var distance = 10000.0
 	@State private var visibleRegion: MKCoordinateRegion?
-	@State private var currentCamera: MapCamera?
-	@State private var userTrackingMode: MeshMapUserTrackingMode = .none
-	@State private var showingLocationPermissionAlert = false
 	@State private var editingSettings = false
 	@State private var editingFilters = false
 	@State var selectedNode: MeshMapSelectedNode?
@@ -181,8 +148,7 @@ struct MeshMap: View {
 			MapReader { reader in
 					Map(
 						position: $position,
-						bounds: MapCameraBounds(minimumDistance: 1, maximumDistance: .infinity),
-						scope: mapScope
+						bounds: MapCameraBounds(minimumDistance: 1, maximumDistance: .infinity)
 					) {
 						MeshMapContent(
 							showUserLocation: $showUserLocation,
@@ -197,14 +163,15 @@ struct MeshMap: View {
 						)
 					}
 					.id(meshMapDistance)
-					.mapScope(mapScope)
 					.mapStyle(mapStyle)
 					.mapControls {
-						MapScaleView(scope: mapScope)
+						MapScaleView()
 							.mapControlVisibility(.automatic)
-						MapPitchToggle(scope: mapScope)
+						MapPitchToggle()
 							.mapControlVisibility(.automatic)
-						MapCompass(scope: mapScope)
+						MapUserLocationButton()
+							.mapControlVisibility(.automatic)
+						MapCompass()
 							.mapControlVisibility(.automatic)
 					}
 					.controlSize(.regular)
@@ -213,7 +180,6 @@ struct MeshMap: View {
 							// distance is only used for long-press waypoint creation, so we don't need continuous updates which touch @State and force rerenders as we pan and (for distance in particular) zoom around the map. onEnd is more than enough.
 							distance = context.camera.distance
 							visibleRegion = context.region
-							currentCamera = context.camera
 						})
 					.onTapGesture(count: 1, perform: { position in
 						newWaypointCoord = reader.convert(position, from: .local) ?? CLLocationCoordinate2D.init()
@@ -294,14 +260,6 @@ struct MeshMap: View {
 				.sheet(isPresented: $editingSettings) {
 					MapSettingsForm(traffic: $showTraffic, pointsOfInterest: $showPointsOfInterest, mapLayer: $selectedMapLayer, meshMap: $isMeshMap, enabledOverlayConfigs: $enabledOverlayConfigs)
 				}
-				.alert("Location Access Needed", isPresented: $showingLocationPermissionAlert) {
-					Button("Open Settings") {
-						openAppSettings()
-					}
-					Button("Cancel", role: .cancel) {}
-				} message: {
-					Text("Allow location access to center the map on your position.")
-				}
 				.onChange(of: router.mapState) {
 					guard case .map = router.selectedTab else { return }
 					// TODO: handle deep link for waypoints
@@ -339,12 +297,6 @@ struct MeshMap: View {
 				.safeAreaInset(edge: .bottom, alignment: .trailing) {
 					HStack(spacing: 12) {
 						Spacer()
-						MeshMapUserLocationControl(
-							mode: userTrackingMode,
-							centerAction: { centerMapOnUser(followsHeading: false) },
-							followHeadingAction: { centerMapOnUser(followsHeading: true) },
-							stopAction: { stopFollowingUser() }
-						)
 						Button(action: {
 							withAnimation {
 								editingFilters = !editingFilters
@@ -405,11 +357,6 @@ struct MeshMap: View {
 			.onChange(of: positionState.key) {
 				refreshVisiblePositionSnapshots(from: positionState.positions)
 				filters.fallbackLocation = activeDeviceCoordinate
-			}
-			.onChange(of: position.positionedByUser) { _, positionedByUser in
-				if positionedByUser {
-					userTrackingMode = .none
-				}
 			}
 			.onChange(of: allLatestPositions) {
 				filters.fallbackLocation = activeDeviceCoordinate
@@ -606,7 +553,6 @@ struct MeshMap: View {
 
 	// moves the map to a new coordinate
 	private func centerMapAt(coordinate: CLLocationCoordinate2D) {
-		userTrackingMode = .none
 		withAnimation(.easeInOut(duration: 0.2), {
 			position = .camera(
 				MapCamera(
@@ -617,42 +563,6 @@ struct MeshMap: View {
 				)
 			)
 		})
-	}
-
-	private func centerMapOnUser(followsHeading: Bool) {
-		switch LocationsHandler.shared.manager.authorizationStatus {
-		case .authorizedAlways, .authorizedWhenInUse:
-			break
-		case .notDetermined:
-			LocationsHandler.shared.manager.requestWhenInUseAuthorization()
-		case .denied, .restricted:
-			showingLocationPermissionAlert = true
-			return
-		@unknown default:
-			return
-		}
-
-		showUserLocation = true
-		userTrackingMode = followsHeading ? .followingHeading : .centered
-		withAnimation(.easeInOut(duration: 0.2)) {
-			position = .userLocation(followsHeading: followsHeading, fallback: .automatic)
-		}
-	}
-
-	private func stopFollowingUser() {
-		userTrackingMode = .none
-		if let currentCamera {
-			position = .camera(currentCamera)
-		} else if let visibleRegion {
-			position = .region(visibleRegion)
-		} else {
-			position = .automatic
-		}
-	}
-
-	private func openAppSettings() {
-		guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
-		UIApplication.shared.open(settingsURL)
 	}
 }
 
@@ -675,36 +585,5 @@ private extension PositionEntity {
 			return longitude >= minLongitude || longitude <= maxLongitude - 360
 		}
 		return longitude >= minLongitude && longitude <= maxLongitude
-	}
-}
-
-private struct MeshMapUserLocationControl: View {
-	let mode: MeshMapUserTrackingMode
-	let centerAction: () -> Void
-	let followHeadingAction: () -> Void
-	let stopAction: () -> Void
-
-	var body: some View {
-		Menu {
-			Button(action: centerAction) {
-				Label("Center on Me", systemImage: "location.circle")
-			}
-			Button(action: followHeadingAction) {
-				Label("Follow Heading", systemImage: "location.north.circle")
-			}
-			if mode != .none {
-				Divider()
-				Button(action: stopAction) {
-					Label("Stop Following", systemImage: "location.slash")
-				}
-			}
-		} label: {
-			Image(systemName: mode.systemImage)
-		} primaryAction: {
-			centerAction()
-		}
-		.accessibilityLabel(mode.accessibilityLabel)
-		.accessibilityHint(Text("Centers the map on your location. Touch and hold for follow heading."))
-		.glassButtonStyle()
 	}
 }

--- a/Meshtastic/Views/Nodes/MeshMap.swift
+++ b/Meshtastic/Views/Nodes/MeshMap.swift
@@ -17,6 +17,34 @@ private struct MeshMapVisiblePositionState {
 	let key: Int64
 }
 
+private enum MeshMapUserTrackingMode {
+	case none
+	case centered
+	case followingHeading
+
+	var systemImage: String {
+		switch self {
+		case .none:
+			"location.circle"
+		case .centered:
+			"location.circle.fill"
+		case .followingHeading:
+			"location.north.circle.fill"
+		}
+	}
+
+	var accessibilityLabel: Text {
+		switch self {
+		case .none:
+			Text("Center on me")
+		case .centered:
+			Text("Map centered on me")
+		case .followingHeading:
+			Text("Map following my heading")
+		}
+	}
+}
+
 struct MeshMap: View {
 	private let denseMapPositionLimit = 700
 
@@ -44,6 +72,9 @@ struct MeshMap: View {
 	@State var position = MapCameraPosition.automatic
 	@State private var distance = 10000.0
 	@State private var visibleRegion: MKCoordinateRegion?
+	@State private var currentCamera: MapCamera?
+	@State private var userTrackingMode: MeshMapUserTrackingMode = .none
+	@State private var showingLocationPermissionAlert = false
 	@State private var editingSettings = false
 	@State private var editingFilters = false
 	@State var selectedNode: MeshMapSelectedNode?
@@ -161,7 +192,8 @@ struct MeshMap: View {
 								selectedNode: $selectedNode,
 								selectedWaypoint: $selectedWaypoint,
 								enabledOverlayConfigs: $enabledOverlayConfigs,
-								positionSnapshots: visiblePositionSnapshots
+								positionSnapshots: visiblePositionSnapshots,
+								isMapVisible: isMapVisible
 						)
 					}
 					.id(meshMapDistance)
@@ -181,6 +213,7 @@ struct MeshMap: View {
 							// distance is only used for long-press waypoint creation, so we don't need continuous updates which touch @State and force rerenders as we pan and (for distance in particular) zoom around the map. onEnd is more than enough.
 							distance = context.camera.distance
 							visibleRegion = context.region
+							currentCamera = context.camera
 						})
 					.onTapGesture(count: 1, perform: { position in
 						newWaypointCoord = reader.convert(position, from: .local) ?? CLLocationCoordinate2D.init()
@@ -261,6 +294,14 @@ struct MeshMap: View {
 				.sheet(isPresented: $editingSettings) {
 					MapSettingsForm(traffic: $showTraffic, pointsOfInterest: $showPointsOfInterest, mapLayer: $selectedMapLayer, meshMap: $isMeshMap, enabledOverlayConfigs: $enabledOverlayConfigs)
 				}
+				.alert("Location Access Needed", isPresented: $showingLocationPermissionAlert) {
+					Button("Open Settings") {
+						openAppSettings()
+					}
+					Button("Cancel", role: .cancel) {}
+				} message: {
+					Text("Allow location access to center the map on your position.")
+				}
 				.onChange(of: router.mapState) {
 					guard case .map = router.selectedTab else { return }
 					// TODO: handle deep link for waypoints
@@ -298,6 +339,12 @@ struct MeshMap: View {
 				.safeAreaInset(edge: .bottom, alignment: .trailing) {
 					HStack(spacing: 12) {
 						Spacer()
+						MeshMapUserLocationControl(
+							mode: userTrackingMode,
+							centerAction: { centerMapOnUser(followsHeading: false) },
+							followHeadingAction: { centerMapOnUser(followsHeading: true) },
+							stopAction: { stopFollowingUser() }
+						)
 						Button(action: {
 							withAnimation {
 								editingFilters = !editingFilters
@@ -358,6 +405,11 @@ struct MeshMap: View {
 			.onChange(of: positionState.key) {
 				refreshVisiblePositionSnapshots(from: positionState.positions)
 				filters.fallbackLocation = activeDeviceCoordinate
+			}
+			.onChange(of: position.positionedByUser) { _, positionedByUser in
+				if positionedByUser {
+					userTrackingMode = .none
+				}
 			}
 			.onChange(of: allLatestPositions) {
 				filters.fallbackLocation = activeDeviceCoordinate
@@ -554,6 +606,7 @@ struct MeshMap: View {
 
 	// moves the map to a new coordinate
 	private func centerMapAt(coordinate: CLLocationCoordinate2D) {
+		userTrackingMode = .none
 		withAnimation(.easeInOut(duration: 0.2), {
 			position = .camera(
 				MapCamera(
@@ -564,6 +617,42 @@ struct MeshMap: View {
 				)
 			)
 		})
+	}
+
+	private func centerMapOnUser(followsHeading: Bool) {
+		switch LocationsHandler.shared.manager.authorizationStatus {
+		case .authorizedAlways, .authorizedWhenInUse:
+			break
+		case .notDetermined:
+			LocationsHandler.shared.manager.requestWhenInUseAuthorization()
+		case .denied, .restricted:
+			showingLocationPermissionAlert = true
+			return
+		@unknown default:
+			return
+		}
+
+		showUserLocation = true
+		userTrackingMode = followsHeading ? .followingHeading : .centered
+		withAnimation(.easeInOut(duration: 0.2)) {
+			position = .userLocation(followsHeading: followsHeading, fallback: .automatic)
+		}
+	}
+
+	private func stopFollowingUser() {
+		userTrackingMode = .none
+		if let currentCamera {
+			position = .camera(currentCamera)
+		} else if let visibleRegion {
+			position = .region(visibleRegion)
+		} else {
+			position = .automatic
+		}
+	}
+
+	private func openAppSettings() {
+		guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
+		UIApplication.shared.open(settingsURL)
 	}
 }
 
@@ -586,5 +675,36 @@ private extension PositionEntity {
 			return longitude >= minLongitude || longitude <= maxLongitude - 360
 		}
 		return longitude >= minLongitude && longitude <= maxLongitude
+	}
+}
+
+private struct MeshMapUserLocationControl: View {
+	let mode: MeshMapUserTrackingMode
+	let centerAction: () -> Void
+	let followHeadingAction: () -> Void
+	let stopAction: () -> Void
+
+	var body: some View {
+		Menu {
+			Button(action: centerAction) {
+				Label("Center on Me", systemImage: "location.circle")
+			}
+			Button(action: followHeadingAction) {
+				Label("Follow Heading", systemImage: "location.north.circle")
+			}
+			if mode != .none {
+				Divider()
+				Button(action: stopAction) {
+					Label("Stop Following", systemImage: "location.slash")
+				}
+			}
+		} label: {
+			Image(systemName: mode.systemImage)
+		} primaryAction: {
+			centerAction()
+		}
+		.accessibilityLabel(mode.accessibilityLabel)
+		.accessibilityHint(Text("Centers the map on your location. Touch and hold for follow heading."))
+		.glassButtonStyle()
 	}
 }


### PR DESCRIPTION
## Summary
- Add SwiftUI MapKit's native `MapUserLocationButton` to the Mesh Map controls.
- Keep the system/default MapKit control styling instead of a custom bottom-row button or menu.
- Keep `UserAnnotation` visible on the map when user location is enabled and the map is active.
- Remove the custom tracking state, permission alert, and bespoke center/follow menu code from `MeshMap`.

## Reasoning
The map already uses native SwiftUI MapKit controls for scale, pitch, and compass. Using `MapUserLocationButton` keeps the user-location affordance in the same native control stack, lets MapKit own the user-location camera behavior, and avoids the custom glass button styling that looked wrong on device.

## Screenshot
![Native MapKit user location button](https://raw.githubusercontent.com/RCGV1/Meshtastic-Apple-Fork/codex/pr-center-follow-screenshot/pr-assets/center-follow/map-center-follow.png)

## Verification
- Created and used isolated worktree `/Users/benjaminfaershtein/Documents/Meshtastic-Apple-center-follow-worktree` from latest `upstream/main` (`203af583`).
- `git diff --check` -> passed.
- Simulator build:
  `xcodebuild -quiet -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,id=DE3343B3-1E9D-4C2D-9AFE-B50AC465BEBA' -derivedDataPath /tmp/meshtastic-center-follow-derived -skipPackagePluginValidation -skipMacroValidation CODE_SIGNING_ALLOWED=NO build` -> passed with exit code 0.
- Installed the built app on iPhone 16e simulator `DE3343B3-1E9D-4C2D-9AFE-B50AC465BEBA`, launched with `--meshtastic-perf-seed --meshtastic-perf-start-map`, and captured the screenshot above.

Notes: the build still emits existing project warnings, including Swift 6 concurrency warnings, duplicate source build-file warnings, missing local `swiftlint`, and a few node image sync warnings. They do not block this build.
