### PR TITLE
fix: snapshot device metrics in node list rows (deleted-TelemetryEntity SIGTRAP)

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -10,13 +10,16 @@ import CoreLocation
 import Foundation
 
 struct NodeListRowSummary {
-	let latestDeviceMetrics: TelemetryEntity?
-	// Snapshot the position as plain value types at construction time rather than
-	// vending the live PositionEntity. SwiftData fatally traps (SIGTRAP in
-	// _SD_get_faulting_backingdata_tsd) if a deleted @Model's persisted property is
-	// read, and position rows are pruned/replaced constantly underneath the list —
-	// so a view body holding a live PositionEntity can crash mid-render. Value-type
-	// snapshots can never fault.
+	// Snapshot the position and device metrics as plain value types at construction
+	// time rather than vending live PositionEntity/TelemetryEntity objects. SwiftData
+	// fatally traps (SIGTRAP in _SD_get_faulting_backingdata_tsd) if a deleted @Model's
+	// persisted property is read, and both position rows and telemetry history are
+	// pruned constantly underneath the list (telemetry via shouldPruneTelemetryHistory,
+	// nullify relationship — so the captured metrics row can be deleted while the node
+	// stays live). A view body holding either live object can crash mid-render; value-
+	// type snapshots can never fault.
+	let batteryLevel: Int32?
+	let hasDeviceMetrics: Bool
 	let hasPosition: Bool
 	let latestNodeCoordinate: CLLocationCoordinate2D?
 	let hasEnvironmentMetrics: Bool
@@ -29,7 +32,9 @@ struct NodeListRowSummary {
 		includePosition: Bool = true,
 		includeLogAvailability: Bool = true
 	) {
-		latestDeviceMetrics = includeDeviceMetrics ? node.latestDeviceMetrics : nil
+		let latestDeviceMetrics = includeDeviceMetrics ? node.latestDeviceMetrics : nil
+		batteryLevel = latestDeviceMetrics?.batteryLevel
+		hasDeviceMetrics = latestDeviceMetrics != nil
 		let latestPosition = includePosition ? node.latestPosition : nil
 		hasPosition = latestPosition != nil
 		latestNodeCoordinate = latestPosition?.nodeCoordinate
@@ -53,7 +58,7 @@ struct NodeListItem: View {
 		return f
 	}()
 
-	private func accessibilityDescription(cachedMetrics: TelemetryEntity?, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?) -> String {
+	private func accessibilityDescription(batteryLevel: Int32?, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?) -> String {
 		var desc = ""
 		if let shortName = node.user?.shortName {
 			desc = shortName.formatNodeNameForVoiceOver()
@@ -84,7 +89,7 @@ struct NodeListItem: View {
 		if node.hopsAway > 0 {
 			desc += ", \(node.hopsAway) hops away"
 		}
-		if let battery = cachedMetrics?.batteryLevel {
+		if let battery = batteryLevel {
 			if battery > 100 {
 				desc += ", " + "Plugged in".localized
 			} else if battery == 100 {
@@ -176,10 +181,10 @@ struct NodeListItem: View {
 	}
 
 	@ViewBuilder private var rowContent: some View {
-		let cachedMetrics = rowSummary?.latestDeviceMetrics
+		let cachedBatteryLevel = rowSummary?.batteryLevel
 		let cachedLocationData = connectedNode == node.num ? nil : locationData(for: rowSummary?.latestNodeCoordinate)
 		let cachedHasPositions = rowSummary?.hasPosition ?? false
-		let cachedHasDeviceMetrics = cachedMetrics != nil
+		let cachedHasDeviceMetrics = rowSummary?.hasDeviceMetrics ?? false
 		let cachedHasEnvironmentMetrics = rowSummary?.hasEnvironmentMetrics ?? false
 		let cachedHasDetectionSensorMetrics = rowSummary?.hasDetectionSensorMetrics ?? false
 		let cachedHasTraceRoutes = rowSummary?.hasTraceRoutes ?? false
@@ -194,7 +199,7 @@ struct NodeListItem: View {
 				VStack(alignment: .center) {
 					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 70)
 						.padding(.trailing, 5)
-					if let batteryLevel = cachedMetrics?.batteryLevel {
+					if let batteryLevel = cachedBatteryLevel {
 						BatteryCompact(batteryLevel: batteryLevel, font: .caption, iconFont: .callout, color: .accentColor)
 							.padding(.trailing, 5)
 					}
@@ -316,7 +321,7 @@ struct NodeListItem: View {
 			}
 		}
 		.accessibilityElement(children: .ignore)
-		.accessibilityLabel(accessibilityDescription(cachedMetrics: cachedMetrics, cachedLocationData: cachedLocationData))
+		.accessibilityLabel(accessibilityDescription(batteryLevel: cachedBatteryLevel, cachedLocationData: cachedLocationData))
 	}
 }
 

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -39,7 +39,7 @@ struct NodeListItemCompact: View {
 		return f
 	}()
 
-	private func accessibilityDescription(cachedMetrics: TelemetryEntity?, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?) -> String {
+	private func accessibilityDescription(batteryLevel: Int32?, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?) -> String {
 		var desc = ""
 		if let shortName = node.user?.shortName {
 			desc = shortName.formatNodeNameForVoiceOver()
@@ -70,7 +70,7 @@ struct NodeListItemCompact: View {
 		if node.hopsAway > 0 {
 			desc += ", \(node.hopsAway) hops away"
 		}
-		if let battery = cachedMetrics?.batteryLevel {
+		if let battery = batteryLevel {
 			if battery > 100 {
 				desc += ", " + "Plugged in".localized
 			} else if battery == 100 {
@@ -176,12 +176,12 @@ struct NodeListItemCompact: View {
 
 	@ViewBuilder private var rowContent: some View {
 		let circleSize = max(minCircle, min(maxCircle, baseUnit * CGFloat(lineNums)))
-		let cachedMetrics = (shouldShowPower || shouldShowTelemetry) ? rowSummary?.latestDeviceMetrics : nil
+		let cachedBatteryLevel = (shouldShowPower || shouldShowTelemetry) ? rowSummary?.batteryLevel : nil
 		let needsLatestPosition = shouldShowTelemetry || (shouldShowLocation && connectedNode != node.num)
 		let cachedLatestNodeCoordinate = needsLatestPosition ? rowSummary?.latestNodeCoordinate : nil
 		let cachedLocationData = (shouldShowLocation && connectedNode != node.num) ? locationData(for: cachedLatestNodeCoordinate) : nil
 		let cachedHasPositions = shouldShowTelemetry ? (rowSummary?.hasPosition ?? false) : false
-		let cachedHasDeviceMetrics = shouldShowTelemetry && cachedMetrics != nil
+		let cachedHasDeviceMetrics = shouldShowTelemetry && (rowSummary?.hasDeviceMetrics ?? false)
 		let cachedHasEnvironmentMetrics = shouldShowTelemetry ? rowSummary?.hasEnvironmentMetrics ?? false : false
 		let cachedHasDetectionSensorMetrics = shouldShowTelemetry ? rowSummary?.hasDetectionSensorMetrics ?? false : false
 		let cachedHasTraceRoutes = shouldShowTelemetry ? rowSummary?.hasTraceRoutes ?? false : false
@@ -194,7 +194,7 @@ struct NodeListItemCompact: View {
 				VStack(alignment: .center) {
 					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: circleSize)
 						.padding(.trailing, 5)
-					if shouldShowPower, let batteryLevel = cachedMetrics?.batteryLevel {
+					if shouldShowPower, let batteryLevel = cachedBatteryLevel {
 						BatteryCompact(batteryLevel: batteryLevel, font: .caption2, iconFont: .caption, color: .accentColor)
 							.padding(.trailing, 5)
 					}
@@ -310,7 +310,7 @@ struct NodeListItemCompact: View {
 				}
 			}
 			.accessibilityElement(children: .ignore)
-			.accessibilityLabel(accessibilityDescription(cachedMetrics: cachedMetrics, cachedLocationData: cachedLocationData))
+			.accessibilityLabel(accessibilityDescription(batteryLevel: cachedBatteryLevel, cachedLocationData: cachedLocationData))
 	}
 }
 


### PR DESCRIPTION
## Follow-up to #1991 — the missing half

#1991 was squash-merged from its first commit only (the position snapshot + node-liveness guard); the device-metrics snapshot commit was pushed but never got associated with the PR before merge, so it was lost. This PR restores it.

## What happened

Crash report from 2.7.15 (2074), iPhone 13 Pro / iOS 26.5 — the same `_SD_get_faulting_backingdata_tsd` SIGTRAP family as #1991, but in `NodeListItemCompact.body` (lines 179/180/182):

```
0  _assertionFailure
4  SwiftData  _SD_get_faulting_backingdata_tsd
5  closure #1 ... in NodeListItemCompact.body.getter
...
17 NodeListItemCompact.body.getter   NodeListItemCompact.swift:179
```

The first-column block there reads `cachedMetrics?.batteryLevel`, where `cachedMetrics` is a **live `TelemetryEntity`** captured in `NodeListRowSummary` (`latestDeviceMetrics`).

## Why #1991 didn't cover it

#1991 snapshots positions and guards against a deleted *node*. But **telemetry history is pruned independently of the node** — `MeshPackets.shouldPruneTelemetryHistory`, `UpdateSwiftData` deleting `node.telemetries`, and the node↔telemetry `@Relationship(deleteRule: .nullify)`. So the captured metrics row can be deleted while the node stays live; the node-liveness guard passes, and reading `cachedMetrics?.batteryLevel` on the deleted row faults.

## The fix

Snapshot the only telemetry field the rows actually read — `batteryLevel: Int32?` — plus `hasDeviceMetrics: Bool`, at `@MainActor` construction time, exactly mirroring the position snapshot. Neither `NodeListItem` nor `NodeListItemCompact` now holds a faultable `TelemetryEntity`.

## Testing

⚠️ Could **not** build/test here — scheme embeds a Watch app and watchOS SDK isn't installed (`unable to resolve module 'WatchKit'`), unrelated to this change. Reviewed by inspection. **Please build + run before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)