### PR TITLE
fix: stop SwiftData SIGTRAP when node list rows read deleted positions

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -11,7 +11,14 @@ import Foundation
 
 struct NodeListRowSummary {
 	let latestDeviceMetrics: TelemetryEntity?
-	let latestPosition: PositionEntity?
+	// Snapshot the position as plain value types at construction time rather than
+	// vending the live PositionEntity. SwiftData fatally traps (SIGTRAP in
+	// _SD_get_faulting_backingdata_tsd) if a deleted @Model's persisted property is
+	// read, and position rows are pruned/replaced constantly underneath the list —
+	// so a view body holding a live PositionEntity can crash mid-render. Value-type
+	// snapshots can never fault.
+	let hasPosition: Bool
+	let latestNodeCoordinate: CLLocationCoordinate2D?
 	let hasEnvironmentMetrics: Bool
 	let hasDetectionSensorMetrics: Bool
 	let hasTraceRoutes: Bool
@@ -23,7 +30,9 @@ struct NodeListRowSummary {
 		includeLogAvailability: Bool = true
 	) {
 		latestDeviceMetrics = includeDeviceMetrics ? node.latestDeviceMetrics : nil
-		latestPosition = includePosition ? node.latestPosition : nil
+		let latestPosition = includePosition ? node.latestPosition : nil
+		hasPosition = latestPosition != nil
+		latestNodeCoordinate = latestPosition?.nodeCoordinate
 		hasEnvironmentMetrics = includeLogAvailability ? node.hasEnvironmentMetrics : false
 		hasDetectionSensorMetrics = includeLogAvailability ? node.hasDetectionSensorMetrics : false
 		hasTraceRoutes = includeLogAvailability ? node.hasTraceRoutes : false
@@ -44,7 +53,7 @@ struct NodeListItem: View {
 		return f
 	}()
 
-	private func accessibilityDescription(cachedMetrics: TelemetryEntity?, cachedLocationData: (PositionEntity, CLLocation)?) -> String {
+	private func accessibilityDescription(cachedMetrics: TelemetryEntity?, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?) -> String {
 		var desc = ""
 		if let shortName = node.user?.shortName {
 			desc = shortName.formatNodeNameForVoiceOver()
@@ -84,8 +93,7 @@ struct NodeListItem: View {
 				desc += ", battery \(battery)%"
 			}
 		}
-		if !isDirectlyConnected, let (lastPosition, myCoord) = cachedLocationData {
-			let nodeCoord = CLLocation(latitude: lastPosition.nodeCoordinate!.latitude, longitude: lastPosition.nodeCoordinate!.longitude)
+		if !isDirectlyConnected, let (nodeCoord, myCoord) = cachedLocationData {
 			let metersAway = nodeCoord.distance(from: myCoord)
 			let formattedDistance = Self.distanceFormatter.string(fromMeters: metersAway)
 			desc += ", " + String(format: "%@: %@", "Distance".localized, formattedDistance)
@@ -138,27 +146,39 @@ struct NodeListItem: View {
 		return (image, color)
 	}
 	
-	func locationData(for lastPosition: PositionEntity?) -> (PositionEntity, CLLocation)? {
-		guard let lastPosition else {
+	func locationData(for nodeCoordinate: CLLocationCoordinate2D?) -> (nodeLocation: CLLocation, myLocation: CLLocation)? {
+		guard let nodeCoordinate else {
 			return nil
 		}
 		guard let currentLocation = LocationsHandler.shared.locationsArray.last else {
 			return nil
 		}
-		
+
 		let myCoord = CLLocation(latitude: currentLocation.coordinate.latitude, longitude: currentLocation.coordinate.longitude)
-		
-		if lastPosition.nodeCoordinate != nil && myCoord.coordinate.longitude != LocationsHandler.DefaultLocation.longitude && myCoord.coordinate.latitude != LocationsHandler.DefaultLocation.latitude {
-			return (lastPosition, myCoord)
+
+		if myCoord.coordinate.longitude != LocationsHandler.DefaultLocation.longitude && myCoord.coordinate.latitude != LocationsHandler.DefaultLocation.latitude {
+			return (CLLocation(latitude: nodeCoordinate.latitude, longitude: nodeCoordinate.longitude), myCoord)
 		}
 		return nil
 	}
 	
 	var body: some View {
+		// A List row view can be retained and re-evaluate its body after the underlying
+		// node row has been deleted (nodes/positions are pruned constantly). Reading any
+		// persisted property of a deleted @Model fatally traps in SwiftData, so bail to an
+		// empty row when the node is no longer live — the List drops it on its next rebuild.
+		// Mirrors the modelContext guard already used in NodeList/NodeDetail.
+		if node.modelContext != nil && !node.isDeleted {
+			rowContent
+		} else {
+			EmptyView()
+		}
+	}
+
+	@ViewBuilder private var rowContent: some View {
 		let cachedMetrics = rowSummary?.latestDeviceMetrics
-		let cachedLatestPosition = rowSummary?.latestPosition
-		let cachedLocationData = connectedNode == node.num ? nil : locationData(for: cachedLatestPosition)
-		let cachedHasPositions = cachedLatestPosition != nil
+		let cachedLocationData = connectedNode == node.num ? nil : locationData(for: rowSummary?.latestNodeCoordinate)
+		let cachedHasPositions = rowSummary?.hasPosition ?? false
 		let cachedHasDeviceMetrics = cachedMetrics != nil
 		let cachedHasEnvironmentMetrics = rowSummary?.hasEnvironmentMetrics ?? false
 		let cachedHasDetectionSensorMetrics = rowSummary?.hasDetectionSensorMetrics ?? false
@@ -218,8 +238,7 @@ struct NodeListItem: View {
 					
 					if connectedNode != node.num {
 						HStack {
-							if let (lastPostion, myCoord) = cachedLocationData {
-								let nodeCoord = CLLocation(latitude: lastPostion.nodeCoordinate!.latitude, longitude: lastPostion.nodeCoordinate!.longitude)
+							if let (nodeCoord, myCoord) = cachedLocationData {
 								let metersAway = nodeCoord.distance(from: myCoord)
 								Image(systemName: "lines.measurement.horizontal")
 									.font(.callout)

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -39,7 +39,7 @@ struct NodeListItemCompact: View {
 		return f
 	}()
 
-	private func accessibilityDescription(cachedMetrics: TelemetryEntity?, cachedLocationData: (PositionEntity, CLLocation)?) -> String {
+	private func accessibilityDescription(cachedMetrics: TelemetryEntity?, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?) -> String {
 		var desc = ""
 		if let shortName = node.user?.shortName {
 			desc = shortName.formatNodeNameForVoiceOver()
@@ -79,8 +79,7 @@ struct NodeListItemCompact: View {
 				desc += ", battery \(battery)%"
 			}
 		}
-		if !isDirectlyConnected, let (lastPosition, myCoord) = cachedLocationData {
-			let nodeCoord = CLLocation(latitude: lastPosition.nodeCoordinate!.latitude, longitude: lastPosition.nodeCoordinate!.longitude)
+		if !isDirectlyConnected, let (nodeCoord, myCoord) = cachedLocationData {
 			let metersAway = nodeCoord.distance(from: myCoord)
 			let formattedDistance = Self.distanceFormatter.string(fromMeters: metersAway)
 			desc += ", " + String(format: "%@: %@", "Distance".localized, formattedDistance)
@@ -133,18 +132,18 @@ struct NodeListItemCompact: View {
 		return (image, color)
 	}
 	
-	func locationData(for lastPosition: PositionEntity?) -> (PositionEntity, CLLocation)? {
-		guard let lastPosition else {
+	func locationData(for nodeCoordinate: CLLocationCoordinate2D?) -> (nodeLocation: CLLocation, myLocation: CLLocation)? {
+		guard let nodeCoordinate else {
 			return nil
 		}
 		guard let currentLocation = LocationsHandler.shared.locationsArray.last else {
 			return nil
 		}
-		
+
 		let myCoord = CLLocation(latitude: currentLocation.coordinate.latitude, longitude: currentLocation.coordinate.longitude)
-		
-		if lastPosition.nodeCoordinate != nil && myCoord.coordinate.longitude != LocationsHandler.DefaultLocation.longitude && myCoord.coordinate.latitude != LocationsHandler.DefaultLocation.latitude {
-			return (lastPosition, myCoord)
+
+		if myCoord.coordinate.longitude != LocationsHandler.DefaultLocation.longitude && myCoord.coordinate.latitude != LocationsHandler.DefaultLocation.latitude {
+			return (CLLocation(latitude: nodeCoordinate.latitude, longitude: nodeCoordinate.longitude), myCoord)
 		}
 		return nil
 	}
@@ -163,12 +162,25 @@ struct NodeListItemCompact: View {
 	}
 	
 	var body: some View {
+		// A List row view can be retained and re-evaluate its body after the underlying
+		// node row has been deleted (nodes/positions are pruned constantly). Reading any
+		// persisted property of a deleted @Model fatally traps in SwiftData, so bail to an
+		// empty row when the node is no longer live — the List drops it on its next rebuild.
+		// Mirrors the modelContext guard already used in NodeList/NodeDetail.
+		if node.modelContext != nil && !node.isDeleted {
+			rowContent
+		} else {
+			EmptyView()
+		}
+	}
+
+	@ViewBuilder private var rowContent: some View {
 		let circleSize = max(minCircle, min(maxCircle, baseUnit * CGFloat(lineNums)))
 		let cachedMetrics = (shouldShowPower || shouldShowTelemetry) ? rowSummary?.latestDeviceMetrics : nil
 		let needsLatestPosition = shouldShowTelemetry || (shouldShowLocation && connectedNode != node.num)
-		let cachedLatestPosition = needsLatestPosition ? rowSummary?.latestPosition : nil
-		let cachedLocationData = (shouldShowLocation && connectedNode != node.num) ? locationData(for: cachedLatestPosition) : nil
-		let cachedHasPositions = shouldShowTelemetry ? cachedLatestPosition != nil : false
+		let cachedLatestNodeCoordinate = needsLatestPosition ? rowSummary?.latestNodeCoordinate : nil
+		let cachedLocationData = (shouldShowLocation && connectedNode != node.num) ? locationData(for: cachedLatestNodeCoordinate) : nil
+		let cachedHasPositions = shouldShowTelemetry ? (rowSummary?.hasPosition ?? false) : false
 		let cachedHasDeviceMetrics = shouldShowTelemetry && cachedMetrics != nil
 		let cachedHasEnvironmentMetrics = shouldShowTelemetry ? rowSummary?.hasEnvironmentMetrics ?? false : false
 		let cachedHasDetectionSensorMetrics = shouldShowTelemetry ? rowSummary?.hasDetectionSensorMetrics ?? false : false
@@ -217,8 +229,7 @@ struct NodeListItemCompact: View {
 					// Distance, bearing, hops, signal, role, telemetry row
 					HStack(alignment: .center, spacing: 6) {
 						if shouldShowLocation && connectedNode != node.num {
-							if let (lastPostion, myCoord) = cachedLocationData {
-								let nodeCoord = CLLocation(latitude: lastPostion.nodeCoordinate!.latitude, longitude: lastPostion.nodeCoordinate!.longitude)
+							if let (nodeCoord, myCoord) = cachedLocationData {
 								let metersAway = nodeCoord.distance(from: myCoord)
 								DistanceText(meters: metersAway, isCompact: true)
 									.font(.callout)


### PR DESCRIPTION
## What happened

A crash report from 2.7.15 (2074), iPhone 16 Pro / iOS 26.5:

```
0  _assertionFailure
2  SwiftData __swift_memcpy9_8
4  SwiftData _SD_get_faulting_backingdata_tsd
5  PositionEntity.nodeCoordinate.getter
6  NodeListItem.locationData(for: PositionEntity?)   NodeListItem.swift:151
7  NodeListItem.body.getter                          NodeListItem.swift:160
```

A node-list row body read `PositionEntity.nodeCoordinate` (which reads the persisted `latitudeI`). SwiftData tried to fire the fault to load the backing row, the row had been **deleted**, and SwiftData **fatally asserts** (SIGTRAP) instead of returning nil.

Why it happens in practice: position rows are pruned/replaced constantly (a new position prunes old ones; node deletion / DB clears too). A retained `List` row re-evaluates its body via AttributeGraph **before** the `List` rebuilds and drops the row — so the body reads a deleted `@Model`. The existing `node.modelContext != nil` guard in `NodeList` only runs at List rebuild, not on the re-render race.

## The fix

**1. Snapshot the position as value types (the durable fix).** `NodeListRowSummary` no longer vends a live `PositionEntity`. It captures, at `@MainActor` construction time:

```swift
let hasPosition: Bool
let latestNodeCoordinate: CLLocationCoordinate2D?
```

`locationData(...)` now takes a `CLLocationCoordinate2D?` and returns `CLLocation` values, so the row body and the accessibility-label builder work entirely from value types that can never fault. Also removes four `nodeCoordinate!` force-unwraps.

**2. Guard the remaining live `node.*` reads.** `NodeListItem` and `NodeListItemCompact` bodies bail to `EmptyView` when the node is no longer live (`modelContext == nil || isDeleted`). Mirrors the `modelContext` guard already used in `NodeList`/`NodeDetail`. The List drops the empty row on its next rebuild.

Behavior is otherwise identical (`hasPosition` ≡ the old `latestPosition != nil`).

## Testing

⚠️ I could **not** run a build/tests in my environment — the `Meshtastic` scheme embeds a Watch app and watchOS SDK wasn't installed (`unable to resolve module 'WatchKit'`), which is the only build failure and is unrelated to these files. Changes are type-checked by inspection only. **Please build + run before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)