### PR TITLE
fix(map): keep the camera stable under heavy node load

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
@@ -79,6 +79,23 @@ struct ClusterMapDecoration: Identifiable {
 	var onTap: (() -> Void)?
 }
 
+// MARK: - One-shot camera command
+
+/// A one-shot programmatic camera move. The wrapper applies each distinct command EXACTLY ONCE
+/// (tracked by `id` in the coordinator), so re-renders never re-apply it and streaming data can't
+/// yank the camera out from under the user. Use this — not the continuous `region` binding — to
+/// drive the camera (e.g. the initial framing). After the command fires, the user owns the camera
+/// and we never push the region back in.
+struct ClusterMapCameraCommand: Equatable {
+	let id: UUID
+	let region: MKCoordinateRegion
+	var animated: Bool = false
+
+	static func == (lhs: ClusterMapCameraCommand, rhs: ClusterMapCameraCommand) -> Bool {
+		lhs.id == rhs.id
+	}
+}
+
 // MARK: - Public declarative API
 
 /// A data-driven map. Pass your `items` and a `@ViewBuilder` that turns one item into its annotation
@@ -99,9 +116,13 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 	let items: [Item]
 	/// Per-item coordinate. A closure (not a key-path constraint) so items model location freely.
 	let coordinate: (Item) -> CLLocationCoordinate2D
-	/// Two-way camera binding. A `nil` wrapped value means "don't drive the camera"; supply a real
-	/// binding to read the user's pans/zooms back out AND to push programmatic region changes in.
+	/// Camera WRITE-BACK binding (map → SwiftUI). Supply a real binding to read the user's pans/zooms
+	/// back out (e.g. to filter visible content). We never push this value back INTO the map — that's
+	/// what `cameraCommand` is for — so high-frequency data updates can't fight the user's gestures.
 	let region: Binding<MKCoordinateRegion?>?
+	/// One-shot programmatic camera move (e.g. the initial frame), applied exactly once per distinct
+	/// id. The ONLY thing that moves the camera programmatically; after it fires the user is in control.
+	let cameraCommand: ClusterMapCameraCommand?
 	/// When true, annotations share a `clusteringIdentifier` so MapKit collapses nearby pins.
 	let clustering: Bool
 	/// Builds the SwiftUI view for one item's pin.
@@ -130,6 +151,7 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		items: [Item],
 		coordinate: @escaping (Item) -> CLLocationCoordinate2D,
 		region: Binding<MKCoordinateRegion?>? = nil,
+		cameraCommand: ClusterMapCameraCommand? = nil,
 		clustering: Bool = true,
 		onSelect: ((Item) -> Void)? = nil,
 		configuration: ClusterMapConfiguration = .init(),
@@ -144,6 +166,7 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		self.items = items
 		self.coordinate = coordinate
 		self.region = region
+		self.cameraCommand = cameraCommand
 		self.clustering = clustering
 		self.onSelect = onSelect
 		self.configuration = configuration
@@ -196,10 +219,12 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		context.coordinator.syncCoverage(areas: coverageAreas, dark: colorScheme == .dark, on: mapView)
 		context.coordinator.syncDecorations(decorations, on: mapView)
 
-		// Initial camera, if the caller drives one. Guarded so we don't echo it back out.
-		if let region = region?.wrappedValue {
+		// Initial camera, if a one-shot command is already pending at creation. Guarded so we don't
+		// echo it back out. (The continuous `region` binding is never pushed INTO the map.)
+		if let command = cameraCommand {
+			context.coordinator.appliedCameraCommandID = command.id
 			context.coordinator.isApplyingExternalRegion = true
-			mapView.setRegion(region, animated: false)
+			mapView.setRegion(command.region, animated: false)
 			context.coordinator.isApplyingExternalRegion = false
 		}
 
@@ -229,13 +254,15 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		context.coordinator.sync(items: items, coordinate: coordinate,
 								 clustering: clustering, on: mapView)
 
-		// 3) Push an external region change in — but never while the user is driving the map, and
-		//    skip no-op writes. That's the feedback-loop guard (see Coordinator).
-		if let region = region?.wrappedValue,
-		   !context.coordinator.isUpdatingRegionFromMap,
-		   !context.coordinator.regionsApproximatelyEqual(mapView.region, region) {
+		// 3) Apply a one-shot camera command (e.g. the initial frame) EXACTLY ONCE. We deliberately
+		//    do NOT push the `region` binding back into the map: under heavy traffic the data churns
+		//    every frame, and a reactive setRegion would fight the user's pan/zoom and "re-frame" the
+		//    map constantly. After the initial command fires, the user owns the camera.
+		if let command = cameraCommand,
+		   context.coordinator.appliedCameraCommandID != command.id {
+			context.coordinator.appliedCameraCommandID = command.id
 			context.coordinator.isApplyingExternalRegion = true
-			mapView.setRegion(region, animated: true)
+			mapView.setRegion(command.region, animated: command.animated)
 			// Cleared in regionDidChangeAnimated; also clear async in case no event fires.
 			DispatchQueue.main.async { context.coordinator.isApplyingExternalRegion = false }
 		}
@@ -305,6 +332,9 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		/// True for the duration of a user-driven region write-back (so an interleaved update won't
 		/// fight the gesture by re-applying the binding mid-pan).
 		var isUpdatingRegionFromMap = false
+		/// id of the last `ClusterMapCameraCommand` we applied, so each command moves the camera once
+		/// and re-renders never re-apply it (the guard that keeps streaming data off the camera).
+		var appliedCameraCommandID: UUID?
 
 		/// Shared clustering identifier — all clustered item annotations use the same one so MapKit
 		/// groups them. (Computed, not stored: the Coordinator is nested in the generic
@@ -750,6 +780,7 @@ extension ClusterMapView where Cluster == ClusterBadge {
 		items: [Item],
 		coordinate: @escaping (Item) -> CLLocationCoordinate2D,
 		region: Binding<MKCoordinateRegion?>? = nil,
+		cameraCommand: ClusterMapCameraCommand? = nil,
 		clustering: Bool = true,
 		onSelect: ((Item) -> Void)? = nil,
 		configuration: ClusterMapConfiguration = .init(),
@@ -763,6 +794,7 @@ extension ClusterMapView where Cluster == ClusterBadge {
 		self.init(items: items,
 				  coordinate: coordinate,
 				  region: region,
+				  cameraCommand: cameraCommand,
 				  clustering: clustering,
 				  onSelect: onSelect,
 				  configuration: configuration,

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -57,6 +57,10 @@ struct MeshMapMK: View {
 	@State private var spreadOverrides: [Int64: CLLocationCoordinate2D] = [:]
 	/// Guards the one-time initial camera framing (GPS-centered, zoomed out, ~100 miles max).
 	@State private var didInitialFrame = false
+	/// One-shot camera move fed to the map. Set ONCE by the initial framing; after that the user
+	/// drives the camera and we never move it programmatically, so a flood of incoming positions
+	/// can't re-frame the map mid-gesture.
+	@State private var cameraCommand: ClusterMapCameraCommand?
 	/// Offline basemap rendered as native MKOverlays (slate/cream vector content) -- matches the old
 	/// SwiftUI map's look and aligns the coverage border/label exactly (no tile-grid mismatch).
 	@StateObject private var offlineVectors = OfflineVectorTileProvider()
@@ -228,6 +232,7 @@ struct MeshMapMK: View {
 				items: visiblePositionSnapshots,
 				coordinate: { spreadOverrides[$0.nodeNum] ?? $0.coordinate },
 				region: $visibleRegion,
+				cameraCommand: cameraCommand,
 				clustering: enableMapClustering,
 				onSelect: { snapshot in selectedWaypoint = nil; editingWaypoint = nil; selectedNode = MeshMapSelectedNode(id: snapshot.nodeNum) },
 				configuration: clusterConfiguration,
@@ -546,9 +551,10 @@ struct MeshMapMK: View {
 
 	/// One-time initial camera framing. Centers on the phone's GPS (else the connected device's GPS,
 	/// else the node centroid) and zooms out to fit nearby nodes -- capped at ~100 miles so we "start
-	/// zoomed out but local." After it fires once the user drives the camera; we never re-frame.
+	/// zoomed out but local." After it fires once the user drives the camera; we never re-frame, even
+	/// as positions pour in.
 	private func frameInitialRegionIfNeeded() {
-		guard !didInitialFrame, visibleRegion == nil else { return }
+		guard !didInitialFrame else { return }
 		let nodeCoords = allLatestPositions.compactMap { $0.nodeCoordinate ?? $0.fuzzedNodeCoordinate }
 		guard let center = LocationsHandler.currentLocation ?? activeDeviceCoordinate ?? coordinateCentroid(of: nodeCoords) else {
 			return // No GPS and no nodes yet -- try again on the next refresh.
@@ -563,10 +569,14 @@ struct MeshMapMK: View {
 		let latDelta = min(max(maxLat * 2.5, minSpan), maxSpan)
 		let lonDelta = min(max(maxLon * 2.5, minSpan), maxSpan)
 		didInitialFrame = true
-		visibleRegion = MKCoordinateRegion(
+		let region = MKCoordinateRegion(
 			center: center,
 			span: MKCoordinateSpan(latitudeDelta: latDelta, longitudeDelta: lonDelta)
 		)
+		// Seed `visibleRegion` so content filtering reflects the frame immediately, and emit the
+		// one-shot command that actually moves the map (the only programmatic camera move we make).
+		visibleRegion = region
+		cameraCommand = ClusterMapCameraCommand(id: UUID(), region: region)
 	}
 
 	/// Average of a coordinate list (nil when empty).

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -718,6 +718,21 @@ private struct RegionInfo {
 			self.init(freqStart: 917.0, freqEnd: 921.0)
 		case .euN868:
 			self.init(freqStart: 869.4, freqEnd: 869.65)
+		case .itu32M:
+			// ITU Region 3 Amateur Radio 2m band.
+			self.init(freqStart: 144.0, freqEnd: 148.0)
+		case .itu170Cm:
+			// ITU Region 1 Amateur Radio 70cm band.
+			self.init(freqStart: 430.0, freqEnd: 440.0)
+		case .itu270Cm:
+			// ITU Region 2 Amateur Radio 70cm band.
+			self.init(freqStart: 420.0, freqEnd: 450.0)
+		case .itu370Cm:
+			// ITU Region 3 Amateur Radio 70cm band.
+			self.init(freqStart: 430.0, freqEnd: 450.0)
+		case .itu2125Cm:
+			// ITU Region 2 Amateur Radio 1.25m (125cm) band.
+			self.init(freqStart: 220.0, freqEnd: 225.0)
 		}
 	}
 
@@ -748,6 +763,8 @@ private extension ModemPresets {
 			return 0.125
 		case .narrowFast, .narrowSlow:
 			return 0.0625
+		case .tinyFast, .tinySlow:
+			return 0.020
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The Map tab becomes unusable under event-scale traffic (e.g. DEFCON replays). As positions stream in, the camera repeatedly "re-frames" itself and fights the user's pan/zoom, so you can't hold a view or work with clusters.

### Root cause

The camera was driven by a two-way region binding. In `updateUIView`, every render where the live map region differed from the binding pushed `setRegion(animated: true)`:

```swift
if let region = region?.wrappedValue,
   !isUpdatingRegionFromMap,
   !regionsApproximatelyEqual(mapView.region, region) {
    mapView.setRegion(region, animated: true)
}
```

Under heavy load the `@Query` latest-positions set churns nearly every frame → constant re-renders → `updateUIView` fires constantly. While the user is mid-gesture the live map has moved but the binding still holds the last settled value, the equality guard fails, and `setRegion(animated:)` yanks the map back. The `isUpdatingRegionFromMap` guard only covered the synchronous write-back, not the whole gesture, leaving a window every frame.

## Fix — make the camera one-way

- Add `ClusterMapCameraCommand`: a one-shot programmatic move applied **exactly once** per `id` (tracked in the coordinator), so re-renders can never re-apply it.
- Drop the reactive region push in `updateUIView`. The `region` binding is now **write-back only** (map → SwiftUI) and is read solely to filter the visible positions — never pushed back into the map.
- `frameInitialRegionIfNeeded()` emits a single command for the initial GPS / connected-device / centroid frame (still capped at ~100 mi). After that the user fully owns the camera; streaming positions cannot move it.

Net behavior: the map frames once on the local mesh, then stays put. Pan, zoom, and cluster expansion all behave normally as nodes pour in.

## Incidental build fix

This branch also wouldn't compile due to a **pre-existing** non-exhaustive `switch` in `Channels.swift` (the protobuf `RegionCodes`/`ModemPresets` enums gained cases the switches predate). Added the real missing cases:

- Regions: `itu32M`, `itu170Cm`, `itu270Cm`, `itu370Cm`, `itu2125Cm` — frequencies taken from the protobuf definitions (2 m / 70 cm / 1.25 m amateur bands).
- Modem presets: `tinyFast` / `tinySlow` → 20 kHz bandwidth.

Left as explicit cases (no `@unknown default`) so future upstream additions still fail the build deliberately.

## Testing

- `xcodebuild -scheme Meshtastic -destination 'platform=macOS,variant=Mac Catalyst'` → **BUILD SUCCEEDED**.
- Manual: connect via TCP to a replay source and load high-volume databases; confirm the map frames once (~100 mi local) then holds while pins/clusters stream in.