### PR TITLE
fix: render MultiPoint GeoJSON markers on the mesh map

### DIFF
--- a/Meshtastic/Helpers/GeoJSONOverlayConfig.swift
+++ b/Meshtastic/Helpers/GeoJSONOverlayConfig.swift
@@ -165,6 +165,19 @@ struct GeoJSONFeature: Codable {
 		default: return 4.0
 		}
 	}
+
+	/// Coordinates to draw as map markers. A Point yields one coordinate; a MultiPoint yields
+	/// one per sub-coordinate. Empty for every other geometry type (those render as overlays).
+	var markerCoordinates: [CLLocationCoordinate2D] {
+		switch geometry.type.lowercased() {
+		case "point":
+			return geometry.coordinates.toCoordinate().map { [$0] } ?? []
+		case "multipoint":
+			return geometry.coordinates.toCoordinates()
+		default:
+			return []
+		}
+	}
 }
 
 // MARK: - Styled Feature Wrapper
@@ -353,5 +366,12 @@ enum AnyCodableValue: Codable {
 			return CLLocationCoordinate2D(latitude: lat, longitude: lon)
 		}
 		return nil
+	}
+
+	/// Convert a MultiPoint-style array of [lon, lat] pairs to coordinates.
+	/// Malformed entries are skipped rather than failing the whole set.
+	func toCoordinates() -> [CLLocationCoordinate2D] {
+		guard case .array(let items) = self else { return [] }
+		return items.compactMap { $0.toCoordinate() }
 	}
 }

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -668,18 +668,21 @@ struct MeshMapMK: View {
 										)
 										if let overlay = styled.createOverlay() {
 											overlays.append(ClusterMapOverlay(id: "geojson-\(styled.id)", overlay: overlay, style: style))
-										} else if let coordinate = styled.feature.geometry.coordinates.toCoordinate() {
+										} else {
+											// Point yields one marker; MultiPoint yields one per sub-coordinate.
 											let radius = styled.feature.markerRadius
-											decorations.append(ClusterMapDecoration(
-												id: "geojson-pt-\(styled.id)",
-												coordinate: coordinate,
-												content: AnyView(
-													Circle()
-														.fill(styled.fillColor)
-														.overlay(Circle().stroke(styled.strokeColor, style: stroke))
-														.frame(width: radius * 2, height: radius * 2)
-												)
-											))
+											for (index, coordinate) in styled.feature.markerCoordinates.enumerated() {
+												decorations.append(ClusterMapDecoration(
+													id: "geojson-pt-\(styled.id)-\(index)",
+													coordinate: coordinate,
+													content: AnyView(
+														Circle()
+															.fill(styled.fillColor)
+															.overlay(Circle().stroke(styled.strokeColor, style: stroke))
+															.frame(width: radius * 2, height: radius * 2)
+													)
+												))
+											}
 										}
 									}
 									geoJSONOverlays = overlays


### PR DESCRIPTION
## What does this PR do?

Fixes **MultiPoint** GeoJSON markers on the mesh map. The MKMapView GeoJSON path (`MeshMapMK.rebuildGeoJSONOverlays`) only drew a marker when `AnyCodableValue.toCoordinate()` returned a single coordinate. A `MultiPoint` geometry stores a nested array (`[[lon,lat], …]`), so `toCoordinate()` returns `nil` and **no markers were rendered at all**.

### Changes
- **`GeoJSONFeature.markerCoordinates`** — one coordinate for `Point`, one per sub-coordinate for `MultiPoint`, empty for everything else (those render as overlays).
- **`AnyCodableValue.toCoordinates()`** — decodes a MultiPoint-style array of `[lon, lat]` pairs, skipping malformed entries.
- **`MeshMapMK.rebuildGeoJSONOverlays`** — emits one `ClusterMapDecoration` per coordinate (unique id `geojson-pt-<id>-<index>`).

### Context
`MultiPolygon` / `MultiLineString` already render correctly via `MKGeoJSONDecoder` (→ `MKMultiPolygon` / `MKMultiPolyline`) and the `ClusterMapView` multi-geometry renderers. This closes the one remaining geometry gap that #1987 set out to fix. #1987 itself was superseded by the MKMapView migration in #1989 — it patched the now-removed SwiftUI `MeshMapContent` renderer — and is being closed in favor of this.

### Testing
`swiftc -parse` is clean and braces balance. A focused unit test for `markerCoordinates` / `toCoordinates()` is a good follow-up but is intentionally omitted here: `MeshtasticTests` files must be registered in `project.pbxproj` (it isn't a synchronized group), which can't be safely verified without a local Xcode build.
