### PR TITLE
fix(messages): guard message rows against deleted SwiftData models (2.7.15 top crash)

### DIFF
--- a/Meshtastic/Views/Messages/ChannelMessageRow.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageRow.swift
@@ -51,6 +51,20 @@ struct ChannelMessageRow: View {
 	}
 
 	var body: some View {
+		// A retained message row can re-evaluate its body after the underlying MessageEntity has been
+		// deleted/invalidated (messages are pruned underneath the list). Reading any persisted property
+		// of a deleted @Model — directly, via the `fromUser` relationship, or through the MessageEntity
+		// computed-property extensions — fatally traps in SwiftData (SIGTRAP). Bail to an empty row when
+		// the message is no longer live; the List drops it on its next rebuild. Mirrors the NodeListItem
+		// guard.
+		if message.modelContext != nil && !message.isDeleted {
+			rowContent
+		} else {
+			EmptyView()
+		}
+	}
+
+	@ViewBuilder private var rowContent: some View {
 		VStack(alignment: .leading, spacing: 0) {
 			
 			// Timestamp Header

--- a/Meshtastic/Views/Messages/UserMessageRow.swift
+++ b/Meshtastic/Views/Messages/UserMessageRow.swift
@@ -57,6 +57,20 @@ struct UserMessageRow: View {
 	}
 	
 	var body: some View {
+		// A retained message row can re-evaluate its body after the underlying MessageEntity has been
+		// deleted/invalidated (messages are pruned underneath the list). Reading any persisted property
+		// of a deleted @Model — directly, via the `fromUser` relationship, or through the MessageEntity
+		// computed-property extensions — fatally traps in SwiftData (SIGTRAP). Bail to an empty row when
+		// the message is no longer live; the List drops it on its next rebuild. Mirrors the NodeListItem
+		// guard.
+		if message.modelContext != nil && !message.isDeleted {
+			rowContent
+		} else {
+			EmptyView()
+		}
+	}
+
+	@ViewBuilder private var rowContent: some View {
 		VStack(alignment: .leading, spacing: 0) {
 			
 			// Timestamp Header


### PR DESCRIPTION
## What changed?

Guard `ChannelMessageRow` and `UserMessageRow` against reading a deleted/invalidated SwiftData model: each row body now bails to `EmptyView()` unless `message.modelContext != nil && !message.isDeleted`.

## Why did it change?

This is the **top remaining crash family in 2.7.15** (App Store). Both message rows hold an `@Bindable var message: MessageEntity` and read its persisted properties throughout the body — directly (`message.timestamp`, `message.ackError`, `message.messageId`…), via the `fromUser` relationship (`message.fromUser?.num/shortName/longName`), and through the `MessageEntity` computed-property extensions (`displayedPayload`, `canRetry`, …) — with **no liveness check**.

A list row can be retained and re-evaluate its body after the underlying `MessageEntity` has been deleted/invalidated underneath the list (messages are pruned constantly). Reading any persisted property of a deleted `@Model` fatally traps in SwiftData (`SIGTRAP` in `_SD_get_faulting_backingdata_tsd`).

Datadog (App Store, 2.7.15): `MessageEntityExtension.swift` accounts for ~240 crashes, plus the `MessageEntity.fromUser` / `ChannelEntity` persisted-property accessors — all the same root cause, reached through these two rows.

This mirrors the fix already shipped for the node-list rows in #1991 (`NodeListItem` / `NodeListItemCompact`), which used the identical `modelContext != nil && !isDeleted` body guard.

## How is this tested?

Builds clean for the iOS Simulator and Mac Catalyst. The guard matches the proven node-row pattern; when the model is live the row renders exactly as before, and when it's been deleted the row collapses to an empty cell that the List discards on its next rebuild instead of trapping.

## Screenshots/Videos (when applicable)

N/A — crash fix, no visual change for live messages.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. No user-facing behavior change — internal crash guard; no docs needed.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message rows now safely handle messages that have been removed or invalidated, preventing crashes when scrolling or updating the list.
  * If a message is no longer available, the app now skips rendering that row instead of trying to display stale content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->