### PR TITLE
[codex] Restore Share Contact QR from node details

### DIFF
--- a/Meshtastic/Extensions/SwiftData/NodeInfoEntityToNodeInfo.swift
+++ b/Meshtastic/Extensions/SwiftData/NodeInfoEntityToNodeInfo.swift
@@ -15,9 +15,7 @@ extension NodeInfoEntity {
             userProto.shortName = user.shortName ?? ""
             userProto.hwModel = HardwareModel(rawValue: Int(user.hwModelId)) ?? .unset
             userProto.isLicensed = user.isLicensed
-			if userProto.hasIsUnmessagable == true {
-				userProto.isUnmessagable = user.unmessagable
-			}
+			userProto.isUnmessagable = user.unmessagable
 			userProto.role = Config.DeviceConfig.Role(rawValue: Int(user.role)) ?? .client
 			userProto.publicKey = user.publicKey?.subdata(in: 0..<user.publicKey!.count) ?? Data()
         }
@@ -37,9 +35,7 @@ extension UserEntity {
 			userProto.shortName = self.shortName ?? ""
 			userProto.hwModel = HardwareModel(rawValue: Int(self.hwModelId)) ?? .unset
 			userProto.isLicensed = self.isLicensed
-			if userProto.hasIsUnmessagable == true {
-				userProto.isUnmessagable = self.unmessagable
-			}
+			userProto.isUnmessagable = self.unmessagable
 			userProto.role = Config.DeviceConfig.Role(rawValue: Int(self.role)) ?? .client
 			userProto.publicKey = self.publicKey?.subdata(in: 0..<self.publicKey!.count) ?? Data()
 		return userProto

--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -378,16 +378,16 @@
             "direct",
             "client",
             "supported",
+            "show",
             "mesh",
             "long",
             "local",
             "links",
             "hops",
             "heard",
-            "filter",
-            "display"
+            "filter"
         ],
-        "charCount": 8333
+        "charCount": 8466
     },
     {
         "id": "settings",

--- a/Meshtastic/Resources/docs/markdown/user/nodes.md
+++ b/Meshtastic/Resources/docs/markdown/user/nodes.md
@@ -154,6 +154,8 @@ Tap any node to see the full detail view with hardware info, signal metrics, env
 
 ![Node Detail](../assets/screenshots/nodeDetail.png)
 
+For messageable nodes, use **Actions > Share Contact QR** to show a Meshtastic contact link and QR code that another device can scan.
+
 ### Signed Node
 
 If a node signs its broadcast packets, a green shield (🛡️) **Signed node** row appears in the detail view, marked **Verified automatically**. This means the radio has cryptographically verified an XEdDSA signature from this node (firmware 2.8 or later). Because a node's identity broadcast is itself signed, its name and identity are verified by extension.

--- a/Meshtastic/Resources/docs/user/nodes.html
+++ b/Meshtastic/Resources/docs/user/nodes.html
@@ -269,6 +269,7 @@
 <h2>Node Detail View</h2>
 <p>Tap any node to see the full detail view with hardware info, signal metrics, environment sensors, and log navigation:</p>
 <p><img src="../assets/screenshots/nodeDetail.png" alt="Node Detail" /></p>
+<p>For messageable nodes, use <strong>Actions &gt; Share Contact QR</strong> to show a Meshtastic contact link and QR code that another device can scan.</p>
 <h3>Signed Node</h3>
 <p>If a node signs its broadcast packets, a green shield (🛡️) <strong>Signed node</strong> row appears in the detail view, marked <strong>Verified automatically</strong>. This means the radio has cryptographically verified an XEdDSA signature from this node (firmware 2.8 or later). Because a node's identity broadcast is itself signed, its name and identity are verified by extension.</p>
 <p>This is <em>automatic</em> trust observed from the radio — distinct from manually verifying a contact's public key out-of-band, which is a separate, user-asserted action. The row only ever affirms the good state; nodes that don't sign simply show no shield, which is not a warning.</p>

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -46,6 +46,7 @@ struct NodeDetail: View {
 	@State private var latestEnvironmentMetrics: TelemetryEntity?
 	@State private var latestPowerMetrics: TelemetryEntity?
 	@State private var logAvailability = NodeDetailLogAvailability()
+	@State private var showingShareContactQR = false
 
 	/// The currently BLE-connected (or remotely administered) node, derived reactively
 	/// from accessoryManager.activeDeviceNum so it stays current if the connection changes.
@@ -74,10 +75,16 @@ struct NodeDetail: View {
 					.frame(height: 0) // Ensure it has no height
 					.id("topOfList")
 					nodeDetailList
-					.sheet(isPresented: $showingCompassSheet) {
-						CompassView(waypointLocation: latestPosition?.nodeCoordinate ?? nil, waypointLongName: node.user?.displayLongName, waypointShortName: node.user?.shortName, color: Color(UIColor(hex: UInt32(node.num))))
-							}
-					.displayNameAlert(node: $nodeForDisplayNameEdit)
+						.sheet(isPresented: $showingCompassSheet) {
+							CompassView(waypointLocation: latestPosition?.nodeCoordinate ?? nil, waypointLongName: node.user?.displayLongName, waypointShortName: node.user?.shortName, color: Color(UIColor(hex: UInt32(node.num))))
+						}
+						.sheet(isPresented: $showingShareContactQR) {
+							ShareContactQRDialog(
+								manuallyVerified: node.num == accessoryManager.activeDeviceNum,
+								node: node.toProto()
+							)
+						}
+						.displayNameAlert(node: $nodeForDisplayNameEdit)
 					.onReceive(NotificationCenter.default.publisher(for: NodeDisplayNameStore.didChangeNotification)) { notification in
 						// Scoped to this node: the notification's object is unconditionally `nil`
 						// otherwise, and `displayNameRefresh` drives `.id()` below (which recreates
@@ -630,6 +637,13 @@ struct NodeDetail: View {
 					node: node,
 					user: user
 				)
+				if ShareContactQR.canShareContact(for: node) {
+					Button {
+						showingShareContactQR = true
+					} label: {
+						Label("Share Contact QR", systemImage: "qrcode")
+					}
+				}
 			}
 			if let connectedNode {
 				FavoriteNodeButton(

--- a/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
+++ b/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
@@ -12,66 +12,89 @@ import SwiftData
 import MeshtasticProtobufs
 import OSLog
 
-struct ShareContactQRDialog: View {
-	let manuallyVerified: Bool
-    let node: NodeInfo
-    @Environment(\.dismiss) private var dismiss
-    var qrString: String {
+enum ShareContactQR {
+	static let urlPrefix = "https://meshtastic.org/v/#"
+
+	static func canShareContact(for node: NodeInfoEntity) -> Bool {
+		node.user?.unmessagable == false
+	}
+
+	static func canShareContact(for node: NodeInfo) -> Bool {
+		node.hasUser && !node.user.isUnmessagable
+	}
+
+	static func urlString(for node: NodeInfo, manuallyVerified: Bool) -> String? {
+		guard canShareContact(for: node) else { return nil }
+
 		var contact = SharedContact()
 		contact.nodeNum = node.num
 		contact.user = node.user
 		contact.manuallyVerified = manuallyVerified
-        do {
-            let contactString = try contact.serializedData().base64EncodedString()
-			return ("https://meshtastic.org/v/#" + contactString.base64ToBase64url())
-        } catch {
+		do {
+			let contactString = try contact.serializedData().base64EncodedString()
+			return urlPrefix + contactString.base64ToBase64url()
+		} catch {
 			Logger.services.error("Error serializing contact: \(error)")
-            return ""
-        }
-    }
-    var qrImage: UIImage {
-        let context = CIContext()
-        let filter = CIFilter.qrCodeGenerator()
-        filter.setValue(Data(qrString.utf8), forKey: "inputMessage")
-        let transform = CGAffineTransform(scaleX: 10, y: 10)
-        if let outputImage = filter.outputImage?.transformed(by: transform),
-           let cgimg = context.createCGImage(outputImage, from: outputImage.extent) {
-            return UIImage(cgImage: cgimg)
-        }
-        return UIImage(systemName: "xmark.circle") ?? UIImage()
-    }
-    var body: some View {
-        VStack(spacing: 20) {
-            Text("Share Contact QR")
-                .font(.title2)
-                .padding(.top)
+			return nil
+		}
+	}
+}
+
+struct ShareContactQRDialog: View {
+	let manuallyVerified: Bool
+	let node: NodeInfo
+	@Environment(\.dismiss) private var dismiss
+
+	var qrString: String {
+		ShareContactQR.urlString(for: node, manuallyVerified: manuallyVerified) ?? ""
+	}
+
+	var qrImage: UIImage {
+		let context = CIContext()
+		let filter = CIFilter.qrCodeGenerator()
+		filter.setValue(Data(qrString.utf8), forKey: "inputMessage")
+		let transform = CGAffineTransform(scaleX: 10, y: 10)
+		if let outputImage = filter.outputImage?.transformed(by: transform),
+		   let cgimg = context.createCGImage(outputImage, from: outputImage.extent) {
+			return UIImage(cgImage: cgimg)
+		}
+		return UIImage(systemName: "xmark.circle") ?? UIImage()
+	}
+
+	var body: some View {
+		VStack(spacing: 20) {
+			Text("Share Contact QR")
+				.font(.title2)
+				.padding(.top)
 			Text(node.user.longName)
-                .font(.headline)
-            Image(uiImage: qrImage)
-                .interpolation(.none)
-                .resizable()
-                .scaledToFit()
-                .background(Color(.systemBackground))
-                .cornerRadius(16)
-                .shadow(radius: 4)
+				.font(.headline)
+			Image(uiImage: qrImage)
+				.interpolation(.none)
+				.resizable()
+				.scaledToFit()
+				.background(Color(.systemBackground))
+				.cornerRadius(16)
+				.shadow(radius: 4)
 			Text("Scan this QR code to add \(node.user.longName) to another device.")
-                .font(.subheadline)
-                .multilineTextAlignment(.center)
-                .foregroundColor(.secondary)
+				.font(.subheadline)
+				.multilineTextAlignment(.center)
+				.foregroundColor(.secondary)
 			ShareLink("Share QR Code & Link",
-						item: Image(uiImage: qrImage),
+					  item: Image(uiImage: qrImage),
 					  subject: Text("Add Meshtastic Node \(node.user.shortName) as a contact"),
 					  message: Text(qrString),
-					  preview: SharePreview("Add Meshtastic Node \(node.user.shortName) as a contact",
-						image: Image(uiImage: qrImage))
+					  preview: SharePreview(
+						"Add Meshtastic Node \(node.user.shortName) as a contact",
+						image: Image(uiImage: qrImage)
+					  )
 			)
-            Button("Done") { dismiss() }
-                .buttonStyle(.borderedProminent)
-                .padding(.bottom)
-        }
-        .padding()
-        .frame(maxWidth: 350)
-    }
+			Button("Done") { dismiss() }
+				.buttonStyle(.borderedProminent)
+				.padding(.bottom)
+		}
+		.padding()
+		.frame(maxWidth: 350)
+	}
 }
 
 #if DEBUG

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -94,6 +94,66 @@ struct CreateNodeInfoTests {
 	}
 }
 
+// MARK: - Share Contact QR Tests
+
+@Suite("ShareContactQR")
+struct ShareContactQRTests {
+
+	private func makeNodeInfo(num: UInt32 = 0x1234_ABCD, unmessagable: Bool = false) -> NodeInfo {
+		var user = User()
+		user.id = "!\(String(num, radix: 16))"
+		user.longName = "Node Alpha"
+		user.shortName = "ALFA"
+		user.hwModel = .tbeam
+		user.role = .client
+		user.publicKey = Data([0x01, 0x02, 0x03, 0x04])
+		user.isUnmessagable = unmessagable
+
+		var node = NodeInfo()
+		node.num = num
+		node.user = user
+		return node
+	}
+
+	@Test func contactURLRoundTripsSharedContactPayload() throws {
+		let node = makeNodeInfo()
+
+		let urlString = try #require(ShareContactQR.urlString(for: node, manuallyVerified: true))
+		#expect(urlString.hasPrefix("https://meshtastic.org/v/#"))
+
+		let payload = try #require(urlString.split(separator: "#").last.map(String.init))
+		let decodedData = try #require(Data(base64Encoded: payload.base64urlToBase64()))
+		let contact = try SharedContact(serializedBytes: decodedData)
+
+		#expect(contact.nodeNum == node.num)
+		#expect(contact.user.longName == node.user.longName)
+		#expect(contact.user.shortName == node.user.shortName)
+		#expect(contact.user.publicKey == node.user.publicKey)
+		#expect(contact.manuallyVerified)
+	}
+
+	@Test func contactURLUnavailableForUnmessagableNode() {
+		let node = makeNodeInfo(unmessagable: true)
+
+		#expect(ShareContactQR.urlString(for: node, manuallyVerified: false) == nil)
+	}
+
+	@Test @MainActor func availabilityUsesNodeUserMessagingState() {
+		let node = NodeInfoEntity()
+		let user = UserEntity()
+		user.unmessagable = false
+		node.user = user
+
+		#expect(ShareContactQR.canShareContact(for: node))
+
+		user.unmessagable = true
+		#expect(!ShareContactQR.canShareContact(for: node))
+
+		node.user = nil
+		#expect(!ShareContactQR.canShareContact(for: node))
+	}
+}
+
 // MARK: - findOrCreateNode Tests
 //
 // NodeInfoEntity.num is @Attribute(.unique). SwiftData resolves unique collisions against the saved

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -136,6 +136,14 @@ struct ShareContactQRTests {
 		let node = makeNodeInfo(unmessagable: true)
 
 		#expect(ShareContactQR.urlString(for: node, manuallyVerified: false) == nil)
+		#expect(ShareContactQR.urlString(for: node, manuallyVerified: true) == nil)
+	}
+
+	@Test func contactURLUnavailableWhenUserAbsent() {
+		let node = NodeInfo()
+
+		#expect(!ShareContactQR.canShareContact(for: node))
+		#expect(ShareContactQR.urlString(for: node, manuallyVerified: false) == nil)
 	}
 
 	@Test @MainActor func availabilityUsesNodeUserMessagingState() {
@@ -151,6 +159,25 @@ struct ShareContactQRTests {
 
 		node.user = nil
 		#expect(!ShareContactQR.canShareContact(for: node))
+	}
+
+	@Test @MainActor func nodeProtoPreservesUnmessagableStateForQRAvailability() {
+		let node = NodeInfoEntity()
+		let user = UserEntity()
+		user.unmessagable = true
+		node.user = user
+
+		let proto = node.toProto()
+
+		#expect(proto.user.isUnmessagable)
+		#expect(!ShareContactQR.canShareContact(for: proto))
+	}
+
+	@Test @MainActor func userProtoPreservesUnmessagableState() {
+		let user = UserEntity()
+		user.unmessagable = true
+
+		#expect(user.toProto().isUnmessagable)
 	}
 }
 

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -154,6 +154,8 @@ Tap any node to see the full detail view with hardware info, signal metrics, env
 
 ![Node Detail](../assets/screenshots/nodeDetail.png)
 
+For messageable nodes, use **Actions > Share Contact QR** to show a Meshtastic contact link and QR code that another device can scan.
+
 ### Signed Node
 
 If a node signs its broadcast packets, a green shield (🛡️) **Signed node** row appears in the detail view, marked **Verified automatically**. This means the radio has cryptographically verified an XEdDSA signature from this node (firmware 2.8 or later). Because a node's identity broadcast is itself signed, its name and identity are verified by extension.


### PR DESCRIPTION
## Summary
- Restore the Share Contact QR action to a selected node's detail Actions section.
- Keep the long-press node-list menu aligned with the canonical cleanup from #1850 instead of adding QR back there.
- Extract the `/v/` contact URL generation into a small helper and add regression coverage for payload round-tripping and unmessagable-node gating.

## Regression history
This disappeared in `64e8b04b302e863196f5344b99aa91ee95bf6df8` from #1850 on May 20, 2026. That cleanup removed Share Contact QR from the node-list context menu with the note that it was still accessible from Node Detail, but no Node Detail entry point was added. The existing dialog and sheet state remained in the codebase, but there was no reachable action setting the selected contact node anymore.

This PR restores the intended Node Detail access path for the selected node while preserving the simplified context menu behavior from #1850.

## Verification
- Red check before implementation: targeted `ShareContactQRTests/contactURLRoundTripsSharedContactPayload` failed to build because `ShareContactQR` did not exist yet.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MeshtasticTests/ShareContactQRTests`
- `git diff --check`

The focused Swift Testing suite ran 3 tests and passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Share Contact QR** action in the Node Detail View for eligible nodes, allowing users to show a Meshtastic contact link and QR code for other devices to scan.
* **Documentation**
  * Updated node documentation (including the Node Detail View section) to explain how to use **Actions > Share Contact QR**.
* **Tests**
  * Added coverage for QR sharing eligibility and URL/serialization behavior, including handling of unmessagable nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->