### PR TITLE
fix: run relayDisplay() on the main actor, not a background queue

### DIFF
--- a/Meshtastic/Views/Messages/MessageContextMenuItems.swift
+++ b/Meshtastic/Views/Messages/MessageContextMenuItems.swift
@@ -28,12 +28,13 @@ struct MessageContextMenuItems: View {
 			Text("Channel") + Text(": \(message.channel)")
 		}
 		.onAppear {
-			DispatchQueue.global(qos: .userInitiated).async {
-				let result = message.relayDisplay()
-				DispatchQueue.main.async {
-					relayDisplay = result
-				}
-			}
+			// relayDisplay() is @MainActor and reads the shared main ModelContext plus
+			// SwiftData @Model relationships, none of which are thread-safe. The previous
+			// DispatchQueue.global hop ran it on background threads — concurrently across
+			// every visible message's context menu — which corrupted the SwiftData object
+			// graph and aborted with a double-free (SIGABRT in libmalloc). onAppear already
+			// runs on the main actor, so call it directly on the right queue.
+			relayDisplay = message.relayDisplay()
 		}
 
 		Button("Tapback") {


### PR DESCRIPTION
## What happened

Crash report from 2.7.15 (2074), iPhone 15 / iOS 18.7.8 — a **SIGABRT heap corruption** (`POINTER_BEING_FREED_WAS_NOT_ALLOCATED` / double-free in libmalloc), thrown off the main thread:

```
3  libsystem_malloc  ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
6  libswiftCore      _swift_release_dealloc
11 SwiftData         _SD_remove_faulting_backingdata_tsd
20 Meshtastic        MessageEntity.relayDisplay()              MessageEntityExtension.swift:72
21 Meshtastic        ...MessageContextMenuItems.body.getter    MessageContextMenuItems.swift:32
```

The crashing thread is a `_dispatch_worker_thread2`, and **9+ background worker threads are simultaneously inside `relayDisplay()`** → SwiftData → CoreData `performBlockAndWait` / relationship faulting.

## Root cause

`MessageContextMenuItems.onAppear` dispatched `message.relayDisplay()` onto `DispatchQueue.global`:

```swift
.onAppear {
    DispatchQueue.global(qos: .userInitiated).async {
        let result = message.relayDisplay()        // @MainActor method, background thread
        DispatchQueue.main.async { relayDisplay = result }
    }
}
```

But `relayDisplay()` is `@MainActor` and reads the **shared main `ModelContext`** (`PersistenceController.shared.context`), fetches `UserEntity`, and walks `userNode?.hopsAway` relationships. SwiftData `@Model` objects and their context are **not thread-safe / not `Sendable`**. Running this on background threads, concurrently across every visible message's context menu, corrupts the SwiftData/CoreData object graph → double-free → abort.

The `@MainActor` contract didn't stop it at compile time because the project isn't on strict concurrency, so the cross-thread call compiled.

## The fix

`onAppear` already runs on the main actor — call `relayDisplay()` directly, no queue hop:

```swift
.onAppear {
    relayDisplay = message.relayDisplay()
}
```

The context menu only builds on long-press, so the synchronous main-actor call is fine.

## Follow-up (not in this PR)

`relayDisplay()` does `FetchDescriptor<UserEntity>()` — fetches **every** user and filters in memory — on each appearance, just to map one relay byte to a name. That inefficiency is presumably why it was (unsafely) backgrounded. Worth predicating the fetch or precomputing/caching the relay name when relay info updates.

## Testing

⚠️ Could **not** build/test here — the scheme embeds a Watch app and watchOS SDK isn't installed (`unable to resolve module 'WatchKit'`), unrelated to this change. One-line behavioral change, reviewed by inspection. **Please build + run before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)