### PR TITLE
fix(map): stop Map tab resetting to the South Atlantic (0,0) on launch (#2016)

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
@@ -168,6 +168,9 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 	/// One-shot programmatic camera move (e.g. the initial frame), applied exactly once per distinct
 	/// id. The ONLY thing that moves the camera programmatically; after it fires the user is in control.
 	let cameraCommand: ClusterMapCameraCommand?
+	/// Floor fallback: while no camera command has framed the map yet, follow the user's location
+	/// instead of sitting at MKMapView's default (0,0) region. A camera command supersedes this.
+	let followsUserLocationUntilFramed: Bool
 	/// When true, annotations share a `clusteringIdentifier` so MapKit collapses nearby pins.
 	let clustering: Bool
 	/// Builds the SwiftUI view for one item's pin.
@@ -204,6 +207,7 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		coordinate: @escaping (Item) -> CLLocationCoordinate2D,
 		region: Binding<MKCoordinateRegion?>? = nil,
 		cameraCommand: ClusterMapCameraCommand? = nil,
+		followsUserLocationUntilFramed: Bool = false,
 		clustering: Bool = true,
 		onSelect: ((Item) -> Void)? = nil,
 		configuration: ClusterMapConfiguration = .init(),
@@ -221,6 +225,7 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		self.coordinate = coordinate
 		self.region = region
 		self.cameraCommand = cameraCommand
+		self.followsUserLocationUntilFramed = followsUserLocationUntilFramed
 		self.clustering = clustering
 		self.onSelect = onSelect
 		self.configuration = configuration
@@ -240,8 +245,15 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 	func makeCoordinator() -> Coordinator { Coordinator() }
 
 	func makeUIView(context: Context) -> MKMapView {
-		let mapView = MKMapView()
+		let mapView = LayoutObservingMapView()
 		mapView.delegate = context.coordinator
+		// Backstop for landing a deferred initial frame: if the map gains its first non-zero size via a
+		// layout pass that emits neither an updateUIView nor a region-change delegate call, this fires.
+		// Cheap no-op once nothing is pending.
+		mapView.onLayout = { [weak coordinator = context.coordinator, weak mapView] in
+			guard let coordinator, let mapView else { return }
+			coordinator.applyPendingCameraCommandIfPossible(on: mapView)
+		}
 		refreshClosures(on: context.coordinator)
 
 		// Register the reusable view classes ONCE. With registered classes MapKit dequeues + reuses
@@ -275,14 +287,14 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		context.coordinator.syncCoverage(areas: coverageAreas, dark: colorScheme == .dark, on: mapView)
 		context.coordinator.syncDecorations(decorations, on: mapView)
 
-		// Initial camera, if a one-shot command is already pending at creation. Guarded so we don't
-		// echo it back out. (The continuous `region` binding is never pushed INTO the map.)
+		// Initial camera, if a one-shot command is already pending at creation. Routed through the
+		// pending mechanism so it isn't lost when the map has no layout size yet (it retries once sized).
 		if let command = cameraCommand {
-			context.coordinator.appliedCameraCommandID = command.id
-			context.coordinator.isApplyingExternalRegion = true
-			mapView.setRegion(command.region, animated: false)
-			context.coordinator.isApplyingExternalRegion = false
+			context.coordinator.pendingCameraCommand = command
+			context.coordinator.applyPendingCameraCommandIfPossible(on: mapView)
 		}
+		// Follow-the-user floor while nothing has framed the map yet (avoids the default (0,0) view).
+		context.coordinator.applyUserTrackingFallback(followsUserLocationUntilFramed, on: mapView)
 
 		// Seed the annotations through the same diffing path used by updates.
 		context.coordinator.sync(items: items, coordinate: coordinate,
@@ -327,23 +339,15 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		// 3) Apply a one-shot camera command (e.g. the initial frame) EXACTLY ONCE. We deliberately
 		//    do NOT push the `region` binding back into the map: under heavy traffic the data churns
 		//    every frame, and a reactive setRegion would fight the user's pan/zoom and "re-frame" the
-		//    map constantly. After the initial command fires, the user owns the camera.
-		if let command = cameraCommand,
-		   coordinator.appliedCameraCommandID != command.id {
-			coordinator.appliedCameraCommandID = command.id
-			let currentRegion = mapView.region
-			coordinator.isApplyingExternalRegion = true
-			mapView.setRegion(command.region, animated: command.animated)
-			// `regionDidChangeAnimated` clears the guard when the move completes — for an *animated*
-			// move that's only after the animation finishes, so we must NOT clear it early. Only fall
-			// back to an async clear when the target equals the current region: MapKit fires no
-			// callback then, so without this the guard would stick and suppress the next user pan.
-			// (An unconditional async clear would race ahead of an animated move's later callback and
-			// let the programmatic change leak into `regionBinding`.)
-			if coordinator.regionsApproximatelyEqual(currentRegion, command.region) {
-				DispatchQueue.main.async { coordinator.isApplyingExternalRegion = false }
-			}
+		//    map constantly. After the initial command fires, the user owns the camera. A new command
+		//    becomes pending; `applyPendingCameraCommandIfPossible` lands it once the map is sized.
+		if let command = cameraCommand, coordinator.appliedCameraCommandID != command.id {
+			coordinator.pendingCameraCommand = command
 		}
+		coordinator.applyPendingCameraCommandIfPossible(on: mapView)
+
+		// 4) Follow-the-user floor (no-op once a command has landed) so we never sit at (0,0).
+		coordinator.applyUserTrackingFallback(followsUserLocationUntilFramed, on: mapView)
 	}
 
 	/// Re-capture the SwiftUI builders + camera binding onto the (persistent) coordinator.
@@ -423,6 +427,15 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 		/// id of the last `ClusterMapCameraCommand` we applied, so each command moves the camera once
 		/// and re-renders never re-apply it (the guard that keeps streaming data off the camera).
 		var appliedCameraCommandID: UUID?
+		/// A camera command received but not yet *landed* — the map can't honor `setRegion` until it has
+		/// a real (non-zero) layout size, so we hold the command here and retry (on each update and when
+		/// the visible region first changes after layout) until it actually applies. Without this, an
+		/// initial frame applied pre-layout is silently dropped yet marked done, stranding the map at the
+		/// default (0,0) region.
+		var pendingCameraCommand: ClusterMapCameraCommand?
+		/// Whether the follow-the-user floor has been asserted. Latched so we set `.follow` only once and
+		/// never re-assert it over the user's manual pan (see `applyUserTrackingFallback`).
+		var didApplyUserTrackingFallback = false
 
 		/// Shared clustering identifier — all clustered item annotations use the same one so MapKit
 		/// groups them. (Computed, not stored: the Coordinator is nested in the generic
@@ -823,7 +836,52 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 			return renderer
 		}
 
+		// MARK: One-shot camera command (self-healing: retries until it lands)
+
+		/// Apply the pending camera command IFF the map has a real layout size. `setRegion` on a
+		/// zero-bounds map is silently dropped (MapKit can't aspect-fit the span), so we defer and let a
+		/// later call — the next `updateUIView` or `mapViewDidChangeVisibleRegion` after layout — retry.
+		/// Marks the command applied and clears the pending slot only once it has actually been sent.
+		func applyPendingCameraCommandIfPossible(on mapView: MKMapView) {
+			guard let command = pendingCameraCommand else { return }
+			guard mapView.bounds.width > 1, mapView.bounds.height > 1 else { return } // not laid out yet
+			appliedCameraCommandID = command.id
+			pendingCameraCommand = nil
+			let currentRegion = mapView.region
+			isApplyingExternalRegion = true
+			mapView.setRegion(command.region, animated: command.animated)
+			// `regionDidChangeAnimated` clears the guard when the move completes — for an *animated*
+			// move that's only after the animation finishes, so we must NOT clear it early. Only fall
+			// back to an async clear when the target equals the current region: MapKit fires no
+			// callback then, so without this the guard would stick and suppress the next user pan.
+			// (An unconditional async clear would race ahead of an animated move's later callback and
+			// let the programmatic change leak into `regionBinding`.)
+			if regionsApproximatelyEqual(currentRegion, command.region) {
+				DispatchQueue.main.async { self.isApplyingExternalRegion = false }
+			}
+		}
+
+		/// Floor fallback: follow the user's location while no camera command has framed the map yet, so
+		/// we never sit at MKMapView's default (0,0) region. Applied AT MOST ONCE: re-asserting `.follow`
+		/// on every `updateUIView` would fight the user (MapKit demotes follow→none on a manual pan, and
+		/// we'd snap it straight back). Once it's asserted, the user — or a landed camera command, whose
+		/// `setRegion` cancels follow — owns the camera; we never force tracking again.
+		func applyUserTrackingFallback(_ follow: Bool, on mapView: MKMapView) {
+			guard follow, !didApplyUserTrackingFallback,
+				  appliedCameraCommandID == nil, pendingCameraCommand == nil else { return }
+			didApplyUserTrackingFallback = true
+			if mapView.userTrackingMode != .follow { mapView.userTrackingMode = .follow }
+		}
+
 		// MARK: Camera write-back (user gestures → region binding), loop-guarded
+
+		/// Lighter-weight than `regionDidChangeAnimated`; fires as the region changes, including the
+		/// first time MapKit computes one for a freshly-laid-out (now non-zero) frame — our cue to land a
+		/// camera command that was deferred while the map had no size. Guarded by `pendingCameraCommand`
+		/// so it's a cheap no-op during normal panning.
+		func mapViewDidChangeVisibleRegion(_ mapView: MKMapView) {
+			if pendingCameraCommand != nil { applyPendingCameraCommandIfPossible(on: mapView) }
+		}
 
 		func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
 			// Ignore the callback caused by our own external write (guard #1).
@@ -872,6 +930,7 @@ extension ClusterMapView where Cluster == ClusterBadge {
 		coordinate: @escaping (Item) -> CLLocationCoordinate2D,
 		region: Binding<MKCoordinateRegion?>? = nil,
 		cameraCommand: ClusterMapCameraCommand? = nil,
+		followsUserLocationUntilFramed: Bool = false,
 		clustering: Bool = true,
 		onSelect: ((Item) -> Void)? = nil,
 		configuration: ClusterMapConfiguration = .init(),
@@ -888,6 +947,7 @@ extension ClusterMapView where Cluster == ClusterBadge {
 				  coordinate: coordinate,
 				  region: region,
 				  cameraCommand: cameraCommand,
+				  followsUserLocationUntilFramed: followsUserLocationUntilFramed,
 				  clustering: clustering,
 				  onSelect: onSelect,
 				  configuration: configuration,
@@ -900,6 +960,19 @@ extension ClusterMapView where Cluster == ClusterBadge {
 				suppressRegionUpdates: suppressRegionUpdates,
 				  content: pinContent,
 				  clusterContent: { ClusterBadge(count: $0) })
+	}
+}
+
+// MARK: - Layout-observing map view (lands a deferred initial frame once the map is sized)
+
+/// `MKMapView` that forwards `layoutSubviews` so a camera command deferred while the map had no size
+/// can be applied the moment it first gets a non-zero frame — covering layout passes that emit no
+/// region-change delegate call or `updateUIView`. `onLayout` is a cheap no-op when nothing is pending.
+private final class LayoutObservingMapView: MKMapView {
+	var onLayout: (() -> Void)?
+	override func layoutSubviews() {
+		super.layoutSubviews()
+		onLayout?()
 	}
 }
 

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -61,6 +61,18 @@ struct MeshMapMK: View {
 	/// drives the camera and we never move it programmatically, so a flood of incoming positions
 	/// can't re-frame the map mid-gesture.
 	@State private var cameraCommand: ClusterMapCameraCommand?
+	/// Floor fallback: while we have nothing to frame on yet (no saved region, no GPS, no node
+	/// positions), follow the user's location instead of sitting at MKMapView's default (0,0) region
+	/// — the "South Atlantic Ocean" the map otherwise reset to. A real frame later supersedes this.
+	@State private var followUserLocation = false
+	/// Persisted last map region, restored on launch so the map reopens where the user left it
+	/// (parity with the pre-MKMapView map). `hasSavedRegion` gates validity so a fresh install
+	/// doesn't read a 0/0 default as a real coordinate.
+	@AppStorage("meshMapHasSavedRegion") private var hasSavedRegion = false
+	@AppStorage("meshMapLastLatitude") private var lastRegionLatitude = 0.0
+	@AppStorage("meshMapLastLongitude") private var lastRegionLongitude = 0.0
+	@AppStorage("meshMapLastLatDelta") private var lastRegionLatDelta = 0.0
+	@AppStorage("meshMapLastLonDelta") private var lastRegionLonDelta = 0.0
 	/// Offline basemap rendered as native MKOverlays (slate/cream vector content) -- matches the old
 	/// SwiftUI map's look and aligns the coverage border/label exactly (no tile-grid mismatch).
 	@StateObject private var offlineVectors = OfflineVectorTileProvider()
@@ -259,6 +271,7 @@ struct MeshMapMK: View {
 				coordinate: { spreadOverrides[$0.nodeNum] ?? $0.coordinate },
 				region: $visibleRegion,
 				cameraCommand: cameraCommand,
+				followsUserLocationUntilFramed: followUserLocation,
 				clustering: enableMapClustering,
 				onSelect: { snapshot in selectedWaypoint = nil; editingWaypoint = nil; selectedNode = MeshMapSelectedNode(id: snapshot.nodeNum) },
 				configuration: clusterConfiguration,
@@ -499,7 +512,10 @@ struct MeshMapMK: View {
 			.onChange(of: accessoryManager.activeDeviceNum) {
 				syncFallbackLocation()
 			}
-			.onChange(of: accessoryManager.isInBackground) {
+			.onChange(of: accessoryManager.isInBackground) { _, isInBackground in
+				// Save the viewport before the app is backgrounded (it may be terminated without ever
+				// firing onDisappear), so the next launch reopens where the user left the map.
+				if isInBackground { persistCurrentRegion() }
 				// Foreground/background flips isMapVisible; refresh so the overlay-bearing
 				// snapshots are dropped when backgrounded and rebuilt when foregrounded.
 				refreshVisiblePositionSnapshots(from: positionState.positions)
@@ -537,6 +553,7 @@ struct MeshMapMK: View {
 			refreshVisiblePositionSnapshots(from: positionState.positions)
 		}
 		.onDisappear(perform: {
+			persistCurrentRegion()
 			UIApplication.shared.isIdleTimerDisabled = false
 			GeoJSONOverlayManager.shared.clearCache()
 			visiblePositionSnapshots = []
@@ -549,6 +566,7 @@ struct MeshMapMK: View {
 				refreshVisiblePositionSnapshots()
 				applyTraceRouteSelection()
 			} else {
+				persistCurrentRegion()
 				flyover.stop(restoreCamera: false)
 				UIApplication.shared.isIdleTimerDisabled = false
 				GeoJSONOverlayManager.shared.clearCache()
@@ -638,15 +656,28 @@ struct MeshMapMK: View {
 		return overrides
 	}
 
-	/// One-time initial camera framing. Centers on the phone's GPS (else the connected device's GPS,
+	/// One-time initial camera framing. Prefers the user's persisted last region (so the map reopens
+	/// where they left it); otherwise centers on the phone's GPS (else the connected device's GPS,
 	/// else the node centroid) and zooms out to fit nearby nodes -- capped at ~100 miles so we "start
 	/// zoomed out but local." After it fires once the user drives the camera; we never re-frame, even
 	/// as positions pour in.
 	private func frameInitialRegionIfNeeded() {
 		guard !didInitialFrame else { return }
+
+		// 1) Restore the user's last region if we have one. Matches the pre-migration behavior and can
+		//    never land on (0,0) (persistRegion only stores valid, user-driven regions).
+		if let saved = savedRegion {
+			applyInitialFrame(saved)
+			return
+		}
+
+		// 2) Frame on the best available origin, fitting nearby nodes.
 		let nodeCoords = allLatestPositions.compactMap { $0.nodeCoordinate ?? $0.fuzzedNodeCoordinate }
 		guard let center = LocationsHandler.currentLocation ?? activeDeviceCoordinate ?? coordinateCentroid(of: nodeCoords) else {
-			return // No GPS and no nodes yet -- try again on the next refresh.
+			// 3) Nothing to frame on yet: follow the user's location as a floor (never sit at the
+			//    default (0,0) South Atlantic view) and retry on the next refresh once data arrives.
+			followUserLocation = true
+			return
 		}
 		// ~100 miles is about 1.45 deg latitude; floor ~20 miles so a lone node still starts zoomed out.
 		let maxSpan = 1.45, minSpan = 0.30
@@ -657,15 +688,53 @@ struct MeshMapMK: View {
 		}
 		let latDelta = min(max(maxLat * 2.5, minSpan), maxSpan)
 		let lonDelta = min(max(maxLon * 2.5, minSpan), maxSpan)
-		didInitialFrame = true
-		let region = MKCoordinateRegion(
+		applyInitialFrame(MKCoordinateRegion(
 			center: center,
 			span: MKCoordinateSpan(latitudeDelta: latDelta, longitudeDelta: lonDelta)
-		)
-		// Seed `visibleRegion` so content filtering reflects the frame immediately, and emit the
-		// one-shot command that actually moves the map (the only programmatic camera move we make).
+		))
+	}
+
+	/// Commit the one-shot initial frame: mark it done, drop the follow-the-user floor, seed
+	/// `visibleRegion` so content filtering reflects the frame immediately, and emit the one-shot
+	/// command that actually moves the map (the only programmatic camera move we make).
+	private func applyInitialFrame(_ region: MKCoordinateRegion) {
+		didInitialFrame = true
+		followUserLocation = false
 		visibleRegion = region
 		cameraCommand = ClusterMapCameraCommand(id: UUID(), region: region)
+	}
+
+	/// The persisted last region, or nil when there isn't a valid one saved. Validation (incl. the
+	/// (0,0) reject that also self-heals any (0,0) saved by a pre-fix build) lives in the testable
+	/// `MeshMapRegionPersistence` helper.
+	private var savedRegion: MKCoordinateRegion? {
+		MeshMapRegionPersistence.restoredRegion(
+			hasSaved: hasSavedRegion,
+			latitude: lastRegionLatitude,
+			longitude: lastRegionLongitude,
+			latitudeDelta: lastRegionLatDelta,
+			longitudeDelta: lastRegionLonDelta
+		)
+	}
+
+	/// Save the map's current viewport so the next launch reopens here. Called at natural commit points
+	/// (leaving the tab / backgrounding) rather than on every region callback, so user panning doesn't
+	/// hammer UserDefaults on the gesture hot path. Persists regardless of `didInitialFrame` so a
+	/// follow-mode session's final viewport is still saved.
+	private func persistCurrentRegion() {
+		guard let visibleRegion else { return }
+		persistRegion(visibleRegion)
+	}
+
+	/// Save a (validated) region so the next launch reopens here. Rejects (0,0) so MKMapView's default
+	/// (0,0) region — the "South Atlantic" the user reported — can never be persisted and restored.
+	private func persistRegion(_ region: MKCoordinateRegion) {
+		guard MeshMapRegionPersistence.isPersistable(region) else { return }
+		lastRegionLatitude = region.center.latitude
+		lastRegionLongitude = region.center.longitude
+		lastRegionLatDelta = region.span.latitudeDelta
+		lastRegionLonDelta = region.span.longitudeDelta
+		hasSavedRegion = true
 	}
 
 	/// Average of a coordinate list (nil when empty).
@@ -1342,5 +1411,43 @@ private struct RouteEndpointMarker: View {
 			.fill(color)
 			.overlay(Circle().stroke(.white, lineWidth: 3))
 			.frame(width: 15, height: 15)
+	}
+}
+
+// MARK: - Region persistence rules
+
+/// Pure validation + (de)serialization for the map's persisted last region, factored out of the
+/// `MeshMapMK` view so the issue #2016 regression — the map restoring MKMapView's default (0,0)
+/// "South Atlantic" region — is unit-testable without a live map view. `internal` so tests can reach
+/// it via `@testable import`.
+enum MeshMapRegionPersistence {
+	/// Center magnitude (deg) at/under which we treat a region as the (0,0) "Null Island" default and
+	/// refuse to persist or restore it. No Meshtastic mesh realistically sits in this open-ocean cell,
+	/// so rejecting it is safe and stops the default map region from ever being saved.
+	static let nullIslandEpsilon = 0.0001
+
+	/// Whether `region` is safe to persist/restore: a valid, non-(0,0) center with positive spans.
+	static func isPersistable(_ region: MKCoordinateRegion) -> Bool {
+		let center = region.center
+		guard CLLocationCoordinate2DIsValid(center),
+			  region.span.latitudeDelta > 0, region.span.longitudeDelta > 0 else { return false }
+		return !(abs(center.latitude) < nullIslandEpsilon && abs(center.longitude) < nullIslandEpsilon)
+	}
+
+	/// Reconstruct a persisted region from stored fields, or nil when unset/invalid. Applies the same
+	/// `isPersistable` gate as saving, so a (0,0) written by a pre-fix build is self-healed (ignored).
+	static func restoredRegion(
+		hasSaved: Bool,
+		latitude: Double,
+		longitude: Double,
+		latitudeDelta: Double,
+		longitudeDelta: Double
+	) -> MKCoordinateRegion? {
+		guard hasSaved else { return nil }
+		let region = MKCoordinateRegion(
+			center: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+			span: MKCoordinateSpan(latitudeDelta: latitudeDelta, longitudeDelta: longitudeDelta)
+		)
+		return isPersistable(region) ? region : nil
 	}
 }

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -1426,11 +1426,17 @@ enum MeshMapRegionPersistence {
 	/// so rejecting it is safe and stops the default map region from ever being saved.
 	static let nullIslandEpsilon = 0.0001
 
-	/// Whether `region` is safe to persist/restore: a valid, non-(0,0) center with positive spans.
+	/// Whether `region` is safe to persist/restore: a valid, non-(0,0) center with finite, positive,
+	/// in-bounds spans. The span deltas must be finite and within MapKit's valid range (≤180° lat,
+	/// ≤360° lon) — a bare `> 0` check would accept `.infinity` (and a stored garbage value could
+	/// reach `MKMapView.setRegion` on launch); `NaN` already fails `> 0`.
 	static func isPersistable(_ region: MKCoordinateRegion) -> Bool {
 		let center = region.center
+		let span = region.span
 		guard CLLocationCoordinate2DIsValid(center),
-			  region.span.latitudeDelta > 0, region.span.longitudeDelta > 0 else { return false }
+			  span.latitudeDelta.isFinite, span.longitudeDelta.isFinite,
+			  span.latitudeDelta > 0, span.longitudeDelta > 0,
+			  span.latitudeDelta <= 180, span.longitudeDelta <= 360 else { return false }
 		return !(abs(center.latitude) < nullIslandEpsilon && abs(center.longitude) < nullIslandEpsilon)
 	}
 

--- a/MeshtasticTests/MapDataModelTests.swift
+++ b/MeshtasticTests/MapDataModelTests.swift
@@ -3,6 +3,7 @@
 
 import Testing
 import Foundation
+import MapKit
 @testable import Meshtastic
 
 // MARK: - MapDataMetadata Tests
@@ -279,3 +280,87 @@ struct OfflineVectorPerfTests {
 }
 
 // swiftlint:enable disable_print
+
+// MARK: - Map region persistence (issue #2016: map reset to South Atlantic / (0,0))
+
+/// Regression coverage for the map restoring MKMapView's default (0,0) "South Atlantic" region.
+/// The map persists its last viewport and restores it on launch; these tests pin the rule that a
+/// (0,0) / invalid region can never round-trip, so the bug can't silently return.
+@Suite("MeshMapRegionPersistence")
+struct MeshMapRegionPersistenceTests {
+
+	private func region(_ lat: Double, _ lon: Double, _ latDelta: Double = 0.3, _ lonDelta: Double = 0.3) -> MKCoordinateRegion {
+		MKCoordinateRegion(
+			center: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+			span: MKCoordinateSpan(latitudeDelta: latDelta, longitudeDelta: lonDelta)
+		)
+	}
+
+	// MARK: isPersistable
+
+	@Test func isPersistable_acceptsValidRegion() {
+		#expect(MeshMapRegionPersistence.isPersistable(region(47.6062, -122.3321)))
+	}
+
+	@Test func isPersistable_rejectsNullIsland() {
+		// The exact (0,0) default region MKMapView shows unconfigured — the reported bug.
+		#expect(!MeshMapRegionPersistence.isPersistable(region(0, 0)))
+	}
+
+	@Test func isPersistable_rejectsNearNullIsland() {
+		// Float noise around (0,0) must also be rejected so it can't sneak past the guard.
+		#expect(!MeshMapRegionPersistence.isPersistable(region(0.00005, -0.00005)))
+	}
+
+	@Test func isPersistable_acceptsEquatorAndPrimeMeridianAwayFromOrigin() {
+		// A real location ON the equator (lat 0) or prime meridian (lon 0) — but not at the origin —
+		// is legitimate and must NOT be rejected (only the (0,0) corner is the default sentinel).
+		#expect(MeshMapRegionPersistence.isPersistable(region(0, -78.4678)))   // Quito, ~equator
+		#expect(MeshMapRegionPersistence.isPersistable(region(51.4769, 0)))    // Greenwich, prime meridian
+	}
+
+	@Test func isPersistable_rejectsNonPositiveSpan() {
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, 0, 0.3)))
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, 0.3, 0)))
+	}
+
+	@Test func isPersistable_rejectsOutOfRangeCoordinate() {
+		// CLLocationCoordinate2DIsValid rejects |lat| > 90 / |lon| > 180.
+		#expect(!MeshMapRegionPersistence.isPersistable(region(120, 0)))
+		#expect(!MeshMapRegionPersistence.isPersistable(region(0, 300)))
+	}
+
+	// MARK: restoredRegion
+
+	@Test func restoredRegion_roundTripsValidRegion() {
+		let restored = MeshMapRegionPersistence.restoredRegion(
+			hasSaved: true, latitude: 47.6062, longitude: -122.3321, latitudeDelta: 0.4, longitudeDelta: 0.5
+		)
+		#expect(restored != nil)
+		#expect(abs((restored?.center.latitude ?? 0) - 47.6062) < 1e-9)
+		#expect(abs((restored?.center.longitude ?? 0) + 122.3321) < 1e-9)
+		#expect(abs((restored?.span.latitudeDelta ?? 0) - 0.4) < 1e-9)
+		#expect(abs((restored?.span.longitudeDelta ?? 0) - 0.5) < 1e-9)
+	}
+
+	@Test func restoredRegion_nilWhenNotSaved() {
+		// Fresh install: hasSaved=false must yield nil so framing falls through to GPS/nodes/follow.
+		#expect(MeshMapRegionPersistence.restoredRegion(
+			hasSaved: false, latitude: 47.6, longitude: -122.3, latitudeDelta: 0.3, longitudeDelta: 0.3
+		) == nil)
+	}
+
+	@Test func restoredRegion_selfHealsPersistedNullIsland() {
+		// A (0,0) written by a pre-fix build must NOT be restored — otherwise the bug persists across
+		// the upgrade. The restore path reapplies the same reject as saving.
+		#expect(MeshMapRegionPersistence.restoredRegion(
+			hasSaved: true, latitude: 0, longitude: 0, latitudeDelta: 180, longitudeDelta: 360
+		) == nil)
+	}
+
+	@Test func restoredRegion_nilWhenSpanZeroed() {
+		#expect(MeshMapRegionPersistence.restoredRegion(
+			hasSaved: true, latitude: 47.6, longitude: -122.3, latitudeDelta: 0, longitudeDelta: 0
+		) == nil)
+	}
+}

--- a/MeshtasticTests/MapDataModelTests.swift
+++ b/MeshtasticTests/MapDataModelTests.swift
@@ -324,6 +324,23 @@ struct MeshMapRegionPersistenceTests {
 		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, 0.3, 0)))
 	}
 
+	@Test func isPersistable_rejectsNonFiniteSpan() {
+		// `infinity > 0` is true, so a bare positivity check would accept it and let a garbage span
+		// reach MKMapView.setRegion. NaN already fails `> 0` but is pinned here too.
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, .infinity, 0.3)))
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, 0.3, .infinity)))
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, .nan, 0.3)))
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, 0.3, .nan)))
+	}
+
+	@Test func isPersistable_rejectsOutOfRangeSpan() {
+		// Finite but larger than the whole globe (>180° lat / >360° lon), e.g. a corrupted stored value.
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, .greatestFiniteMagnitude, 0.3)))
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, 0.3, .greatestFiniteMagnitude)))
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, 181, 0.3)))
+		#expect(!MeshMapRegionPersistence.isPersistable(region(47.6, -122.3, 0.3, 361)))
+	}
+
 	@Test func isPersistable_rejectsOutOfRangeCoordinate() {
 		// CLLocationCoordinate2DIsValid rejects |lat| > 90 / |lon| > 180.
 		#expect(!MeshMapRegionPersistence.isPersistable(region(120, 0)))
@@ -361,6 +378,20 @@ struct MeshMapRegionPersistenceTests {
 	@Test func restoredRegion_nilWhenSpanZeroed() {
 		#expect(MeshMapRegionPersistence.restoredRegion(
 			hasSaved: true, latitude: 47.6, longitude: -122.3, latitudeDelta: 0, longitudeDelta: 0
+		) == nil)
+	}
+
+	@Test func restoredRegion_nilWhenSpanNonFiniteOrOversized() {
+		// A corrupted persisted span (non-finite or larger than the globe) must be rejected on the
+		// restore path so it never reaches MKMapView.setRegion at launch.
+		#expect(MeshMapRegionPersistence.restoredRegion(
+			hasSaved: true, latitude: 47.6, longitude: -122.3, latitudeDelta: .infinity, longitudeDelta: 0.3
+		) == nil)
+		#expect(MeshMapRegionPersistence.restoredRegion(
+			hasSaved: true, latitude: 47.6, longitude: -122.3, latitudeDelta: 0.3, longitudeDelta: .nan
+		) == nil)
+		#expect(MeshMapRegionPersistence.restoredRegion(
+			hasSaved: true, latitude: 47.6, longitude: -122.3, latitudeDelta: .greatestFiniteMagnitude, longitudeDelta: 0.3
 		) == nil)
 	}
 }


### PR DESCRIPTION
## What changed?

Fixes #2016 — the Map tab opening centered on (0,0) (Null Island / the South Atlantic) on every launch, requiring the user to manually pan/zoom back to their region each time.

Three related fixes to the `MeshMapMK` / `ClusterMapView` map introduced in the MKMapView migration:

1. **Persist & restore the last region.** New `@AppStorage` keys store the user's viewport and `frameInitialRegionIfNeeded` restores it first, so the map reopens where it was left. Saving happens at lifecycle commit points (leaving the tab, backgrounding) rather than on every region callback, to keep UserDefaults off the pan/zoom hot path.
2. **Self-healing one-shot frame.** Camera commands stage as `pendingCameraCommand` and only commit once the map has a non-zero layout size, backstopped by `mapViewDidChangeVisibleRegion` and a small `LayoutObservingMapView` that forwards `layoutSubviews`.
3. **Follow-the-user floor.** When there's nothing to frame on (no saved region, no GPS, no connected device, no node positions), the map follows the user's location instead of sitting at (0,0). It's asserted at most once so it never fights a manual pan.

Region-persistence rules are factored into a small, testable `MeshMapRegionPersistence` helper.

## Why did it change?

The migrated MKMapView Map tab positioned its camera **exactly once** via a one-shot `ClusterMapCameraCommand`, with no persistence and no retry. If that single frame didn't land — e.g. the `setRegion` was applied before the map had a layout size (it was then silently dropped yet permanently marked applied), or there was no GPS/device/node coordinate available at that instant — the map fell back to MKMapView's default unconfigured region, whose center is (0,0): the South Atlantic. The pre-migration SwiftUI map framed continuously, so this was a regression.

## How is this tested?

- Added **10 regression tests** (`MeshMapRegionPersistenceTests`) pinning the core invariant: a (0,0)/invalid region can never be persisted or restored, including self-healing a (0,0) saved by a pre-fix build, plus valid-region round-trip and not-yet-saved cases. All pass on the iOS 18 simulator.
- App + test targets build clean.
- Reviewed the diff with a high-effort code review and addressed all findings (follow-fallback fighting manual pans, follow-mode pans not being persisted, hot-path UserDefaults churn, pending-command stranding).

## Screenshots/Videos (when applicable)

N/A — behavioral fix to initial map framing.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. No user-facing doc page documents map auto-framing behavior; requesting the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The map now remembers your last viewed area and restores it when you return.
  * If no saved region is available yet, the map can follow your location until it has enough data to frame.
  * Initial map framing is improved: it waits for layout to complete before applying the one-time view update.
* **Bug Fixes**
  * Improved handling of invalid saved map regions, including edge cases near (0,0) and other invalid/unsafe bounds.
  * Added safeguards to avoid unexpected viewport changes after manual interaction.
* **Tests**
  * Added coverage for region persistence validation and restoration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->