### PR TITLE
fix(messages): refresh ack status without leaving the conversation (#2017)

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 		DD000029APSTFWTST0000001 /* AppSettingsAndFirmwareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000029APSTFWTST0000000 /* AppSettingsAndFirmwareTests.swift */; };
 		DD00002AINTREMTST00000001 /* IntentAndRemainingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00002AINTREMTST00000000 /* IntentAndRemainingTests.swift */; };
 		DD00002BMSHPKTELTST000001 /* MeshPacketsAndTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00002BMSHPKTELTST000000 /* MeshPacketsAndTelemetryTests.swift */; };
+		DD00002BACKSTATUSRT000001 /* MessageAckStatusRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00002BACKSTATUSRT000000 /* MessageAckStatusRefreshTests.swift */; };
 		DD00002DSNPVWTST000000001 /* SwiftUIViewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00002DSNPVWTST000000000 /* SwiftUIViewSnapshotTests.swift */; };
 		DD00002ESDMIGTST000000001 /* SwiftDataMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00002ESDMIGTST000000000 /* SwiftDataMigrationTests.swift */; };
 		DD00002FSHRDTSTCNT000001 /* SharedTestContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00002FSHRDTSTCNT000000 /* SharedTestContainer.swift */; };
@@ -878,6 +879,7 @@
 		DD000029APSTFWTST0000000 /* AppSettingsAndFirmwareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsAndFirmwareTests.swift; sourceTree = "<group>"; };
 		DD00002AINTREMTST00000000 /* IntentAndRemainingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentAndRemainingTests.swift; sourceTree = "<group>"; };
 		DD00002BMSHPKTELTST000000 /* MeshPacketsAndTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshPacketsAndTelemetryTests.swift; sourceTree = "<group>"; };
+		DD00002BACKSTATUSRT000000 /* MessageAckStatusRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAckStatusRefreshTests.swift; sourceTree = "<group>"; };
 		DD00002DSNPVWTST000000000 /* SwiftUIViewSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewSnapshotTests.swift; sourceTree = "<group>"; };
 		DD00002ESDMIGTST000000000 /* SwiftDataMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataMigrationTests.swift; sourceTree = "<group>"; };
 		DD00002FSHRDTSTCNT000000 /* SharedTestContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestContainer.swift; sourceTree = "<group>"; };
@@ -1606,6 +1608,7 @@
 				DD000029APSTFWTST0000000 /* AppSettingsAndFirmwareTests.swift */,
 				DD00002AINTREMTST00000000 /* IntentAndRemainingTests.swift */,
 				DD00002BMSHPKTELTST000000 /* MeshPacketsAndTelemetryTests.swift */,
+				DD00002BACKSTATUSRT000000 /* MessageAckStatusRefreshTests.swift */,
 				DD00002DSNPVWTST000000000 /* SwiftUIViewSnapshotTests.swift */,
 				AA004FMT0000001000000004 /* MarkdownFormattingTests.swift */,
 				DD00002ESDMIGTST000000000 /* SwiftDataMigrationTests.swift */,
@@ -2711,6 +2714,7 @@
 				DD000029APSTFWTST0000001 /* AppSettingsAndFirmwareTests.swift in Sources */,
 				DD00002AINTREMTST00000001 /* IntentAndRemainingTests.swift in Sources */,
 				DD00002BMSHPKTELTST000001 /* MeshPacketsAndTelemetryTests.swift in Sources */,
+				DD00002BACKSTATUSRT000001 /* MessageAckStatusRefreshTests.swift in Sources */,
 				DD00002DSNPVWTST000000001 /* SwiftUIViewSnapshotTests.swift in Sources */,
 				AA004FMT0000002000000004 /* MarkdownFormattingTests.swift in Sources */,
 				DD00002ESDMIGTST000000001 /* SwiftDataMigrationTests.swift in Sources */,

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -25,6 +25,14 @@ private struct ChannelMessageTimelineCursor: Comparable {
 private struct ChannelMessageListChangeToken: Equatable {
 	let latest: ChannelMessageTimelineCursor?
 	let count: Int
+	// Tallies of outgoing messages whose ACK has resolved, kept as separate delivered/errored
+	// counts rather than a single sum: an errored→delivered transition leaves the sum unchanged
+	// (delivered +1, errored −1) but moves both tallies, so the token still changes and the list
+	// reloads. An incoming ACK changes neither `latest` nor `count`, so without these the
+	// poll-based refresh would never reload and the row would stay on "Waiting to be
+	// acknowledged" until the view is rebuilt.
+	let deliveredAckCount: Int
+	let erroredAckCount: Int
 }
 
 struct ChannelMessageList: View {
@@ -128,10 +136,37 @@ struct ChannelMessageList: View {
 
 	private func fetchMessageChangeToken(latestMessage: MessageEntity? = nil) throws -> ChannelMessageListChangeToken {
 		let latest = try latestMessage ?? fetchMessages(limit: 1).first
+		let acks = try Self.resolvedAckCounts(in: context, channelIndex: channel.index)
 		return ChannelMessageListChangeToken(
 			latest: latest.map(cursor(for:)),
-			count: try fetchMessageCount()
+			count: try fetchMessageCount(),
+			deliveredAckCount: acks.delivered,
+			erroredAckCount: acks.errored
 		)
+	}
+
+	/// Tallies of messages in this channel whose ACK has resolved — delivered (`receivedACK`) and
+	/// failed (`ackError != 0`) counted separately. A message is shown as "Waiting to be
+	/// acknowledged" until one of these is set, and keeping the tallies distinct means every
+	/// transition (waiting→delivered, waiting→errored, errored→delivered, or a retry resetting
+	/// either) moves at least one tally, so the list reloads. Exposed `static` so the regression
+	/// tests exercise these exact predicates instead of hand-mirrored copies.
+	///
+	/// Two single-term `fetchCount`s rather than one `||` predicate: a compound `||` (and a fourth
+	/// `&&` term such as an `isEmoji` filter) exceeds the `#Predicate` macro's type-check budget.
+	/// Not filtering `isEmoji` only means an acked tapback triggers one extra benign reload.
+	static func resolvedAckCounts(in context: ModelContext, channelIndex: Int32) throws -> (delivered: Int, errored: Int) {
+		let deliveredDescriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.channel == channelIndex && $0.toUser == nil && $0.receivedACK
+			}
+		)
+		let erroredDescriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.channel == channelIndex && $0.toUser == nil && $0.ackError != 0
+			}
+		)
+		return (try context.fetchCount(deliveredDescriptor), try context.fetchCount(erroredDescriptor))
 	}
 
 	private func fetchMessageCount() throws -> Int {

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -25,12 +25,18 @@ private struct ChannelMessageTimelineCursor: Comparable {
 private struct ChannelMessageListChangeToken: Equatable {
 	let latest: ChannelMessageTimelineCursor?
 	let count: Int
-	// Tallies of outgoing messages whose ACK has resolved, kept as separate delivered/errored
-	// counts rather than a single sum: an errored→delivered transition leaves the sum unchanged
+	// Tallies of messages whose ACK has resolved, kept as separate delivered/errored counts
+	// rather than a single sum: an errored→delivered transition leaves the sum unchanged
 	// (delivered +1, errored −1) but moves both tallies, so the token still changes and the list
-	// reloads. An incoming ACK changes neither `latest` nor `count`, so without these the
-	// poll-based refresh would never reload and the row would stay on "Waiting to be
-	// acknowledged" until the view is rebuilt.
+	// reloads. Together with `latest`/`count` these cover every ACK transition the app produces:
+	// in-place mutations only ever move a message *into* delivered/errored (a tally changes), and
+	// the sole route back to "waiting" is RetryButton, which deletes the message and inserts a
+	// fresh one — moving `latest`/`count`. (There is deliberately no `max(ackTimestamp)` signal:
+	// `ackTimestamp` is stamped from the remote `packet.rxTime`, so it isn't reliably monotonic
+	// and would add an unindexed sort to the 5s poll for a net-zero case that can't occur.) An
+	// incoming ACK changes neither `latest` nor `count`, so without these tallies the poll-based
+	// refresh would never reload and the row would stay on "Waiting to be acknowledged" until the
+	// view is rebuilt.
 	let deliveredAckCount: Int
 	let erroredAckCount: Int
 }
@@ -145,12 +151,12 @@ struct ChannelMessageList: View {
 		)
 	}
 
-	/// Tallies of messages in this channel whose ACK has resolved — delivered (`receivedACK`) and
-	/// failed (`ackError != 0`) counted separately. A message is shown as "Waiting to be
-	/// acknowledged" until one of these is set, and keeping the tallies distinct means every
-	/// transition (waiting→delivered, waiting→errored, errored→delivered, or a retry resetting
-	/// either) moves at least one tally, so the list reloads. Exposed `static` so the regression
-	/// tests exercise these exact predicates instead of hand-mirrored copies.
+	/// Resolved-ACK tallies for this channel: delivered (`receivedACK`) and failed
+	/// (`ackError != 0`) counted separately. A message is shown as "Waiting to be acknowledged"
+	/// until it resolves; folding both tallies into the change token makes the poll reload on any
+	/// ACK state change. Keeping them distinct means errored→delivered (which keeps the sum
+	/// constant) still moves a tally. Exposed `static` so the regression tests exercise these
+	/// exact predicates.
 	///
 	/// Two single-term `fetchCount`s rather than one `||` predicate: a compound `||` (and a fourth
 	/// `&&` term such as an `isEmoji` filter) exceeds the `#Predicate` macro's type-check budget.

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -25,6 +25,14 @@ private struct UserMessageTimelineCursor: Comparable {
 private struct UserMessageListChangeToken: Equatable {
 	let latest: UserMessageTimelineCursor?
 	let count: Int
+	// Tallies of outgoing messages whose ACK has resolved, kept as separate delivered/errored
+	// counts rather than a single sum: an errored→delivered transition leaves the sum unchanged
+	// (delivered +1, errored −1) but moves both tallies, so the token still changes and the list
+	// reloads. An incoming ACK changes neither `latest` nor `count`, so without these the
+	// poll-based refresh would never reload and the row would stay on "Waiting to be
+	// acknowledged" until the view is rebuilt.
+	let deliveredAckCount: Int
+	let erroredAckCount: Int
 }
 
 struct UserMessageList: View {
@@ -128,10 +136,43 @@ struct UserMessageList: View {
 
 	private func fetchMessageChangeToken(latestMessage: MessageEntity? = nil) throws -> UserMessageListChangeToken {
 		let latest = try latestMessage ?? fetchMessages(limit: 1).first
+		let acks = try Self.resolvedAckCounts(in: context, toUserNum: user.num)
 		return UserMessageListChangeToken(
 			latest: latest.map(cursor(for:)),
-			count: try fetchIncomingMessageCount() + fetchOutgoingMessageCount()
+			count: try fetchIncomingMessageCount() + fetchOutgoingMessageCount(),
+			deliveredAckCount: acks.delivered,
+			erroredAckCount: acks.errored
 		)
+	}
+
+	/// Tallies of outgoing messages in this conversation whose ACK has resolved — delivered
+	/// (`receivedACK`) and failed (`ackError != 0`) counted separately. A message is shown as
+	/// "Waiting to be acknowledged" until one of these is set, and keeping the tallies distinct
+	/// means every transition (waiting→delivered, waiting→errored, errored→delivered, or a retry
+	/// resetting either) moves at least one tally, so the list reloads. Only outgoing messages
+	/// carry ACK state, so the incoming side is excluded. Exposed `static` so the regression tests
+	/// exercise these exact predicates instead of hand-mirrored copies.
+	///
+	/// Two single-term `fetchCount`s rather than one `||` predicate: a compound `||` (and an extra
+	/// `&&` term such as an `isEmoji` filter) exceeds the `#Predicate` macro's type-check budget.
+	/// Not filtering `isEmoji` only means an acked tapback triggers one extra benign reload.
+	static func resolvedAckCounts(in context: ModelContext, toUserNum userNum: Int64) throws -> (delivered: Int, errored: Int) {
+		let detectionSensorPortNum: Int32 = 10
+		let deliveredDescriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.toUser?.num == userNum
+				&& $0.admin == false && $0.portNum != detectionSensorPortNum
+				&& $0.receivedACK
+			}
+		)
+		let erroredDescriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.toUser?.num == userNum
+				&& $0.admin == false && $0.portNum != detectionSensorPortNum
+				&& $0.ackError != 0
+			}
+		)
+		return (try context.fetchCount(deliveredDescriptor), try context.fetchCount(erroredDescriptor))
 	}
 
 	private func fetchIncomingMessageCount() throws -> Int {

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -28,9 +28,15 @@ private struct UserMessageListChangeToken: Equatable {
 	// Tallies of outgoing messages whose ACK has resolved, kept as separate delivered/errored
 	// counts rather than a single sum: an errored→delivered transition leaves the sum unchanged
 	// (delivered +1, errored −1) but moves both tallies, so the token still changes and the list
-	// reloads. An incoming ACK changes neither `latest` nor `count`, so without these the
-	// poll-based refresh would never reload and the row would stay on "Waiting to be
-	// acknowledged" until the view is rebuilt.
+	// reloads. Together with `latest`/`count` these cover every ACK transition the app produces:
+	// in-place mutations only ever move a message *into* delivered/errored (a tally changes), and
+	// the sole route back to "waiting" is RetryButton, which deletes the message and inserts a
+	// fresh one — moving `latest`/`count`. (There is deliberately no `max(ackTimestamp)` signal:
+	// `ackTimestamp` is stamped from the remote `packet.rxTime`, so it isn't reliably monotonic
+	// and would add an unindexed sort to the 5s poll for a net-zero case that can't occur.) An
+	// incoming ACK changes neither `latest` nor `count`, so without these tallies the poll-based
+	// refresh would never reload and the row would stay on "Waiting to be acknowledged" until the
+	// view is rebuilt.
 	let deliveredAckCount: Int
 	let erroredAckCount: Int
 }
@@ -145,13 +151,13 @@ struct UserMessageList: View {
 		)
 	}
 
-	/// Tallies of outgoing messages in this conversation whose ACK has resolved — delivered
-	/// (`receivedACK`) and failed (`ackError != 0`) counted separately. A message is shown as
-	/// "Waiting to be acknowledged" until one of these is set, and keeping the tallies distinct
-	/// means every transition (waiting→delivered, waiting→errored, errored→delivered, or a retry
-	/// resetting either) moves at least one tally, so the list reloads. Only outgoing messages
-	/// carry ACK state, so the incoming side is excluded. Exposed `static` so the regression tests
-	/// exercise these exact predicates instead of hand-mirrored copies.
+	/// Resolved-ACK tallies for this conversation's outgoing messages: delivered (`receivedACK`)
+	/// and failed (`ackError != 0`) counted separately. A message is shown as "Waiting to be
+	/// acknowledged" until it resolves; folding both tallies into the change token makes the poll
+	/// reload on any ACK state change. Keeping them distinct means errored→delivered (which keeps
+	/// the sum constant) still moves a tally. Only outgoing messages carry ACK state, so the
+	/// incoming side is excluded. Exposed `static` so the regression tests exercise these exact
+	/// predicates.
 	///
 	/// Two single-term `fetchCount`s rather than one `||` predicate: a compound `||` (and an extra
 	/// `&&` term such as an `isEmoji` filter) exceeds the `#Predicate` macro's type-check budget.

--- a/MeshtasticTests/MessageAckStatusRefreshTests.swift
+++ b/MeshtasticTests/MessageAckStatusRefreshTests.swift
@@ -39,8 +39,8 @@ struct MessageAckStatusRefreshTests {
 	/// Total resolved (delivered + errored) count via the *production* helper, so the tests
 	/// exercise the real predicates rather than a hand-mirrored copy that could silently drift.
 	private func resolvedChannelCount(_ channelIndex: Int32) throws -> Int {
-		let counts = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
-		return counts.delivered + counts.errored
+		let acks = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
+		return acks.delivered + acks.errored
 	}
 
 	/// Mirrors `ChannelMessageList.fetchMessageCount()` (the legacy token's `count`).
@@ -107,16 +107,16 @@ struct MessageAckStatusRefreshTests {
 	}
 
 	@Test func channelErroredThenDelivered_movesToken() throws {
-		// Finding #1 regression: a message that resolves to an error and is then delivered keeps
-		// the *summed* resolved count constant (delivered +1, errored −1). The change token must
-		// still move so the row updates from the error display to "Acknowledged".
+		// A message that resolves to an error and is then delivered keeps the *summed* resolved
+		// count constant (delivered +1, errored −1). Tracking the tallies separately means a tally
+		// still moves, so the token changes and the row updates from the error to "Acknowledged".
 		let channelIndex: Int32 = 7_705
 		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_500_001)
 
 		msg.ackError = Int32(RoutingError.maxRetransmit.rawValue)
 		try context.save()
 		let errored = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
-		#expect(errored == (delivered: 0, errored: 1))
+		#expect(errored.delivered == 0 && errored.errored == 1)
 
 		// A later success packet flips ackError→0 and receivedACK→true.
 		msg.ackError = 0
@@ -124,10 +124,38 @@ struct MessageAckStatusRefreshTests {
 		try context.save()
 		let delivered = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
 
-		#expect(delivered == (delivered: 1, errored: 0))
+		#expect(delivered.delivered == 1 && delivered.errored == 0)
 		// The summed count would be blind to this transition; the separate tallies are not.
 		#expect(errored.delivered + errored.errored == delivered.delivered + delivered.errored)
 		#expect(errored != delivered)
+	}
+
+	@Test func channelRetry_movesLatestCursorWhenTallyNetsZero() throws {
+		// The net-zero-tally concern (two messages making offsetting same-type ACK transitions in
+		// one poll window) can only arise via RetryButton, which is the sole route back to
+		// "waiting" — and it *deletes* the failed message and *inserts* a fresh one rather than
+		// mutating in place. So even when the errored tally nets to zero, the brand-new message
+		// becomes the newest row and moves the legacy `latest` cursor, changing the token. This is
+		// why a separate ackTimestamp signal isn't needed.
+		let channelIndex: Int32 = 7_706
+		let msgA = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_600_001, timestamp: 1_700_000_000)
+		let msgB = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_600_002, timestamp: 1_700_000_010)
+		msgB.ackError = Int32(RoutingError.maxRetransmit.rawValue)
+		try context.save()
+		let erroredBefore = try resolvedChannelCount(channelIndex)
+		let cursorBefore = try latestChannelCursor(channelIndex)
+		#expect(erroredBefore == 1)
+
+		// A resolves to errored (+1). B is retried: the failed row is deleted and a new waiting row
+		// is sent (newest timestamp). Errored tally nets to zero (A +1, B −1 via deletion)…
+		msgA.ackError = Int32(RoutingError.maxRetransmit.rawValue)
+		context.delete(msgB)
+		try insertChannelMessage(channelIndex: channelIndex, messageId: 970_600_003, timestamp: 1_700_000_020)
+		try context.save()
+
+		#expect(try resolvedChannelCount(channelIndex) == erroredBefore)
+		// …but the freshly-sent retry message is now the newest, so the `latest` cursor moved.
+		#expect(try latestChannelCursor(channelIndex) != cursorBefore)
 	}
 
 	@Test func channelRoutingError_movesResolvedCount() throws {
@@ -143,28 +171,19 @@ struct MessageAckStatusRefreshTests {
 		#expect(try resolvedChannelCount(channelIndex) == 1)
 	}
 
-	@Test func channelRetry_resetsResolvedCount() throws {
-		let channelIndex: Int32 = 7_703
-		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_300_001)
-
-		// Resolve as failed, then retry (RetryButton path) clears the ACK state back to waiting.
-		msg.ackError = Int32(RoutingError.maxRetransmit.rawValue)
-		try context.save()
-		#expect(try resolvedChannelCount(channelIndex) == 1)
-
-		msg.receivedACK = false
-		msg.ackError = 0
-		try context.save()
-
-		// Back to "Waiting…", and the token moves again so the row reflects the reset.
-		#expect(try resolvedChannelCount(channelIndex) == 0)
-	}
-
 	@Test func incomingChannelMessage_isNotCountedAsResolved() throws {
 		let channelIndex: Int32 = 7_704
-		// Incoming broadcast: same channel scope, but no ACK state (it isn't ours to ack).
-		try insertChannelMessage(channelIndex: channelIndex, messageId: 970_400_001)
+		// An incoming broadcast from another node. Incoming channel messages are never
+		// self-acknowledged — the device doesn't ACK its own received traffic — so receivedACK
+		// stays false and ackError stays 0, which is the genuine state under test. (The channel
+		// change-token predicate is intentionally sender-agnostic, so the guarantee is "unresolved
+		// rows don't count", not "incoming rows are filtered out".)
+		let sender = try makeUser(num: 0x2017_00AA)
+		let incoming = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_400_001)
+		incoming.fromUser = sender
+		try context.save()
 
+		#expect(incoming.receivedACK == false && incoming.ackError == 0)
 		#expect(try totalChannelCount(channelIndex) == 1)
 		#expect(try resolvedChannelCount(channelIndex) == 0)
 	}
@@ -174,8 +193,8 @@ struct MessageAckStatusRefreshTests {
 	/// Total resolved (delivered + errored) count via the *production* helper, so the tests
 	/// exercise the real predicates rather than a hand-mirrored copy that could silently drift.
 	private func resolvedDirectCount(userNum: Int64) throws -> Int {
-		let counts = try UserMessageList.resolvedAckCounts(in: context, toUserNum: userNum)
-		return counts.delivered + counts.errored
+		let acks = try UserMessageList.resolvedAckCounts(in: context, toUserNum: userNum)
+		return acks.delivered + acks.errored
 	}
 
 	private func makeUser(num: Int64) throws -> UserEntity {
@@ -216,22 +235,24 @@ struct MessageAckStatusRefreshTests {
 	}
 
 	@Test func directMessageErroredThenDelivered_movesToken() throws {
-		// Finding #1 regression, DM path: error then delivery leaves the summed count unchanged
-		// but must still move the change token so the conversation reloads.
+		// DM path: error then delivery leaves the summed count unchanged, but a separate tally
+		// still moves so the change token differs and the conversation reloads. (The net-zero
+		// offsetting case is covered by the same retry-deletes-and-reinserts mechanism asserted in
+		// channelRetry_movesLatestCursorWhenTallyNetsZero — it is identical for both lists.)
 		let user = try makeUser(num: 0x2017_0004)
 		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_004)
 
 		msg.ackError = Int32(RoutingError.noResponse.rawValue)
 		try context.save()
 		let errored = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
-		#expect(errored == (delivered: 0, errored: 1))
+		#expect(errored.delivered == 0 && errored.errored == 1)
 
 		msg.ackError = 0
 		msg.receivedACK = true
 		try context.save()
 		let delivered = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
 
-		#expect(delivered == (delivered: 1, errored: 0))
+		#expect(delivered.delivered == 1 && delivered.errored == 0)
 		#expect(errored.delivered + errored.errored == delivered.delivered + delivered.errored)
 		#expect(errored != delivered)
 	}

--- a/MeshtasticTests/MessageAckStatusRefreshTests.swift
+++ b/MeshtasticTests/MessageAckStatusRefreshTests.swift
@@ -1,0 +1,261 @@
+//
+//  MessageAckStatusRefreshTests.swift
+//  MeshtasticTests
+//
+//  Regression coverage for issue #2017: a sent message's status stayed on
+//  "Waiting to be acknowledged" until the channel/conversation view was rebuilt.
+//
+//  ChannelMessageList / UserMessageList snapshot their rows into @State and only
+//  reload when a lightweight "change token" differs. Before the fix that token keyed
+//  only on the newest-message cursor (timestamp + messageId) and the total message
+//  count — neither of which changes when an incoming ACK merely flips `receivedACK` /
+//  `ackError` on an existing row, so the poll never reloaded and the row kept showing
+//  the stale "Waiting…" state.
+//
+//  The fix folds an "acknowledged count" (messages whose ACK has resolved) into the
+//  token. These tests mirror the exact SwiftData predicates the views use and lock in
+//  the contract the fix depends on: the resolved count moves on every ack/fail/retry
+//  transition, while the legacy token signals stay put.
+//
+
+import Testing
+import Foundation
+import SwiftData
+@testable import Meshtastic
+
+@Suite("Message ACK status refresh (#2017)")
+@MainActor
+struct MessageAckStatusRefreshTests {
+
+	private var context: ModelContext { TestContainerProvider.shared.mainContext }
+
+	private struct Cursor: Equatable {
+		let timestamp: Int32
+		let messageId: Int64
+	}
+
+	// MARK: - Channel-message mirrors of ChannelMessageList
+
+	/// Total resolved (delivered + errored) count via the *production* helper, so the tests
+	/// exercise the real predicates rather than a hand-mirrored copy that could silently drift.
+	private func resolvedChannelCount(_ channelIndex: Int32) throws -> Int {
+		let counts = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
+		return counts.delivered + counts.errored
+	}
+
+	/// Mirrors `ChannelMessageList.fetchMessageCount()` (the legacy token's `count`).
+	private func totalChannelCount(_ channelIndex: Int32) throws -> Int {
+		let descriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.channel == channelIndex && $0.toUser == nil && $0.isEmoji == false
+			}
+		)
+		return try context.fetchCount(descriptor)
+	}
+
+	/// Mirrors the legacy token's `latest` cursor: newest message by (timestamp, messageId).
+	private func latestChannelCursor(_ channelIndex: Int32) throws -> Cursor? {
+		var descriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.channel == channelIndex && $0.toUser == nil && $0.isEmoji == false
+			},
+			sortBy: [
+				SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse),
+				SortDescriptor(\MessageEntity.messageId, order: .reverse)
+			]
+		)
+		descriptor.fetchLimit = 1
+		return try context.fetch(descriptor).first.map { Cursor(timestamp: $0.messageTimestamp, messageId: $0.messageId) }
+	}
+
+	@discardableResult
+	private func insertChannelMessage(channelIndex: Int32, messageId: Int64, timestamp: Int32 = 1_700_000_000) throws -> MessageEntity {
+		let msg = MessageEntity()
+		msg.channel = channelIndex
+		msg.toUser = nil
+		msg.isEmoji = false
+		msg.messageId = messageId
+		msg.messageTimestamp = timestamp
+		msg.receivedACK = false
+		msg.ackError = 0
+		context.insert(msg)
+		try context.save()
+		return msg
+	}
+
+	// MARK: - Channel tests
+
+	@Test func channelAck_movesResolvedCount_butNotLegacyToken() throws {
+		let channelIndex: Int32 = 7_701
+		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_100_001)
+
+		// Baseline: a sent-but-unacknowledged message is "Waiting…".
+		#expect(try resolvedChannelCount(channelIndex) == 0)
+		let baselineTotal = try totalChannelCount(channelIndex)
+		let baselineCursor = try latestChannelCursor(channelIndex)
+		#expect(baselineTotal == 1)
+
+		// An incoming ACK flips `receivedACK` on the existing row.
+		msg.receivedACK = true
+		try context.save()
+
+		// New signal moves → the list reloads and the row updates to "Acknowledged".
+		#expect(try resolvedChannelCount(channelIndex) == 1)
+		// Legacy token signals are blind to the ACK — this is exactly why the bug existed.
+		#expect(try totalChannelCount(channelIndex) == baselineTotal)
+		#expect(try latestChannelCursor(channelIndex) == baselineCursor)
+	}
+
+	@Test func channelErroredThenDelivered_movesToken() throws {
+		// Finding #1 regression: a message that resolves to an error and is then delivered keeps
+		// the *summed* resolved count constant (delivered +1, errored −1). The change token must
+		// still move so the row updates from the error display to "Acknowledged".
+		let channelIndex: Int32 = 7_705
+		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_500_001)
+
+		msg.ackError = Int32(RoutingError.maxRetransmit.rawValue)
+		try context.save()
+		let errored = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
+		#expect(errored == (delivered: 0, errored: 1))
+
+		// A later success packet flips ackError→0 and receivedACK→true.
+		msg.ackError = 0
+		msg.receivedACK = true
+		try context.save()
+		let delivered = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
+
+		#expect(delivered == (delivered: 1, errored: 0))
+		// The summed count would be blind to this transition; the separate tallies are not.
+		#expect(errored.delivered + errored.errored == delivered.delivered + delivered.errored)
+		#expect(errored != delivered)
+	}
+
+	@Test func channelRoutingError_movesResolvedCount() throws {
+		let channelIndex: Int32 = 7_702
+		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_200_001)
+		#expect(try resolvedChannelCount(channelIndex) == 0)
+
+		// A failed delivery resolves via a non-zero routing error (receivedACK stays false).
+		msg.ackError = Int32(RoutingError.maxRetransmit.rawValue)
+		try context.save()
+
+		#expect(msg.ackError != 0)
+		#expect(try resolvedChannelCount(channelIndex) == 1)
+	}
+
+	@Test func channelRetry_resetsResolvedCount() throws {
+		let channelIndex: Int32 = 7_703
+		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_300_001)
+
+		// Resolve as failed, then retry (RetryButton path) clears the ACK state back to waiting.
+		msg.ackError = Int32(RoutingError.maxRetransmit.rawValue)
+		try context.save()
+		#expect(try resolvedChannelCount(channelIndex) == 1)
+
+		msg.receivedACK = false
+		msg.ackError = 0
+		try context.save()
+
+		// Back to "Waiting…", and the token moves again so the row reflects the reset.
+		#expect(try resolvedChannelCount(channelIndex) == 0)
+	}
+
+	@Test func incomingChannelMessage_isNotCountedAsResolved() throws {
+		let channelIndex: Int32 = 7_704
+		// Incoming broadcast: same channel scope, but no ACK state (it isn't ours to ack).
+		try insertChannelMessage(channelIndex: channelIndex, messageId: 970_400_001)
+
+		#expect(try totalChannelCount(channelIndex) == 1)
+		#expect(try resolvedChannelCount(channelIndex) == 0)
+	}
+
+	// MARK: - Direct-message mirrors of UserMessageList
+
+	/// Total resolved (delivered + errored) count via the *production* helper, so the tests
+	/// exercise the real predicates rather than a hand-mirrored copy that could silently drift.
+	private func resolvedDirectCount(userNum: Int64) throws -> Int {
+		let counts = try UserMessageList.resolvedAckCounts(in: context, toUserNum: userNum)
+		return counts.delivered + counts.errored
+	}
+
+	private func makeUser(num: Int64) throws -> UserEntity {
+		let user = UserEntity()
+		user.num = num
+		context.insert(user)
+		try context.save()
+		return user
+	}
+
+	@discardableResult
+	private func insertOutgoingDirectMessage(to user: UserEntity, messageId: Int64, portNum: Int32 = 1) throws -> MessageEntity {
+		let msg = MessageEntity()
+		msg.toUser = user
+		msg.isEmoji = false
+		msg.admin = false
+		msg.portNum = portNum
+		msg.messageId = messageId
+		msg.messageTimestamp = 1_700_000_000
+		msg.receivedACK = false
+		msg.ackError = 0
+		context.insert(msg)
+		try context.save()
+		return msg
+	}
+
+	// MARK: - Direct-message tests
+
+	@Test func directMessageAck_movesResolvedCount() throws {
+		let user = try makeUser(num: 0x2017_0001)
+		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_001)
+		#expect(try resolvedDirectCount(userNum: user.num) == 0)
+
+		msg.receivedACK = true
+		try context.save()
+
+		#expect(try resolvedDirectCount(userNum: user.num) == 1)
+	}
+
+	@Test func directMessageErroredThenDelivered_movesToken() throws {
+		// Finding #1 regression, DM path: error then delivery leaves the summed count unchanged
+		// but must still move the change token so the conversation reloads.
+		let user = try makeUser(num: 0x2017_0004)
+		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_004)
+
+		msg.ackError = Int32(RoutingError.noResponse.rawValue)
+		try context.save()
+		let errored = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
+		#expect(errored == (delivered: 0, errored: 1))
+
+		msg.ackError = 0
+		msg.receivedACK = true
+		try context.save()
+		let delivered = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
+
+		#expect(delivered == (delivered: 1, errored: 0))
+		#expect(errored.delivered + errored.errored == delivered.delivered + delivered.errored)
+		#expect(errored != delivered)
+	}
+
+	@Test func directMessageRoutingError_movesResolvedCount() throws {
+		let user = try makeUser(num: 0x2017_0002)
+		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_002)
+		#expect(try resolvedDirectCount(userNum: user.num) == 0)
+
+		msg.ackError = Int32(RoutingError.noResponse.rawValue)
+		try context.save()
+
+		#expect(try resolvedDirectCount(userNum: user.num) == 1)
+	}
+
+	@Test func detectionSensorDirectMessage_isExcludedFromResolvedCount() throws {
+		let user = try makeUser(num: 0x2017_0003)
+		// Detection-sensor messages don't surface an ACK status row, so they must not
+		// drive the conversation's refresh signal even once acknowledged.
+		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_003, portNum: 10)
+
+		msg.receivedACK = true
+		try context.save()
+
+		#expect(try resolvedDirectCount(userNum: user.num) == 0)
+	}
+}


### PR DESCRIPTION
## What changed?

The channel and direct-message lists now reload when an outgoing message's ACK resolves, so its status updates in place instead of only after the conversation view is rebuilt.

Both `ChannelMessageList` and `UserMessageList` snapshot their rows into a `@State` array and only re-fetch when a lightweight *change token* differs. That token keyed solely on the newest-message cursor `(timestamp, messageId)` and the total message count. An incoming ACK changes neither — it just flips `receivedACK` / `ackError` on an existing row — so the poll-based refresh skipped the reload.

This folds the resolved-ACK state into each list's change token as **separate `deliveredAckCount` / `erroredAckCount` tallies** (via a shared `static resolvedAckCounts(...)` helper) so the existing 5-second poll reloads the moment any message leaves the waiting state. The tallies are kept distinct rather than summed so an `errored → delivered` transition — which nets zero on a sum — still moves the token.

## Why did it change?

Fixes #2017: a sent message stayed on "Waiting to be acknowledged. . ." indefinitely and only updated to its real status after backing out of the channel and re-entering.

The ACK itself was received and persisted correctly — this is purely a UI-refresh gap. It's a regression from two compounding performance changes already on `main`:

- **#1901** replaced the reactive message list with a manual `@State` snapshot + change-token poll. The token didn't include ACK state.
- **#1914** moved packet handling onto a background `@ModelActor` and switched the routing-ACK save to a debounced write. The ACK mutates a background-context instance, so the view's main-context `@Bindable` row never observes it directly.

With the reactive binding gone *and* the ACK applied on a separate context, nothing triggered a reload until the view was recreated.

## How is this tested?

New `MessageAckStatusRefreshTests` suite (9 tests, passing on iPhone 16 / iOS 18.2): covers delivery-ack, routing-error, **errored→delivered**, retry-reset, incoming-message-not-counted, and detection-sensor exclusion across both the channel and DM paths. One test also asserts the *legacy* token signals stay unchanged on an ACK, locking in the root cause. Tests call the production `resolvedAckCounts` helper directly so the predicates can't silently drift.

Reviewed with `/code-review` at high effort, which caught the sum-vs-tallies correctness issue (fixed before this PR).

> [!NOTE]
> SwiftData's `#Predicate` macro can't type-check a compound `||` (or a fourth `&&` term) in this predicate shape without exceeding its budget, so the count is split into two single-term `fetchCount`s. `isEmoji` is intentionally not filtered for the same reason — an acked tapback costs one extra benign reload, never wrong data. Both are documented inline.

## Screenshots/Videos (when applicable)

N/A — no visual change; the existing "Waiting to be acknowledged. . ." / "Acknowledged" text simply updates without re-entering the view.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. No doc update needed — internal refresh logic only; please add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message and conversation lists now refresh reliably when delivery acknowledgment status changes, even if the total message count and latest cursor remain unchanged.
  * Improves handling of both successful and errored delivery transitions (including retries) so the UI doesn’t get stuck or go stale.
  * Ensures incoming broadcast-style messages and detection-sensor direct messages don’t incorrectly affect refresh behavior.

* **Tests**
  * Added regression tests covering ACK-resolution–driven refresh behavior for both channel messages and direct messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->