### PR TITLE
fix: stop nodes bleeding across radios on device switch; batch the node dump

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -139,18 +139,26 @@ extension AccessoryManager {
 			}
 			
 			// Step 5: Send WantConfig (database)
-			Step(timeout: .seconds(3.0), onFailure: .retryStep(attempts: 3)) { @MainActor _ in
+			Step(timeout: .seconds(10.0), onFailure: .retryStep(attempts: 3)) { @MainActor _ in
 				guard wantDatabase else {
 					Logger.transport.info("👟 [Connect] Step 5: wantDatabase = false, skipping wantDatabase")
+					return
+				}
+				// A retry of this step must never re-request the dump while one is already
+				// streaming: the radio would restart the node DB from the top and the two dumps
+				// would interleave (slow connects, duplicate processing). If nodes are already
+				// arriving, treat the request as delivered and let Step 5a's gate do the waiting.
+				if case .retrievingDatabase(let nodeCount) = self.state, nodeCount > 0 {
+					Logger.transport.info("🔗👟 [Connect] Step 5: node dump already streaming (\(nodeCount) nodes) — not re-requesting")
 					return
 				}
 				Logger.transport.info("🔗👟 [Connect] Step 5: Send wantConfig (database)")
 				self.updateState(.retrievingDatabase(nodeCount: 0))
 				self.allowDisconnect = true
-				
+
 				Logger.transport.info("🔗 Saving preferredPeripheralId: \(device.id.uuidString)")
 				UserDefaults.preferredPeripheralId = device.id.uuidString
-				
+
 				try await self.sendWantDatabase()
 			}
 			
@@ -224,6 +232,11 @@ extension AccessoryManager {
 			Step { @MainActor _ in
 				Logger.transport.debug("🔗👟 [Connect] Step 8: Initialize MQTT and Location Provider")
 				self.stopDiscovery()
+				// Prune stale nodes now that the dump is in, instead of at the head of
+				// sendWantConfig where the fetch+delete+save serialized ahead of the whole
+				// handshake on the ingestion actor. Post-dump lastHeard values also make the
+				// pruning decisions more accurate.
+				_ = await MeshPackets.shared.clearStaleNodes(nodeExpireDays: Int(UserDefaults.purgeStaleNodeDays))
 				await self.initializeMqtt()
 				self.initializeLocationProvider()
 				if transport.requiresPeriodicHeartbeat {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Discovery.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Discovery.swift
@@ -61,7 +61,11 @@ extension AccessoryManager {
 							}
 						}
 						
+						// Never auto-connect while a device switch is mid-flight: the switch's own
+						// connect must be the only one running, or its database clear/restore
+						// races a second node dump (nodes bleeding between radios).
 						if self.shouldAutomaticallyConnectToPreferredPeripheralAfterError, !userRequestedConnectionCancellation,
+						   !self.isSwitchingDevices,
 						   UserDefaults.autoconnectOnDiscovery, UserDefaults.preferredPeripheralId == newDevice.id.uuidString {
 							Logger.transport.debug("🔎 [Discovery] Found preferred peripheral \(newDevice.name)")
 							self.connectToPreferredDevice(device: newDevice)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -92,6 +92,21 @@ extension AccessoryManager {
 
 		updateDevice(key: \.num, value: Int64(myNodeInfo.myNodeNum))
 
+		// Defensive cross-device guard: if this connect landed on another radio's database
+		// without going through the switch flow's clear+restore, reset before ingesting
+		// anything for the new radio. Nodes carry no owner column — the store is global — so
+		// any path that reaches here with a different radio's data (switch to a never-seen
+		// radio, interrupted switch + auto-reconnect, BLE restore) would otherwise merge the
+		// two node sets ("nodes bleeding across databases").
+		//
+		// Trigger only when the store has a MyInfoEntity for a DIFFERENT node and NONE for the
+		// connecting one. A backup restored for this radio always contains its own MyInfo row,
+		// so a legitimate switch+restore never trips this — including legacy backups that may
+		// carry extra foreign rows from the pre-fix bleed era.
+		await defensiveResetIfForeignDatabase(incomingNodeNum: Int64(myNodeInfo.myNodeNum))
+
+		let myInfoId = await MeshPackets.shared.myInfoPacket(myInfo: myNodeInfo, peripheralId: connectedDeviceId)
+
 		// Resolve on a throwaway context, NOT the long-lived main context. After a database clear
 		// (manual reset, or the clear inside a device switch) the main context can still hold an
 		// invalidated instance registered under a rowid that SwiftData then reuses for the
@@ -99,19 +114,20 @@ extension AccessoryManager {
 		// traps with "destroyed by ModelContext.reset". A fresh context has no such registrations,
 		// so it faults the current row from the store.
 		let myInfoResolveContext = ModelContext(context.container)
-		if let myInfoId = await MeshPackets.shared.myInfoPacket(myInfo: myNodeInfo, peripheralId: connectedDeviceId),
-		   let myInfo = try? myInfoResolveContext.model(for: myInfoId) as? MyInfoEntity {
+		if let myInfoId, let myInfo = try? myInfoResolveContext.model(for: myInfoId) as? MyInfoEntity {
 			if let bleName = myInfo.bleName {
 				updateDevice(key: \.name, value: bleName)
 				updateDevice(key: \.longName, value: bleName)
 			}
-			
+
 			if myNodeInfo.nodedbCount > 0 {
 				expectedNodeDBSize = Int(myNodeInfo.nodedbCount)
 			}
-			
-			UserDefaults.preferredPeripheralNum = Int(myInfo.myNodeNum)
+
+			// Compare BEFORE persisting the new num — the previous code assigned first, so
+			// newConnection was always false and this hook was dead.
 			let newConnection = Int64(UserDefaults.preferredPeripheralNum) != Int64(myInfo.myNodeNum)
+			UserDefaults.preferredPeripheralNum = Int(myInfo.myNodeNum)
 			if newConnection {
 				// Onboard a new device connection here
 			}
@@ -124,6 +140,44 @@ extension AccessoryManager {
 
 		// Initialize TAK bridge for TAK integration
 		initializeTAKBridge()
+	}
+
+	/// Detects a connect that landed on a different radio's database (no MyInfo row for the
+	/// connecting node, but rows for other nodes) and resets: back up the foreign radio's data
+	/// so nothing is lost, clear the store, repoint the container, and refresh the UI. See the
+	/// call site in `handleMyInfo` for when this can happen. No-ops for a fresh install (no
+	/// MyInfo rows) and for reconnects/restores (a MyInfo row for the incoming node exists).
+	private func defensiveResetIfForeignDatabase(incomingNodeNum: Int64) async {
+		// Fresh throwaway context: no stale registrations, and this runs before any ingest for
+		// the new radio, so what it sees is exactly what the previous session left behind.
+		let checkContext = ModelContext(context.container)
+		guard let myInfos = try? checkContext.fetch(FetchDescriptor<MyInfoEntity>()), !myInfos.isEmpty else {
+			return // Fresh/empty store — nothing to protect.
+		}
+		let nums = myInfos.map(\.myNodeNum)
+		guard !nums.contains(incomingNodeNum) else {
+			return // The store already belongs to (or was restored for) this radio.
+		}
+
+		Logger.data.warning("💾 [Database] Connected to node \(incomingNodeNum.toHex(), privacy: .public) but the store belongs to \(nums.map { $0.toHex() }.joined(separator: ", "), privacy: .public) — backing up and resetting to prevent cross-device node bleed")
+
+		// Preserve the previous radio's data exactly like the switch flow would have.
+		if let previousNum = nums.first {
+			let previousName = devices.first(where: { $0.num == previousNum })?.longName
+			_ = await NodeBackupManager.shared.createBackup(forNode: previousNum, nodeName: previousName)
+		}
+
+		await MeshPackets.shared.flushDebouncedSaves()
+		let cleared = await MeshPackets.shared.clearDatabase(includeRoutes: false)
+		if !cleared {
+			// A half-cleared store must not receive this radio's dump (that IS the bleed).
+			// Escalate to a guaranteed-empty store; the foreign radio's data was backed up above.
+			Logger.data.error("💾 [Database] clearDatabase failed during cross-device reset — escalating to store destruction")
+			PersistenceController.shared.destroyStoreAndRecreateContainer()
+		}
+		// Pops views, repoints the container (recreating the MeshPackets actor), and bumps
+		// databaseResetID so @Query views rebind before the new radio's data starts landing.
+		await resetDatabaseAfterClear()
 	}
 
 	/// When event firmware is detected (DEFCON, BURNING_MAN, OPEN_SAUCE, etc.),
@@ -150,42 +204,41 @@ extension AccessoryManager {
 			self.firstDatabaseNodeInfoContinuation = nil
 			continuation.resume()
 		}
-		
+
 		guard nodeInfo.num > 0 else {
 			Logger.services.error("NodeInfo packet with a zero nodeNum")
 			return
 		}
 
-		// Check if we're in database retrieval mode to defer saves for performance
-		// Commented out: No need to defer save when nodeInfoPacket is now happening off the main thread
-		// let isRetrievingDatabase = if case .retrievingDatabase = self.state { true } else { false }
-		
 		// TODO: nodeInfoPacket's channel: parameter is not used
-		// deferSave hard coded: No need to defer save when nodeInfoPacket is now happening off the main thread
-		// Resolve on a throwaway context (see handleMyInfo): the long-lived main context can return
-		// a stale instance registered under a rowid reused after a database clear, which traps with
-		// "destroyed by ModelContext.reset". A fresh context faults the current row from the store.
-		let nodeInfoResolveContext = ModelContext(context.container)
-		if let nodeInfoId = await MeshPackets.shared.nodeInfoPacket(nodeInfo: nodeInfo, channel: 0, deferSave: false),
-		   let nodeInfo = try? nodeInfoResolveContext.model(for: nodeInfoId) as? NodeInfoEntity {
-			if let activeDevice = activeConnection?.device, activeDevice.num == nodeInfo.num {
-				if let user = nodeInfo.user {
-					updateDevice(deviceId: activeDevice.id, key: \.shortName, value: user.shortName ?? "?")
-					updateDevice(deviceId: activeDevice.id, key: \.longName, value: user.longName ?? "Unknown".localized)
-					updateDevice(deviceId: activeDevice.id, key: \.hardwareModel, value: user.hwModel)
-					
-					if activeDevice.isManualConnection {
-						// We just received a NodeInfo for the currently connected node and this is a
-						// manual connection.  Update the metadata for the device entry in UserDefaults
-						// with this information for better display later
-						ManualConnectionList.shared.updateDevice(deviceId: activeDevice.id, key: \.shortName, value: user.shortName)
-						ManualConnectionList.shared.updateDevice(deviceId: activeDevice.id, key: \.longName, value: user.longName)
-						ManualConnectionList.shared.updateDevice(deviceId: activeDevice.id, key: \.hardwareModel, value: user.hwModel)
-					}
-				}
+		// Defer the save: during the node-DB dump this handler runs once per node, and a
+		// save-per-node on the ingestion actor (plus a main-actor hop each way) was the
+		// throughput cliff behind slow/hung connects on large meshes. Deferred writes are
+		// flushed by the actor's debounced save (at most every 5s) and finally at
+		// configCompleteID (NONCE_ONLY_DB), which also batch-saves the main context.
+		_ = await MeshPackets.shared.nodeInfoPacket(nodeInfo: nodeInfo, channel: 0, deferSave: true)
+
+		// Update the connected device's display metadata straight from the protobuf — the
+		// previous code resolved the just-inserted entity on a fresh ModelContext for every
+		// node in the dump only to read fields the proto already carries.
+		if let activeDevice = activeConnection?.device, activeDevice.num == Int64(nodeInfo.num), nodeInfo.hasUser {
+			let shortName = nodeInfo.user.shortName
+			let longName = nodeInfo.user.longName
+			let hwModel = String(describing: nodeInfo.user.hwModel).uppercased()
+			updateDevice(deviceId: activeDevice.id, key: \.shortName, value: shortName.isEmpty ? "?" : shortName)
+			updateDevice(deviceId: activeDevice.id, key: \.longName, value: longName.isEmpty ? "Unknown".localized : longName)
+			updateDevice(deviceId: activeDevice.id, key: \.hardwareModel, value: hwModel)
+
+			if activeDevice.isManualConnection {
+				// We just received a NodeInfo for the currently connected node and this is a
+				// manual connection.  Update the metadata for the device entry in UserDefaults
+				// with this information for better display later
+				ManualConnectionList.shared.updateDevice(deviceId: activeDevice.id, key: \.shortName, value: shortName.isEmpty ? nil : shortName)
+				ManualConnectionList.shared.updateDevice(deviceId: activeDevice.id, key: \.longName, value: longName.isEmpty ? nil : longName)
+				ManualConnectionList.shared.updateDevice(deviceId: activeDevice.id, key: \.hardwareModel, value: hwModel)
 			}
 		}
-		
+
 		// Bump the nodeCount
 		if case let .retrievingDatabase(nodeCount: nodeCount) = self.state {
 			updateState(.retrievingDatabase(nodeCount: nodeCount+1))

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -210,6 +210,14 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	var shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
 	var userRequestedConnectionCancellation = false
 
+	/// True while a device switch (backup → clear → restore → connect) is in flight.
+	/// Suppresses the discovery restart in `closeConnection()` and auto-connect on
+	/// discovery events: the disconnect at the start of a switch must not let discovery
+	/// fire a concurrent connect whose node dump would interleave with the database
+	/// clear/restore (one source of nodes bleeding between radios). Set/cleared by
+	/// `switchToDevice` (Views/Connect/Connect.swift).
+	var isSwitchingDevices = false
+
 	// Conncetion process
 	var connectionSteps: SequentialSteps?
 	
@@ -281,8 +289,11 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			return
 		}
 
-		_ = await MeshPackets.shared.clearStaleNodes(nodeExpireDays: Int(UserDefaults.purgeStaleNodeDays))
-		
+		// Note: stale-node pruning used to run here, serializing a full fetch+delete+save on the
+		// ingestion actor ahead of the config handshake and node-DB dump (one cause of slow/hung
+		// connects). It now runs after the connection completes — see connect() Step 8 — where it
+		// also prunes against post-dump lastHeard values instead of pre-dump ones.
+
 		try await withTaskCancellationHandler {
 			var toRadio: ToRadio = ToRadio()
 			toRadio.wantConfigID = UInt32(NONCE_ONLY_CONFIG)
@@ -403,8 +414,14 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		// startDiscovery() would silently no-op and the device would never reappear in the list.
 		discoveryTask?.cancel()
 		discoveryTask = nil
-		
-		self.startDiscovery()
+
+		// During a device switch the teardown must NOT re-arm discovery: with autoconnect on,
+		// discovery can immediately re-connect (and start a node dump) while the switch is
+		// still clearing/restoring the database — interleaving one radio's dump with another
+		// radio's data. The switch flow restarts discovery itself if its connect fails.
+		if !isSwitchingDevices {
+			self.startDiscovery()
+		}
 	}
 	
 	// Should only be called by UI-facing callers.
@@ -874,25 +891,31 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			case UInt32(NONCE_ONLY_DB):
 				// Open the gate for the wantDatabaseContinuation
 				Task { await wantDatabaseGate.open() }
-				
+
 				// If we get the "done" for NONCE_ONLY_DB, but are still waiting for the first NodeInfo,
 				// Then the database is probably empty, and can continue
 				if let firstDatabaseNodeInfoContinuation {
 					self.firstDatabaseNodeInfoContinuation = nil
 					firstDatabaseNodeInfoContinuation.resume()
 				}
-				
+
 				// Perform a single batch save after database retrieval completes
 				// This significantly improves performance on reconnect
-				do {
-					try context.save()
-					Logger.data.info("💾 [Database] Batch saved all node info after database retrieval")
+				Task {
+					// The dump was ingested with deferred saves on the MeshPackets actor
+					// (see handleNodeInfo); flush it so every node from the dump is persisted
+					// now rather than waiting on the debounce timer.
+					await MeshPackets.shared.flushDebouncedSaves()
+					do {
+						try context.save()
+						Logger.data.info("💾 [Database] Batch saved all node info after database retrieval")
 
-					// Push updated node data to the companion Watch app
-					WatchSessionManager.shared.sendNodesToWatch()
-				} catch {
-					let nsError = error as NSError
-					Logger.data.error("💥 [Database] Error saving batch node info: \(nsError, privacy: .public)")
+						// Push updated node data to the companion Watch app
+						WatchSessionManager.shared.sendNodesToWatch()
+					} catch {
+						let nsError = error as NSError
+						Logger.data.error("💥 [Database] Error saving batch node info: \(nsError, privacy: .public)")
+					}
 				}
 				
 			default:

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -96,16 +96,38 @@ actor MeshPackets {
 	/// Call after DB retrieval completes or periodically to release accumulated memory.
 	static func recreateShared() {
 		_lock.lock()
+		let previous = _shared
 		_shared = MeshPackets(modelContainer: _container)
 		_lock.unlock()
+		// Invalidate the retired instance. In-flight tasks that captured `MeshPackets.shared`
+		// before the swap (a debounced save, a late packet for the previous radio) still hold
+		// the old actor, whose context is bound to the old container — which points at the SAME
+		// on-disk store as the new one. Letting those writes land after a device-switch
+		// clearDatabase resurrects the previous radio's rows (nodes bleeding across devices)
+		// and can trip reused-rowid "destroyed by ModelContext.reset" traps.
+		Task { await previous.invalidate() }
 		Logger.data.info("♻️ [MeshPackets] Recreated shared instance to release ModelContext memory")
 	}
 
 	// MARK: - Save Helpers
 
+	/// Set when this instance has been replaced by `recreateShared()`. A retired instance must
+	/// never persist again — see `recreateShared()`.
+	private var invalidated = false
+
+	func invalidate() {
+		invalidated = true
+		debounceSaveTask?.cancel()
+		debounceSaveTask = nil
+	}
+
 	/// Saves any pending changes in the model context. Call once at the end of each
 	/// top-level packet handler to batch all mutations from a single packet into one write.
 	func savePendingChanges(caller: String = #function) {
+		guard !invalidated else {
+			Logger.data.warning("💾 [\(caller, privacy: .public)] Dropped save on retired MeshPackets instance")
+			return
+		}
 		guard modelContext.hasChanges else { return }
 		do {
 			try modelContext.save()
@@ -139,6 +161,7 @@ actor MeshPackets {
 	/// keep arriving continuously, a save is forced every 5 seconds.
 	/// Use for high-frequency packet types (position, telemetry) instead of `savePendingChanges`.
 	func scheduleDebouncedSave() {
+		guard !invalidated else { return }
 		debounceSaveTask?.cancel()
 		let elapsed = ContinuousClock.now - lastDebouncedSaveTime
 		if elapsed >= Self.maxDebounceDelay {
@@ -522,6 +545,10 @@ actor MeshPackets {
 						if !deferSave {
 							savePendingChanges()
 							Logger.data.debug("💾 Saved a new Node Info For: \(String(nodeInfo.num), privacy: .public)")
+						} else {
+							// Deferred (node-DB dump): batch writes, but still persist at least
+							// every maxDebounceDelay so a long dump isn't one giant save.
+							scheduleDebouncedSave()
 						}
 						return newNode.persistentModelID
 					} catch {
@@ -639,6 +666,8 @@ actor MeshPackets {
 						if !deferSave {
 							savePendingChanges()
 							Logger.data.debug("💾 [Node Info] saved for \(nodeInfo.num.toHex(), privacy: .public)")
+						} else {
+							scheduleDebouncedSave()
 						}
 						return fetchedNode[0].persistentModelID
 					} catch {

--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -70,6 +70,25 @@ class PersistenceController {
 		}
 	}
 
+	/// Nuclear reset: delete the on-disk store files and reopen a brand-new, guaranteed-empty
+	/// container. Used by the device-switch / cross-device reset paths as an escalation when the
+	/// per-model `clearDatabase` fails part-way (e.g. a relationship constraint aborts the batch
+	/// deletes) — proceeding on a half-cleared store is how one radio's nodes leak into another's
+	/// session. POSIX unlink semantics make this safe with stragglers: any old context still
+	/// holding the previous container writes to the unlinked inode, never into the new store.
+	/// Not usable when data must be preserved (routes, favorites) — everything is erased.
+	func destroyStoreAndRecreateContainer() {
+		guard !inMemory else {
+			recreateContainer()
+			return
+		}
+		let schema = Schema(versionedSchema: MeshtasticSchema.current)
+		let config = ModelConfiguration(storeName, schema: schema, isStoredInMemoryOnly: false, allowsSave: true)
+		Self.removeStoreFiles(at: config.url)
+		recreateContainer()
+		Logger.data.warning("💾 Store files destroyed and container recreated (escalated database reset)")
+	}
+
 	private static func removeStoreFiles(at storeURL: URL) {
 		let fm = FileManager.default
 		let storeFiles = [
@@ -209,9 +228,14 @@ class PersistenceController {
 		// Saving after each delete keeps every reconcile against already-committed, consistent state.
 		// Mirrors MeshPackets.clearDatabase.
 		do {
+			// Sever tags AND images from the owning side before the batch deletes: batch-deleting
+			// the images while a device still references them fails with "mandatory OTO nullify
+			// inverse on DeviceHardwareImageEntity/device", aborting the whole clear.
+			// Mirrors MeshPackets.clearDatabase.
 			let hardwareDevices = try container.mainContext.fetch(FetchDescriptor<DeviceHardwareEntity>())
 			for device in hardwareDevices {
 				device.tags.removeAll()
+				device.images.removeAll()
 			}
 			if container.mainContext.hasChanges {
 				try container.mainContext.save()

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -146,7 +146,11 @@ extension MeshPackets {
 		}
 	}
 	
-	public func clearDatabase(includeRoutes: Bool, preserveFavorites: Bool = false) {
+	/// Returns true when every delete committed; false when the clear aborted part-way (callers
+	/// that require an empty store — the device-switch and cross-device reset paths — must
+	/// escalate, e.g. destroy and recreate the store, rather than proceed on a half-cleared one).
+	@discardableResult
+	public func clearDatabase(includeRoutes: Bool, preserveFavorites: Bool = false) -> Bool {
 		// Delete + SAVE one model type at a time. SwiftData's batch `delete(model:)` ENQUEUES a
 		// deletion (committed on the next save) and nullifies inverse relationships. Reconciling MANY
 		// types' deletions in a SINGLE trailing save makes SwiftData tear down objects whose inverse
@@ -163,12 +167,17 @@ extension MeshPackets {
 		}
 
 		do {
-			// Sever the DeviceHardware many-to-many from the owning side first (a batch delete alone
-			// trips the mandatory MTM nullify inverse between DeviceHardwareEntity.tags and
-			// DeviceHardwareTagEntity.devices), saving before deleting the tag/image entities.
+			// Sever the DeviceHardware relationships from the owning side first: a batch delete
+			// alone trips the mandatory MTM nullify inverse between DeviceHardwareEntity.tags and
+			// DeviceHardwareTagEntity.devices, and likewise batch-deleting the images fails with
+			// "mandatory OTO nullify inverse on DeviceHardwareImageEntity/device" while any device
+			// still references them ("Constraint trigger violation" — which aborted the whole clear
+			// and quietly left EVERY entity in place, the direct cause of one radio's nodes
+			// surviving into another radio's session). Save the severing before the batch deletes.
 			let hardwareDevices = try modelContext.fetch(FetchDescriptor<DeviceHardwareEntity>())
 			for device in hardwareDevices {
 				device.tags.removeAll()
+				device.images.removeAll()
 			}
 			try commit()
 			try modelContext.delete(model: DeviceHardwareTagEntity.self)
@@ -222,9 +231,11 @@ extension MeshPackets {
 				try modelContext.delete(model: modelType)
 				try commit()
 			}
+			return true
 		} catch {
 			// Abort before the next type so a failed save can't leave a multi-type batch pending.
 			Logger.data.error("💥 Failed while clearing database, aborted: \(error.localizedDescription, privacy: .public)")
+			return false
 		}
 	}
 	

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -834,7 +834,7 @@ func backupCurrentDatabase(forTargetNode targetNodeNum: Int64?, accessoryManager
 
 @MainActor
 func backupCurrentAndRestoreDatabase(
-	forNode targetNodeNum: Int64,
+	forNode targetNodeNum: Int64?,
 	accessoryManager: AccessoryManager,
 	appState: AppState,
 	selectedTab: NavigationState.Tab,
@@ -855,16 +855,39 @@ func backupCurrentAndRestoreDatabase(
 	await Task.yield()
 
 	await MeshPackets.shared.flushDebouncedSaves()
-	await MeshPackets.shared.clearDatabase(includeRoutes: false)
-	// Repoint at a fresh container so the restore below (and the post-restore UI refresh) operate
-	// on a context with no stale registrations. The databaseResetID bump stays after the restore.
-	accessoryManager.repointToFreshContainer()
-	Logger.backup.info("💾 Database cleared and container recreated")
+	let cleared = await MeshPackets.shared.clearDatabase(includeRoutes: false)
+	if cleared {
+		// Repoint at a fresh container so the restore below (and the post-restore UI refresh)
+		// operate on a context with no stale registrations. The databaseResetID bump stays after
+		// the restore.
+		accessoryManager.repointToFreshContainer()
+		Logger.backup.info("💾 Database cleared and container recreated")
+	} else {
+		// The per-model clear aborted part-way (e.g. a relationship constraint failed a batch
+		// delete). A half-cleared store MUST NOT receive the next radio's dump — that is exactly
+		// how nodes bleed between radios — so escalate: destroy the store files and reopen a
+		// guaranteed-empty container. The current radio's data was backed up above; routes are
+		// lost in this (already-broken) path, which beats merging two radios' databases.
+		Logger.backup.error("💾 clearDatabase failed — escalating to store destruction before the switch")
+		PersistenceController.shared.destroyStoreAndRecreateContainer()
+		// Repoint re-creates once more on the fresh (now empty) store and rebuilds the
+		// MeshPackets actor + cached context; the double recreate is harmless.
+		accessoryManager.repointToFreshContainer()
+	}
 
-	let restoreResult = await NodeBackupManager.shared.restoreFromBackup(
-		forNode: targetNodeNum,
-		into: PersistenceController.shared.container
-	)
+	// The clear above is unconditional — a switch must NEVER dump the new radio's nodes on top
+	// of the old radio's (nodes have no owner column; the store is global). The restore is the
+	// only optional part: with no resolvable target node (first connect to a never-seen radio)
+	// there is simply no backup to import, and the radio populates the now-empty store fresh.
+	let restoreResult: NodeBackupResult
+	if let targetNodeNum {
+		restoreResult = await NodeBackupManager.shared.restoreFromBackup(
+			forNode: targetNodeNum,
+			into: PersistenceController.shared.container
+		)
+	} else {
+		restoreResult = .noBackupFound
+	}
 
 	// The clear ran on the MeshPackets context and the restore imported through a separate
 	// liveContext, neither of which the UI's main context observes — and a batch delete sends
@@ -905,30 +928,39 @@ func switchToDevice(
 	}()
 	Logger.backup.info("💾 Node switch — current: \(currentNodeNum.map { String($0) } ?? "nil", privacy: .public), target: \(targetNodeNum.map { String($0) } ?? "unknown", privacy: .public)")
 
+	// Mark the switch in flight so the disconnect's teardown doesn't re-arm discovery and
+	// auto-connect can't launch a second connect + node dump while the store is mid-reset.
+	accessoryManager.isSwitchingDevices = true
+	defer {
+		accessoryManager.isSwitchingDevices = false
+		// closeConnection suppressed its usual discovery restart during the switch; if the
+		// switch's connect didn't succeed, restart discovery now so devices reappear.
+		if !accessoryManager.isConnected {
+			accessoryManager.startDiscovery()
+		}
+	}
+
 	// 4. Disconnect from current device
 	if accessoryManager.allowDisconnect {
 		try? await accessoryManager.disconnect()
 	}
 
-	await backupCurrentDatabase(forTargetNode: targetNodeNum, accessoryManager: accessoryManager)
-
-	if let targetNodeNum {
-		let restoreResult = await backupCurrentAndRestoreDatabase(
-			forNode: targetNodeNum,
-			accessoryManager: accessoryManager,
-			appState: appState,
-			selectedTab: .connect
-		)
-		switch restoreResult {
-		case .success:
-			Logger.backup.info("💾 Backup restored for target node \(targetNodeNum)")
-		case .skipped(let reason):
-			Logger.backup.warning("💾 Restore skipped: \(reason, privacy: .public)")
-		case .noBackupFound:
-			Logger.backup.info("💾 No backup for target node \(targetNodeNum) — radio will populate fresh data")
-		}
-	} else {
-		Logger.backup.warning("💾 Target node num is nil — cannot restore, radio will populate fresh data")
+	// Clear (always) and restore (when the target has a backup). Runs even when the target
+	// node number is unknown — a switch to a never-seen radio previously skipped the clear
+	// and dumped the new radio's nodes on top of the old radio's data.
+	let restoreResult = await backupCurrentAndRestoreDatabase(
+		forNode: targetNodeNum,
+		accessoryManager: accessoryManager,
+		appState: appState,
+		selectedTab: .connect
+	)
+	switch restoreResult {
+	case .success:
+		Logger.backup.info("💾 Backup restored for target node \(targetNodeNum.map { String($0) } ?? "?", privacy: .public)")
+	case .skipped(let reason):
+		Logger.backup.warning("💾 Restore skipped: \(reason, privacy: .public)")
+	case .noBackupFound:
+		Logger.backup.info("💾 No backup for target node \(targetNodeNum.map { String($0) } ?? "unknown", privacy: .public) — radio will populate fresh data")
 	}
 
 	onRestoreComplete?()


### PR DESCRIPTION
## What changed?

Fixes the family of bugs behind nodes from one radio appearing under another after a device switch, and the intermittently slow/hung initial node-DB dump.

1. **`clearDatabase` was silently a no-op whenever hardware images existed.** Batch-deleting `DeviceHardwareImageEntity` fails with `mandatory OTO nullify inverse on DeviceHardwareImageEntity/device` ("Constraint trigger violation"), and the clear aborts before touching any other entity — so a device switch proceeded on a full store and the next radio's dump merged straight into the previous radio's data. The fix severs `device.images` from the owning side (exactly like the existing `tags` workaround) before the batch deletes, in both `MeshPackets.clearDatabase` and `PersistenceController.clearDatabase`. `clearDatabase` now reports success, and the switch / cross-device reset paths **escalate to destroying the store files and reopening a guaranteed-empty container** if a clear ever fails again — a half-cleared store must never receive another radio's dump.
2. **Switching to a never-seen radio skipped the clear entirely** (`switchToDevice` gated the whole clear+restore on resolving a target node number). The clear is now unconditional; only the restore remains conditional on a backup existing.
3. **The plain-connect path had no cross-device guard.** Connecting to radio B on top of radio A's store (interrupted switch, BLE restore, autoconnect) merged the node sets — nodes carry no owner column, so isolation is entirely procedural. `handleMyInfo` now detects a store owned by a different node (a MyInfo row for another node and none for the incoming one), backs the old radio up, clears, and repoints the container before ingesting anything for the new radio. No-ops for fresh installs, same-device reconnects, and post-restore connects. Also fixes the `newConnection` detection, which assigned `preferredPeripheralNum` before comparing and could never fire.
4. **Teardown re-armed discovery mid-switch.** `closeConnection()` ended with `startDiscovery()`, and autoconnect could launch a second connect + node dump concurrently with the clear/restore. A switch now suppresses the discovery restart and autoconnect until it completes (and restarts discovery itself if its connect fails). Retired `MeshPackets` actor instances are invalidated on `recreateShared()`, so in-flight tasks holding the old actor — whose context is bound to the old container on the same store file — can no longer persist writes after a clear.
5. **The node dump is now batched.** Previously each NodeInfo in the dump did a save on the ingestion actor plus a main-actor hop and a throwaway-`ModelContext` fetch; stale-node pruning ran a fetch+delete+save ahead of the whole handshake; and the wantDatabase step's 3-second retry could re-request the dump over an in-flight one, interleaving two dumps. Dump inserts now defer saves (bounded by the existing debounced flush and a final flush at `configCompleteID`), the connected device's display metadata is read straight from the protobuf, pruning runs after the connection completes (against post-dump `lastHeard`), and the retry (now 10s) never re-requests while nodes are already streaming.

## Why did it change?

Users switching between radios saw the new radio's node list contaminated with the previous radio's nodes, and the initial node dump was sometimes fast, sometimes hung. The store is global (nodes keyed only by `num`, no owner), so per-device isolation depends entirely on the clear-and-restore choreography — which was broken at several independent points above.

## How is this tested?

- **End-to-end against two synthetic TCP radios** (meshtastic-mcp `replay` fake radios with different node sets and observer node numbers): connect to radio C, then switch to never-before-seen radio D via the Connect tab. After the switch the store contains exactly D's nodes and MyInfo with zero C rows, and C's backup is on disk. The same scenario on the unfixed code reproduces the merged store deterministically.
- The cross-device guard was separately exercised on the plain-connect path (connecting to a different radio without the switch flow) and correctly detected the foreign store, backed it up, and reset.
- Node dumps completed in a few seconds consistently for both radios, with no retry re-dumps in the logs.
- Existing connect/backup/persistence/message test suites pass; full app builds for simulator.

Manual verification on physical radios (BLE, including a mid-switch app background/foreground) is the remaining real-world confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved device switching with safer restore handling and better recovery when switching radios.

* **Bug Fixes**
  * Prevented auto-connecting to the wrong device during an in-progress switch.
  * Reduced connection race conditions and stale node data by tightening when discovery, syncing, and cleanup happen.
  * Added stronger database reset recovery so the app can rebuild a clean local state if clearing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->