### PR TITLE
feat(telemetry): ingest PM air-quality metrics + EPA NowCast AQI (#2040)

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -233,6 +233,9 @@
 		BBFF00000000000000000007 /* RegionSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF00000000000000000007 /* RegionSelectorView.swift */; };
 		BBFF00000000000000000008 /* OfflineMapDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF00000000000000000008 /* OfflineMapDetailView.swift */; };
 		BBFF00000000000000000009 /* PMTilesExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF00000000000000000009 /* PMTilesExtractorTests.swift */; };
+		DDA1B0000000000000000001 /* AirQualityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA1C0000000000000000001 /* AirQualityCalculator.swift */; };
+		DDA1B0000000000000000002 /* AirQualityMetricsLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA1C0000000000000000002 /* AirQualityMetricsLog.swift */; };
+		DDA1B0000000000000000003 /* AirQualityCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA1C0000000000000000003 /* AirQualityCalculatorTests.swift */; };
 		BC10380F2DD4334400B00BFA /* AddContactIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC10380E2DD4333C00B00BFA /* AddContactIntent.swift */; };
 		BC6B45FF2CB2F98900723CEB /* SaveChannelSettingsIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6B45FE2CB2F98900723CEB /* SaveChannelSettingsIntent.swift */; };
 		BC996F276BA82B1229C119D8 /* DiscoveryHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EB21EF91CA0B50FDC20B85 /* DiscoveryHistoryView.swift */; };
@@ -833,6 +836,9 @@
 		AAFF00000000000000000007 /* RegionSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RegionSelectorView.swift; path = Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift; sourceTree = SOURCE_ROOT; };
 		AAFF00000000000000000008 /* OfflineMapDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OfflineMapDetailView.swift; path = Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapDetailView.swift; sourceTree = SOURCE_ROOT; };
 		AAFF00000000000000000009 /* PMTilesExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PMTilesExtractorTests.swift; path = MeshtasticTests/PMTilesExtractorTests.swift; sourceTree = SOURCE_ROOT; };
+		DDA1C0000000000000000001 /* AirQualityCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AirQualityCalculator.swift; path = Meshtastic/Helpers/AirQualityCalculator.swift; sourceTree = SOURCE_ROOT; };
+		DDA1C0000000000000000002 /* AirQualityMetricsLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AirQualityMetricsLog.swift; path = Meshtastic/Views/Nodes/AirQualityMetricsLog.swift; sourceTree = SOURCE_ROOT; };
+		DDA1C0000000000000000003 /* AirQualityCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AirQualityCalculatorTests.swift; path = MeshtasticTests/AirQualityCalculatorTests.swift; sourceTree = SOURCE_ROOT; };
 		AB61EBF02E3326DC00B35962 /* NodeListItemCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeListItemCompact.swift; sourceTree = "<group>"; };
 		AB6E72752E3FC85A00639328 /* LayoutEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutEnums.swift; sourceTree = "<group>"; };
 		ABA8E63F2E2F2A2300E27791 /* AppIconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconButton.swift; sourceTree = "<group>"; };
@@ -2052,6 +2058,9 @@
 				AAFF00000000000000000007 /* RegionSelectorView.swift */,
 				AAFF00000000000000000008 /* OfflineMapDetailView.swift */,
 				AAFF00000000000000000009 /* PMTilesExtractorTests.swift */,
+				DDA1C0000000000000000001 /* AirQualityCalculator.swift */,
+				DDA1C0000000000000000002 /* AirQualityMetricsLog.swift */,
+				DDA1C0000000000000000003 /* AirQualityCalculatorTests.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -2810,6 +2819,7 @@
 				DD00001CMAPDATTST0000001 /* MapDataModelTests.swift in Sources */,
 				DD00001CMAPDMGRTST000001 /* MapDataManagerTests.swift in Sources */,
 				BBFF00000000000000000009 /* PMTilesExtractorTests.swift in Sources */,
+				DDA1B0000000000000000003 /* AirQualityCalculatorTests.swift in Sources */,
 				DD00001DCDENTTST00000001 /* EntityTests.swift in Sources */,
 				DD00001EURLDETTST0000001 /* URLExtensionDetailedTests.swift in Sources */,
 				DD00001FFWVMERRTST000001 /* FirmwareViewModelErrorTests.swift in Sources */,
@@ -2863,6 +2873,8 @@
 				BBFF00000000000000000006 /* DownloadNewMapView.swift in Sources */,
 				BBFF00000000000000000007 /* RegionSelectorView.swift in Sources */,
 				BBFF00000000000000000008 /* OfflineMapDetailView.swift in Sources */,
+				DDA1B0000000000000000001 /* AirQualityCalculator.swift in Sources */,
+				DDA1B0000000000000000002 /* AirQualityMetricsLog.swift in Sources */,
 				BB0001000000000000000000 /* MBTilesArchive.swift in Sources */,
 				BB0003000000000000000000 /* PMTilesMapView.swift in Sources */,
 				BB0005000000000000000000 /* MeshMapMK.swift in Sources */,

--- a/Meshtastic/Export/WriteCsvFile.swift
+++ b/Meshtastic/Export/WriteCsvFile.swift
@@ -63,6 +63,25 @@ func telemetryToCsvFile<S: Sequence>(telemetry: S, metricsType: Int) -> String w
 			csvString += ", "
 			csvString += dm.time?.formatted(date: .numeric, time: .shortened).replacing(",", with: "") ?? ""
 		}
+	} else if metricsType == 3 {
+		// Create Air Quality Metrics Header (particulate matter, µg/m³)
+		csvString = "PM1.0 Standard, PM2.5 Standard, PM10.0 Standard, PM1.0 Environmental, PM2.5 Environmental, PM10.0 Environmental, \("Timestamp".localized)"
+		for dm in telemetry where dm.metricsType == 3 {
+			csvString += "\n"
+			csvString += dm.pm10Standard?.formatted(.number.grouping(.never)) ?? ""
+			csvString += ", "
+			csvString += dm.pm25Standard?.formatted(.number.grouping(.never)) ?? ""
+			csvString += ", "
+			csvString += dm.pm100Standard?.formatted(.number.grouping(.never)) ?? ""
+			csvString += ", "
+			csvString += dm.pm10Environmental?.formatted(.number.grouping(.never)) ?? ""
+			csvString += ", "
+			csvString += dm.pm25Environmental?.formatted(.number.grouping(.never)) ?? ""
+			csvString += ", "
+			csvString += dm.pm100Environmental?.formatted(.number.grouping(.never)) ?? ""
+			csvString += ", "
+			csvString += dm.time?.formatted(date: .numeric, time: .shortened).replacing(",", with: "") ?? ""
+		}
 	} else if metricsType == 4 {
 		// Create Local Stats Header
 		csvString = "Noise Floor, Uptime, Relayed, Canceled, Dupes, Packets Tx, Packets Rx, Bad Rx, Nodes Online, Total Nodes, \("Timestamp".localized)"

--- a/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
@@ -191,6 +191,36 @@ extension NodeInfoEntity {
 		return ((try? ctx.fetch(descriptor)) ?? []).isEmpty == false
 	}
 
+	var hasAirQualityMetrics: Bool {
+		guard let ctx = modelContext else { return false }
+		let nodeNum = self.num
+		let metricsType: Int32 = 3
+		var descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == metricsType }
+		)
+		descriptor.fetchLimit = 1
+		return ((try? ctx.fetch(descriptor)) ?? []).isEmpty == false
+	}
+
+	/// The most recent reported PM2.5 concentration (µg/m³) for this node, if any.
+	var latestPm25: UInt32? {
+		safeTelemetries(ofType: 3).first(where: { $0.pm25Standard != nil })?.pm25Standard
+	}
+
+	/// The current EPA NowCast AQI (0–500) computed from this node's PM2.5 history, or `nil` when
+	/// there isn't enough recent history (per meshtastic/design#54). Callers should fall back to the
+	/// raw `latestPm25` reading rather than showing a misleading instantaneous value.
+	func currentNowCastAqi(now: Date = Date()) -> Int? {
+		let readings: [(time: TimeInterval, pm25: Double)] = safeTelemetries(ofType: 3).compactMap { telemetry in
+			guard let pm25 = telemetry.pm25Standard, let time = telemetry.time else { return nil }
+			return (time.timeIntervalSince1970, Double(pm25))
+		}
+		guard let nowCast = AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now.timeIntervalSince1970) else {
+			return nil
+		}
+		return AirQualityCalculator.pm25ToAqi(nowCast)
+	}
+
 	var latestLocalStats: TelemetryEntity? {
 		guard let ctx = modelContext else { return nil }
 		let nodeNum = self.num

--- a/Meshtastic/Helpers/AirQualityCalculator.swift
+++ b/Meshtastic/Helpers/AirQualityCalculator.swift
@@ -1,0 +1,99 @@
+//
+//  AirQualityCalculator.swift
+//  Meshtastic
+//
+//  EPA NowCast + AQI breakpoint math for PM2.5, per meshtastic/design#54.
+//
+//  Ported from the Android reference implementation (Meshtastic-Android PR #6102) so both
+//  platforms compute identical AQI values from the same PM2.5 history.
+//
+//  NowCast is a 12-hour rolling average of PM2.5 that weights recent hours more heavily than
+//  older ones. It is used in lieu of the official 24h EPA AQI average because it can report a
+//  value well before a full day of data exists — while still refusing to report a misleading
+//  instantaneous value when there isn't enough recent history.
+//  See https://www.airnow.gov (NowCast) and the EPA PM2.5 AQI breakpoint table.
+//
+
+import Foundation
+
+enum AirQualityCalculator {
+
+	private static let nowCastWindowHours = 12
+	private static let secondsPerHour: TimeInterval = 3600
+	/// EPA requires the most recent hour plus at least 2 of the 3 most recent hours, or NowCast isn't reported.
+	private static let minValidHours = 2
+	private static let recentWindowHours = 3
+	private static let minWeightFactor = 0.5
+
+	/// Computes the NowCast PM2.5 concentration (µg/m³) from a node's PM2.5 `readings`
+	/// (epoch-seconds → µg/m³), relative to `nowEpochSeconds`. Readings are binned into hourly
+	/// buckets (0 = most recent hour) and averaged within each bucket.
+	///
+	/// Returns `nil` if there isn't enough history yet: the most recent hour must have a reading,
+	/// and at least `minValidHours` of the `recentWindowHours` most recent hours must be populated
+	/// (EPA's minimum-data rule) — so stale data spread across the older end of the 12h window can't
+	/// produce a value. Callers should fall back to showing the raw latest reading in that case.
+	static func computeNowCastPm25(readings: [(time: TimeInterval, pm25: Double)], nowEpochSeconds: TimeInterval) -> Double? {
+		var sums = [Double](repeating: 0, count: nowCastWindowHours)
+		var counts = [Int](repeating: 0, count: nowCastWindowHours)
+		for reading in readings {
+			let hoursAgo = Int((nowEpochSeconds - reading.time) / secondsPerHour)
+			if hoursAgo >= 0 && hoursAgo < nowCastWindowHours {
+				sums[hoursAgo] += reading.pm25
+				counts[hoursAgo] += 1
+			}
+		}
+		let hourlyAverages: [Double?] = (0..<nowCastWindowHours).map { counts[$0] > 0 ? sums[$0] / Double(counts[$0]) : nil }
+		let present: [(hoursAgo: Int, value: Double)] = hourlyAverages.enumerated().compactMap { index, value in
+			value.map { (index, $0) }
+		}
+
+		let recentValid = hourlyAverages.prefix(recentWindowHours).filter { $0 != nil }.count
+		guard hourlyAverages[0] != nil, recentValid >= minValidHours else {
+			return nil
+		}
+
+		let maxValue = present.map { $0.value }.max() ?? 0
+		let minValue = present.map { $0.value }.min() ?? 0
+		let weightFactor = maxValue <= 0 ? 1.0 : max(1.0 - (maxValue - minValue) / maxValue, minWeightFactor)
+
+		var weightedSum = 0.0
+		var weightTotal = 0.0
+		for entry in present {
+			let weight = pow(weightFactor, Double(entry.hoursAgo))
+			weightedSum += weight * entry.value
+			weightTotal += weight
+		}
+		return weightedSum / weightTotal
+	}
+
+	private struct Breakpoint {
+		let concentrationLow: Double
+		let concentrationHigh: Double
+		let aqiLow: Int
+		let aqiHigh: Int
+	}
+
+	// Standard EPA PM2.5 (µg/m³) breakpoint table.
+	private static let breakpoints: [Breakpoint] = [
+		Breakpoint(concentrationLow: 0.0, concentrationHigh: 12.0, aqiLow: 0, aqiHigh: 50),
+		Breakpoint(concentrationLow: 12.1, concentrationHigh: 35.4, aqiLow: 51, aqiHigh: 100),
+		Breakpoint(concentrationLow: 35.5, concentrationHigh: 55.4, aqiLow: 101, aqiHigh: 150),
+		Breakpoint(concentrationLow: 55.5, concentrationHigh: 150.4, aqiLow: 151, aqiHigh: 200),
+		Breakpoint(concentrationLow: 150.5, concentrationHigh: 250.4, aqiLow: 201, aqiHigh: 300),
+		Breakpoint(concentrationLow: 250.5, concentrationHigh: 500.4, aqiLow: 301, aqiHigh: 500)
+	]
+
+	/// Converts a PM2.5 concentration (µg/m³) to a 0–500 EPA AQI value via linear interpolation over
+	/// the standard breakpoint table. Negative inputs clamp to 0; concentrations above the top
+	/// breakpoint clamp to AQI 500. The result is always in `0...500`, safe to pass to `Aqi.getAqi(for:)`.
+	static func pm25ToAqi(_ concentration: Double) -> Int {
+		let clamped = max(concentration, 0)
+		let breakpoint = breakpoints.last(where: { clamped >= $0.concentrationLow }) ?? breakpoints[0]
+		if clamped > breakpoint.concentrationHigh { return breakpoint.aqiHigh }
+		let aqi = Double(breakpoint.aqiHigh - breakpoint.aqiLow) /
+			(breakpoint.concentrationHigh - breakpoint.concentrationLow) *
+			(clamped - breakpoint.concentrationLow) + Double(breakpoint.aqiLow)
+		return Int(aqi.rounded())
+	}
+}

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -918,7 +918,7 @@ actor MeshPackets {
 
 	func telemetryPacket(packet: MeshPacket, connectedNode: Int64) {
 		if let telemetryMessage = try? Telemetry(serializedBytes: packet.decoded.payload) {
-			if telemetryMessage.variant != Telemetry.OneOf_Variant.deviceMetrics(telemetryMessage.deviceMetrics) && telemetryMessage.variant != Telemetry.OneOf_Variant.environmentMetrics(telemetryMessage.environmentMetrics) && telemetryMessage.variant != Telemetry.OneOf_Variant.localStats(telemetryMessage.localStats) && telemetryMessage.variant != Telemetry.OneOf_Variant.powerMetrics(telemetryMessage.powerMetrics) {
+			if telemetryMessage.variant != Telemetry.OneOf_Variant.deviceMetrics(telemetryMessage.deviceMetrics) && telemetryMessage.variant != Telemetry.OneOf_Variant.environmentMetrics(telemetryMessage.environmentMetrics) && telemetryMessage.variant != Telemetry.OneOf_Variant.localStats(telemetryMessage.localStats) && telemetryMessage.variant != Telemetry.OneOf_Variant.powerMetrics(telemetryMessage.powerMetrics) && telemetryMessage.variant != Telemetry.OneOf_Variant.airQualityMetrics(telemetryMessage.airQualityMetrics) {
 				/// Other unhandled telemetry packets
 				return
 			}
@@ -1008,6 +1008,18 @@ actor MeshPackets {
 				telemetry.powerCh3Voltage = telemetryMessage.powerMetrics.hasCh3Voltage.then(telemetryMessage.powerMetrics.ch3Voltage)
 				telemetry.powerCh3Current = telemetryMessage.powerMetrics.hasCh3Current.then(telemetryMessage.powerMetrics.ch3Current)
 				telemetry.metricsType = 2
+			} else if telemetryMessage.variant == Telemetry.OneOf_Variant.airQualityMetrics(telemetryMessage.airQualityMetrics) {
+				// Air Quality Metrics (particulate matter). Persisted here, in the main ingest path, so
+				// PM data is queryable by the UI — previously these packets were only counted by the
+				// Discovery scan engine and otherwise discarded. See meshtastic/design#54.
+				Logger.data.debug("📈 [Telemetry] Air Quality Metrics Received for Node: \(packet.from.toHex(), privacy: .public)")
+				telemetry.pm10Standard = telemetryMessage.airQualityMetrics.hasPm10Standard.then(telemetryMessage.airQualityMetrics.pm10Standard)
+				telemetry.pm25Standard = telemetryMessage.airQualityMetrics.hasPm25Standard.then(telemetryMessage.airQualityMetrics.pm25Standard)
+				telemetry.pm100Standard = telemetryMessage.airQualityMetrics.hasPm100Standard.then(telemetryMessage.airQualityMetrics.pm100Standard)
+				telemetry.pm10Environmental = telemetryMessage.airQualityMetrics.hasPm10Environmental.then(telemetryMessage.airQualityMetrics.pm10Environmental)
+				telemetry.pm25Environmental = telemetryMessage.airQualityMetrics.hasPm25Environmental.then(telemetryMessage.airQualityMetrics.pm25Environmental)
+				telemetry.pm100Environmental = telemetryMessage.airQualityMetrics.hasPm100Environmental.then(telemetryMessage.airQualityMetrics.pm100Environmental)
+				telemetry.metricsType = 3
 			}
 			telemetry.snr = packet.rxSnr
 			telemetry.rssi = packet.rxRssi

--- a/Meshtastic/Model/TelemetryEntity.swift
+++ b/Meshtastic/Model/TelemetryEntity.swift
@@ -35,6 +35,13 @@ final class TelemetryEntity {
 	var irLux: Float?
 	var lux: Float?
 	var noiseFloor: Int32?
+	// Air quality (particulate matter, µg/m³) from the AirQualityMetrics telemetry variant.
+	var pm10Standard: UInt32?
+	var pm25Standard: UInt32?
+	var pm100Standard: UInt32?
+	var pm10Environmental: UInt32?
+	var pm25Environmental: UInt32?
+	var pm100Environmental: UInt32?
 	var powerCh1Current: Float?
 	var powerCh1Voltage: Float?
 	var powerCh2Current: Float?

--- a/Meshtastic/Views/Nodes/AirQualityMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/AirQualityMetricsLog.swift
@@ -1,0 +1,214 @@
+//
+//  AirQualityMetricsLog.swift
+//  Meshtastic
+//
+//  Displays particulate-matter (PM) air-quality telemetry and an EPA NowCast AQI, per
+//  meshtastic/design#54. When there is enough PM2.5 history a computed AQI is shown via the
+//  existing AirQualityIndex view; otherwise the raw latest PM2.5 reading is shown so a
+//  misleading instantaneous AQI is never displayed.
+//
+
+import Foundation
+import SwiftUI
+import Charts
+import OSLog
+
+struct AirQualityMetricsLog: View {
+
+	@Environment(\.modelContext) private var context
+	@EnvironmentObject var accessoryManager: AccessoryManager
+	@Bindable var node: NodeInfoEntity
+	private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
+	@State private var sortOrder = [KeyPathComparator(\TelemetryEntity.time, order: .reverse)]
+	@State private var selection: TelemetryEntity.ID?
+	@State private var chartSelection: Date?
+
+	@State private var isPresentingClearLogConfirm: Bool = false
+	@State var isExporting = false
+	@State var exportString = ""
+
+	@State private var airQualityMetrics: [TelemetryEntity] = []
+	@State private var chartData: [TelemetryEntity] = []
+	@State private var totalReadings = 0
+
+	var body: some View {
+		VStack {
+			if totalReadings > 0 {
+				// Current air quality: NowCast AQI when enough history exists, otherwise the raw
+				// latest PM2.5 reading (design#54 — never show a misleading instantaneous AQI).
+				GroupBox {
+					if let aqi = node.currentNowCastAqi() {
+						VStack(alignment: .leading, spacing: 4) {
+							AirQualityIndex(aqi: aqi)
+							Text("EPA NowCast AQI from PM2.5")
+								.font(.caption)
+								.foregroundStyle(.secondary)
+						}
+						.frame(maxWidth: .infinity, alignment: .leading)
+					} else if let pm25 = node.latestPm25 {
+						VStack(alignment: .leading, spacing: 4) {
+							Label("PM2.5: \(pm25) µg/m³", systemImage: "aqi.low")
+							Text("Not enough recent history for a NowCast AQI yet — showing the latest raw reading.")
+								.font(.caption)
+								.foregroundStyle(.secondary)
+						}
+						.frame(maxWidth: .infinity, alignment: .leading)
+					}
+				}
+				.padding(.horizontal)
+
+				if chartData.count > 0 {
+					GroupBox(label: Label("\(totalReadings) Readings Total", systemImage: "chart.xyaxis.line")) {
+						Chart {
+							ForEach(chartData, id: \.self) { point in
+								if let pm25 = point.pm25Standard {
+									LineMark(
+										x: .value("Time", point.time ?? Date()),
+										y: .value("PM2.5", Double(pm25))
+									)
+									.foregroundStyle(by: .value("Series", "PM2.5"))
+									.interpolationMethod(.linear)
+									.accessibilityLabel("PM2.5")
+									.accessibilityValue("X: \(point.time ?? Date()), Y: \(pm25)")
+								}
+								if let pm100 = point.pm100Standard {
+									LineMark(
+										x: .value("Time", point.time ?? Date()),
+										y: .value("PM10.0", Double(pm100))
+									)
+									.foregroundStyle(by: .value("Series", "PM10.0"))
+									.interpolationMethod(.linear)
+									.accessibilityLabel("PM10.0")
+									.accessibilityValue("X: \(point.time ?? Date()), Y: \(pm100)")
+								}
+							}
+							if let chartSelection {
+								RuleMark(x: .value("Second", chartSelection, unit: .second))
+									.foregroundStyle(.tertiary.opacity(0.5))
+							}
+						}
+						.chartXAxis(content: {
+							AxisMarks(position: .top)
+						})
+						.chartXAxis(.automatic)
+						.chartXSelection(value: $chartSelection)
+						.chartForegroundStyleScale([
+							"PM2.5": .orange,
+							"PM10.0": .purple
+						])
+						.chartLegend(position: .automatic, alignment: .bottom)
+					}
+					.padding(.horizontal)
+				}
+
+				Table(airQualityMetrics, selection: $selection, sortOrder: $sortOrder) {
+					TableColumn("PM2.5") { m in
+						m.pm25Standard.map { Text("\($0) µg/m³") } ?? Text(Constants.nilValueIndicator)
+					}
+					.width(min: 90)
+					TableColumn("PM1.0") { m in
+						m.pm10Standard.map { Text("\($0) µg/m³") } ?? Text(Constants.nilValueIndicator)
+					}
+					.width(min: 90)
+					TableColumn("PM10.0") { m in
+						m.pm100Standard.map { Text("\($0) µg/m³") } ?? Text(Constants.nilValueIndicator)
+					}
+					.width(min: 90)
+					TableColumn("Timestamp") { m in
+						Text(m.time?.formatted(date: .numeric, time: .shortened) ?? "Unknown Age".localized)
+					}
+					.width(min: 180)
+				}
+				.onChange(of: selection) { _, newSelection in
+					guard let metrics = airQualityMetrics.first(where: { $0.id == newSelection }) else {
+						return
+					}
+					chartSelection = metrics.time
+				}
+
+				HStack {
+					Button(role: .destructive) {
+						isPresentingClearLogConfirm = true
+					} label: {
+						Label("Clear Log", systemImage: "trash.fill")
+					}
+					.buttonStyle(.bordered)
+					.buttonBorderShape(.capsule)
+					.controlSize(idiom == .phone ? .regular : .large)
+					.padding(.bottom)
+					.padding(.leading)
+					.confirmationDialog(
+						"Are you sure?",
+						isPresented: $isPresentingClearLogConfirm,
+						titleVisibility: .visible
+					) {
+						Button("Delete Air Quality metrics?", role: .destructive) {
+							Task {
+								if await MeshPackets.shared.clearTelemetry(destNum: node.num, metricsType: 3) {
+									Logger.data.notice("Cleared Air Quality Metrics for \(node.num, privacy: .public)")
+									await MainActor.run {
+										refreshMetrics()
+										NotificationCenter.default.post(name: .nodeLogAvailabilityDidChange, object: node.num)
+									}
+								} else {
+									Logger.data.error("Clear Air Quality Metrics Log Failed")
+								}
+							}
+						}
+					}
+
+					Button {
+						exportString = telemetryToCsvFile(telemetry: airQualityMetrics, metricsType: 3)
+						isExporting = true
+					} label: {
+						Label("Save", systemImage: "square.and.arrow.down")
+					}
+					.buttonStyle(.bordered)
+					.buttonBorderShape(.capsule)
+					.controlSize(idiom == .phone ? .regular : .large)
+					.padding(.bottom)
+					.padding(.trailing)
+				}
+			} else {
+				ContentUnavailableView("No Air Quality Metrics", systemImage: "slash.circle")
+			}
+		}
+		.onAppear {
+			refreshMetrics()
+		}
+		.onChange(of: node.lastHeard) {
+			refreshMetrics()
+		}
+		.navigationTitle("Air Quality Metrics Log")
+		.navigationBarTitleDisplayMode(.inline)
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
+		.fileExporter(
+			isPresented: $isExporting,
+			document: CsvDocument(emptyCsv: exportString),
+			contentType: .commaSeparatedText,
+			defaultFilename: String("\(node.user?.longName ?? "Node") \("Air Quality Metrics Log".localized) \(Date.now.exportTimestamp)"),
+			onCompletion: { result in
+				switch result {
+				case .success:
+					self.isExporting = false
+					Logger.services.info("Air quality metrics log download succeeded.")
+				case .failure(let error):
+					Logger.services.error("Air quality metrics log download failed: \(error.localizedDescription, privacy: .public)")
+				}
+			}
+		)
+	}
+
+	private func refreshMetrics() {
+		totalReadings = node.telemetryCount(ofType: 3, context: context)
+		airQualityMetrics = node.safeTelemetries(ofType: 3)
+		let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date.distantPast
+		chartData = airQualityMetrics
+			.filter { ($0.time ?? Date.distantPast) >= oneWeekAgo }
+			.sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -20,6 +20,7 @@ private struct NodeDetailLogAvailability {
 	var hasEnvironmentMetrics = false
 	var hasTraceRoutes = false
 	var hasPowerMetrics = false
+	var hasAirQualityMetrics = false
 	var hasDetectionSensorMetrics = false
 	var hasPax = false
 }
@@ -509,6 +510,7 @@ struct NodeDetail: View {
 		let hasEnvironmentMetrics = logAvailability.hasEnvironmentMetrics
 		let hasTraceRoutes = logAvailability.hasTraceRoutes
 		let hasPowerMetrics = logAvailability.hasPowerMetrics
+		let hasAirQualityMetrics = logAvailability.hasAirQualityMetrics
 		let hasDetectionSensorMetrics = logAvailability.hasDetectionSensorMetrics
 		let hasPax = logAvailability.hasPax
 
@@ -581,6 +583,17 @@ struct NodeDetail: View {
 				}
 			}
 			.disabled(!hasPowerMetrics)
+			NavigationLink {
+				AirQualityMetricsLog(node: node)
+			} label: {
+				Label {
+					Text("Air Quality Metrics Log")
+				} icon: {
+					Image(systemName: "aqi.medium")
+						.symbolRenderingMode(.multicolor)
+				}
+			}
+			.disabled(!hasAirQualityMetrics)
 			NavigationLink {
 				DetectionSensorLog(node: node)
 			} label: {
@@ -806,6 +819,7 @@ struct NodeDetail: View {
 			hasEnvironmentMetrics: environmentMetrics != nil,
 			hasTraceRoutes: node.hasTraceRoutes,
 			hasPowerMetrics: powerMetrics != nil,
+			hasAirQualityMetrics: node.hasAirQualityMetrics,
 			hasDetectionSensorMetrics: node.hasDetectionSensorMetrics,
 			hasPax: node.hasPax
 		)

--- a/MeshtasticTests/AirQualityCalculatorTests.swift
+++ b/MeshtasticTests/AirQualityCalculatorTests.swift
@@ -1,0 +1,102 @@
+//
+//  AirQualityCalculatorTests.swift
+//  MeshtasticTests
+//
+//  Verifies the EPA NowCast + AQI breakpoint math (meshtastic/design#54). Expected values mirror
+//  the Android reference test (Meshtastic-Android AirQualityIndexTest) so both platforms stay aligned.
+//
+
+import XCTest
+@testable import Meshtastic
+
+final class AirQualityCalculatorTests: XCTestCase {
+
+	private let secondsPerHour: TimeInterval = 3600
+	private let now: TimeInterval = 1_000_000
+	private let epsilon = 0.001
+
+	// MARK: - pm25ToAqi
+
+	func testPm25ToAqiMatchesEpaBreakpointTable() {
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(0.0), 0)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(12.0), 50)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(12.1), 51)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(35.4), 100)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(35.5), 101)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(55.4), 150)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(55.5), 151)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(150.4), 200)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(150.5), 201)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(250.4), 300)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(250.5), 301)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(500.4), 500)
+	}
+
+	func testPm25ToAqiClampsNegativeAndAboveScale() {
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(-5.0), 0)
+		XCTAssertEqual(AirQualityCalculator.pm25ToAqi(1000.0), 500)
+	}
+
+	// MARK: - computeNowCastPm25
+
+	func testReturnsNilWhenMostRecentHourMissing() {
+		// Only hour 1 (an hour ago) has data — EPA requires the most recent hour to be present.
+		let readings = [(time: now - secondsPerHour, pm25: 20.0)]
+		XCTAssertNil(AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now))
+	}
+
+	func testReturnsNilWithFewerThanTwoValidHours() {
+		let readings = [(time: now, pm25: 20.0)]
+		XCTAssertNil(AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now))
+	}
+
+	func testReturnsNilWhenSecondValidHourOutsideRecentThree() {
+		// Two valid hours in the 12h window (now + 11h ago), but only one within the most recent 3.
+		let readings = [(time: now, pm25: 20.0), (time: now - 11 * secondsPerHour, pm25: 20.0)]
+		XCTAssertNil(AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now))
+	}
+
+	func testAveragesStableReadingsWithWeightFactorOne() {
+		let readings = [
+			(time: now, pm25: 20.0),
+			(time: now - secondsPerHour, pm25: 20.0),
+			(time: now - 2 * secondsPerHour, pm25: 20.0)
+		]
+		let result = AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now)
+		XCTAssertEqual(try XCTUnwrap(result), 20.0, accuracy: epsilon)
+	}
+
+	func testWeightsRecentHoursMoreHeavilyWhenDeclining() {
+		// c1=20 (now), c2=10 (1h ago). weightFactor = 1 - (20-10)/20 = 0.5. NowCast = (20*1 + 10*0.5)/(1+0.5).
+		let readings = [(time: now, pm25: 20.0), (time: now - secondsPerHour, pm25: 10.0)]
+		let result = AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now)
+		XCTAssertEqual(try XCTUnwrap(result), 25.0 / 1.5, accuracy: epsilon)
+	}
+
+	func testAppliesMinimumWeightFactorFloor() {
+		// Range far exceeds max, so the raw weight factor would go negative — it must floor at 0.5.
+		let readings = [(time: now, pm25: 100.0), (time: now - secondsPerHour, pm25: 1.0)]
+		let result = AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now)
+		XCTAssertEqual(try XCTUnwrap(result), 100.5 / 1.5, accuracy: epsilon)
+	}
+
+	func testAveragesMultipleReadingsWithinSameHour() {
+		let readings = [
+			(time: now, pm25: 10.0),
+			(time: now - 60, pm25: 30.0), // same hour bucket -> averages to 20.0
+			(time: now - secondsPerHour, pm25: 20.0)
+		]
+		let result = AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now)
+		XCTAssertEqual(try XCTUnwrap(result), 20.0, accuracy: epsilon)
+	}
+
+	func testIgnoresReadingsOlderThanTwelveHourWindow() {
+		let readings = [
+			(time: now, pm25: 20.0),
+			(time: now - secondsPerHour, pm25: 20.0),
+			(time: now - 13 * secondsPerHour, pm25: 500.0)
+		]
+		let result = AirQualityCalculator.computeNowCastPm25(readings: readings, nowEpochSeconds: now)
+		XCTAssertEqual(try XCTUnwrap(result), 20.0, accuracy: epsilon)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the iOS side of the cross-platform AQI standard ([meshtastic/design#54](https://github.com/meshtastic/design/issues/54)), closing #2040. `AirQualityMetrics` telemetry (PM1.0 / PM2.5 / PM10.0, standard + environmental) was previously received but **discarded** — only counted by the Discovery scan engine, never persisted or shown. This ingests and persists it, and computes an EPA **NowCast** AQI from PM2.5 history.

Ported 1:1 from the merged Android reference ([Meshtastic-Android#6102](https://github.com/meshtastic/Meshtastic-Android/pull/6102)) so both platforms produce identical AQI values.

## Changes

**Stage 1 — ingest & persist**
- `TelemetryEntity`: add `pm10/25/100Standard` + `pm10/25/100Environmental` (optional → automatic SwiftData lightweight migration).
- `MeshPackets.telemetryPacket`: parse the `airQualityMetrics` variant and store as `metricsType 3` (`MetricsTypes.airQuality`, which already existed).
- CSV export (`WriteCsvFile`) gains a PM columns branch.

**Stage 2 — NowCast & display**
- `AirQualityCalculator`: EPA NowCast (12h recency-weighted rolling average) + PM2.5→0–500 AQI breakpoint math. Pure/testable; **10 unit tests** mirror the Android test vectors exactly.
- New **Air Quality Metrics Log** (PM2.5/PM10 chart + table + CSV export + clear), wired into `NodeDetail`.
- Shows the computed NowCast AQI via the **existing** `AirQualityIndex` view when there's enough recent history; otherwise the raw latest PM2.5 reading — never a misleading instantaneous AQI (per design#54).

## Verification

`xcodebuild test` on the iPhone 16 simulator builds the full app + test target and runs the new suite:

```
Test Suite 'AirQualityCalculatorTests' passed
Executed 10 tests, with 0 failures
** TEST SUCCEEDED **
```

(Building the test target compiles the entire app target, so the whole change set compiles clean.) End-to-end display with live PM hardware hasn't been exercised on-device — worth a smoke test before release.

## Notes
- The `AirQualityIndex` view / `Aqi` enum were already present but had **zero real call sites**; this gives them their first caller, unchanged.
- Follows the issue's staged approach — raw readings are useful immediately; NowCast refines once ~history accrues.

Refs meshtastic/design#54 · aligns with Meshtastic-Android#6102

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added air quality metrics support for nodes, including a new log view, chart, table, and CSV export.
  * Display now includes an AQI estimate or the latest PM2.5 reading when available.
  * Air quality logs can be cleared from the app with confirmation.

* **Bug Fixes**
  * Air quality telemetry is now recognized, stored, and included in log availability.
  * CSV exports now include air quality readings with timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->