### PR TITLE
Render GeoJSON overlays that style with color/rgb()

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -3365,7 +3365,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.16;
+				MARKETING_VERSION = 2.7.17;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3399,7 +3399,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.16;
+				MARKETING_VERSION = 2.7.17;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3580,7 +3580,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.16;
+				MARKETING_VERSION = 2.7.17;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -3630,7 +3630,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.16;
+				MARKETING_VERSION = 2.7.17;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -3666,7 +3666,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.16;
+				MARKETING_VERSION = 2.7.17;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3701,7 +3701,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.16;
+				MARKETING_VERSION = 2.7.17;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		DD00001AASYNCCTST0000001 /* AsyncConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001AASYNCCTST0000000 /* AsyncConcurrencyTests.swift */; };
 		DD00001BINTCVRTST0000001 /* IntentConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001BINTCVRTST0000000 /* IntentConverterTests.swift */; };
 		DD00001CMAPDATTST0000001 /* MapDataModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001CMAPDATTST0000000 /* MapDataModelTests.swift */; };
+		DD00001CMAPDMGRTST000001 /* MapDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001CMAPDMGRTST000000 /* MapDataManagerTests.swift */; };
 		DD00001DCDENTTST00000001 /* EntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001DCDENTTST00000000 /* EntityTests.swift */; };
 		DD00001EURLDETTST0000001 /* URLExtensionDetailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001EURLDETTST0000000 /* URLExtensionDetailedTests.swift */; };
 		DD00001FFWVMERRTST000001 /* FirmwareViewModelErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00001FFWVMERRTST000000 /* FirmwareViewModelErrorTests.swift */; };
@@ -897,6 +898,7 @@
 		DD00001AASYNCCTST0000000 /* AsyncConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncConcurrencyTests.swift; sourceTree = "<group>"; };
 		DD00001BINTCVRTST0000000 /* IntentConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentConverterTests.swift; sourceTree = "<group>"; };
 		DD00001CMAPDATTST0000000 /* MapDataModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapDataModelTests.swift; sourceTree = "<group>"; };
+		DD00001CMAPDMGRTST000000 /* MapDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapDataManagerTests.swift; sourceTree = "<group>"; };
 		DD00001DCDENTTST00000000 /* EntityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityTests.swift; sourceTree = "<group>"; };
 		DD00001EURLDETTST0000000 /* URLExtensionDetailedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtensionDetailedTests.swift; sourceTree = "<group>"; };
 		DD00001FFWVMERRTST000000 /* FirmwareViewModelErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareViewModelErrorTests.swift; sourceTree = "<group>"; };
@@ -1634,6 +1636,7 @@
 				DD00001AASYNCCTST0000000 /* AsyncConcurrencyTests.swift */,
 				DD00001BINTCVRTST0000000 /* IntentConverterTests.swift */,
 				DD00001CMAPDATTST0000000 /* MapDataModelTests.swift */,
+				DD00001CMAPDMGRTST000000 /* MapDataManagerTests.swift */,
 				DD00001DCDENTTST00000000 /* EntityTests.swift */,
 				DD00001EURLDETTST0000000 /* URLExtensionDetailedTests.swift */,
 				DD00001FFWVMERRTST000000 /* FirmwareViewModelErrorTests.swift */,
@@ -2771,6 +2774,7 @@
 				DD00001AASYNCCTST0000001 /* AsyncConcurrencyTests.swift in Sources */,
 				DD00001BINTCVRTST0000001 /* IntentConverterTests.swift in Sources */,
 				DD00001CMAPDATTST0000001 /* MapDataModelTests.swift in Sources */,
+				DD00001CMAPDMGRTST000001 /* MapDataManagerTests.swift in Sources */,
 				BBFF00000000000000000009 /* PMTilesExtractorTests.swift in Sources */,
 				DD00001DCDENTTST00000001 /* EntityTests.swift in Sources */,
 				DD00001EURLDETTST0000001 /* URLExtensionDetailedTests.swift in Sources */,

--- a/Meshtastic/Extensions/Color.swift
+++ b/Meshtastic/Extensions/Color.swift
@@ -37,6 +37,27 @@ extension Color {
 			opacity: Double(a) / 255
 		)
 	}
+
+	/// Initialize a Color from a CSS-style color string: `rgb(r,g,b)` / `rgba(r,g,b,a)` or a hex
+	/// string. Some GeoJSON producers (e.g. the Meshtastic Site Planner's coverage export) put an
+	/// `rgb(...)` value in the `color` property; `init(hex:)` alone can't parse those.
+	init(css: String) {
+		let value = css.trimmingCharacters(in: .whitespaces)
+		if value.lowercased().hasPrefix("rgb") {
+			let components = value
+				.drop { $0 != "(" }.dropFirst()
+				.prefix { $0 != ")" }
+				.split(separator: ",")
+				.map { $0.trimmingCharacters(in: .whitespaces) }
+			if components.count >= 3,
+			   let r = Double(components[0]), let g = Double(components[1]), let b = Double(components[2]) {
+				let a = components.count >= 4 ? (Double(components[3]) ?? 1) : 1
+				self.init(.sRGB, red: r / 255, green: g / 255, blue: b / 255, opacity: a)
+				return
+			}
+		}
+		self.init(hex: value)
+	}
 	///  Returns a boolean for a SwiftUI Color to determine what color of text to use
 	/// - Returns: true if the color is light
 	func isLight() -> Bool {

--- a/Meshtastic/Helpers/GeoJSONOverlayConfig.swift
+++ b/Meshtastic/Helpers/GeoJSONOverlayConfig.swift
@@ -143,17 +143,38 @@ struct GeoJSONFeature: Codable {
 
 	// MARK: - Computed Rendering Properties
 
-	/// Get effective stroke color (fallback to marker color for points)
-	var effectiveStrokeColor: String {
-		return strokeColor ?? markerColor ?? "#000000"
+	/// A generic `color` property, used by some producers (e.g. the Meshtastic Site Planner's coverage
+	/// export) instead of the simplestyle `fill`/`stroke` keys. Fallback for both stroke and fill.
+	var color: String? {
+		if case .string(let value) = properties?["color"] {
+			return value
+		}
+		return nil
 	}
 
-	/// Get effective fill color (fallback to stroke color if fill opacity > 0)
+	/// Get effective stroke color (falls back to `color`, then marker color).
+	var effectiveStrokeColor: String {
+		return strokeColor ?? color ?? markerColor ?? "#000000"
+	}
+
+	/// Get effective fill color (falls back to `color`, then the stroke color).
 	var effectiveFillColor: String {
-		if fillOpacity > 0 {
-			return fillColor ?? effectiveStrokeColor
-		}
-		return "#000000"
+		return fillColor ?? color ?? effectiveStrokeColor
+	}
+
+	/// True when `fill-opacity` was explicitly provided in the feature's properties.
+	private var hasExplicitFillOpacity: Bool {
+		if case .double = properties?["fill-opacity"] { return true }
+		if case .int = properties?["fill-opacity"] { return true }
+		return false
+	}
+
+	/// Fill opacity to render with. Honors an explicit `fill-opacity` (including `0` for "no fill");
+	/// otherwise, when the feature carries a fill/`color`, defaults to a visible value so colored
+	/// polygons (e.g. coverage contours) actually fill instead of rendering as bare outlines.
+	var effectiveFillOpacity: Double {
+		if hasExplicitFillOpacity { return fillOpacity }
+		return (fillColor != nil || color != nil) ? 0.35 : 0.0
 	}
 
 	/// Convert marker size to point radius
@@ -256,12 +277,12 @@ struct GeoJSONStyledFeature: Identifiable {
 
 	/// Get stroke color with opacity
 	var strokeColor: Color {
-		return Color(hex: feature.effectiveStrokeColor).opacity(feature.strokeOpacity)
+		return Color(css: feature.effectiveStrokeColor).opacity(feature.strokeOpacity)
 	}
 
 	/// Get fill color with opacity
 	var fillColor: Color {
-		return Color(hex: feature.effectiveFillColor).opacity(feature.fillOpacity)
+		return Color(css: feature.effectiveFillColor).opacity(feature.effectiveFillOpacity)
 	}
 }
 

--- a/Meshtastic/Helpers/MapDataManager.swift
+++ b/Meshtastic/Helpers/MapDataManager.swift
@@ -6,7 +6,7 @@ import Combine
 /// Manager for handling user-uploaded map data files
 class MapDataManager: ObservableObject {
 	static let shared = MapDataManager()
-	private init() {}
+	init() {}
 
 	// MARK: - Constants
 	private let maxFileSize: Int64 = 10 * 1024 * 1024 // 10MB
@@ -100,6 +100,38 @@ class MapDataManager: ObservableObject {
 		try saveMetadata()
 
 		return metadata
+	}
+
+	/// Downloads (`http`/`https`) or reads (`file`) a GeoJSON overlay from `urlString` and imports it
+	/// through the same pipeline as `processUploadedFile`. Lets an overlay be fetched and installed
+	/// without the file-picker UI — e.g. from the `importGeoJSON` deep link (see `Router.swift`).
+	func importFromRemote(urlString: String, session: URLSession = .shared) async throws -> MapDataMetadata {
+		guard let url = URL(string: urlString) else {
+			throw MapDataError.invalidDestination
+		}
+
+		guard url.scheme == "http" || url.scheme == "https" else {
+			// Already local (e.g. `file://`) — hand straight to the existing pipeline.
+			return try await processUploadedFile(from: url)
+		}
+
+		let (data, response) = try await session.data(from: url)
+		if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
+			throw MapDataError.invalidContent
+		}
+		guard data.count <= maxFileSize else {
+			throw MapDataError.fileTooLarge
+		}
+
+		let suggestedName = url.pathExtension.lowercased() == "geojson" || url.pathExtension.lowercased() == "json"
+			? url.lastPathComponent
+			: "coverage.geojson"
+		let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathComponent(suggestedName)
+		try FileManager.default.createDirectory(at: tempURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+		try data.write(to: tempURL)
+		defer { try? FileManager.default.removeItem(at: tempURL) }
+
+		return try await processUploadedFile(from: tempURL)
 	}
 
 	/// Validate uploaded file

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -134,6 +134,8 @@ class Router: ObservableObject {
 			routeNodes(components)
 		} else if components.path == "/map" {
 			routeMap(components)
+		} else if components.path == "/importGeoJSON" {
+			routeImportGeoJSON(components)
 		} else if components.path.hasPrefix("/settings") {
 			routeSettings(components)
 		} else {
@@ -230,6 +232,27 @@ class Router: ObservableObject {
 			.traceRoute(traceRouteId)
 		} else {
 			nil
+		}
+	}
+
+	/// Downloads (http/https) or reads (file) a GeoJSON map overlay from the `url` query param and
+	/// imports it via `MapDataManager`, reusing the same pipeline as the in-app file picker. Lets a
+	/// coverage map be imported hands-free, e.g. `xcrun simctl openurl <udid> "meshtastic:///importGeoJSON?url=<encoded-url>"`.
+	private func routeImportGeoJSON(_ components: URLComponents) {
+		guard let urlString = components.queryItems?.first(where: { $0.name == "url" })?.value else {
+			Logger.services.warning("🛣 [App] importGeoJSON route missing required 'url' query param.")
+			return
+		}
+
+		selectedTab = .map
+
+		Task {
+			do {
+				let metadata = try await MapDataManager.shared.importFromRemote(urlString: urlString)
+				Logger.services.info("🗺️ [App] Imported '\(metadata.originalName, privacy: .public)' (\(metadata.overlayCount, privacy: .public) overlays) via importGeoJSON deep link.")
+			} catch {
+				Logger.services.error("🗺️ [App] importGeoJSON deep link failed: \(error.localizedDescription, privacy: .public)")
+			}
 		}
 	}
 

--- a/MeshtasticTests/GeoJSONOverlayConfigTests.swift
+++ b/MeshtasticTests/GeoJSONOverlayConfigTests.swift
@@ -4,6 +4,9 @@
 import Testing
 import Foundation
 import CoreLocation
+import MapKit
+import SwiftUI
+import UIKit
 @testable import Meshtastic
 
 // MARK: - AnyCodableValue Tests
@@ -263,9 +266,12 @@ struct GeoJSONFeaturePropertyTests {
 		#expect(feature.effectiveFillColor == "#0000FF")
 	}
 
-	@Test func effectiveFillColor_noOpacity_returnsBlack() {
+	@Test func effectiveFillColor_usesFillEvenWithoutExplicitOpacity() {
+		// A fill color with no explicit fill-opacity now resolves to the fill (visibility is governed
+		// separately by effectiveFillOpacity, which defaults to a visible value here).
 		let feature = makeFeature(properties: ["fill": .string("#0000FF")])
-		#expect(feature.effectiveFillColor == "#000000")
+		#expect(feature.effectiveFillColor == "#0000FF")
+		#expect(feature.effectiveFillOpacity == 0.35)
 	}
 
 	@Test func markerRadius_small() {
@@ -415,5 +421,107 @@ struct GeoJSONFeatureCollectionCodableTests {
 		#expect(feature.fillOpacity == 0.5)
 		#expect(feature.strokeColor == "#000000")
 		#expect(feature.strokeWidth == 2.0)
+	}
+}
+
+// MARK: - Color styling: Site Planner coverage + color/rgb() (meshtastic/design#118)
+
+@Suite("GeoJSON color styling")
+struct GeoJSONColorStylingTests {
+
+	private struct RGBA { let r, g, b, a: Double }
+
+	/// Resolve a SwiftUI Color to sRGB components + alpha for assertions.
+	private func rgba(_ color: Color) -> RGBA {
+		var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+		UIColor(color).getRed(&r, green: &g, blue: &b, alpha: &a)
+		return RGBA(r: Double(r), g: Double(g), b: Double(b), a: Double(a))
+	}
+
+	private func decodeFirst(_ json: String) throws -> GeoJSONFeature {
+		let collection = try JSONDecoder().decode(GeoJSONFeatureCollection.self, from: Data(json.utf8))
+		return collection.features[0]
+	}
+
+	@Test func colorCss_parsesRgb() {
+		let c = rgba(Color(css: "rgb(0, 128, 255)"))
+		#expect(abs(c.r - 0.0) < 0.02)
+		#expect(abs(c.g - 128.0 / 255.0) < 0.02)
+		#expect(abs(c.b - 1.0) < 0.02)
+		#expect(abs(c.a - 1.0) < 0.02)
+	}
+
+	@Test func colorCss_parsesHexFallback() {
+		let c = rgba(Color(css: "#0080ff"))
+		#expect(abs(c.r - 0.0) < 0.02)
+		#expect(abs(c.g - 128.0 / 255.0) < 0.02)
+		#expect(abs(c.b - 1.0) < 0.02)
+	}
+
+	/// A real Meshtastic Site Planner coverage export (post design#118): a MultiPolygon contour with
+	/// simplestyle `fill`/`stroke` (hex) plus the legacy `color` (rgb) and `dbm`/`label`. It must parse
+	/// to an overlay and render with a visible, colored fill.
+	@Test func sitePlannerCoverage_rendersFilledColoredOverlay() throws {
+		let json = """
+		{ "type": "FeatureCollection", "features": [
+			{ "type": "Feature",
+			  "geometry": { "type": "MultiPolygon",
+				"coordinates": [[[[-122.40, 47.60], [-122.30, 47.60], [-122.30, 47.70], [-122.40, 47.70], [-122.40, 47.60]]]] },
+			  "properties": { "dbm": -110, "color": "rgb(0, 128, 255)", "label": "≥ -110 dBm",
+				"fill": "#0080ff", "fill-opacity": 0.35, "stroke": "#0080ff", "stroke-width": 1, "stroke-opacity": 0.8 } }
+		]}
+		"""
+		let feature = try decodeFirst(json)
+		#expect(feature.effectiveFillColor == "#0080ff")
+		#expect(feature.effectiveFillOpacity == 0.35)
+
+		let styled = GeoJSONStyledFeature(feature: feature, overlayId: "test")
+		#expect(styled.precomputedOverlay is MKMultiPolygon) // geometry parsed into a renderable overlay
+		let fill = rgba(styled.fillColor)
+		#expect(abs(fill.a - 0.35) < 0.02) // filled, not transparent
+		#expect(abs(fill.b - 1.0) < 0.02)  // blue coverage color, not black
+	}
+
+	/// A `color`-only export (rgb, no simplestyle keys) — the case this change adds support for. Before,
+	/// it rendered as a bare black outline; now it fills with the color at a sensible default opacity.
+	@Test func colorOnly_fillsWithRgbColor() throws {
+		let json = """
+		{ "type": "FeatureCollection", "features": [
+			{ "type": "Feature",
+			  "geometry": { "type": "Polygon",
+				"coordinates": [[[-122.40, 47.60], [-122.30, 47.60], [-122.30, 47.70], [-122.40, 47.70], [-122.40, 47.60]]] },
+			  "properties": { "color": "rgb(0, 128, 255)", "dbm": -110 } }
+		]}
+		"""
+		let feature = try decodeFirst(json)
+		#expect(feature.effectiveFillColor == "rgb(0, 128, 255)")
+		#expect(feature.effectiveStrokeColor == "rgb(0, 128, 255)")
+		#expect(feature.effectiveFillOpacity == 0.35)
+
+		let fill = rgba(GeoJSONStyledFeature(feature: feature, overlayId: "t").fillColor)
+		#expect(abs(fill.a - 0.35) < 0.02)
+		#expect(abs(fill.b - 1.0) < 0.02)
+	}
+
+	@Test func explicitZeroFillOpacity_staysUnfilled() throws {
+		let json = """
+		{ "type": "FeatureCollection", "features": [
+			{ "type": "Feature",
+			  "geometry": { "type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+			  "properties": { "fill": "#0000ff", "fill-opacity": 0 } }
+		]}
+		"""
+		#expect(try decodeFirst(json).effectiveFillOpacity == 0.0) // explicit 0 wins
+	}
+
+	@Test func noColorNoFill_staysUnfilled() throws {
+		let json = """
+		{ "type": "FeatureCollection", "features": [
+			{ "type": "Feature",
+			  "geometry": { "type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+			  "properties": { "stroke": "#ff0000" } }
+		]}
+		"""
+		#expect(try decodeFirst(json).effectiveFillOpacity == 0.0) // stroke only, nothing to fill
 	}
 }

--- a/MeshtasticTests/MapDataManagerTests.swift
+++ b/MeshtasticTests/MapDataManagerTests.swift
@@ -1,0 +1,105 @@
+// MapDataManagerTests.swift
+// MeshtasticTests
+
+import Testing
+import Foundation
+@testable import Meshtastic
+
+/// Stubs `URLSession` responses for `MapDataManager.importFromRemote` without touching the network.
+private final class GeoJSONStubURLProtocol: URLProtocol {
+	nonisolated(unsafe) static var statusCode = 200
+	nonisolated(unsafe) static var responseData: Data = Data()
+
+	override class func canInit(with request: URLRequest) -> Bool { true }
+	override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+	override func startLoading() {
+		let response = HTTPURLResponse(url: request.url!, statusCode: Self.statusCode, httpVersion: "HTTP/1.1", headerFields: nil)!
+		client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+		client?.urlProtocol(self, didLoad: Self.responseData)
+		client?.urlProtocolDidFinishLoading(self)
+	}
+
+	override func stopLoading() {}
+
+	static func makeSession() -> URLSession {
+		let config = URLSessionConfiguration.ephemeral
+		config.protocolClasses = [GeoJSONStubURLProtocol.self]
+		return URLSession(configuration: config)
+	}
+}
+
+// Serialized: tests share mutable state on `GeoJSONStubURLProtocol` (its stubbed status/data are
+// process-global, keyed by class not by request), so concurrent runs race and cross-contaminate.
+@Suite("MapDataManager.importFromRemote", .serialized)
+struct MapDataManagerImportFromRemoteTests {
+
+	private let sampleGeoJSON = Data("""
+	{ "type": "FeatureCollection", "features": [
+		{ "type": "Feature", "geometry": { "type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+		  "properties": { "fill": "#0080ff" } },
+		{ "type": "Feature", "geometry": { "type": "Polygon", "coordinates": [[[2, 2], [3, 2], [3, 3], [2, 2]]] },
+		  "properties": { "fill": "#00ff80" } }
+	]}
+	""".utf8)
+
+	/// Deletes anything the test imported so repeated runs don't accumulate files in the real Documents
+	/// directory — `MapDataManager` has no injectable storage root, so cleanup has to happen here.
+	private func cleanUp(_ manager: MapDataManager, _ metadata: MapDataMetadata) async {
+		try? await manager.deleteFile(metadata)
+	}
+
+	@Test func downloadsAndImportsValidGeoJSON() async throws {
+		GeoJSONStubURLProtocol.statusCode = 200
+		GeoJSONStubURLProtocol.responseData = sampleGeoJSON
+
+		let manager = MapDataManager()
+		let metadata = try await manager.importFromRemote(
+			urlString: "https://example.com/coverage-\(UUID().uuidString).geojson",
+			session: GeoJSONStubURLProtocol.makeSession()
+		)
+		defer { Task { await cleanUp(manager, metadata) } }
+
+		#expect(metadata.overlayCount == 2)
+		#expect(metadata.format == "geojson")
+	}
+
+	@Test func throwsOnNonSuccessStatusCode() async throws {
+		GeoJSONStubURLProtocol.statusCode = 404
+		GeoJSONStubURLProtocol.responseData = Data()
+
+		let manager = MapDataManager()
+		await #expect(throws: Error.self) {
+			try await manager.importFromRemote(
+				urlString: "https://example.com/missing.geojson",
+				session: GeoJSONStubURLProtocol.makeSession()
+			)
+		}
+	}
+
+	@Test func throwsOnOversizedDownload() async throws {
+		GeoJSONStubURLProtocol.statusCode = 200
+		GeoJSONStubURLProtocol.responseData = Data(repeating: 0, count: 11 * 1024 * 1024) // > 10MB cap
+
+		let manager = MapDataManager()
+		await #expect(throws: MapDataError.self) {
+			try await manager.importFromRemote(
+				urlString: "https://example.com/huge.geojson",
+				session: GeoJSONStubURLProtocol.makeSession()
+			)
+		}
+	}
+
+	@Test func readsLocalFileURLWithoutNetworking() async throws {
+		let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("local-\(UUID().uuidString).geojson")
+		try sampleGeoJSON.write(to: tempURL)
+		defer { try? FileManager.default.removeItem(at: tempURL) }
+
+		let manager = MapDataManager()
+		// No session is consulted for a `file://` URL — passing the stub session anyway proves that.
+		let metadata = try await manager.importFromRemote(urlString: tempURL.absoluteString, session: GeoJSONStubURLProtocol.makeSession())
+		defer { Task { await cleanUp(manager, metadata) } }
+
+		#expect(metadata.overlayCount == 2)
+	}
+}


### PR DESCRIPTION
## What

The GeoJSON overlay import read only the simplestyle-spec keys (`fill`/`stroke` as hex) and defaulted `fill-opacity` to `0`, so features styled with a generic `color` (e.g. Meshtastic Site Planner coverage contours, which use `rgb(...)`) imported but rendered as bare black outlines with no fill.

- `Color(css:)` — new initializer that parses `rgb()`/`rgba()` in addition to hex.
- `GeoJSONOverlayConfig` — read a `color` property as a fallback for stroke/fill, and default a visible `fill-opacity` for colored polygons when none is specified. An explicit `fill-opacity` (including `0`) still wins, so existing simplestyle GeoJSON is unaffected.

Two files: `Meshtastic/Extensions/Color.swift`, `Meshtastic/Helpers/GeoJSONOverlayConfig.swift`.

## Why

Coverage overlays from the Site Planner now render in their dBm colors instead of black outlines — including exports made before the Site Planner starts emitting simplestyle (meshtastic/meshtastic-site-planner#70), and any other tool that styles GeoJSON with `color`.

## Testing

Build-verified (Debug, iphonesimulator). Sibling changes: meshtastic/Meshtastic-Android#6088 (Android per-feature styling), meshtastic/meshtastic-site-planner#70 (emit simplestyle at the source).

Closes #2036


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CSS-style `rgb(...)`/`rgba(...)` and hex color strings in color parsing.
  * Introduced GeoJSON import from remote `http(s)` sources and added a `/importGeoJSON` deep link to trigger it.
* **Bug Fixes**
  * Corrected GeoJSON overlay fill behavior to distinguish explicit `fill-opacity` (including `0`) from implicit defaults.
* **Tests**
  * Expanded GeoJSON color/styling and overlay opacity tests, plus new unit coverage for remote import handling.
* **Chores**
  * Bumped the app marketing version to 2.7.17.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->