### PR TITLE
fix: render GeoJSON Multi* geometries on the mesh map

### DIFF
--- a/Meshtastic/Helpers/GeoJSONOverlayConfig.swift
+++ b/Meshtastic/Helpers/GeoJSONOverlayConfig.swift
@@ -165,6 +165,19 @@ struct GeoJSONFeature: Codable {
 		default: return 4.0
 		}
 	}
+
+	/// Coordinates to draw as map markers. A Point yields one coordinate; a MultiPoint yields one
+	/// per sub-coordinate. Empty for every other geometry type (those render as overlays instead).
+	var markerCoordinates: [CLLocationCoordinate2D] {
+		switch geometry.type.lowercased() {
+		case "point":
+			return geometry.coordinates.toCoordinate().map { [$0] } ?? []
+		case "multipoint":
+			return geometry.coordinates.toCoordinates()
+		default:
+			return []
+		}
+	}
 }
 
 // MARK: - Styled Feature Wrapper
@@ -174,26 +187,32 @@ struct GeoJSONStyledFeature: Identifiable {
 	let id = UUID()
 	let feature: GeoJSONFeature
 	let overlayId: String
-	/// MKOverlay pre-computed once at init — avoids repeated JSONSerialization + MKGeoJSONDecoder
-	/// calls on every map render pass.
-	let precomputedOverlay: MKOverlay?
+	/// MKOverlays pre-computed once at init — avoids repeated JSONSerialization + MKGeoJSONDecoder
+	/// calls on every map render pass. A Multi* geometry contributes one overlay per sub-geometry,
+	/// so this is an array rather than a single optional. Empty for Point/MultiPoint (drawn as
+	/// annotations) and for geometries that produce no valid overlay.
+	let precomputedOverlays: [MKOverlay]
+	/// Marker coordinates pre-computed once at init for the same reason as `precomputedOverlays`:
+	/// `overlayContent` is rebuilt on every map render pass, so deriving these per frame would
+	/// re-walk the raw GeoJSON coordinate arrays each time.
+	let precomputedMarkerCoordinates: [CLLocationCoordinate2D]
 
 	init(feature: GeoJSONFeature, overlayId: String) {
 		self.feature = feature
 		self.overlayId = overlayId
-		// Call the static helper after all stored properties are assigned so `self` is available
-		// for the instance — but we don't actually need self here, so this is safe.
-		self.precomputedOverlay = GeoJSONStyledFeature.makeOverlay(for: feature)
+		// Compute the overlays/markers once here so the render path just iterates cached values.
+		self.precomputedOverlays = GeoJSONStyledFeature.makeOverlays(for: feature)
+		self.precomputedMarkerCoordinates = feature.markerCoordinates
 	}
 
-	/// Builds an MKOverlay from a GeoJSON feature. Static so it can be called from init.
-	private static func makeOverlay(for feature: GeoJSONFeature) -> MKOverlay? {
+	/// Builds the MKOverlays for a GeoJSON feature. Static so it can be called from init.
+	private static func makeOverlays(for feature: GeoJSONFeature) -> [MKOverlay] {
 		// Point/MultiPoint geometries render as map annotations (markers), not overlays —
 		// MKGeoJSONDecoder returns an MKPointAnnotation (not an MKOverlay) for them, so running them
 		// through the overlay path below logged a spurious "no valid MKOverlay geometry" error for
 		// every point. Skip them silently; they're drawn via the annotation path (#1970).
 		let geometryType = feature.geometry.type.lowercased()
-		guard geometryType != "point", geometryType != "multipoint" else { return nil }
+		guard geometryType != "point", geometryType != "multipoint" else { return [] }
 
 		let featureDict: [String: Any] = [
 			"type": feature.type,
@@ -207,20 +226,34 @@ struct GeoJSONStyledFeature: Identifiable {
 		do {
 			let geojsonData = try JSONSerialization.data(withJSONObject: featureDict)
 			let mkFeatures = try MKGeoJSONDecoder().decode(geojsonData)
-			if let mkFeature = mkFeatures.first as? MKGeoJSONFeature,
-			   let geometry = mkFeature.geometry.first as? MKOverlay {
-				return geometry
-			} else {
+			guard let mkFeature = mkFeatures.first as? MKGeoJSONFeature else {
+				Logger.services.error("🗺️ GeoJSONStyledFeature: Failed to create overlay - no MKGeoJSONFeature decoded.")
+				return []
+			}
+			// A Multi* geometry decodes into several shapes; flatten any MKMultiPolygon/MKMultiPolyline
+			// wrapper into its components so the render layer only ever deals with simple MKPolygon /
+			// MKPolyline. Previously this kept only `.first`, silently dropping every other sub-geometry.
+			let overlays: [MKOverlay] = mkFeature.geometry.flatMap { shape -> [MKOverlay] in
+				switch shape {
+				case let multiPolygon as MKMultiPolygon:
+					return multiPolygon.polygons
+				case let multiPolyline as MKMultiPolyline:
+					return multiPolyline.polylines
+				case let overlay as MKOverlay:
+					return [overlay]
+				default:
+					return []
+				}
+			}
+			if overlays.isEmpty {
 				Logger.services.error("🗺️ GeoJSONStyledFeature: Failed to create overlay - no valid MKOverlay geometry.")
 			}
+			return overlays
 		} catch {
 			Logger.services.error("🗺️ GeoJSONStyledFeature: Failed to build overlay: \(error.localizedDescription)")
 		}
-		return nil
+		return []
 	}
-
-	/// Returns the pre-computed overlay. Retained for API compatibility.
-	func createOverlay() -> MKOverlay? { precomputedOverlay }
 
 	/// Get stroke style for this feature
 	var strokeStyle: StrokeStyle {
@@ -353,5 +386,12 @@ enum AnyCodableValue: Codable {
 			return CLLocationCoordinate2D(latitude: lat, longitude: lon)
 		}
 		return nil
+	}
+
+	// Helper to convert a MultiPoint-style array of [lon, lat] pairs to coordinates. Malformed
+	// entries are skipped rather than failing the whole set.
+	func toCoordinates() -> [CLLocationCoordinate2D] {
+		guard case .array(let items) = self else { return [] }
+		return items.compactMap { $0.toCoordinate() }
 	}
 }

--- a/Meshtastic/Helpers/MapDataManager.swift
+++ b/Meshtastic/Helpers/MapDataManager.swift
@@ -158,8 +158,8 @@ class MapDataManager: ObservableObject {
 		// Validate each feature
 		for feature in features {
 			guard let geometry = feature["geometry"] as? [String: Any],
-				  let coordinates = geometry["coordinates"] as? [Any],
-				  let geometryType = geometry["type"] as? String else {
+				  geometry["coordinates"] is [Any],
+				  geometry["type"] is String else {
 				throw NSError(domain: "MapDataManager", code: 3, userInfo: [NSLocalizedDescriptionKey: "Invalid feature structure in GeoJSON"])
 			}
 		}

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -244,27 +244,31 @@ struct MeshMapContent: MapContent {
 			// avoiding full teardown/rebuild of overlay views on each render.
 			ForEach(allStyledFeatures) { styledFeature in
 				let feature = styledFeature.feature
-				let geometryType = feature.geometry.type
-				
-				if geometryType == "Point" {
-					if let coordinate = feature.geometry.coordinates.toCoordinate() {
-						Annotation(feature.name, coordinate: coordinate) {
-							Circle()
-								.fill(styledFeature.fillColor)
-								.stroke(styledFeature.strokeColor, style: styledFeature.strokeStyle)
-								.frame(width: feature.markerRadius * 2, height: feature.markerRadius * 2)
-						}
-						.annotationTitles(.automatic)
-						.annotationSubtitles(.hidden)
-					}
-				} else if geometryType == "LineString" {
-					if let overlay = styledFeature.createOverlay() as? MKPolyline {
-						MapPolyline(overlay)
+
+				// Point and MultiPoint render as marker annotations — one per coordinate. Both the
+				// coordinates and overlays below are precomputed at init, and we iterate their indices
+				// to avoid allocating an Array(enumerated()) on every render pass.
+				ForEach(styledFeature.precomputedMarkerCoordinates.indices, id: \.self) { index in
+					Annotation(feature.name, coordinate: styledFeature.precomputedMarkerCoordinates[index]) {
+						Circle()
+							.fill(styledFeature.fillColor)
 							.stroke(styledFeature.strokeColor, style: styledFeature.strokeStyle)
+							.frame(width: feature.markerRadius * 2, height: feature.markerRadius * 2)
 					}
-				} else if geometryType == "Polygon" {
-					if let overlay = styledFeature.createOverlay() as? MKPolygon {
-						MapPolygon(overlay)
+					.annotationTitles(.automatic)
+					.annotationSubtitles(.hidden)
+				}
+
+				// LineString/Polygon and their Multi* variants render as one map shape per
+				// sub-geometry. precomputedOverlays has already flattened MKMulti* wrappers down to
+				// simple MKPolyline / MKPolygon, so a single type switch covers every overlay type.
+				ForEach(styledFeature.precomputedOverlays.indices, id: \.self) { index in
+					let overlay = styledFeature.precomputedOverlays[index]
+					if let polyline = overlay as? MKPolyline {
+						MapPolyline(polyline)
+							.stroke(styledFeature.strokeColor, style: styledFeature.strokeStyle)
+					} else if let polygon = overlay as? MKPolygon {
+						MapPolygon(polygon)
 							.foregroundStyle(styledFeature.fillColor)
 							.stroke(styledFeature.strokeColor, style: styledFeature.strokeStyle)
 					}

--- a/MeshtasticTests/GeoJSONOverlayConfigTests.swift
+++ b/MeshtasticTests/GeoJSONOverlayConfigTests.swift
@@ -4,6 +4,7 @@
 import Testing
 import Foundation
 import CoreLocation
+import MapKit
 @testable import Meshtastic
 
 // MARK: - AnyCodableValue Tests
@@ -415,5 +416,163 @@ struct GeoJSONFeatureCollectionCodableTests {
 		#expect(feature.fillOpacity == 0.5)
 		#expect(feature.strokeColor == "#000000")
 		#expect(feature.strokeWidth == 2.0)
+	}
+}
+
+// MARK: - Marker Coordinate Tests
+
+@Suite("GeoJSONFeature markerCoordinates")
+struct GeoJSONFeatureMarkerCoordinatesTests {
+
+	private func feature(type: String, coordinates: AnyCodableValue) -> GeoJSONFeature {
+		GeoJSONFeature(
+			type: "Feature",
+			id: nil,
+			geometry: GeoJSONGeometry(type: type, coordinates: coordinates),
+			properties: nil
+		)
+	}
+
+	@Test func pointYieldsSingleCoordinate() {
+		let f = feature(type: "Point", coordinates: .array([.double(-122.0), .double(37.0)]))
+		let coords = f.markerCoordinates
+		#expect(coords.count == 1)
+		#expect(abs(coords[0].latitude - 37.0) < 0.0001)
+		#expect(abs(coords[0].longitude - (-122.0)) < 0.0001)
+	}
+
+	@Test func multiPointYieldsOnePerCoordinate() {
+		let f = feature(type: "MultiPoint", coordinates: .array([
+			.array([.double(0), .double(0)]),
+			.array([.double(1), .double(1)]),
+			.array([.double(2), .double(2)])
+		]))
+		#expect(f.markerCoordinates.count == 3)
+	}
+
+	@Test func multiPointSkipsMalformedCoordinates() {
+		let f = feature(type: "MultiPoint", coordinates: .array([
+			.array([.double(0), .double(0)]),
+			.array([.double(1)]),            // too few elements
+			.string("nope")                  // not an array
+		]))
+		#expect(f.markerCoordinates.count == 1)
+	}
+
+	@Test func polygonHasNoMarkerCoordinates() {
+		let f = feature(type: "Polygon", coordinates: .array([.array([
+			.array([.double(0), .double(0)]),
+			.array([.double(1), .double(0)]),
+			.array([.double(1), .double(1)]),
+			.array([.double(0), .double(0)])
+		])]))
+		#expect(f.markerCoordinates.isEmpty)
+	}
+
+	@Test func toCoordinatesParsesPairs() {
+		let value = AnyCodableValue.array([
+			.array([.double(10), .double(20)]),
+			.array([.int(30), .int(40)])
+		])
+		let coords = value.toCoordinates()
+		#expect(coords.count == 2)
+		#expect(abs(coords[0].longitude - 10.0) < 0.0001)
+		#expect(abs(coords[1].latitude - 40.0) < 0.0001)
+	}
+
+	@Test func toCoordinatesOnNonArrayIsEmpty() {
+		#expect(AnyCodableValue.string("x").toCoordinates().isEmpty)
+	}
+}
+
+// MARK: - Multi* Overlay Tests
+
+/// Regression coverage for the Multi* geometry gap: `makeOverlays` must emit one overlay per
+/// sub-geometry (the old code kept only `.first`, silently dropping the rest), and Point/MultiPoint
+/// must produce no overlays (they render as annotations).
+@Suite("GeoJSONStyledFeature overlays")
+struct GeoJSONStyledFeatureOverlayTests {
+
+	private func styledFeature(geometryJSON: String) throws -> GeoJSONStyledFeature {
+		let json = """
+		{ "type": "FeatureCollection", "features": [
+			{ "type": "Feature", "geometry": \(geometryJSON), "properties": {} }
+		]}
+		"""
+		let collection = try JSONDecoder().decode(GeoJSONFeatureCollection.self, from: Data(json.utf8))
+		return GeoJSONStyledFeature(feature: collection.features[0], overlayId: "test")
+	}
+
+	@Test func singlePolygonProducesOneOverlay() throws {
+		let sf = try styledFeature(geometryJSON: """
+		{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]}
+		""")
+		#expect(sf.precomputedOverlays.count == 1)
+		#expect(sf.precomputedOverlays.first is MKPolygon)
+	}
+
+	@Test func multiPolygonProducesOnePolygonPerSubGeometry() throws {
+		let sf = try styledFeature(geometryJSON: """
+		{"type":"MultiPolygon","coordinates":[
+			[[[0,0],[0,1],[1,1],[1,0],[0,0]]],
+			[[[2,2],[2,3],[3,3],[3,2],[2,2]]]
+		]}
+		""")
+		// The pre-fix code returned only the first sub-polygon (count 1).
+		#expect(sf.precomputedOverlays.count == 2)
+		#expect(sf.precomputedOverlays.allSatisfy { $0 is MKPolygon })
+	}
+
+	@Test func multiLineStringProducesOnePolylinePerSubGeometry() throws {
+		let sf = try styledFeature(geometryJSON: """
+		{"type":"MultiLineString","coordinates":[
+			[[0,0],[1,1]],
+			[[2,2],[3,3]],
+			[[4,4],[5,5]]
+		]}
+		""")
+		#expect(sf.precomputedOverlays.count == 3)
+		#expect(sf.precomputedOverlays.allSatisfy { $0 is MKPolyline })
+	}
+
+	@Test func lineStringProducesOnePolyline() throws {
+		let sf = try styledFeature(geometryJSON: """
+		{"type":"LineString","coordinates":[[0,0],[1,1],[2,2]]}
+		""")
+		#expect(sf.precomputedOverlays.count == 1)
+		#expect(sf.precomputedOverlays.first is MKPolyline)
+	}
+
+	@Test func pointProducesNoOverlays() throws {
+		let sf = try styledFeature(geometryJSON: """
+		{"type":"Point","coordinates":[-122.0,37.0]}
+		""")
+		#expect(sf.precomputedOverlays.isEmpty)
+	}
+
+	@Test func multiPointProducesNoOverlays() throws {
+		let sf = try styledFeature(geometryJSON: """
+		{"type":"MultiPoint","coordinates":[[0,0],[1,1]]}
+		""")
+		#expect(sf.precomputedOverlays.isEmpty)
+	}
+
+	// A geometry whose coordinates decode but yield no drawable shape (here an empty MultiPolygon)
+	// must return [] cleanly — the empty-result branch that logs "no valid MKOverlay geometry".
+	@Test func emptyMultiPolygonProducesNoOverlays() throws {
+		let sf = try styledFeature(geometryJSON: """
+		{"type":"MultiPolygon","coordinates":[]}
+		""")
+		#expect(sf.precomputedOverlays.isEmpty)
+	}
+
+	// Malformed coordinates that fail MKGeoJSONDecoder must fall through the catch to [] rather
+	// than returning a partial/garbage overlay set.
+	@Test func malformedGeometryProducesNoOverlays() throws {
+		// A LineString whose coordinates are strings, not [lon, lat] number pairs.
+		let sf = try styledFeature(geometryJSON: """
+		{"type":"LineString","coordinates":["nope","still nope"]}
+		""")
+		#expect(sf.precomputedOverlays.isEmpty)
 	}
 }


### PR DESCRIPTION
## What changed?

GeoJSON `MultiPoint`, `MultiLineString`, and `MultiPolygon` features now render on the mesh map. Previously they produced no (or only partial) map content:

- `MeshMapContent.overlayContent` only branched on `Point` / `LineString` / `Polygon`, so Multi* geometry types matched no branch and drew nothing.
- `GeoJSONStyledFeature` kept only `mkFeature.geometry.first`, so even where a branch existed, every sub-geometry past the first was silently dropped.

The fix:

- `GeoJSONStyledFeature` now collects **all** decoded sub-geometries into `precomputedOverlays`, flattening any `MKMultiPolygon` / `MKMultiPolyline` wrapper into simple `MKPolygon` / `MKPolyline` so the render layer handles one uniform list.
- `overlayContent` renders the overlay layer by switching on overlay type (`MKPolyline` → `MapPolyline`, `MKPolygon` → `MapPolygon`), so `LineString`/`Polygon` and their Multi* variants are drawn the same way.
- A new `markerCoordinates` (precomputed at init, like the overlays) draws annotations for both `Point` and `MultiPoint`.
- Tidied an unused-binding warning in `MapDataManager.validateFile`.

## Why did it change?

Valid, common GeoJSON that uses Multi* geometries silently produced no/partial map content. The gap was surfaced during the #1970 review (the Point overlay log-spam fix); after #1970 quieted the spurious Point overlay error, the silent drop became even easier to miss. This makes the map render the geometry types that the GeoJSON spec — and typical exported overlays — routinely contain.

## How is this tested?

Added model-layer tests in `MeshtasticTests/GeoJSONOverlayConfigTests.swift` (Swift Testing). All GeoJSON tests pass (64 total); run via the workspace on an iPhone 16 / iOS 18 simulator (matching CI):

- **Overlay counts per geometry**: single Polygon → 1, MultiPolygon → 2 (the direct regression guard against the old `.first` truncation), MultiLineString → 3, LineString → 1, and Point / MultiPoint → 0 overlays.
- **Marker coordinates**: Point → 1, MultiPoint → N, malformed sub-coords skipped, Polygon → none; plus `toCoordinates()` parsing.
- **Empty/malformed input**: empty MultiPolygon and malformed coordinates → empty overlay set (the error/empty-result branches).

```
xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic \
  -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.x' \
  -only-testing:MeshtasticTests/GeoJSONStyledFeatureOverlayTests \
  -only-testing:MeshtasticTests/GeoJSONFeatureMarkerCoordinatesTests
# ** TEST SUCCEEDED **
```

Note: a SwiftUI `Map` snapshot test was evaluated and deliberately not included — MapKit draws overlays asynchronously, so an off-screen snapshot captures a blank base map and can't assert overlay rendering. The deterministic guard lives at the model layer (overlay/marker counts) instead.

Known follow-up (out of scope): `GeometryCollection` member points still aren't drawn as markers.

## Screenshots/Videos (when applicable)

<!-- N/A — see the testing note above on why a map snapshot isn't meaningful for overlays. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. _No doc update needed — this fixes rendering of existing GeoJSON overlay support; no new user-facing settings or views. Requesting the **`skip-docs-check`** label (external-contributor PR can't self-apply it)._
- [x] I have tested the change to ensure that it works as intended.
