### PR TITLE
fix: stop SwiftData SIGTRAP in node list rows and message relay display

### DIFF
--- a/Meshtastic/Extensions/SwiftData/MessageEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/MessageEntityExtension.swift
@@ -90,16 +90,14 @@ extension MessageEntity {
 			if !name.isEmpty { return name }
 		}
 
-		// If no exact match, find the node with the smallest hopsAway. Guard the userNode
-		// relationship read per user so a faulted node can't trap the comparison.
-		if let closestNode = matchingUsers.min(by: { lhs, rhs in
-			guard let lhsHops = lhs.liveUserNode?.hopsAway,
-				let rhsHops = rhs.liveUserNode?.hopsAway
-			else {
-				return false
-			}
-			return lhsHops < rhsHops
-		}) {
+		// If no exact match, find the node with the smallest hopsAway. Users whose hops are unknown
+		// can't be ranked, so filter them out before comparing — leaving them in makes the comparator
+		// return false for every pair involving them, which isn't a strict weak ordering and lets a
+		// nil-hops user "win" purely by its position in the array. Fall back to the first match when
+		// none have hops. `liveUserNode` guards the relationship read so a faulted node can't trap.
+		let rankable = matchingUsers.filter { $0.liveUserNode?.hopsAway != nil }
+		if let closestNode = rankable.min(by: { ($0.liveUserNode?.hopsAway ?? .max) < ($1.liveUserNode?.hopsAway ?? .max) })
+			?? matchingUsers.first {
 			let name = closestNode.displayLongName
 			if !name.isEmpty { return name }
 		}

--- a/Meshtastic/Extensions/SwiftData/MessageEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/MessageEntityExtension.swift
@@ -62,17 +62,27 @@ extension MessageEntity {
 
 	@MainActor
 	func relayDisplay() -> String? {
+		// This message can be read from a retained row after it (or the models it reaches through)
+		// were deleted underneath the list; reading a persisted property of a dead @Model fatally
+		// traps in SwiftData (SIGTRAP). Bail while `self` is no longer live before touching any of
+		// its stored properties. Mirrors the row guard in ChannelMessageRow/UserMessageRow (#2014).
+		guard modelContext != nil, !isDeleted else { return nil }
 
 		guard self.relayNode != 0 else { return nil }
-		let context = PersistenceController.shared.context
-
 		let relaySuffix = Int64(self.relayNode & 0xFF)
+		let hexFallback = String(format: "Node 0x%02X", UInt32(self.relayNode & 0xFF))
+
+		let context = PersistenceController.shared.context
 		let descriptor = FetchDescriptor<UserEntity>()
 
 		guard let users = try? context.fetch(descriptor) else {
-			return String(format: "Node 0x%02X", UInt32(self.relayNode & 0xFF))
+			return hexFallback
 		}
-		let matchingUsers = users.filter { ($0.num & 0xFF) == relaySuffix }
+		// Only consider users still live in the context — a freshly-fetched set can still contain
+		// entries being torn down, and reading their name or `userNode` relationship would trap.
+		let matchingUsers = users.filter { user in
+			user.modelContext != nil && !user.isDeleted && (user.num & 0xFF) == relaySuffix
+		}
 
 		// If exactly one match is found, return its name
 		if matchingUsers.count == 1 {
@@ -80,10 +90,11 @@ extension MessageEntity {
 			if !name.isEmpty { return name }
 		}
 
-		// If no exact match, find the node with the smallest hopsAway
+		// If no exact match, find the node with the smallest hopsAway. Guard the userNode
+		// relationship read per user so a faulted node can't trap the comparison.
 		if let closestNode = matchingUsers.min(by: { lhs, rhs in
-			guard let lhsHops = lhs.userNode?.hopsAway,
-				let rhsHops = rhs.userNode?.hopsAway
+			guard let lhsHops = lhs.liveUserNode?.hopsAway,
+				let rhsHops = rhs.liveUserNode?.hopsAway
 			else {
 				return false
 			}
@@ -94,6 +105,16 @@ extension MessageEntity {
 		}
 
 		// Fallback to hex node number if no matches
-		return String(format: "Node 0x%02X", UInt32(self.relayNode & 0xFF))
+		return hexFallback
+	}
+}
+
+extension UserEntity {
+	/// The `userNode` relationship, but only when this user is still live in its context. Reading a
+	/// relationship on a deleted/zombie @Model fatally traps in SwiftData; callers on render paths
+	/// use this so a node pruned underneath them can't crash the read.
+	var liveUserNode: NodeInfoEntity? {
+		guard modelContext != nil, !isDeleted else { return nil }
+		return userNode
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -9,15 +9,44 @@ import SwiftUI
 import CoreLocation
 import Foundation
 
+/// A complete, value-type snapshot of everything a node-list row renders, captured from the live
+/// `NodeInfoEntity` (and its `user` relationship) while it is valid.
+///
+/// SwiftData fatally traps (SIGTRAP in `_SD_get_faulting_backingdata_tsd`) when a persisted
+/// property — especially a relationship like `NodeInfoEntity.user` — is read on a model whose
+/// backing row has been removed. Bulk deletes (`clearStaleNodes`, `clearDatabase`'s
+/// `delete(model:)`) invalidate in-memory instances *without* flipping `isDeleted`, so a retained
+/// List row that re-evaluates its body before the List drops it reads a zombie and crashes — the
+/// top crash on 2.7.15 (NodeListItem/NodeListItemCompact, ~48% of crashes).
+///
+/// The row memoizes one of these snapshots in `@State` (see `NodeListItem.body`) and renders from
+/// it, so a re-evaluation after the model dies never touches the live object. Value types can't
+/// fault.
 struct NodeListRowSummary {
-	// Snapshot the position and device metrics as plain value types at construction
-	// time rather than vending live PositionEntity/TelemetryEntity objects. SwiftData
-	// fatally traps (SIGTRAP in _SD_get_faulting_backingdata_tsd) if a deleted @Model's
-	// persisted property is read, and both position rows and telemetry history are
-	// pruned constantly underneath the list (telemetry via shouldPruneTelemetryHistory,
-	// nullify relationship — so the captured metrics row can be deleted while the node
-	// stays live). A view body holding either live object can crash mid-render; value-
-	// type snapshots can never fault.
+	// Identity / name
+	let num: Int64
+	let shortName: String?
+	let displayLongName: String
+	let role: DeviceRoles?
+	let pkiEncrypted: Bool
+	let keyMatch: Bool
+	let unmessagable: Bool
+
+	// Node scalars
+	let favorite: Bool
+	let hasXeddsaSigned: Bool
+	let statusMessage: String?
+	let lastHeard: Date?
+	let isOnline: Bool
+	let hopsAway: Int32
+	let snr: Float
+	let rssi: Int32
+	let channel: Int32
+	let viaMqtt: Bool
+	let isStoreForwardRouter: Bool
+
+	// Snapshotted metrics / position / log availability (never vend live PositionEntity/
+	// TelemetryEntity — those rows are pruned constantly underneath the list and would fault too).
 	let batteryLevel: Int32?
 	let hasDeviceMetrics: Bool
 	let hasPosition: Bool
@@ -32,6 +61,27 @@ struct NodeListRowSummary {
 		includePosition: Bool = true,
 		includeLogAvailability: Bool = true
 	) {
+		num = node.num
+		let user = node.user
+		shortName = user?.shortName
+		displayLongName = user?.displayLongName ?? "Unknown".localized
+		role = DeviceRoles(rawValue: Int(user?.role ?? 0))
+		pkiEncrypted = user?.pkiEncrypted ?? false
+		keyMatch = user?.keyMatch ?? false
+		unmessagable = user?.unmessagable ?? false
+
+		favorite = node.favorite
+		hasXeddsaSigned = node.hasXeddsaSigned
+		statusMessage = node.statusMessageDisplay
+		lastHeard = node.lastHeard
+		isOnline = node.isOnline
+		hopsAway = node.hopsAway
+		snr = node.snr
+		rssi = node.rssi
+		channel = node.channel
+		viaMqtt = node.viaMqtt
+		isStoreForwardRouter = node.isStoreForwardRouter
+
 		let latestDeviceMetrics = includeDeviceMetrics ? node.latestDeviceMetrics : nil
 		batteryLevel = latestDeviceMetrics?.batteryLevel
 		hasDeviceMetrics = latestDeviceMetrics != nil
@@ -41,6 +91,15 @@ struct NodeListRowSummary {
 		hasEnvironmentMetrics = includeLogAvailability ? node.hasEnvironmentMetrics : false
 		hasDetectionSensorMetrics = includeLogAvailability ? node.hasDetectionSensorMetrics : false
 		hasTraceRoutes = includeLogAvailability ? node.hasTraceRoutes : false
+	}
+
+	/// The lock/key glyph and color for the node's PKI state — derived from the snapshot so the row
+	/// never re-reads `node.user` at render time.
+	var keyStatus: (image: String, color: Color) {
+		if pkiEncrypted {
+			return keyMatch ? ("lock.fill", .green) : ("key.slash", .red)
+		}
+		return ("lock.open.fill", .yellow)
 	}
 }
 
@@ -58,43 +117,42 @@ struct NodeListItem: View {
 		return f
 	}()
 
-	private func accessibilityDescription(batteryLevel: Int32?, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?, status: String?) -> String {
+	private func accessibilityDescription(_ summary: NodeListRowSummary, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?) -> String {
 		var desc = ""
 		// The device shortName is never overridden by a local display name, so it's safe to branch
 		// on it directly here; only the longName fallback needs the display-name-aware variant.
-		if let shortName = node.user?.shortName, !shortName.isEmpty {
+		if let shortName = summary.shortName, !shortName.isEmpty {
 			desc = shortName.formatNodeNameForVoiceOver()
-		} else if let user = node.user, let longName = user.longName, !longName.isEmpty {
-			desc = user.displayLongName
+		} else if !summary.displayLongName.isEmpty {
+			desc = summary.displayLongName
 		} else {
 			desc = "Unknown".localized + " " + "Node".localized
 		}
 		if isDirectlyConnected {
 			desc += ", currently connected"
 		}
-		if node.favorite {
+		if summary.favorite {
 			desc += ", favorite"
 		}
-		if let status {
+		if let status = summary.statusMessage {
 			desc += ", status: " + status
 		}
-		if let lastHeard = node.lastHeard {
+		if let lastHeard = summary.lastHeard {
 			let relative = Self.relativeDateFormatter.localizedString(for: lastHeard, relativeTo: Date())
 			desc += ", last heard " + relative
 		}
-		if node.isOnline {
+		if summary.isOnline {
 			desc += ", online"
 		} else {
 			desc += ", offline"
 		}
-		let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
-		if let roleName = role?.name {
+		if let roleName = summary.role?.name {
 			desc += ", role: \(roleName)"
 		}
-		if node.hopsAway > 0 {
-			desc += ", \(node.hopsAway) hops away"
+		if summary.hopsAway > 0 {
+			desc += ", \(summary.hopsAway) hops away"
 		}
-		if let battery = batteryLevel {
+		if let battery = summary.batteryLevel {
 			if battery > 100 {
 				desc += ", " + "Plugged in".localized
 			} else if battery == 100 {
@@ -112,11 +170,11 @@ struct NodeListItem: View {
 			let formattedHeading = heading.formatted(.measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0))))
 			desc += ", " + "Heading".localized + " " + formattedHeading
 		}
-		if node.snr != 0 && !node.viaMqtt {
+		if summary.snr != 0 && !summary.viaMqtt {
 			let signalStrength: BLESignalStrength
-			if node.snr < -10 {
+			if summary.snr < -10 {
 				signalStrength = .weak
-			} else if node.snr < 5 {
+			} else if summary.snr < 5 {
 				signalStrength = .normal
 			} else {
 				signalStrength = .strong
@@ -134,33 +192,21 @@ struct NodeListItem: View {
 		}
 		// Mirror the visual "Signed node" trust signal (see the shield row below) so VoiceOver
 		// announces it too — affirmative only, never for unsigned nodes.
-		if node.hasXeddsaSigned {
+		if summary.hasXeddsaSigned {
 			desc += ", " + "Signed node".localized
 		}
 		return desc
 	}
-	
+
 	@Bindable var node: NodeInfoEntity
+	/// The memoized value-type snapshot the row renders from. Captured while the node is live and
+	/// never re-derived from the live model during a plain re-evaluation, so a retained row can't
+	/// fault on a zombie @Model. Refreshed (guarded) when the node's `lastHeard` changes.
 	@State private var rowSummary: NodeListRowSummary?
 	var isDirectlyConnected: Bool
 	var connectedNode: Int64
 	var modemPreset: ModemPresets = ModemPresets(rawValue: UserDefaults.modemPreset) ?? ModemPresets.longFast
-	
-	var userKeyStatus: (String, Color) {
-		var image = "lock.open.fill"
-		var color = Color.yellow
-		if node.user?.pkiEncrypted ?? false {
-			if !(node.user?.keyMatch ?? false) {
-				image = "key.slash"
-				color = .red
-			} else {
-				image = "lock.fill"
-				color = .green
-			}
-		}
-		return (image, color)
-	}
-	
+
 	func locationData(for nodeCoordinate: CLLocationCoordinate2D?) -> (nodeLocation: CLLocation, myLocation: CLLocation)? {
 		guard let nodeCoordinate else {
 			return nil
@@ -176,32 +222,33 @@ struct NodeListItem: View {
 		}
 		return nil
 	}
-	
+
 	var body: some View {
-		// A List row view can be retained and re-evaluate its body after the underlying
-		// node row has been deleted (nodes/positions are pruned constantly). Reading any
-		// persisted property of a deleted @Model fatally traps in SwiftData, so bail to an
-		// empty row when the node is no longer live — the List drops it on its next rebuild.
-		// Mirrors the modelContext guard already used in NodeList/NodeDetail.
-		if node.modelContext != nil && !node.isDeleted {
-			rowContent
+		// Render from the cached snapshot whenever we have one — this path never touches the live
+		// @Model, so a row retained past the node's deletion (nodes/positions are pruned constantly;
+		// bulk deletes leave zombies that `isDeleted` doesn't flag) can't fault. Only the first
+		// appearance reads the live node, and only while it's still valid.
+		if let rowSummary {
+			rowContent(rowSummary)
+		} else if node.modelContext != nil && !node.isDeleted {
+			let summary = NodeListRowSummary(node: node)
+			rowContent(summary)
+				.onAppear { rowSummary = summary }
 		} else {
 			EmptyView()
 		}
 	}
 
-	@ViewBuilder private var rowContent: some View {
-		let cachedBatteryLevel = rowSummary?.batteryLevel
-		let cachedLocationData = connectedNode == node.num ? nil : locationData(for: rowSummary?.latestNodeCoordinate)
-		let cachedHasPositions = rowSummary?.hasPosition ?? false
-		let cachedHasDeviceMetrics = rowSummary?.hasDeviceMetrics ?? false
-		let cachedHasEnvironmentMetrics = rowSummary?.hasEnvironmentMetrics ?? false
-		let cachedHasDetectionSensorMetrics = rowSummary?.hasDetectionSensorMetrics ?? false
-		let cachedHasTraceRoutes = rowSummary?.hasTraceRoutes ?? false
+	@ViewBuilder private func rowContent(_ summary: NodeListRowSummary) -> some View {
+		let cachedBatteryLevel = summary.batteryLevel
+		let cachedLocationData = connectedNode == summary.num ? nil : locationData(for: summary.latestNodeCoordinate)
+		let cachedHasPositions = summary.hasPosition
+		let cachedHasDeviceMetrics = summary.hasDeviceMetrics
+		let cachedHasEnvironmentMetrics = summary.hasEnvironmentMetrics
+		let cachedHasDetectionSensorMetrics = summary.hasDetectionSensorMetrics
+		let cachedHasTraceRoutes = summary.hasTraceRoutes
 		let cachedHasLogs = cachedHasPositions || cachedHasEnvironmentMetrics || cachedHasDetectionSensorMetrics || cachedHasTraceRoutes
-		// Resolve the status once per render and reuse it for the row + accessibility label,
-		// rather than re-traversing the relationship for each read.
-		let statusMessage = node.statusMessageDisplay
+		let statusMessage = summary.statusMessage
 		// A plain VStack — NOT LazyVStack. A LazyVStack reports inconsistent self-sized
 		// heights when measured inside a List cell (it sizes lazily from a scroll viewport),
 		// which sends UICollectionViewCompositionalLayout into a recursive layout loop and
@@ -210,7 +257,7 @@ struct NodeListItem: View {
 		VStack(alignment: .leading) {
 			HStack {
 				VStack(alignment: .center) {
-					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: 70)
+					CircleText(text: summary.shortName ?? "?", color: Color(UIColor(hex: UInt32(summary.num))), circleSize: 70)
 						.padding(.trailing, 5)
 					if let batteryLevel = cachedBatteryLevel {
 						BatteryCompact(batteryLevel: batteryLevel, font: .caption, iconFont: .callout, color: .accentColor)
@@ -219,12 +266,12 @@ struct NodeListItem: View {
 				}
 				VStack(alignment: .leading) {
 					HStack {
-						let (image, color) = userKeyStatus
+						let (image, color) = summary.keyStatus
 						IconAndText(systemName: image,
 									imageColor: color,
-									text: node.user?.displayLongName.addingVariationSelectors ?? "Unknown".localized,
+									text: summary.displayLongName.addingVariationSelectors,
 									textColor: .primary)
-						if node.favorite {
+						if summary.favorite {
 							Spacer()
 							Image(systemName: "star.fill")
 								.symbolRenderingMode(.multicolor)
@@ -232,7 +279,7 @@ struct NodeListItem: View {
 					}
 					// Signed node = XEdDSA-signed NodeInfo broadcast → identity verified by the radio.
 					// Affirmative only; never shown for unsigned nodes. Mirrors the Node Detail row.
-					if node.hasXeddsaSigned {
+					if summary.hasXeddsaSigned {
 						IconAndText(systemName: "checkmark.shield.fill",
 									imageColor: .green,
 									text: "Signed node".localized)
@@ -253,26 +300,25 @@ struct NodeListItem: View {
 									imageColor: .green,
 									text: "Connected".localized)
 					}
-					if node.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && node.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
-						IconAndText(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
-									imageColor: node.isOnline ? .green : .orange,
-							text: node.lastHeard?.formatted(date: .numeric, time: .shortened) ?? "Unknown Age".localized)
+					if summary.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && summary.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
+						IconAndText(systemName: summary.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
+									imageColor: summary.isOnline ? .green : .orange,
+							text: summary.lastHeard?.formatted(date: .numeric, time: .shortened) ?? "Unknown Age".localized)
 					}
-					let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
-					IconAndText(systemName: role?.systemName ?? "figure",
-								text: "Role: \(role?.name ?? "Unknown".localized)")
-					if node.user?.unmessagable ?? false {
+					IconAndText(systemName: summary.role?.systemName ?? "figure",
+								text: "Role: \(summary.role?.name ?? "Unknown".localized)")
+					if summary.unmessagable {
 						IconAndText(systemName: "iphone.slash",
 									renderingMode: .multicolor,
 									text: "Unmonitored")
 					}
-					if node.isStoreForwardRouter {
+					if summary.isStoreForwardRouter {
 						IconAndText(systemName: "envelope.arrow.triangle.branch",
 									renderingMode: .multicolor,
 									text: "Store & Forward".localized)
 					}
-					
-					if connectedNode != node.num {
+
+					if connectedNode != summary.num {
 						HStack {
 							if let (nodeCoord, myCoord) = cachedLocationData {
 								let metersAway = nodeCoord.distance(from: myCoord)
@@ -298,11 +344,11 @@ struct NodeListItem: View {
 						}
 					}
 					HStack {
-						if node.channel > 0 {
-							IconAndText(systemName: "\(node.channel).circle.fill", text: "Channel")
+						if summary.channel > 0 {
+							IconAndText(systemName: "\(summary.channel).circle.fill", text: "Channel")
 						}
-						
-						if node.viaMqtt && connectedNode != node.num {
+
+						if summary.viaMqtt && connectedNode != summary.num {
 							IconAndText(systemName: "dot.radiowaves.up.forward",
 										renderingMode: .multicolor,
 										text: "MQTT")
@@ -328,15 +374,15 @@ struct NodeListItem: View {
 							}
 						}
 					}
-					if node.hopsAway > 0 {
+					if summary.hopsAway > 0 {
 						HStack {
 							IconAndText(systemName: "hare", text: "Hops Away:")
-							Image(systemName: "\(node.hopsAway).square")
+							Image(systemName: "\(summary.hopsAway).square")
 								.font(.title2)
 						}
 					} else {
-						if node.snr != 0 && !node.viaMqtt {
-							LoRaSignalStrengthMeter(snr: node.snr, rssi: node.rssi, preset: modemPreset, compact: true)
+						if summary.snr != 0 && !summary.viaMqtt {
+							LoRaSignalStrengthMeter(snr: summary.snr, rssi: summary.rssi, preset: modemPreset, compact: true)
 								.padding(.top, cachedHasLogs ? 0 : 15)
 						}
 					}
@@ -347,12 +393,12 @@ struct NodeListItem: View {
 		.padding(.top, 3)
 		.padding(.bottom, 3)
 		.task(id: node.lastHeard) {
-			rowSummary = await MainActor.run {
-				NodeListRowSummary(node: node)
-			}
+			// Refresh the snapshot when the node changes, but only while it is still live.
+			guard node.modelContext != nil && !node.isDeleted else { return }
+			rowSummary = NodeListRowSummary(node: node)
 		}
 		.accessibilityElement(children: .ignore)
-		.accessibilityLabel(accessibilityDescription(batteryLevel: cachedBatteryLevel, cachedLocationData: cachedLocationData, status: statusMessage))
+		.accessibilityLabel(accessibilityDescription(summary, cachedLocationData: cachedLocationData))
 	}
 }
 
@@ -412,7 +458,7 @@ struct IconAndText: View {
 	var renderingMode: SymbolRenderingMode = .hierarchical
 	let text: String
 	var textColor: Color = .gray
-	
+
 	@ViewBuilder
 	var image: some View {
 		if let color = imageColor {
@@ -422,7 +468,7 @@ struct IconAndText: View {
 			Image(systemName: systemName)
 		}
 	}
-	
+
 	var body: some View {
 		HStack {
 			image

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -392,7 +392,9 @@ struct NodeListItem: View {
 		}
 		.padding(.top, 3)
 		.padding(.bottom, 3)
-		.task(id: node.lastHeard) {
+		// Gate the identity on liveness too: `.task(id:)` reads `node.lastHeard` during body
+		// construction, which would fault on an invalidated model before the body's guard runs.
+		.task(id: (node.modelContext != nil && !node.isDeleted) ? node.lastHeard : nil) {
 			// Refresh the snapshot when the node changes, but only while it is still live.
 			guard node.modelContext != nil && !node.isDeleted else { return }
 			rowSummary = NodeListRowSummary(node: node)

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -333,7 +333,9 @@ struct NodeListItemCompact: View {
 		}
 			.padding(.top, 2)
 			.padding(.bottom, 2)
-			.task(id: node.lastHeard) {
+			// Gate the identity on liveness too: `.task(id:)` reads `node.lastHeard` during body
+			// construction, which would fault on an invalidated model before the body's guard runs.
+			.task(id: (node.modelContext != nil && !node.isDeleted) ? node.lastHeard : nil) {
 				// Refresh the snapshot when the node changes, but only while it is still live.
 				guard node.modelContext != nil && !node.isDeleted else { return }
 				rowSummary = NodeListRowSummary(

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -39,43 +39,42 @@ struct NodeListItemCompact: View {
 		return f
 	}()
 
-	private func accessibilityDescription(batteryLevel: Int32?, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?, status: String?) -> String {
+	private func accessibilityDescription(_ summary: NodeListRowSummary, cachedLocationData: (nodeLocation: CLLocation, myLocation: CLLocation)?) -> String {
 		var desc = ""
 		// The device shortName is never overridden by a local display name, so it's safe to branch
 		// on it directly here; only the longName fallback needs the display-name-aware variant.
-		if let shortName = node.user?.shortName, !shortName.isEmpty {
+		if let shortName = summary.shortName, !shortName.isEmpty {
 			desc = shortName.formatNodeNameForVoiceOver()
-		} else if let user = node.user, let longName = user.longName, !longName.isEmpty {
-			desc = user.displayLongName
+		} else if !summary.displayLongName.isEmpty {
+			desc = summary.displayLongName
 		} else {
 			desc = "Unknown".localized + " " + "Node".localized
 		}
 		if isDirectlyConnected {
 			desc += ", currently connected"
 		}
-		if node.favorite {
+		if summary.favorite {
 			desc += ", favorite"
 		}
-		if let status {
+		if let status = summary.statusMessage {
 			desc += ", status: " + status
 		}
-		if let lastHeard = node.lastHeard {
+		if let lastHeard = summary.lastHeard {
 			let relative = Self.relativeDateFormatter.localizedString(for: lastHeard, relativeTo: Date())
 			desc += ", last heard " + relative
 		}
-		if node.isOnline {
+		if summary.isOnline {
 			desc += ", online"
 		} else {
 			desc += ", offline"
 		}
-		let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
-		if let roleName = role?.name {
+		if let roleName = summary.role?.name {
 			desc += ", role: \(roleName)"
 		}
-		if node.hopsAway > 0 {
-			desc += ", \(node.hopsAway) hops away"
+		if summary.hopsAway > 0 {
+			desc += ", \(summary.hopsAway) hops away"
 		}
-		if let battery = batteryLevel {
+		if let battery = summary.batteryLevel {
 			if battery > 100 {
 				desc += ", " + "Plugged in".localized
 			} else if battery == 100 {
@@ -93,11 +92,11 @@ struct NodeListItemCompact: View {
 			let formattedHeading = heading.formatted(.measurement(width: .narrow, numberFormatStyle: .number.precision(.fractionLength(0))))
 			desc += ", " + "Heading".localized + " " + formattedHeading
 		}
-		if node.snr != 0 && !node.viaMqtt {
+		if summary.snr != 0 && !summary.viaMqtt {
 			let signalStrength: BLESignalStrength
-			if node.snr < -10 {
+			if summary.snr < -10 {
 				signalStrength = .weak
-			} else if node.snr < 5 {
+			} else if summary.snr < 5 {
 				signalStrength = .normal
 			} else {
 				signalStrength = .strong
@@ -115,33 +114,20 @@ struct NodeListItemCompact: View {
 		}
 		// Mirror the visual "Signed node" shield (rendered below) so VoiceOver announces it in the
 		// compact list too — affirmative only, never for unsigned nodes.
-		if node.hasXeddsaSigned {
+		if summary.hasXeddsaSigned {
 			desc += ", " + "Signed node".localized
 		}
 		return desc
 	}
 
 		@Bindable var node: NodeInfoEntity
+		// Memoized value-type snapshot; rendered from instead of re-reading the live @Model on every
+		// body re-evaluation, so a retained row can't fault on a deleted/zombie node. See NodeListItem.
 		@State private var rowSummary: NodeListRowSummary?
 		var isDirectlyConnected: Bool
 		var connectedNode: Int64
 	var modemPreset: ModemPresets = ModemPresets(rawValue: UserDefaults.modemPreset) ?? ModemPresets.longFast
-	
-	var userKeyStatus: (String, Color) {
-		var image = "lock.open.fill"
-		var color = Color.yellow
-		if node.user?.pkiEncrypted ?? false {
-			if !(node.user?.keyMatch ?? false) {
-				image = "key.slash"
-				color = .red
-			} else {
-				image = "lock.fill"
-				color = .green
-			}
-		}
-		return (image, color)
-	}
-	
+
 	func locationData(for nodeCoordinate: CLLocationCoordinate2D?) -> (nodeLocation: CLLocation, myLocation: CLLocation)? {
 		guard let nodeCoordinate else {
 			return nil
@@ -158,12 +144,12 @@ struct NodeListItemCompact: View {
 		return nil
 	}
 	
-	var lineNums: Int {
+	private func lineNums(hasXeddsaSigned: Bool) -> Int {
 		var lines = 1
 		if shouldShowRole || shouldShowLocation || shouldShowTelemetry || shouldShowChannel || shouldShowHops || shouldShowSignal {
 			lines += 1
 		}
-		
+
 		if shouldShowLastHeard {
 			lines += 1
 		}
@@ -171,7 +157,7 @@ struct NodeListItemCompact: View {
 		// The signed-node ("Signed node") row renders on its own line whenever the node is signed,
 		// so reserve space for it too — otherwise the avatar circle is sized too short for signed
 		// nodes, most visibly when last-heard / telemetry rows are disabled.
-		if node.hasXeddsaSigned {
+		if hasXeddsaSigned {
 			lines += 1
 		}
 
@@ -179,33 +165,41 @@ struct NodeListItemCompact: View {
 		// `statusMessage` value, so `node.statusMessageDisplay` is evaluated only once.
 		return lines
 	}
-	
+
 	var body: some View {
-		// A List row view can be retained and re-evaluate its body after the underlying
-		// node row has been deleted (nodes/positions are pruned constantly). Reading any
-		// persisted property of a deleted @Model fatally traps in SwiftData, so bail to an
-		// empty row when the node is no longer live — the List drops it on its next rebuild.
-		// Mirrors the modelContext guard already used in NodeList/NodeDetail.
-		if node.modelContext != nil && !node.isDeleted {
-			rowContent
+		// Render from the cached value-type snapshot whenever we have one — that path never touches
+		// the live @Model, so a row retained past the node's deletion (bulk deletes leave zombies
+		// that `isDeleted` doesn't flag) can't fault. Only the first appearance reads the live node,
+		// and only while it's still valid. See NodeListItem for the full explanation.
+		if let rowSummary {
+			rowContent(rowSummary)
+		} else if node.modelContext != nil && !node.isDeleted {
+			let summary = NodeListRowSummary(
+				node: node,
+				includeDeviceMetrics: shouldShowPower || shouldShowTelemetry,
+				includePosition: shouldShowTelemetry || (shouldShowLocation && connectedNode != node.num),
+				includeLogAvailability: shouldShowTelemetry
+			)
+			rowContent(summary)
+				.onAppear { rowSummary = summary }
 		} else {
 			EmptyView()
 		}
 	}
 
-	@ViewBuilder private var rowContent: some View {
+	@ViewBuilder private func rowContent(_ summary: NodeListRowSummary) -> some View {
 		// Resolve the status once per render; reused for the row, circle sizing, and a11y.
-		let statusMessage = node.statusMessageDisplay
-		let circleSize = max(minCircle, min(maxCircle, baseUnit * CGFloat(lineNums + (statusMessage != nil ? 1 : 0))))
-		let cachedBatteryLevel = (shouldShowPower || shouldShowTelemetry) ? rowSummary?.batteryLevel : nil
-		let needsLatestPosition = shouldShowTelemetry || (shouldShowLocation && connectedNode != node.num)
-		let cachedLatestNodeCoordinate = needsLatestPosition ? rowSummary?.latestNodeCoordinate : nil
-		let cachedLocationData = (shouldShowLocation && connectedNode != node.num) ? locationData(for: cachedLatestNodeCoordinate) : nil
-		let cachedHasPositions = shouldShowTelemetry ? (rowSummary?.hasPosition ?? false) : false
-		let cachedHasDeviceMetrics = shouldShowTelemetry && (rowSummary?.hasDeviceMetrics ?? false)
-		let cachedHasEnvironmentMetrics = shouldShowTelemetry ? rowSummary?.hasEnvironmentMetrics ?? false : false
-		let cachedHasDetectionSensorMetrics = shouldShowTelemetry ? rowSummary?.hasDetectionSensorMetrics ?? false : false
-		let cachedHasTraceRoutes = shouldShowTelemetry ? rowSummary?.hasTraceRoutes ?? false : false
+		let statusMessage = summary.statusMessage
+		let circleSize = max(minCircle, min(maxCircle, baseUnit * CGFloat(lineNums(hasXeddsaSigned: summary.hasXeddsaSigned) + (statusMessage != nil ? 1 : 0))))
+		let cachedBatteryLevel = (shouldShowPower || shouldShowTelemetry) ? summary.batteryLevel : nil
+		let needsLatestPosition = shouldShowTelemetry || (shouldShowLocation && connectedNode != summary.num)
+		let cachedLatestNodeCoordinate = needsLatestPosition ? summary.latestNodeCoordinate : nil
+		let cachedLocationData = (shouldShowLocation && connectedNode != summary.num) ? locationData(for: cachedLatestNodeCoordinate) : nil
+		let cachedHasPositions = shouldShowTelemetry ? summary.hasPosition : false
+		let cachedHasDeviceMetrics = shouldShowTelemetry && summary.hasDeviceMetrics
+		let cachedHasEnvironmentMetrics = shouldShowTelemetry ? summary.hasEnvironmentMetrics : false
+		let cachedHasDetectionSensorMetrics = shouldShowTelemetry ? summary.hasDetectionSensorMetrics : false
+		let cachedHasTraceRoutes = shouldShowTelemetry ? summary.hasTraceRoutes : false
 		// Plain VStack, not LazyVStack: a LazyVStack inside a List cell returns inconsistent
 		// self-sized heights and trips UICollectionViewCompositionalLayout's recursive
 		// layout-loop trap on iOS 18+/26. See NodeListItem for the full explanation.
@@ -213,7 +207,7 @@ struct NodeListItemCompact: View {
 			HStack {
 				// First Column
 				VStack(alignment: .center) {
-					CircleText(text: node.user?.shortName ?? "?", color: Color(UIColor(hex: UInt32(node.num))), circleSize: circleSize)
+					CircleText(text: summary.shortName ?? "?", color: Color(UIColor(hex: UInt32(summary.num))), circleSize: circleSize)
 						.padding(.trailing, 5)
 					if shouldShowPower, let batteryLevel = cachedBatteryLevel {
 						BatteryCompact(batteryLevel: batteryLevel, font: .caption2, iconFont: .caption, color: .accentColor)
@@ -224,12 +218,12 @@ struct NodeListItemCompact: View {
 				// Second Column
 				VStack(alignment: .leading, spacing: rowSpacing) {
 					HStack(alignment: .firstTextBaseline) {
-						let (image, color) = userKeyStatus
+						let (image, color) = summary.keyStatus
 						IconAndText(systemName: image,
 									imageColor: color,
-									text: node.user?.displayLongName.addingVariationSelectors ?? "Unknown".localized,
+									text: summary.displayLongName.addingVariationSelectors,
 									textColor: .primary)
-						if node.favorite {
+						if summary.favorite {
 							Spacer()
 							Image(systemName: "star.fill")
 								.symbolRenderingMode(.multicolor)
@@ -237,7 +231,7 @@ struct NodeListItemCompact: View {
 					}
 					// Signed node = XEdDSA-signed NodeInfo broadcast → identity verified by the radio.
 					// Affirmative only; never shown for unsigned nodes. Mirrors the Node Detail row.
-					if node.hasXeddsaSigned {
+					if summary.hasXeddsaSigned {
 						IconAndText(systemName: "checkmark.shield.fill",
 									imageColor: .green,
 									text: "Signed node".localized)
@@ -255,21 +249,21 @@ struct NodeListItemCompact: View {
 						)
 						.padding(EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 0))
 					}
-					if shouldShowLastHeard && node.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && node.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
-						
+					if shouldShowLastHeard && summary.lastHeard?.timeIntervalSince1970 ?? 0 > 0 && summary.lastHeard! < Calendar.current.date(byAdding: .year, value: 1, to: Date())! {
+
 						let lastHeardText = lastHeardIsRelative ?
-						node.lastHeard?.formatted(Date.RelativeFormatStyle()) :
-						node.lastHeard?.formatted()
-						
+						summary.lastHeard?.formatted(Date.RelativeFormatStyle()) :
+						summary.lastHeard?.formatted()
+
 						IconAndText(
-							systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
-							imageColor: node.isOnline ? .green : .orange,
+							systemName: summary.isOnline ? "checkmark.circle.fill" : "moon.circle.fill",
+							imageColor: summary.isOnline ? .green : .orange,
 							text: lastHeardText ?? "Unknown Age".localized
 						)
 					}
 					// Distance, bearing, hops, signal, role, telemetry row
 					HStack(alignment: .center, spacing: 6) {
-						if shouldShowLocation && connectedNode != node.num {
+						if shouldShowLocation && connectedNode != summary.num {
 							if let (nodeCoord, myCoord) = cachedLocationData {
 								let metersAway = nodeCoord.distance(from: myCoord)
 								DistanceText(meters: metersAway, isCompact: true)
@@ -284,31 +278,30 @@ struct NodeListItemCompact: View {
 									.rotationEffect(Angle(degrees: headingDegrees.value))
 							}
 						}
-						if shouldShowHops && node.hopsAway > 0 {
+						if shouldShowHops && summary.hopsAway > 0 {
 							Divider().frame(height: 15)
-							DefaultIconCompact(systemName: "\(node.hopsAway).square")
+							DefaultIconCompact(systemName: "\(summary.hopsAway).square")
 						}
-						if shouldShowSignal && node.hopsAway == 0 && node.snr != 0 && !node.viaMqtt {
+						if shouldShowSignal && summary.hopsAway == 0 && summary.snr != 0 && !summary.viaMqtt {
 							Divider().frame(height: 15)
 							DefaultIconCompact(systemName: "dot.radiowaves.left.and.right")
-								.foregroundColor(getSnrColor(snr: node.snr, preset: modemPreset))
+								.foregroundColor(getSnrColor(snr: summary.snr, preset: modemPreset))
 						}
-						if shouldShowChannel && node.channel > 0 {
+						if shouldShowChannel && summary.channel > 0 {
 							Divider().frame(height: 15)
-							DefaultIconCompact(systemName: "\(node.channel).circle.fill")
+							DefaultIconCompact(systemName: "\(summary.channel).circle.fill")
 						}
 						// Device Role
 						if shouldShowRole {
 							Divider().frame(height: 15)
-							let role = DeviceRoles(rawValue: Int(node.user?.role ?? 0))
-							DefaultIconCompact(systemName: role?.systemName ?? "figure")
-							if node.user?.unmessagable ?? false {
+							DefaultIconCompact(systemName: summary.role?.systemName ?? "figure")
+							if summary.unmessagable {
 								DefaultIconCompact(systemName: "iphone.slash")
 							}
-							if node.isStoreForwardRouter {
+							if summary.isStoreForwardRouter {
 								DefaultIconCompact(systemName: "envelope.arrow.triangle.branch")
 							}
-							if node.viaMqtt && connectedNode != node.num {
+							if summary.viaMqtt && connectedNode != summary.num {
 								DefaultIconCompact(systemName: "dot.radiowaves.up.forward")
 							}
 						}
@@ -341,17 +334,17 @@ struct NodeListItemCompact: View {
 			.padding(.top, 2)
 			.padding(.bottom, 2)
 			.task(id: node.lastHeard) {
-				rowSummary = await MainActor.run {
-					NodeListRowSummary(
-						node: node,
-						includeDeviceMetrics: shouldShowPower || shouldShowTelemetry,
-						includePosition: needsLatestPosition,
-						includeLogAvailability: shouldShowTelemetry
-					)
-				}
+				// Refresh the snapshot when the node changes, but only while it is still live.
+				guard node.modelContext != nil && !node.isDeleted else { return }
+				rowSummary = NodeListRowSummary(
+					node: node,
+					includeDeviceMetrics: shouldShowPower || shouldShowTelemetry,
+					includePosition: needsLatestPosition,
+					includeLogAvailability: shouldShowTelemetry
+				)
 			}
 			.accessibilityElement(children: .ignore)
-			.accessibilityLabel(accessibilityDescription(batteryLevel: cachedBatteryLevel, cachedLocationData: cachedLocationData, status: statusMessage))
+			.accessibilityLabel(accessibilityDescription(summary, cachedLocationData: cachedLocationData))
 	}
 }
 


### PR DESCRIPTION
## What changed?

Node-list rows and message relay display no longer read live SwiftData `@Model` objects during a re-evaluation, which was the source of the top ongoing crash on the current App Store release.

- **NodeListItem / NodeListItemCompact**: expanded `NodeListRowSummary` into a full value-type snapshot of everything the row renders (name/short name, key status, role, favorite, signed, status message, last heard, online, hops, SNR/RSSI, channel, MQTT, store-and-forward, battery, position, and log availability). The rows memoize one snapshot in `@State` and render from it. The live node is read only on first appearance (while it is valid) and in a guarded refresh keyed to `lastHeard` — no `node.user?…` relationship reads remain on the re-evaluation path.
- **MessageEntityExtension.relayDisplay()**: guards `self` liveness before touching stored properties, filters the fetched users to live ones, and reads the `userNode` relationship through a new `UserEntity.liveUserNode` that returns nil for a deleted/zombie user instead of trapping.

## Why did it change?

This is the remaining half of the SwiftData row-crash family (Error Tracking issue `ab285602`, a SIGTRAP in `NodeListItem.swift` faulting on the `NodeInfoEntity.user` / `UserEntity.userNode` relationship accessors; the message side surfaces in `MessageEntityExtension.swift`).

#1991 guarded the row bodies with `modelContext != nil && !isDeleted` and snapshotted position/metrics, but the bodies still read the `user` relationship and many `node.*` persisted properties directly on every re-evaluation. `isDeleted` does **not** catch a model invalidated by a bulk delete or a delete on another context (`clearStaleNodes`, `clearDatabase`, live ingestion): the instance reports `isDeleted == false` while its backing row is gone, so a retained List row that re-evaluates before the List drops it reads a zombie `@Model` and SwiftData fatally traps. Rendering from a snapshot captured while the model was live removes that read entirely on the dangerous path.

## How is this tested?

- Builds for the iOS Simulator and Mac Catalyst.
- Launched with seeded nodes in **both** standard and compact node-list density; the list renders identically to before (avatars, key status, favorite, signed shield, role, telemetry/log icons, hops, channel, MQTT, battery) and the app is stable with a large node set.
- Follows the value-type-snapshot approach established in #1991 / #2014.

Manual on-device soak (a busy mesh with node pruning / a NodeDB reset while the node list is open) is the real-world confirmation, since the crash depends on models being deleted underneath a mounted list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in message relay display by safely handling cases where persisted data is no longer live, preventing SwiftData faults.
  * Refreshed node list rendering to use memoized row snapshots instead of re-reading live values during updates, reducing stale UI and inconsistent behavior.
  * Improved VoiceOver accessibility for node rows with consistent snapshot-based labels (including last-heard/online status, role, hops, battery, and signal strength).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->