### PR TITLE
fix(messages): stop empty channel list after notification back navigation

### DIFF
--- a/Meshtastic/Router/NavigationState.swift
+++ b/Meshtastic/Router/NavigationState.swift
@@ -11,6 +11,23 @@ enum MessagesNavigationState: Hashable {
 		userNum: Int64? = nil,
 		messageId: Int64? = nil
 	)
+
+	/// The Messages sidebar section this state belongs to, with the deep-link payload
+	/// (channelId/messageId, userNum) stripped.
+	///
+	/// The sidebar `List` only offers `.channels()` and `.directMessages()` rows, so its selection
+	/// (`Router.messagesSection`) must stay payload-free — a payload-carrying value such as
+	/// `.channels(channelId: 2, messageId: 5)` matches no row and corrupts the collapsed
+	/// `NavigationSplitView` back stack (tap back → empty channel list). `Router` derives
+	/// `messagesSection` from each deep-link `messagesState` via this property, keeping the correct
+	/// row selected while the full payload stays on `messagesState` for the Messages view to
+	/// consume once.
+	var sidebarSection: MessagesNavigationState {
+		switch self {
+		case .channels: return .channels()
+		case .directMessages: return .directMessages()
+		}
+	}
 }
 
 // MARK: Map

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -9,8 +9,20 @@ class Router: ObservableObject {
 	@Published
 	var selectedTab: NavigationState.Tab
 
+	/// Transient deep-link *command* for the Messages tab (carries the channelId/userNum payload).
+	/// Set by `route(url:)` / restoration and consumed exactly once by the Messages view, which
+	/// resolves it into a selected conversation and then clears it. Kept separate from
+	/// `messagesSection` so the one-shot payload never reaches the sidebar selection and so a later
+	/// tab re-appear can't re-resolve it and snap the user back into the notified conversation.
 	@Published
 	var messagesState: MessagesNavigationState?
+
+	/// Durable, payload-free Messages sidebar/section selection (`.channels()` / `.directMessages()`
+	/// / nil). Drives the sidebar `List` selection and the content column. Because it only ever
+	/// holds payload-free values it always matches a sidebar row, keeping the collapsed
+	/// `NavigationSplitView` back stack intact. Survives across tab switches; reset by `popToRoot`.
+	@Published
+	var messagesSection: MessagesNavigationState?
 
 	@Published
 	var mapState: MapNavigationState?
@@ -36,6 +48,7 @@ class Router: ObservableObject {
 		set {
 			selectedTab = newValue.selectedTab
 			messagesState = newValue.messages
+			messagesSection = newValue.messages?.sidebarSection
 			selectedNodeNum = newValue.nodeListSelectedNodeNum
 			mapState = newValue.map
 			if let setting = newValue.settings {
@@ -89,6 +102,7 @@ class Router: ObservableObject {
 	) {
 		self.selectedTab = navigationState.selectedTab
 		self.messagesState = navigationState.messages
+		self.messagesSection = navigationState.messages?.sidebarSection
 		if let num = navigationState.nodeListSelectedNodeNum {
 			self.selectedNodeNum = num
 		}
@@ -154,6 +168,7 @@ class Router: ObservableObject {
 		}
 		selectedTab = .messages
 		messagesState = state
+		messagesSection = state?.sidebarSection
 	}
 
 	private func routeNodes(_ components: URLComponents) {
@@ -180,6 +195,7 @@ class Router: ObservableObject {
 		switch tab {
 		case .messages:
 			messagesState = nil
+			messagesSection = nil
 		case .nodes:
 			selectedNodeNum = nil
 		case .map:

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -42,9 +42,25 @@ struct Messages: View {
 		Binding(get: { self.node }, set: { self.nodeNum = $0?.num })
 	}
 
+	/// Sidebar selection binding. Reads/writes the durable, payload-free `router.messagesSection`,
+	/// so the bound value always matches a `.channels()` / `.directMessages()` row and the
+	/// collapsed `NavigationSplitView` back stack stays intact. The setter only fires on a user tap
+	/// (selecting a different section), where we also reset the detail pane so the new section
+	/// starts with nothing selected — matching the behavior of a fresh sidebar navigation.
+	private var sidebarSelection: Binding<MessagesNavigationState?> {
+		Binding(
+			get: { self.router.messagesSection },
+			set: { newValue in
+				self.router.messagesSection = newValue
+				self.channelSelection = nil
+				self.userSelection = nil
+			}
+		)
+	}
+
 	var body: some View {
 		NavigationSplitView(columnVisibility: $columnVisibility) {
-			List(selection: $router.messagesState) {
+			List(selection: sidebarSelection) {
 				NavigationLink(value: MessagesNavigationState.channels()) {
 					Spacer()
 					Label {
@@ -97,7 +113,7 @@ struct Messages: View {
 				}
 			}
 		} content: {
-			switch router.messagesState {
+			switch router.messagesSection {
 			case .channels:
 				ChannelList(node: nodeBinding, channelSelection: $channelSelection)
 					// Removed navigationTitle and navigationBarTitleDisplayMode here.
@@ -115,9 +131,9 @@ struct Messages: View {
 						ChannelMessageList(myInfo: myInfo, channel: channelSelection)
 					} else if let userSelection {
 						UserMessageList(user: userSelection)
-					} else if case .channels = router.messagesState {
+					} else if case .channels = router.messagesSection {
 						Text("Select a channel")
-					} else if case .directMessages = router.messagesState {
+					} else if case .directMessages = router.messagesSection {
 						Text("Select a conversation")
 					}
 				}
@@ -128,39 +144,66 @@ struct Messages: View {
 				}
 			}
 		}.onAppear {
-			setupNavigationState()
-		}.onChange(of: router.messagesState) {
-			setupNavigationState()
+			// Handles the deep link set by `route(url:)` before this view began observing.
+			consumeDeepLink(router.messagesState)
+		}.onChange(of: router.messagesState) { _, newValue in
+			consumeDeepLink(newValue)
+		}.onChange(of: router.messagesSection) { _, newValue in
+			// A reset (e.g. `popToRoot` on disconnect) nils the section; clear the detail pane to
+			// match. Section *changes* between .channels/.directMessages are reset by the sidebar
+			// setter and by `consumeDeepLink`, so only the nil case needs handling here.
+			if newValue == nil {
+				channelSelection = nil
+				userSelection = nil
+			}
 		}
 	}
 
-	private func setupNavigationState() {
+	private func bootstrapNodeNum() {
 		let nodeId = Int64(UserDefaults.preferredPeripheralNum)
 		if nodeId > 0 && nodeNum == nil {
 			nodeNum = nodeId
 		}
+	}
 
-		guard let state = router.messagesState else {
-			channelSelection = nil
-			userSelection = nil
-			return
-		}
+	/// Resolves a deep-link `messagesState` into the selected conversation, then clears the payload
+	/// so it's consumed exactly once. Clearing `router.messagesState` re-fires the `onChange` above
+	/// with `nil`, which this guard turns into a no-op — selections are never clobbered. If the
+	/// target can't be resolved yet (e.g. channels not loaded on a cold launch) the payload is left
+	/// in place so a later `onAppear` can retry instead of silently dropping the deep link.
+	private func consumeDeepLink(_ state: MessagesNavigationState?) {
+		bootstrapNodeNum()
+		guard let state else { return }
 
 		switch state {
 		case .channels(channelId: let channelId, messageId: _):
-			if let channelId {
-				channelSelection = node?.myInfo?.channels.first { $0.id == channelId }
-			} else {
+			router.messagesSection = .channels()
+			guard let channelId else {
 				channelSelection = nil
 				userSelection = nil
+				break
 			}
+			guard let channel = node?.myInfo?.channels.first(where: { $0.id == channelId }) else {
+				return // Not resolvable yet — keep the payload and retry on the next appear.
+			}
+			channelSelection = channel
+			// Clear the sibling DM selection so the detail pane (which prioritizes
+			// channelSelection) can't surface a stale conversation under the Channels section.
+			userSelection = nil
 		case .directMessages(userNum: let userNum, messageId: _):
+			router.messagesSection = .directMessages()
 			if let userNum {
+				// getUser always resolves (creating a placeholder if needed), so a DM deep link
+				// never needs the cold-launch retry that the channel branch does.
 				userSelection = getUser(id: userNum, context: context)
 			} else {
-				channelSelection = nil
 				userSelection = nil
 			}
+			// Clear the sibling channel selection: the detail pane prioritizes channelSelection,
+			// so a previously-open channel would otherwise mask this DM and show the wrong thread.
+			channelSelection = nil
 		}
+
+		router.messagesState = nil // Consumed — prevents a re-appear from re-resolving it.
 	}
 }

--- a/MeshtasticTests/NavigationStateTests.swift
+++ b/MeshtasticTests/NavigationStateTests.swift
@@ -94,6 +94,32 @@ struct MessagesNavigationStateTests {
 		let b = MessagesNavigationState.channels(channelId: 1)
 		#expect(a.hashValue == b.hashValue)
 	}
+
+	// MARK: sidebarSection
+
+	@Test func sidebarSection_channels_stripsPayload() {
+		// A notification deep link carries channelId/messageId; the sidebar only has a
+		// payload-free `.channels()` row, so the section must normalize to match it.
+		#expect(MessagesNavigationState.channels(channelId: 2, messageId: 5).sidebarSection == .channels())
+		#expect(MessagesNavigationState.channels(channelId: 7).sidebarSection == .channels())
+	}
+
+	@Test func sidebarSection_directMessages_stripsPayload() {
+		#expect(MessagesNavigationState.directMessages(userNum: 42, messageId: 9).sidebarSection == .directMessages())
+		#expect(MessagesNavigationState.directMessages(userNum: 13).sidebarSection == .directMessages())
+	}
+
+	@Test func sidebarSection_payloadFree_isIdentity() {
+		// A manual sidebar tap already produces a payload-free value; normalizing is a no-op.
+		#expect(MessagesNavigationState.channels().sidebarSection == .channels())
+		#expect(MessagesNavigationState.directMessages().sidebarSection == .directMessages())
+	}
+
+	@Test func sidebarSection_preservesSection() {
+		// Normalization must not cross sections (channels must never become directMessages).
+		#expect(MessagesNavigationState.channels(channelId: 1).sidebarSection != .directMessages())
+		#expect(MessagesNavigationState.directMessages(userNum: 1).sidebarSection != .channels())
+	}
 }
 
 // MARK: - MapNavigationState

--- a/MeshtasticTests/RouterDeepLinkTests.swift
+++ b/MeshtasticTests/RouterDeepLinkTests.swift
@@ -52,6 +52,60 @@ struct RouterURLRoutingTests {
 		#expect(router.messagesState == nil)
 	}
 
+	// MARK: - messagesSection (durable, payload-free sidebar selection)
+
+	@Test @MainActor func route_messages_channelId_setsPayloadFreeSection() {
+		let router = Router()
+		router.route(url: URL(string: "meshtastic:///messages?channelId=5&messageId=99")!)
+		// The deep-link payload lives on messagesState; the sidebar section is the payload-free
+		// sibling so it matches a real sidebar row.
+		#expect(router.messagesState == .channels(channelId: 5, messageId: 99))
+		#expect(router.messagesSection == .channels())
+	}
+
+	@Test @MainActor func route_messages_userNum_setsPayloadFreeSection() {
+		let router = Router()
+		router.route(url: URL(string: "meshtastic:///messages?userNum=42&messageId=7")!)
+		#expect(router.messagesState == .directMessages(userNum: 42, messageId: 7))
+		#expect(router.messagesSection == .directMessages())
+	}
+
+	@Test @MainActor func route_messages_noParams_clearsSection() {
+		let router = Router()
+		router.route(url: URL(string: "meshtastic:///messages?channelId=5")!)
+		router.route(url: URL(string: "meshtastic:///messages")!)
+		#expect(router.messagesSection == nil)
+	}
+
+	@Test @MainActor func popToRoot_messages_clearsStateAndSection() {
+		let router = Router()
+		router.route(url: URL(string: "meshtastic:///messages?channelId=5")!)
+		#expect(router.messagesSection == .channels())
+		router.popToRoot(tab: .messages)
+		#expect(router.messagesState == nil)
+		#expect(router.messagesSection == nil)
+	}
+
+	@Test @MainActor func init_derivesSectionFromMessagesState() {
+		// Restoration path: a Router built from a persisted NavigationState should expose the
+		// payload-free section immediately, before any view consumes the deep link.
+		let router = Router(navigationState: NavigationState(
+			selectedTab: .messages,
+			messages: .channels(channelId: 3, messageId: 1)
+		))
+		#expect(router.messagesState == .channels(channelId: 3, messageId: 1))
+		#expect(router.messagesSection == .channels())
+	}
+
+	@Test @MainActor func navigationState_setter_derivesSection() {
+		let router = Router()
+		router.navigationState = NavigationState(
+			selectedTab: .messages,
+			messages: .directMessages(userNum: 8)
+		)
+		#expect(router.messagesSection == .directMessages())
+	}
+
 	@Test @MainActor func route_connect() {
 		let router = Router()
 		let url = URL(string: "meshtastic:///connect")!


### PR DESCRIPTION
## What changed?

Fixes a navigation bug where tapping a message notification deep-links into the correct conversation, but tapping **back** leaves the channel list empty — you have to back out once more and re-enter Channels for the list to repopulate.

The Messages sidebar `List` bound its selection directly to `router.messagesState`. A notification deep link sets that to a payload-carrying value (e.g. `.channels(channelId: 2, messageId: 5)`), but the sidebar only offers payload-free `.channels()` / `.directMessages()` rows — so the selection matched no row and corrupted the collapsed `NavigationSplitView` back stack.

This splits the two concerns the single property was serving:

- **`messagesState`** is now a *transient deep-link command* (carries the payload), consumed exactly once by the Messages view and then cleared.
- **`messagesSection`** (new) is the *durable, payload-free* sidebar/section selection. It always matches a sidebar row, keeping the back stack intact, and it survives tab switches. `Router` derives it from each deep link via `sidebarSection`.

Consuming the payload clears `messagesState`, which re-fires `onChange` with `nil`; a guard makes that a no-op, so there's no re-entrancy and a later tab re-appear can't re-resolve the deep link and snap the user back into the notified conversation.

Two related correctness fixes came along:
- A DM notification arriving while a channel was open used to show the *channel* thread (the detail pane prioritizes `channelSelection`). Each branch now clears its sibling selection.
- A channel deep link that arrives before SwiftData has loaded the channels keeps its payload to retry on the next appear, instead of silently dropping.

## Why did it change?

Notification-driven navigation is a primary way users open conversations, and the empty-list-after-back behavior made the app feel broken. The underlying cause was one piece of state doing two incompatible jobs (sidebar selection vs. one-shot deep-link target); decoupling them removes the back-stack corruption at the source rather than papering over it.

## How is this tested?

- New `Router`-level unit tests covering `messagesSection` derivation from deep links, `popToRoot` reset, restoration via `init`, and the `navigationState` setter, plus `sidebarSection` normalization unit tests.
- Full affected suites pass locally (131 tests across `MessagesNavigationState`, `RouterURLRouting`, `RouterTests`, `NavigationStateDetailed`, `NodeNavigation`) on an iPhone 16 / iOS 18 simulator.
- Existing `messagesState` / `navigationState` round-trip tests remain green — the deep-link semantics of `messagesState` are unchanged.

## Screenshots/Videos (when applicable)

N/A — navigation plumbing; no visual change.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. This is a navigation-behavior fix with no documented-view changes — requesting the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
