### PR TITLE
fix(catalyst): drop carplay-communication entitlement from the Mac build (App Store 2.1a)

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -3394,6 +3394,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Meshtastic/Meshtastic.entitlements;
+				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Meshtastic/Meshtastic-Catalyst.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -3443,6 +3444,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Meshtastic/Meshtastic.entitlements;
+				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Meshtastic/Meshtastic-Catalyst.entitlements";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Meshtastic/Meshtastic-Catalyst.entitlements
+++ b/Meshtastic/Meshtastic-Catalyst.entitlements
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.siri</key>
+	<true/>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:meshtastic.org/e/*</string>
+		<string>applinks:meshtastic.org/v/*</string>
+	</array>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
+	<key>com.apple.developer.networking.custom-protocol</key>
+	<true/>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
+	<key>com.apple.developer.usernotifications.critical-alerts</key>
+	<true/>
+	<key>com.apple.developer.weatherkit</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.device.serial</key>
+	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)gvh.MeshtasticClient</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Why
App Store review rejected the submission (**2.7.15 / 2074**) under **Guideline 2.1(a) – App Completeness**: the app declares the CarPlay *communication* capability but doesn't implement `INStartCallIntent`/CallKit (Meshtastic is messaging, not VoIP).

CarPlay is iPhone-only — the **Mac (Catalyst) build can't use it** — but the shared `Meshtastic.entitlements` declared `com.apple.developer.carplay-communication`, and the app is a single universal product (iPhone/iPad + Mac Catalyst, one version). So the CarPlay capability was evaluated against the whole submission and flagged on the Mac side too.

## What
- Add **`Meshtastic/Meshtastic-Catalyst.entitlements`** = the base entitlements **minus** `com.apple.developer.carplay-communication`.
- Select it for Catalyst via **`CODE_SIGN_ENTITLEMENTS[sdk=macosx*]`** in the app target's Debug + Release configs (same `[sdk=macosx*]` pattern the project already uses for `CODE_SIGN_IDENTITY`).
- **iOS is unchanged** — full `Meshtastic.entitlements` with CarPlay messaging + `INSendMessageIntent`.

## Verification
- `xcodebuild -showBuildSettings`: Mac Catalyst → `Meshtastic-Catalyst.entitlements`, iOS → `Meshtastic.entitlements`.
- Mac Catalyst build succeeds; `codesign -d --entitlements` on the built `.app` shows **no `carplay-communication`** (Siri, app-sandbox, networking, NFC, WeatherKit, etc. all retained). iOS build still embeds CarPlay.

## Notes
- Build number bumps via CI at archive time (`CURRENT_PROJECT_VERSION = 1` in-repo); resubmit the Mac build after merge.
- Preserves iOS CarPlay messaging. If iOS ever hits the same 2.1(a), follow-up options are to implement `INStartCallIntent`+CallKit or drop iOS CarPlay as well.