### PR TITLE
fix(map): guard ClusterMapView.updateUIView against re-entrancy (NSHashTable mutation crash)

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
@@ -298,32 +298,43 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		// current on reuse (the representable is recreated each render; the coordinator persists).
 		refreshClosures(on: context.coordinator)
 
+		let coordinator = context.coordinator
+		// RE-ENTRANCY GUARD. Hosting a SwiftUI pin (`UIHostingConfiguration` forces a synchronous
+		// layout) and writing the region binding back are side effects that can synchronously
+		// re-invalidate this representable and call updateUIView AGAIN while we're mid-mutation of
+		// MapKit's annotation/overlay tables. Mutating one of those (an `NSHashTable`) during
+		// MapKit's own enumeration throws NSGenericException ("Collection … was mutated while being
+		// enumerated"). A nested call is always triggered by our own side effects — it carries the
+		// SAME data (real data changes arrive on a later runloop tick, never re-entrantly) — so
+		// skipping it drops nothing. (Repro: clear database → connect → the node flood churns
+		// annotations fast enough to re-enter.)
+		guard !coordinator.isApplyingUpdate else { return }
+		coordinator.isApplyingUpdate = true
+		defer { coordinator.isApplyingUpdate = false }
+
 		// 0) Apple basemap type + controls (diffed; only re-applied when it actually changed).
-		context.coordinator.applyConfiguration(configuration, to: mapView)
-		context.coordinator.installControls(on: mapView, bottomInset: configuration.controlsBottomInset)
+		coordinator.applyConfiguration(configuration, to: mapView)
+		coordinator.installControls(on: mapView, bottomInset: configuration.controlsBottomInset)
 
-		// 1) Offline basemap: rebuild only if the URL or the dark/light flag actually changed.
-
-		// 1b) Vector overlays — diffed by id (object-identity change → remove + re-add).
-		context.coordinator.syncOverlays(overlays, on: mapView)
-		context.coordinator.syncCoverage(areas: coverageAreas, dark: colorScheme == .dark, on: mapView)
-		context.coordinator.syncDecorations(decorations, on: mapView)
+		// 1) Vector overlays — diffed by id (object-identity change → remove + re-add).
+		coordinator.syncOverlays(overlays, on: mapView)
+		coordinator.syncCoverage(areas: coverageAreas, dark: colorScheme == .dark, on: mapView)
+		coordinator.syncDecorations(decorations, on: mapView)
 
 		// 2) Diff annotations by Identifiable id — add/remove/move ONLY what changed (no flicker).
-		context.coordinator.sync(items: items, coordinate: coordinate,
-								 clustering: clustering, on: mapView)
+		coordinator.sync(items: items, coordinate: coordinate, clustering: clustering, on: mapView)
 
 		// 3) Apply a one-shot camera command (e.g. the initial frame) EXACTLY ONCE. We deliberately
 		//    do NOT push the `region` binding back into the map: under heavy traffic the data churns
 		//    every frame, and a reactive setRegion would fight the user's pan/zoom and "re-frame" the
 		//    map constantly. After the initial command fires, the user owns the camera.
 		if let command = cameraCommand,
-		   context.coordinator.appliedCameraCommandID != command.id {
-			context.coordinator.appliedCameraCommandID = command.id
-			context.coordinator.isApplyingExternalRegion = true
+		   coordinator.appliedCameraCommandID != command.id {
+			coordinator.appliedCameraCommandID = command.id
+			coordinator.isApplyingExternalRegion = true
 			mapView.setRegion(command.region, animated: command.animated)
 			// Cleared in regionDidChangeAnimated; also clear async in case no event fires.
-			DispatchQueue.main.async { context.coordinator.isApplyingExternalRegion = false }
+			DispatchQueue.main.async { coordinator.isApplyingExternalRegion = false }
 		}
 	}
 
@@ -386,6 +397,13 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		private var overlaysByID: [AnyHashable: ClusterMapOverlay] = [:]
 		/// Per-MKOverlay style, keyed by object identity, for O(1) lookup in `rendererFor`.
 		private var styleByOverlay: [ObjectIdentifier: ClusterMapOverlayStyle] = [:]
+
+		/// True while `updateUIView` is mutating the map. Mutating annotations/overlays hosts SwiftUI
+		/// pins and writes the region binding back, either of which can synchronously re-invalidate
+		/// the representable and re-enter `updateUIView` mid-mutation — mutating MapKit's annotation
+		/// `NSHashTable` while it is being enumerated, which throws NSGenericException. This flag makes
+		/// the re-entrant call a no-op (it carries the same data, so nothing is lost).
+		var isApplyingUpdate = false
 
 		// Camera feedback-loop guards.
 		/// True while WE push an external region in (so the resulting `regionDidChange` callback

--- a/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
@@ -331,10 +331,18 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		if let command = cameraCommand,
 		   coordinator.appliedCameraCommandID != command.id {
 			coordinator.appliedCameraCommandID = command.id
+			let currentRegion = mapView.region
 			coordinator.isApplyingExternalRegion = true
 			mapView.setRegion(command.region, animated: command.animated)
-			// Cleared in regionDidChangeAnimated; also clear async in case no event fires.
-			DispatchQueue.main.async { coordinator.isApplyingExternalRegion = false }
+			// `regionDidChangeAnimated` clears the guard when the move completes — for an *animated*
+			// move that's only after the animation finishes, so we must NOT clear it early. Only fall
+			// back to an async clear when the target equals the current region: MapKit fires no
+			// callback then, so without this the guard would stick and suppress the next user pan.
+			// (An unconditional async clear would race ahead of an animated move's later callback and
+			// let the programmatic change leak into `regionBinding`.)
+			if coordinator.regionsApproximatelyEqual(currentRegion, command.region) {
+				DispatchQueue.main.async { coordinator.isApplyingExternalRegion = false }
+			}
 		}
 	}
 


### PR DESCRIPTION
## What changed?

Guard `ClusterMapView.updateUIView` against re-entrancy with a `coordinator.isApplyingUpdate` flag, so a nested call during an in-progress map mutation is a no-op.

## Why did it change?

`updateUIView` mutates MapKit's annotation/overlay tables. Two of its own side effects can synchronously re-invalidate the SwiftUI representable and call `updateUIView` **again while we're mid-mutation**:

- hosting a SwiftUI pin — `UIHostingConfiguration` → `systemLayoutSizeFitting` forces a synchronous layout, and
- the region binding write-back.

A re-entrant call mutates MapKit's annotation `NSHashTable` while MapKit is enumerating it, which throws `NSGenericException` — *"Collection `<NSConcreteHashTable>` was mutated while being enumerated"* — surfacing as an `EXC_BREAKPOINT` crash.

Crash signature (top frames):

```
-[NSConcreteHashTable countByEnumeratingWithState:objects:count:]
…
Meshtastic … ClusterMapView.updateUIView(_:context:)
SwiftUI … PlatformViewRepresentableAdaptor.updateViewProvider(_:context:)
*** NSGenericException: Collection <NSConcreteHashTable: …> was mutated while being enumerated.
```

The nested call is always triggered by our own side effects and carries the **same data** (real data changes arrive on a later runloop tick, never re-entrantly), so skipping it drops nothing.

## How is this tested?

Reproduced reliably with **clear database → connect to a node**: the resulting node flood churns annotations fast enough to re-enter `updateUIView` mid-mutation. With the guard in place the crash no longer occurs and the map populates normally. Builds clean for the iOS Simulator and Mac Catalyst.

## Screenshots/Videos (when applicable)

N/A — crash fix.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. No user-facing behavior change — internal crash fix; no docs needed.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map stability by preventing nested/overlapping refresh cycles while MapKit updates annotations and overlays.
  * Reduced the likelihood of crashes or visual glitches when syncing map content alongside camera region changes.
  * Made camera region updates more consistent—each change is applied once, with safer handling of temporary external-region state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->