### PR TITLE
Remove camelCaseToWords channel name display helper

### DIFF
--- a/Meshtastic/Extensions/String.swift
+++ b/Meshtastic/Extensions/String.swift
@@ -60,13 +60,6 @@ extension String {
 		return image
 	}
 
-	func camelCaseToWords() -> String {
-		return self
-			.replacingOccurrences(of: "([a-z])([A-Z](?=[A-Z])[a-z]*)", with: "$1 $2", options: .regularExpression)
-			.replacingOccurrences(of: "([A-Z])([A-Z][a-z])", with: "$1 $2", options: .regularExpression)
-			.replacingOccurrences(of: "([a-z])([A-Z][a-z])", with: "$1 $2", options: .regularExpression)
-	}
-
 	var length: Int {
 		return count
 	}

--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -67,14 +67,14 @@ struct ChannelList: View {
 					ChannelLock(channel: channel)
 					if channel.name?.isEmpty ?? false {
 						if channel.role == 1 {
-							Text(String("PrimaryChannel").camelCaseToWords())
+							Text(String("Primary Channel"))
 								.font(.headline)
 						} else {
-							Text(String("Channel \(channel.index)").camelCaseToWords())
+							Text(String("Channel \(channel.index)"))
 								.font(.headline)
 						}
 					} else {
-						Text(String(channel.name ?? "Channel \(channel.index)").camelCaseToWords())
+						Text(String(channel.name ?? "Channel \(channel.index)"))
 							.font(.headline)
 					}
 

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -450,7 +450,7 @@ struct ChannelMessageList: View {
 			ToolbarItem(placement: .principal) {
 				HStack {
 					CircleText(text: String(channel.index), color: .accentColor, circleSize: 44).fixedSize()
-					Text(String(channel.name ?? "Unknown").camelCaseToWords()).font(.headline)
+					Text(String(channel.name ?? "Unknown")).font(.headline)
 				}
 			}
 			ToolbarItem(placement: .navigationBarTrailing) {

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -490,12 +490,12 @@ private struct ChannelRow: View {
 
 	private var title: String {
 		if let name = channel.name, !name.isEmpty {
-			return String(name.camelCaseToWords())
+			return name
 		}
 		if channel.role == 1 {
-			return String("PrimaryChannel").camelCaseToWords()
+			return "Primary Channel"
 		}
-		return String("Channel \(channel.index)").camelCaseToWords()
+		return "Channel \(channel.index)"
 	}
 
 	private var subtitle: String {

--- a/Meshtastic/Views/Settings/SaveChannelQRCode.swift
+++ b/Meshtastic/Views/Settings/SaveChannelQRCode.swift
@@ -376,7 +376,7 @@ struct SaveChannelQRCode: View {
 
 	private func channelTitle(_ channel: ChannelSettings, index: Int) -> String {
 		if !channel.name.isEmpty {
-			return channel.name.camelCaseToWords()
+			return channel.name
 		}
 		return index == 0 ? "Primary" : "Channel \(index)"
 	}

--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -239,7 +239,7 @@ struct ShareChannels: View {
 		if channel.index == 0 && (channel.name?.isEmpty ?? true) {
 			return "Primary"
 		}
-		return ((channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)").camelCaseToWords()
+		return (channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)"
 	}
 
 	func generateChannelSet() {

--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -239,7 +239,7 @@ struct ShareChannels: View {
 		if channel.index == 0 && (channel.name?.isEmpty ?? true) {
 			return "Primary"
 		}
-		return (channel.name?.isEmpty ?? true ? "Channel\(channel.index)" : channel.name) ?? "Channel\(channel.index)"
+		return (channel.name?.isEmpty ?? true ? "Channel \(channel.index)" : channel.name) ?? "Channel \(channel.index)"
 	}
 
 	func generateChannelSet() {

--- a/Meshtastic/Views/Settings/TAKServerConfig.swift
+++ b/Meshtastic/Views/Settings/TAKServerConfig.swift
@@ -429,12 +429,12 @@ struct TAKServerConfig: View {
 	private func channelLabel(_ channel: ChannelEntity) -> some View {
 		if channel.name?.isEmpty ?? false {
 			if channel.role == 1 {
-				Text(String("PrimaryChannel").camelCaseToWords())
+				Text(String("Primary Channel"))
 			} else {
-				Text(String("Channel \(channel.index)").camelCaseToWords())
+				Text(String("Channel \(channel.index)"))
 			}
 		} else {
-			Text(String(channel.name ?? "Channel \(channel.index)").camelCaseToWords())
+			Text(String(channel.name ?? "Channel \(channel.index)"))
 		}
 	}
 

--- a/MeshtasticTests/CoTExtensionTests.swift
+++ b/MeshtasticTests/CoTExtensionTests.swift
@@ -334,28 +334,6 @@ struct Base64URLTests {
 	}
 }
 
-// MARK: - String camelCaseToWords
-
-@Suite("String camelCaseToWords")
-struct CamelCaseTests {
-
-	@Test func simpleCamelCase() {
-		#expect("helloWorld".camelCaseToWords() == "hello World")
-	}
-
-	@Test func multipleParts() {
-		#expect("myLongVariableName".camelCaseToWords() == "my Long Variable Name")
-	}
-
-	@Test func alreadySeparated() {
-		#expect("hello".camelCaseToWords() == "hello")
-	}
-
-	@Test func acronym() {
-		#expect("parseHTTPResponse".camelCaseToWords() == "parse HTTP Response")
-	}
-}
-
 // MARK: - String subscript
 
 @Suite("String Subscript Extended")

--- a/MeshtasticTests/StringExtensionDetailedTests.swift
+++ b/MeshtasticTests/StringExtensionDetailedTests.swift
@@ -84,18 +84,6 @@ struct StringEmojiDetectionDetailedTests {
 @Suite("String Manipulation")
 struct StringManipulationTests {
 
-	@Test func camelCaseToWords_simple() {
-		#expect("helloWorld".camelCaseToWords() == "hello World")
-	}
-
-	@Test func camelCaseToWords_multipleWords() {
-		#expect("myVariableName".camelCaseToWords() == "my Variable Name")
-	}
-
-	@Test func camelCaseToWords_acronym() {
-		#expect("parseHTMLContent".camelCaseToWords() == "parse HTML Content")
-	}
-
 	@Test func length() {
 		#expect("Hello".length == 5)
 		#expect("".length == 0)

--- a/MeshtasticTests/StringExtensionTests.swift
+++ b/MeshtasticTests/StringExtensionTests.swift
@@ -139,41 +139,6 @@ struct CharacterEmojiTests {
 	}
 }
 
-// MARK: - CamelCase Conversion
-
-@Suite("String camelCaseToWords")
-struct StringCamelCaseTests {
-
-	@Test func simpleCamelCase_splitsCorrectly() {
-		#expect("camelCase".camelCaseToWords() == "camel Case")
-	}
-
-	@Test func pascalCase_splitsCorrectly() {
-		#expect("PascalCase".camelCaseToWords() == "Pascal Case")
-	}
-
-	@Test func multipleWords_splitsCorrectly() {
-		#expect("myVariableName".camelCaseToWords() == "my Variable Name")
-	}
-
-	@Test func singleWord_unchanged() {
-		#expect("hello".camelCaseToWords() == "hello")
-	}
-
-	@Test func emptyString_unchanged() {
-		#expect("".camelCaseToWords() == "")
-	}
-
-	@Test func allCaps_unchanged() {
-		// Pure uppercase with no transitions stays together
-		#expect("ABC".camelCaseToWords() == "ABC")
-	}
-
-	@Test func acronymFollowedByWord_splitCorrectly() {
-		#expect("HTTPSConnection".camelCaseToWords() == "HTTPS Connection")
-	}
-}
-
 // MARK: - Subscript and Substring
 
 @Suite("String Subscript & Substring")


### PR DESCRIPTION
## What

Removes the `String.camelCaseToWords()` display helper so channel names render exactly as configured on the device, instead of being transformed from camelCase into spaced words (e.g. a channel named `LongFast` now displays as `LongFast`, not `Long Fast`).

## Why

Channel names are user/device data and should be shown verbatim. Rewriting them for display made the app disagree with the device UI, other clients, and QR share/import flows about what a channel is called.

## Changes

- **Removed** `camelCaseToWords()` from `Meshtastic/Extensions/String.swift`
- **Call sites updated** to show the raw channel name (fallbacks preserved):
  - `Meshtastic/Views/Messages/ChannelList.swift` — channel row title
  - `Meshtastic/Views/Messages/ChannelMessageList.swift` — navigation toolbar title
  - `Meshtastic/Views/Settings/Channels.swift` — `ChannelRow.title`
  - `Meshtastic/Views/Settings/SaveChannelQRCode.swift` — `channelTitle(_:index:)`
  - `Meshtastic/Views/Settings/ShareChannels.swift` — `channelDisplayName(_:)`
  - `Meshtastic/Views/Settings/TAKServerConfig.swift` — `channelLabel(_:)`
- The hard-coded `"PrimaryChannel"` fallback literals (used when a primary channel has an empty name) were relying on the helper to render as "Primary Channel"; they are now written as `"Primary Channel"` directly so the fallback label is unchanged.
- **Tests removed** (they exercised only the deleted helper):
  - `MeshtasticTests/StringExtensionTests.swift` — `StringCamelCaseTests` suite
  - `MeshtasticTests/StringExtensionDetailedTests.swift` — three `camelCaseToWords_*` tests in `StringManipulationTests`
  - `MeshtasticTests/CoTExtensionTests.swift` — `CamelCaseTests` suite

## Testing

- Built the `Meshtastic` scheme for the iPhone 17 Pro simulator
- Ran the string extension test suites
- Visually verified channel names render as-is in the Messages tab with seeded data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how channel titles are rendered across the app to consistently show the saved channel name directly.
  * Primary channels now display the clearer label “Primary Channel” in message and settings contexts.
  * When a channel name is missing, labels now fall back to readable defaults like “Channel 1” rather than transformed text.
  * Navigation titles, channel lists, sharing, and QR code screens now match this consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->