### PR TITLE
fix(channels): don't report QR channel-set save as failed after device reboot (#2010)

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		DD00003ASUPPORTLVL0000001 /* SupportLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */; };
 		DD00003C000SNAP00000001 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DD00003B000SNAP00000000 /* SnapshotTesting */; };
 		DD0000DEVLNKTST000000001 /* DeviceLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */; };
+		DD0000CHSETST0000000001 /* ChannelSetSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000CHSETST0000000000 /* ChannelSetSaveTests.swift */; };
 		DD007BAE2AA4E91200F5FA12 /* MyInfoEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD007BAD2AA4E91200F5FA12 /* MyInfoEntityExtension.swift */; };
 		DD007BB02AA5981000F5FA12 /* NodeInfoEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD007BAF2AA5981000F5FA12 /* NodeInfoEntityExtension.swift */; };
 		DD09240001E7FAD600E70001 /* MapLegend.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD09240002E7FAD600E70001 /* MapLegend.swift */; };
@@ -881,6 +882,7 @@
 		DD000031FWEDTENUM0000000 /* FirmwareEditionEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareEditionEnum.swift; sourceTree = "<group>"; };
 		DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportLevel.swift; sourceTree = "<group>"; };
 		DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLinkTests.swift; sourceTree = "<group>"; };
+		DD0000CHSETST0000000000 /* ChannelSetSaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSetSaveTests.swift; sourceTree = "<group>"; };
 		DD007BAD2AA4E91200F5FA12 /* MyInfoEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoEntityExtension.swift; sourceTree = "<group>"; };
 		DD007BAF2AA5981000F5FA12 /* NodeInfoEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeInfoEntityExtension.swift; sourceTree = "<group>"; };
 		DD04804A2E9295A5005F946C /* MeshtasticDataModelV 55.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 55.xcdatamodel"; sourceTree = "<group>"; };
@@ -1610,6 +1612,7 @@
 				AA009MCT0000001000000001 /* MarkdownConverterTests.swift */,
 				AA003DOC0000001000000008 /* DocTranslationTests.swift */,
 				DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */,
+				DD0000CHSETST0000000000 /* ChannelSetSaveTests.swift */,
 			);
 			path = MeshtasticTests;
 			sourceTree = "<group>";
@@ -2646,6 +2649,7 @@
 				AA003DOC0000002000000005 /* DocBundleTests.swift in Sources */,
 				AA003DOC0000002000000008 /* DocTranslationTests.swift in Sources */,
 				DD0000DEVLNKTST000000001 /* DeviceLinkTests.swift in Sources */,
+				DD0000CHSETST0000000001 /* ChannelSetSaveTests.swift in Sources */,
 				AA009MCT0000002000000001 /* MarkdownConverterTests.swift in Sources */,
 				AA0001012E2730EC00600001 /* ConnectViewTests.swift in Sources */,
 				DD9C70102E9F2A0000029299 /* DeviceOnboardingTests.swift in Sources */,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -447,14 +447,16 @@ extension AccessoryManager {
 			Logger.services.error("Error while sending saveChannelSet request.  No active device.")
 			throw AccessoryError.ioFailed("No active device")
 		}
-		// Before we get started delete the existing channels from the myNodeInfo
-		if !addChannels {
-			tryClearExistingChannels()
-		}
-
 		let decodedString = base64UrlString.base64urlToBase64()
 		if let decodedData = Data(base64Encoded: decodedString) {
 			let channelSet: ChannelSet = try ChannelSet(serializedBytes: decodedData)
+
+			// Only clear the existing channels once we have a valid channel set to
+			// replace them with — a malformed link must not wipe local channels while
+			// leaving the device untouched (which would read as a silent success).
+			if !addChannels {
+				tryClearExistingChannels()
+			}
 
 			var myInfo: MyInfoEntity!
 			var i: Int32 = 0
@@ -527,60 +529,53 @@ extension AccessoryManager {
 				try await send(toRadio, debugDescription: logString)
 				await MeshPackets.shared.channelPacket(channel: chan, fromNum: self.activeDeviceNum ?? 0)
 			}
-			if !addChannels {
+			// Replacing channels also replaces the LoRa config, but only when the
+			// channel set actually carries one. Pushing a default-initialized
+			// LoRaConfig (region UNSET) would knock the radio off its frequency.
+			let didSendLoRaConfig = !addChannels && channelSet.hasLoraConfig
+			if didSendLoRaConfig {
 				// Save the LoRa Config and the device will reboot
 				var adminPacket = AdminMessage()
 				adminPacket.setConfig.lora = channelSet.loraConfig
 				adminPacket.setConfig.lora.configOkToMqtt = okToMQTT // Preserve users okToMQTT choice
-				var meshPacket: MeshPacket = MeshPacket()
+				var meshPacket = MeshPacket()
 				meshPacket.to = UInt32(deviceNum)
-				meshPacket.from	= UInt32(deviceNum)
+				meshPacket.from = UInt32(deviceNum)
 				meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
-				meshPacket.priority =  MeshPacket.Priority.reliable
+				meshPacket.priority = MeshPacket.Priority.reliable
 				meshPacket.wantAck = true
 				meshPacket.channel = 0
-				var dataMessage = DataMessage()
-				guard let adminData: Data = try? adminPacket.serializedData() else {
-					throw AccessoryError.ioFailed("sendReboot: Unable to serialize Admin packet")
+				guard let adminData = try? adminPacket.serializedData() else {
+					throw AccessoryError.ioFailed("saveChannelSet: Unable to serialize LoRa Config packet")
 				}
+				var dataMessage = DataMessage()
 				dataMessage.payload = adminData
 				dataMessage.portnum = PortNum.adminApp
 				meshPacket.decoded = dataMessage
-				var toRadio: ToRadio!
-				toRadio = ToRadio()
+				var toRadio = ToRadio()
 				toRadio.packet = meshPacket
-				
+
 				let logString = String.localizedStringWithFormat("Sent a LoRa.Config for: %@".localized, String(deviceNum))
 				try await send(toRadio, debugDescription: logString)
 			}
-			if !addChannels {
-				// Save the LoRa Config and the device will reboot
-				var adminPacket = AdminMessage()
-				adminPacket.setConfig.lora = channelSet.loraConfig
-				adminPacket.setConfig.lora.configOkToMqtt = okToMQTT // Preserve users okToMQTT choice
-				var meshPacket: MeshPacket = MeshPacket()
-				meshPacket.to = UInt32(deviceNum)
-				meshPacket.from	= UInt32(deviceNum)
-				meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
-				meshPacket.priority =  MeshPacket.Priority.reliable
-				meshPacket.wantAck = true
-				meshPacket.channel = 0
-				var dataMessage = DataMessage()
-				guard let adminData: Data = try? adminPacket.serializedData() else {
-					throw AccessoryError.ioFailed("sendReboot: Unable to serialize Admin packet")
+
+			// Re-sync after the change. When we sent a LoRa config the device reboots
+			// and the connection drops, so the follow-up wantConfig is expected to fail
+			// — treat that as success since the channels/config were already delivered.
+			// When no reboot is expected, let wantConfig errors surface normally.
+			if didSendLoRaConfig {
+				do {
+					Logger.transport.debug("[AccessoryManager] sending wantConfig after channel set (device may reboot)")
+					try await sendWantConfig()
+				} catch {
+					Logger.transport.warning("[AccessoryManager] wantConfig after channel set did not complete; device is likely rebooting: \(error.localizedDescription, privacy: .public)")
 				}
-				dataMessage.payload = adminData
-				dataMessage.portnum = PortNum.adminApp
-				meshPacket.decoded = dataMessage
-				var toRadio: ToRadio!
-				toRadio = ToRadio()
-				toRadio.packet = meshPacket
-				
-				let logString = String.localizedStringWithFormat("Sent a LoRa.Config for: %@".localized, String(deviceNum))
-				try await send(toRadio, debugDescription: logString)
+			} else {
+				Logger.transport.debug("[AccessoryManager] sending wantConfig for saveChannelSet")
+				try await sendWantConfig()
 			}
-			Logger.transport.debug("[AccessoryManager] sending wantConfig for saveChannelSet")
-			try await sendWantConfig()
+		} else {
+			throw AccessoryError.appError("Invalid channel set data")
 		}
 	}
 

--- a/MeshtasticTests/ChannelSetSaveTests.swift
+++ b/MeshtasticTests/ChannelSetSaveTests.swift
@@ -1,0 +1,158 @@
+//
+//  ChannelSetSaveTests.swift
+//  MeshtasticTests
+//
+//  Regression coverage for issue #2010: applying a QR-generated channel set that
+//  makes substantial LoRa changes reboots the device and drops the connection.
+//  The save must NOT surface that expected disconnect as "Failed to save channel
+//  configuration", and the LoRa config must be transmitted exactly once (the
+//  duplicate send block introduced in #1682).
+//
+
+import Testing
+import Foundation
+@testable import Meshtastic
+import MeshtasticProtobufs
+
+/// Minimal in-memory `Connection` that drives `AccessoryManager.saveChannelSet`
+/// without any real BLE/TCP transport.
+///
+/// It models the real failure window: the radio accepts the channel and LoRa
+/// packets, then reboots after the substantial LoRa change. By the time the app
+/// follows up with its `wantConfig`, the link is gone — so this mock throws on
+/// the `wantConfig` send to reproduce the post-reboot disconnect.
+actor MockChannelSetConnection: Connection {
+	let type: TransportType = .ble
+	var isConnected: Bool = true
+
+	/// Every `ToRadio` handed to the transport, in send order.
+	private(set) var sentPackets: [ToRadio] = []
+
+	/// Number of `setConfig.lora` admin packets actually transmitted.
+	var loraConfigSendCount: Int {
+		sentPackets.reduce(into: 0) { count, toRadio in
+			guard case let .packet(meshPacket) = toRadio.payloadVariant,
+				  case let .decoded(dataMessage) = meshPacket.payloadVariant,
+				  let admin = try? AdminMessage(serializedBytes: dataMessage.payload),
+				  case let .setConfig(config) = admin.payloadVariant,
+				  case .lora = config.payloadVariant else { return }
+			count += 1
+		}
+	}
+
+	func send(_ data: ToRadio) async throws {
+		sentPackets.append(data)
+		if case .wantConfigID = data.payloadVariant {
+			// The device rebooted after the LoRa config change; the link is gone.
+			isConnected = false
+			throw AccessoryError.connectionFailed("Simulated reboot disconnect")
+		}
+	}
+
+	func connect() async throws -> AsyncStream<ConnectionEvent> {
+		AsyncStream { $0.finish() }
+	}
+	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {}
+	func drainPendingPackets() async throws {}
+	func startDrainPendingPackets() throws {}
+	func appDidEnterBackground() {}
+	func appDidBecomeActive() {}
+}
+
+@MainActor
+@Suite("Channel Set Save (issue #2010)")
+struct ChannelSetSaveTests {
+
+	/// Builds a base64url ChannelSet string carrying one channel and, by default, a
+	/// reboot-worthy LoRa config — the shape produced by a real "local mesh" QR code.
+	/// Pass `includeLoRaConfig: false` for a channels-only share link.
+	private func makeChannelSetLink(includeLoRaConfig: Bool = true) throws -> String {
+		var primary = ChannelSettings()
+		primary.name = "TestNet"
+
+		var channelSet = ChannelSet()
+		channelSet.settings = [primary]
+
+		if includeLoRaConfig {
+			var lora = Config.LoRaConfig()
+			lora.usePreset = true
+			lora.region = .us
+			lora.modemPreset = .longFast
+			lora.hopLimit = 3
+			channelSet.loraConfig = lora
+		}
+
+		let data = try channelSet.serializedData()
+		return data.base64EncodedString().base64ToBase64url()
+	}
+
+	private func makeManager(connection: MockChannelSetConnection) -> AccessoryManager {
+		let manager = AccessoryManager(transports: [])
+		let device = Device(
+			id: UUID(),
+			name: "Test RAK4631",
+			transportType: .ble,
+			identifier: "test-rak4631",
+			connectionState: .connected,
+			num: 123_456_789
+		)
+		manager.activeConnection = (device: device, connection: connection)
+		return manager
+	}
+
+	@Test("Saving a QR channel set survives the post-reboot disconnect without erroring")
+	func testSaveSurvivesRebootDisconnect() async throws {
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection)
+		let link = try makeChannelSetLink()
+
+		// Regression for #2010: the device reboots after the LoRa config change and the
+		// connection drops; the follow-up wantConfig failure must NOT bubble up as a save
+		// failure. Before the fix this threw, surfacing "Failed to save channel configuration"
+		// even though the config had already been delivered.
+		try await manager.saveChannelSet(base64UrlString: link, addChannels: false, okToMQTT: false)
+	}
+
+	@Test("LoRa config is transmitted exactly once during a replace-all channel save")
+	func testLoRaConfigSentExactlyOnce() async throws {
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection)
+		let link = try makeChannelSetLink()
+
+		try await manager.saveChannelSet(base64UrlString: link, addChannels: false, okToMQTT: false)
+
+		// Regression for the duplicated LoRa send block (#1682): the config must be sent once.
+		let count = await connection.loraConfigSendCount
+		#expect(count == 1)
+	}
+
+	@Test("A malformed channel-set link throws instead of silently succeeding")
+	func testMalformedLinkThrows() async throws {
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection)
+
+		// Regression: before the fix, an undecodable link cleared local channels and
+		// returned success without ever contacting the device. It must now throw, and
+		// nothing should have been put on the wire.
+		await #expect(throws: (any Error).self) {
+			try await manager.saveChannelSet(base64UrlString: "!!!not-valid-base64!!!", addChannels: false, okToMQTT: false)
+		}
+		let sent = await connection.sentPackets
+		#expect(sent.isEmpty)
+	}
+
+	@Test("A channels-only replace does not push a LoRa config to the radio")
+	func testReplaceWithoutLoRaConfigDoesNotSendLoRa() async throws {
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection)
+		let link = try makeChannelSetLink(includeLoRaConfig: false)
+
+		// No embedded LoRa config: the device must not be sent a default-initialized
+		// LoRaConfig (which would reset its region/frequency). The follow-up wantConfig
+		// throws via the mock here — irrelevant to this assertion, so it is ignored.
+		try? await manager.saveChannelSet(base64UrlString: link, addChannels: false, okToMQTT: false)
+
+		let count = await connection.loraConfigSendCount
+		#expect(count == 0)
+	}
+}


### PR DESCRIPTION
## What changed?

Fixes #2010. Applying a QR-generated channel set no longer reports "Failed to save channel configuration" when the configuration is actually applied successfully.

- Treat the post-reboot `wantConfig` disconnect as success in `AccessoryManager.saveChannelSet`. A substantial LoRa change reboots the radio and drops the connection; the follow-up `wantConfig` is expected to fail, and that failure is no longer surfaced as a save error. The tolerance only applies when a reboot-causing LoRa config was actually transmitted — otherwise `wantConfig` errors still surface.
- Removed the duplicated LoRa-config send block (a copy-paste from #1682 that transmitted the config twice).
- Clear the local channels only **after** the channel-set link decodes successfully, and throw on a malformed link. Previously a bad/undecodable link wiped the local channel list and returned a false success without ever contacting the device.
- Skip the LoRa send when the channel set carries no LoRa config, so a channels-only share link no longer pushes a default-initialized (`region UNSET`) config that would knock the radio off its frequency.

## Why did it change?

This is a regression introduced by the BLEManager → AccessoryManager transport refactor. The legacy `BLEManager.saveChannelSet` was non-throwing: writes were fire-and-forget (guarded by `peripheral.state == .connected`) and it returned `true` immediately after kicking off a non-throwing `sendWantConfig()`. A reboot-induced disconnect could therefore never be reported as a failure.

The new path uses an `async throws` `send()` that throws the instant the link is gone, plus an awaited, throwing `sendWantConfig()` that blocks on a continuation. When the device reboots after the LoRa change, those throw, and `SaveChannelQRCode` flattens any error into "Failed to save channel configuration" — even though the channels and LoRa config were already delivered. Android applies the same QR fine, which matches: the config is valid and does get applied.

## How is this tested?

Added `MeshtasticTests/ChannelSetSaveTests.swift` — a `MockChannelSetConnection` actor conforming to `Connection` drives `saveChannelSet` without a real transport and simulates the post-reboot disconnect by throwing on the `wantConfig` send. Four tests, each verified to **fail on the pre-fix code and pass with the fix**:

- A QR channel set save survives the post-reboot disconnect without surfacing an error (#2010).
- The LoRa config is transmitted exactly once (guards the #1682 duplicate).
- A malformed channel-set link throws instead of silently succeeding, and nothing is put on the wire.
- A channels-only replace (no embedded LoRa config) does not transmit a LoRa config.

Run with: `-only-testing:MeshtasticTests/ChannelSetSaveTests` (iPhone 16 / iOS 18 simulator). All pass.

## Screenshots/Videos (when applicable)

N/A — behavior/error-handling fix; no UI changes.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. No doc update is needed (no view/behavior is documented for this path) — requesting the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel-set saving so existing channels are only cleared after the incoming data is successfully validated.
  * Made saving more reliable when a device may briefly disconnect after a configuration update.
  * Prevented duplicate configuration sends during full channel replacement.
  * Invalid channel-set data now fails cleanly without changing saved channels.

* **Tests**
  * Added regression coverage for channel-set saving, including reboot/disconnect handling, malformed data, and configuration send behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->