### PR TITLE
[codex] Reduce location energy and watch fetch churn

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		AA003DOC0000002000000007 /* TranslationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000007 /* TranslationCache.swift */; };
 		AA003DOC0000002000000008 /* DocTranslationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000001000000008 /* DocTranslationTests.swift */; };
 		DD000031STATMSGDISP00001 /* StatusMessageDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000031STATMSGDISP00000 /* StatusMessageDisplayTests.swift */; };
+		CD0DE0010000000000000002 /* WatchSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0DE0010000000000000001 /* WatchSessionManagerTests.swift */; };
 		AA003DOC0000004000000001 /* docs in Resources */ = {isa = PBXBuildFile; fileRef = AA003DOC0000005000000001 /* docs */; };
 		AA003FM00000002000000001 /* FoundationModelAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA003FM00000001000000001 /* FoundationModelAvailability.swift */; };
 		AA004FMT0000002000000001 /* MarkdownFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA004FMT0000001000000001 /* MarkdownFormatting.swift */; };
@@ -791,6 +792,7 @@
 		AA003DOC0000001000000007 /* TranslationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TranslationCache.swift; path = Meshtastic/Services/TranslationCache.swift; sourceTree = "<group>"; };
 		AA003DOC0000001000000008 /* DocTranslationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocTranslationTests.swift; sourceTree = "<group>"; };
 		DD000031STATMSGDISP00000 /* StatusMessageDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusMessageDisplayTests.swift; sourceTree = "<group>"; };
+		CD0DE0010000000000000001 /* WatchSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSessionManagerTests.swift; sourceTree = "<group>"; };
 		AA003DOC0000005000000001 /* docs */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = docs; sourceTree = "<group>"; };
 		AA003FM00000001000000001 /* FoundationModelAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FoundationModelAvailability.swift; path = Meshtastic/Services/FoundationModelAvailability.swift; sourceTree = "<group>"; };
 		AA004FMT0000001000000001 /* MarkdownFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormatting.swift; sourceTree = "<group>"; };
@@ -1663,6 +1665,7 @@
 				DD0000CHSETST0000000000 /* ChannelSetSaveTests.swift */,
 				DD1827FA0000000000000002 /* RegionCodesFirmwareLocaleTests.swift */,
 				DD000031STATMSGDISP00000 /* StatusMessageDisplayTests.swift */,
+				CD0DE0010000000000000001 /* WatchSessionManagerTests.swift */,
 			);
 			path = MeshtasticTests;
 			sourceTree = "<group>";
@@ -2735,6 +2738,7 @@
 				DD0000CHSETST0000000001 /* ChannelSetSaveTests.swift in Sources */,
 				DD1827FB0000000000000002 /* RegionCodesFirmwareLocaleTests.swift in Sources */,
 				DD000031STATMSGDISP00001 /* StatusMessageDisplayTests.swift in Sources */,
+				CD0DE0010000000000000002 /* WatchSessionManagerTests.swift in Sources */,
 				AA009MCT0000002000000001 /* MarkdownConverterTests.swift in Sources */,
 				AA0001012E2730EC00600001 /* ConnectViewTests.swift in Sources */,
 				DD9C70102E9F2A0000029299 /* DeviceOnboardingTests.swift in Sources */,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Position.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Position.swift
@@ -11,10 +11,15 @@ import MeshtasticProtobufs
 import CoreLocation
 
 extension AccessoryManager {
+	nonisolated static func locationProviderSleepSeconds(configuredInterval: Int) -> Int {
+		max(5, configuredInterval)
+	}
+
 	func initializeLocationProvider() {
 		self.locationTask = Task {
 			repeat {
-				try? await Task.sleep(for: .seconds(30)) // sleep for 30 seconds. This throws if task is cancelled
+				let sleepSeconds = Self.locationProviderSleepSeconds(configuredInterval: UserDefaults.provideLocationInterval)
+				try? await Task.sleep(for: .seconds(sleepSeconds)) // Throws if task is cancelled
 
 				guard let fromNodeNum = activeConnection?.device.num else {
 					return

--- a/Meshtastic/Helpers/LocationsHandler.swift
+++ b/Meshtastic/Helpers/LocationsHandler.swift
@@ -16,6 +16,7 @@ import OSLog
 	static let shared = LocationsHandler()  // Create a single, shared instance of the object.
 	public var manager = CLLocationManager()
 	private var background: CLBackgroundActivitySession?
+	private var locationDeliveryStarted = false
 	var enableSmartPosition: Bool = UserDefaults.enableSmartPosition
 
 	@Published var locationsArray: [CLLocation] = [CLLocation]()
@@ -147,57 +148,29 @@ import OSLog
 			Logger.services.warning("📍 [App] Cannot start location updates: insufficient authorization status: \(status.rawValue)")
 			return
 		}
+		guard !locationDeliveryStarted else { return }
 		Logger.services.info("📍 [App] Starting location updates")
-		// Using a Task for asynchronous operations. The @MainActor isolation of the class
-		// ensures that all state changes within this Task (accessing @Published properties)
-		// will be performed on the main actor.
-		Task { @MainActor in
-			do {
-				self.updatesStarted = true
-				// `liveUpdates()` provides a stream of location updates.
-				let updates = CLLocationUpdate.liveUpdates()
-				for try await update in updates {
-					// Check for task cancellation to allow graceful stopping.
-					try Task.checkCancellation()
-					// If `updatesStarted` is set to false (e.g., by `stopLocationUpdates`),
-					// break out of the loop to stop processing updates.
-					if !self.updatesStarted {
-						Logger.services.info("🛑 [App] Location updates loop stopped due to updatesStarted being false.")
-						break
-					}
-					if let loc = update.location {
-						self.isStationary = update.isStationary
-						let locationAdded = addLocation(loc, smartPostion: enableSmartPosition)
-						if !isRecording && locationAdded {
-							self.count = 1
-						} else if locationAdded && isRecording {
-							self.count += 1
-						}
-					}
-				}
-			} catch is CancellationError {
-				// Handle explicit task cancellation gracefully.
-				Logger.services.info("📍 [App] Location updates task was cancelled.")
-			} catch {
-				// Catch any other errors during location updates.
-				Logger.services.error("💥 [App] Could not start location updates: \(error.localizedDescription, privacy: .public)")
-			}
-			// The Task completes implicitly here.
-		}
+		updatesStarted = true
+		beginLocationDelivery()
 	}
-	
+
+	func beginLocationDelivery() {
+		locationDeliveryStarted = true
+		manager.startUpdatingLocation()
+	}
+
 	// New method to start heading updates
 	func startHeadingUpdates() {
 		guard CLLocationManager.headingAvailable() else {
 			Logger.services.warning("📍 [App] Heading updates not available on this device.")
 			return
 		}
-		
+
 		guard manager.authorizationStatus == .authorizedAlways || manager.authorizationStatus == .authorizedWhenInUse else {
 			Logger.services.warning("📍 [App] Cannot start heading updates: insufficient authorization status.")
 			return
 		}
-		
+
 		Logger.services.info("📍 [App] Starting heading updates")
 		manager.startUpdatingHeading()
 		headingUpdatesStarted = true
@@ -217,12 +190,32 @@ import OSLog
 			self.heading = newHeading.trueHeading >= 0 ? newHeading.trueHeading : newHeading.magneticHeading
 		}
 	}
-	
+
+	func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+		Task { @MainActor in
+			guard self.updatesStarted else { return }
+			for location in locations {
+				self.recordLocation(location, isStationary: false)
+			}
+		}
+	}
+
 	/// Stops receiving live location updates.
 	func stopLocationUpdates() {
 		Logger.services.info("🛑 [App] Stopping location updates")
-		// Setting `updatesStarted` to false will cause the `liveUpdates()` loop to break.
 		self.updatesStarted = false
+		self.locationDeliveryStarted = false
+		self.manager.stopUpdatingLocation()
+	}
+
+	private func recordLocation(_ location: CLLocation, isStationary: Bool) {
+		self.isStationary = isStationary
+		let locationAdded = addLocation(location, smartPostion: enableSmartPosition)
+		if !isRecording && locationAdded {
+			self.count = 1
+		} else if locationAdded && isRecording {
+			self.count += 1
+		}
 	}
 
 	/// Escalates to best accuracy during route recording; reverts to battery-friendly defaults otherwise.

--- a/Meshtastic/Helpers/WatchSessionManager.swift
+++ b/Meshtastic/Helpers/WatchSessionManager.swift
@@ -133,55 +133,7 @@ final class WatchSessionManager: NSObject, ObservableObject {
 		do {
 			let results = try context.fetch(descriptor)
 			return results.compactMap { nodeInfo -> WatchNode? in
-				guard let user = nodeInfo.user else { return nil }
-
-				let num = nodeInfo.num
-				let longName = user.longName ?? "Unknown"
-				let shortName = user.shortName ?? "?"
-				let snr: Float? = nodeInfo.snr != 0 ? nodeInfo.snr : nil
-				let lastHeard = nodeInfo.lastHeard
-
-				// Find the latest position using a targeted fetch instead of faulting the entire relationship
-				let nodeNum = nodeInfo.num
-				var posDescriptor = FetchDescriptor<PositionEntity>(
-					predicate: #Predicate<PositionEntity> { $0.nodePosition?.num == nodeNum && $0.latest == true }
-				)
-				posDescriptor.fetchLimit = 1
-				let latestPosition = try? context.fetch(posDescriptor).first
-
-				var latitude: Double?
-				var longitude: Double?
-				var altitude: Int32?
-				var lastPositionTime: Date?
-
-				if let pos = latestPosition {
-					let latI = pos.latitudeI
-					let lonI = pos.longitudeI
-					if latI != 0, lonI != 0 {
-						latitude = Double(latI) / 1e7
-						longitude = Double(lonI) / 1e7
-						altitude = pos.altitude
-						lastPositionTime = pos.time
-					}
-				}
-
-				// Only include nodes within 0.5 miles
-				guard let lat = latitude, let lon = longitude else { return nil }
-				let nodeLocation = CLLocation(latitude: lat, longitude: lon)
-				let distance = userLocation.distance(from: nodeLocation)
-				guard distance <= Self.maxDistanceMeters else { return nil }
-
-				return WatchNode(
-					num: UInt32(num),
-					longName: longName,
-					shortName: shortName,
-					latitude: latitude,
-					longitude: longitude,
-					altitude: altitude,
-					lastPositionTime: lastPositionTime,
-					lastHeard: lastHeard,
-					snr: snr
-				)
+				WatchNode.make(from: nodeInfo, userLocation: userLocation, maxDistanceMeters: Self.maxDistanceMeters)
 			}
 		} catch {
 			logger.error("Failed to fetch nodes for Watch: \(error.localizedDescription, privacy: .public)")
@@ -229,4 +181,30 @@ struct WatchNode: Codable {
 	let lastPositionTime: Date?
 	let lastHeard: Date?
 	let snr: Float?
+
+	static func make(from nodeInfo: NodeInfoEntity, userLocation: CLLocation, maxDistanceMeters: Double) -> WatchNode? {
+		guard let user = nodeInfo.user else { return nil }
+		guard let pos = nodeInfo.latestPosition else { return nil }
+
+		let latI = pos.latitudeI
+		let lonI = pos.longitudeI
+		guard latI != 0, lonI != 0 else { return nil }
+
+		let latitude = Double(latI) / 1e7
+		let longitude = Double(lonI) / 1e7
+		let nodeLocation = CLLocation(latitude: latitude, longitude: longitude)
+		guard userLocation.distance(from: nodeLocation) <= maxDistanceMeters else { return nil }
+
+		return WatchNode(
+			num: UInt32(nodeInfo.num),
+			longName: user.longName ?? "Unknown",
+			shortName: user.shortName ?? "?",
+			latitude: latitude,
+			longitude: longitude,
+			altitude: pos.altitude,
+			lastPositionTime: pos.time,
+			lastHeard: nodeInfo.lastHeard,
+			snr: nodeInfo.snr != 0 ? nodeInfo.snr : nil
+		)
+	}
 }

--- a/MeshtasticTests/WatchSessionManagerTests.swift
+++ b/MeshtasticTests/WatchSessionManagerTests.swift
@@ -1,0 +1,108 @@
+import CoreLocation
+import SwiftData
+import Testing
+@testable import Meshtastic
+
+private final class RecordingLocationManager: CLLocationManager {
+	var startUpdatingLocationCallCount = 0
+	var stopUpdatingLocationCallCount = 0
+
+	override func startUpdatingLocation() {
+		startUpdatingLocationCallCount += 1
+	}
+
+	override func stopUpdatingLocation() {
+		stopUpdatingLocationCallCount += 1
+	}
+}
+
+@Suite("Watch node serialization", .serialized)
+struct WatchNodeSerializationTests {
+
+	@MainActor
+	@Test func usesCachedLatestPosition() throws {
+		let context = sharedModelContainer.mainContext
+		let nodeNum: Int64 = 2_001_003
+
+		let node = NodeInfoEntity()
+		node.num = nodeNum
+		node.snr = 4.25
+		node.lastHeard = Date(timeIntervalSince1970: 1_750_000_000)
+
+		let user = UserEntity()
+		user.num = nodeNum
+		user.longName = "Cached Node"
+		user.shortName = "CN"
+		node.user = user
+
+		let cached = PositionEntity()
+		cached.latitudeI = 371234567
+		cached.longitudeI = -1221234567
+		cached.altitude = 42
+		cached.time = Date(timeIntervalSince1970: 1_750_000_100)
+		cached.nodePosition = node
+		node.latestPositionCache = cached
+
+		let staleLatest = PositionEntity()
+		staleLatest.latitudeI = 376543210
+		staleLatest.longitudeI = -1226543210
+		staleLatest.altitude = 99
+		staleLatest.latest = true
+		staleLatest.time = Date(timeIntervalSince1970: 1_750_000_200)
+		staleLatest.nodePosition = node
+
+		context.insert(node)
+		context.insert(user)
+		context.insert(cached)
+		context.insert(staleLatest)
+		try context.save()
+
+		let userLocation = CLLocation(latitude: 37.12345, longitude: -122.12345)
+		let watchNode = WatchNode.make(from: node, userLocation: userLocation, maxDistanceMeters: 2_000)
+
+		#expect(watchNode?.latitude == Double(cached.latitudeI) / 1e7)
+		#expect(watchNode?.longitude == Double(cached.longitudeI) / 1e7)
+		#expect(watchNode?.altitude == cached.altitude)
+		#expect(watchNode?.longName == "Cached Node")
+		#expect(watchNode?.shortName == "CN")
+		#expect(watchNode?.snr == 4.25)
+	}
+}
+
+@Suite("Location provider cadence")
+struct LocationProviderCadenceTests {
+
+	@Test func sleepIntervalUsesConfiguredIntervalWhenLongerThanMinimum() {
+		#expect(AccessoryManager.locationProviderSleepSeconds(configuredInterval: 300) == 300)
+	}
+
+	@Test func sleepIntervalKeepsASaneMinimum() {
+		#expect(AccessoryManager.locationProviderSleepSeconds(configuredInterval: 0) == 5)
+		#expect(AccessoryManager.locationProviderSleepSeconds(configuredInterval: 3) == 5)
+	}
+}
+
+@Suite("Location updates energy")
+@MainActor
+struct LocationUpdatesEnergyTests {
+
+	@Test func beginsStandardLocationManagerUpdates() {
+		let handler = LocationsHandler()
+		let manager = RecordingLocationManager()
+		handler.manager = manager
+
+		handler.beginLocationDelivery()
+
+		#expect(manager.startUpdatingLocationCallCount == 1)
+	}
+
+	@Test func endsStandardLocationManagerUpdates() {
+		let handler = LocationsHandler()
+		let manager = RecordingLocationManager()
+		handler.manager = manager
+
+		handler.stopLocationUpdates()
+
+		#expect(manager.stopUpdatingLocationCallCount == 1)
+	}
+}


### PR DESCRIPTION
## Summary

This PR tightens two performance/energy rough edges found while profiling latest upstream `main`:

- Replace continuous app location delivery from `CLLocationUpdate.liveUpdates()` with standard `CLLocationManager.startUpdatingLocation()` / `stopUpdatingLocation()`, preserving the idle `kCLLocationAccuracyHundredMeters` default and the existing route-recording escalation to best accuracy.
- Respect the configured provide-location interval for the accessory location provider instead of always sleeping 30 seconds, with a 5-second minimum guard.
- Avoid a per-node SwiftData position fetch while serializing nearby watch nodes by using `NodeInfoEntity.latestPosition` / the existing latest-position cache via a shared `WatchNode.make(...)` helper.

## Why

A real-device Power Profiler trace showed the warm-idle location path escalating CoreLocation energy after launch. Before this change, the trace reached `Energy Impact=High` for 36.19 seconds after `CLLocationManager` changed accuracy to `kCLLocationAccuracyBest` through the MapKit/CoreLocation path.

After switching continuous app delivery back to standard `CLLocationManager` updates, the same warm-idle path stayed at `Energy Impact=None` for the full 2.03 minute trace, with no CoreLocation trace rows for a best-accuracy transition.

The watch serialization change removes another large-store rough edge: the old code fetched the latest `PositionEntity` once per fetched node. The new helper uses the cached latest position already maintained on the node entity.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -derivedDataPath /tmp/meshtastic-pr-focused-test-dd ENABLE_DEBUG_DYLIB=NO ENABLE_PREVIEWS=NO -only-testing:MeshtasticTests/WatchNodeSerializationTests -only-testing:MeshtasticTests/LocationProviderCadenceTests -only-testing:MeshtasticTests/LocationUpdatesEnergyTests`
  - Passed: 5 tests in 3 suites, `** TEST SUCCEEDED **`.
- Real iPhone 15 Pro, iOS 26.5, Power Profiler warm-idle trace after fix:
  - CoreLocation energy: `None` for 2.03 min.
  - CoreLocation trace: no `kCLLocationAccuracyBest` transition rows.
- Comparison trace before the final location fix:
  - CoreLocation energy: `High` for 36.19 s.
  - Cause: `CLLocationManager ... changed accuracy to kCLLocationAccuracyBest`.
- Broader local simulator check from this audit also passed with known unrelated snapshot/stale enum tests excluded: 2127 tests in 400 suites.

Known caveat: the fully unskipped `MeshtasticTests` suite still has existing unrelated failures around snapshot re-recording and a stale `IntervalConfiguration.allCases.count` expectation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location tracking reliability by switching to standard location update handling, helping start and stop updates more consistently.
  * Refined watch data handling so nearby nodes use the latest saved position and ignore invalid or out-of-range entries.
  * Adjusted background location polling to respect the configured interval while keeping a safe minimum delay.

* **Tests**
  * Added coverage for watch node data, location polling timing, and location update start/stop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->