### PR TITLE
perf: move node-list filtering off the main thread

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0516B3FE2F68892000D0FC40 /* NodeFilterParametersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */; };
+		DDFF00000000000000000001 /* NodeListFilteringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFF00000000000000000001 /* NodeListFilteringTests.swift */; };
 		DD0000A10EDD5A00000000B1 /* XEdDSASigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000A20EDD5A00000000B2 /* XEdDSASigningTests.swift */; };
 		05A1B2C32F70000100D0FC40 /* SettingsNodeSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */; };
 		0B9642EC0DB1B971CB26E8AE /* RadarSweepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E06A9BCC789BD452DFA9CFB /* RadarSweepView.swift */; };
@@ -608,6 +609,7 @@
 		DD0000A20EDD5A00000000B2 /* XEdDSASigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XEdDSASigningTests.swift; sourceTree = "<group>"; };
 		05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNodeSortTests.swift; sourceTree = "<group>"; };
 		05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeFilterParametersTests.swift; sourceTree = "<group>"; };
+		CCFF00000000000000000001 /* NodeListFilteringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeListFilteringTests.swift; sourceTree = "<group>"; };
 		05E0BD1A81CF4F6A90D56CE3 /* MeshtasticSchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshtasticSchemaV1.swift; sourceTree = "<group>"; };
 		0618E6D0DF90B74EE32E6C06 /* TAKServerConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKServerConfig.swift; sourceTree = "<group>"; };
 		09936BEBD6D82479B2360FDC /* TAKCertificateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKCertificateManager.swift; sourceTree = "<group>"; };
@@ -1621,6 +1623,7 @@
 				DD9C70112E9F2A0000029299 /* DeviceOnboardingTests.swift */,
 				25F5D5D02C4375DF008036E3 /* RouterTests.swift */,
 				05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */,
+				CCFF00000000000000000001 /* NodeListFilteringTests.swift */,
 				DD0000A20EDD5A00000000B2 /* XEdDSASigningTests.swift */,
 				05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */,
 				AA0120250000000000000C02 /* PacketStreamModelTests.swift */,
@@ -2777,6 +2780,7 @@
 				DD9C70102E9F2A0000029299 /* DeviceOnboardingTests.swift in Sources */,
 				25F5D5D12C4375DF008036E3 /* RouterTests.swift in Sources */,
 				0516B3FE2F68892000D0FC40 /* NodeFilterParametersTests.swift in Sources */,
+				DDFF00000000000000000001 /* NodeListFilteringTests.swift in Sources */,
 				DD0000A10EDD5A00000000B1 /* XEdDSASigningTests.swift in Sources */,
 				05A1B2C32F70000100D0FC40 /* SettingsNodeSortTests.swift in Sources */,
 				AA0120250000000000000C01 /* PacketStreamModelTests.swift in Sources */,

--- a/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
@@ -8,7 +8,7 @@
 import CoreLocation
 import SwiftUI
 
-struct NodeDistanceFilterBounds {
+struct NodeDistanceFilterBounds: Sendable {
 	private static let coordinateScale = 10_000_000.0
 	private static let earthRadiusMeters = 6_371_009.0
 

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -212,7 +212,9 @@ private struct NodeListEntry: Identifiable {
 
 /// Sendable inputs for the SwiftData `#Predicate` shared by the live `@Query` and the off-main
 /// recompute, so the two can never drift (both build the predicate from the same source).
-private struct NodePredicateInputs: Equatable {
+///
+/// Internal (not private) so `NodeListFilteringTests` can build the shared predicate directly.
+struct NodePredicateInputs: Equatable {
 	let showIgnored: Bool
 	let showFavorite: Bool
 	let filterViaLoraOnly: Bool
@@ -243,7 +245,9 @@ private struct NodePredicateInputs: Equatable {
 /// to the background `ModelContext`, so the background fetch must not gate on it. The live `@Query`
 /// (which reflects the toggle immediately) re-applies the filter when `recompute()` intersects the
 /// background nums with the live objects, so the favorite state shown always tracks the live store.
-private func makeNodeListPredicate(_ p: NodePredicateInputs, applyFavoriteFilter: Bool = true) -> Predicate<NodeInfoEntity> {
+// Internal (not private) so `NodeListFilteringTests` can assert the shared predicate's filtering,
+// including the `applyFavoriteFilter` superset semantics the off-main fetch relies on.
+func makeNodeListPredicate(_ p: NodePredicateInputs, applyFavoriteFilter: Bool = true) -> Predicate<NodeInfoEntity> {
 	let showIgnored = p.showIgnored
 	let showFavorite = p.showFavorite && applyFavoriteFilter
 	let filterViaLoraOnly = p.filterViaLoraOnly
@@ -271,7 +275,9 @@ private func makeNodeListPredicate(_ p: NodePredicateInputs, applyFavoriteFilter
 /// A fully-Sendable snapshot of the filter state, built on the main actor and consumed by the
 /// off-main scan. Carrying only value types means no `@MainActor` object or SwiftData model crosses
 /// the isolation boundary.
-private struct FilterSnapshot: Sendable {
+///
+/// Internal (not private) so `NodeListFilteringTests` can drive `computeNodeOrder` off-main.
+struct FilterSnapshot: Sendable {
 	let predicate: NodePredicateInputs
 	let normalizedSearchText: String
 	let roleFilter: Bool
@@ -358,7 +364,8 @@ private final class NodeListRecomputeTrigger {
 ///
 /// Returns `nil` (not `[]`) if the fetch itself fails, so the caller can preserve the currently
 /// displayed list instead of blanking it on a transient SwiftData error.
-private func computeNodeOrder(container: ModelContainer, snapshot s: FilterSnapshot) -> [Int64]? {
+// Internal (not private) so `NodeListFilteringTests` can exercise the full off-main fetch/match path.
+func computeNodeOrder(container: ModelContainer, snapshot s: FilterSnapshot) -> [Int64]? {
 	let context = ModelContext(container)
 	let descriptor = FetchDescriptor<NodeInfoEntity>(
 		predicate: makeNodeListPredicate(s.predicate, applyFavoriteFilter: false),

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -237,9 +237,15 @@ private struct NodePredicateInputs: Equatable {
 /// Builds the query-level predicate (ignored/favorite/viaLora/viaMqtt/hopsAway). Used by BOTH the
 /// `@Query` in `FilteredNodeList.init` and the off-main `computeNodeOrder`, guaranteeing identical
 /// filtering on both sides of the isolation boundary.
-private func makeNodeListPredicate(_ p: NodePredicateInputs) -> Predicate<NodeInfoEntity> {
+///
+/// `applyFavoriteFilter` lets the off-main fetch drop the `favorite` gate so it stays a SUPERSET for
+/// that locally-mutable flag: a node just toggled favorite in the live context may not yet be visible
+/// to the background `ModelContext`, so the background fetch must not gate on it. The live `@Query`
+/// (which reflects the toggle immediately) re-applies the filter when `recompute()` intersects the
+/// background nums with the live objects, so the favorite state shown always tracks the live store.
+private func makeNodeListPredicate(_ p: NodePredicateInputs, applyFavoriteFilter: Bool = true) -> Predicate<NodeInfoEntity> {
 	let showIgnored = p.showIgnored
-	let showFavorite = p.showFavorite
+	let showFavorite = p.showFavorite && applyFavoriteFilter
 	let filterViaLoraOnly = p.filterViaLoraOnly
 	let filterViaMqttOnly = p.filterViaMqttOnly
 	let filterHopsDirect = p.filterHopsDirect
@@ -346,15 +352,25 @@ private final class NodeListRecomputeTrigger {
 ///
 /// Deliberately does NOT partition into connected/favorite/regular: that ordering depends on
 /// `node.favorite` and the active device, which the caller applies on the main actor from the LIVE
-/// @Query objects. Otherwise an in-place favorite toggle (possibly not yet saved to the store this
-/// background context reads) would be invisible until the write committed.
-private func computeNodeOrder(container: ModelContainer, snapshot s: FilterSnapshot) -> [Int64] {
+/// @Query objects. For the same reason it drops the `favorite` gate from its fetch predicate
+/// (`applyFavoriteFilter: false`) so the result is a SUPERSET — an in-place favorite toggle not yet
+/// visible to this background context can't hide a node; the live @Query re-applies the filter.
+///
+/// Returns `nil` (not `[]`) if the fetch itself fails, so the caller can preserve the currently
+/// displayed list instead of blanking it on a transient SwiftData error.
+private func computeNodeOrder(container: ModelContainer, snapshot s: FilterSnapshot) -> [Int64]? {
 	let context = ModelContext(container)
 	let descriptor = FetchDescriptor<NodeInfoEntity>(
-		predicate: makeNodeListPredicate(s.predicate),
+		predicate: makeNodeListPredicate(s.predicate, applyFavoriteFilter: false),
 		sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)]
 	)
-	guard let nodes = try? context.fetch(descriptor) else { return [] }
+	let nodes: [NodeInfoEntity]
+	do {
+		nodes = try context.fetch(descriptor)
+	} catch {
+		Logger.data.error("🚫 [NodeList] Off-main node fetch failed, keeping current list: \(error.localizedDescription, privacy: .public)")
+		return nil
+	}
 
 	let lookup = NodeListFilterLookup(
 		nodes: nodes,
@@ -452,10 +468,17 @@ private struct FilteredNodeList: View {
 		// so the off-main fetch always reads the SAME store the List renders from (previews/tests/any
 		// injected container included).
 		let container = context.container
-		let matching = await Task.detached(priority: .userInitiated) {
+		let result = await Task.detached(priority: .userInitiated) {
 			computeNodeOrder(container: container, snapshot: snapshot)
 		}.value
 		guard !Task.isCancelled else { return }
+		// `nil` means the off-main fetch threw (already logged): keep the current list rather than
+		// blanking it on a transient SwiftData error. An empty match set is `[]`, not `nil`, and DOES
+		// clear the list as expected.
+		guard let matching = result else {
+			hasCompletedFirstRecompute = true
+			return
+		}
 
 		// Map matching nums onto the LIVE @Query objects and partition using their current favorite /
 		// active-device state (cheap scalar reads — no relationship fault). The `modelContext != nil`
@@ -556,9 +579,14 @@ private struct FilteredNodeList: View {
 			// (search/filter edits, node inserts/deletes) still refresh instantly via the onChange
 			// triggers below — this only backstops the un-observable inputs.
 			let backstop = Task {
-				while !Task.isCancelled {
-					try? await Task.sleep(for: .milliseconds(1500))
-					continuation.yield(())
+				do {
+					while true {
+						try await Task.sleep(for: .milliseconds(1500))
+						try Task.checkCancellation()
+						continuation.yield(())
+					}
+				} catch {
+					// Cancelled (sleep or checkCancellation threw): stop yielding and exit cleanly.
 				}
 			}
 			defer { backstop.cancel() }

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -210,16 +210,184 @@ private struct NodeListEntry: Identifiable {
 	let node: NodeInfoEntity
 }
 
+/// Sendable inputs for the SwiftData `#Predicate` shared by the live `@Query` and the off-main
+/// recompute, so the two can never drift (both build the predicate from the same source).
+private struct NodePredicateInputs: Equatable {
+	let showIgnored: Bool
+	let showFavorite: Bool
+	let filterViaLoraOnly: Bool
+	let filterViaMqttOnly: Bool
+	let filterHopsDirect: Bool
+	let filterHopsMax: Bool
+	let maxHops: Int32
+
+	/// Single construction site for the predicate inputs, shared by the `@Query` and the off-main
+	/// fetch so the two can't drift.
+	@MainActor init(_ f: NodeFilterParameters) {
+		showIgnored = f.isIgnored
+		showFavorite = f.isFavorite
+		filterViaLoraOnly = f.viaLora && !f.viaMqtt
+		filterViaMqttOnly = !f.viaLora && f.viaMqtt
+		filterHopsDirect = f.hopsAway == 0.0
+		filterHopsMax = f.hopsAway > 0.0
+		maxHops = Int32(f.hopsAway)
+	}
+}
+
+/// Builds the query-level predicate (ignored/favorite/viaLora/viaMqtt/hopsAway). Used by BOTH the
+/// `@Query` in `FilteredNodeList.init` and the off-main `computeNodeOrder`, guaranteeing identical
+/// filtering on both sides of the isolation boundary.
+private func makeNodeListPredicate(_ p: NodePredicateInputs) -> Predicate<NodeInfoEntity> {
+	let showIgnored = p.showIgnored
+	let showFavorite = p.showFavorite
+	let filterViaLoraOnly = p.filterViaLoraOnly
+	let filterViaMqttOnly = p.filterViaMqttOnly
+	let filterHopsDirect = p.filterHopsDirect
+	let filterHopsMax = p.filterHopsMax
+	let maxHops = p.maxHops
+	return #Predicate<NodeInfoEntity> { node in
+		// Ignored filter (always applied)
+		(showIgnored || !node.ignored) &&
+		(!showIgnored || node.ignored) &&
+		// Favorite filter
+		(!showFavorite || node.favorite) &&
+		// Via LoRa only (exclude MQTT)
+		(!filterViaLoraOnly || !node.viaMqtt) &&
+		// Via MQTT only
+		(!filterViaMqttOnly || node.viaMqtt) &&
+		// Direct nodes only
+		(!filterHopsDirect || node.hopsAway == 0) &&
+		// Hops within range
+		(!filterHopsMax || (node.hopsAway > 0 && node.hopsAway <= maxHops))
+	}
+}
+
+/// A fully-Sendable snapshot of the filter state, built on the main actor and consumed by the
+/// off-main scan. Carrying only value types means no `@MainActor` object or SwiftData model crosses
+/// the isolation boundary.
+private struct FilterSnapshot: Sendable {
+	let predicate: NodePredicateInputs
+	let normalizedSearchText: String
+	let roleFilter: Bool
+	let deviceRoles: Set<Int>
+	let onlineThreshold: Date?
+	let isPkiEncrypted: Bool
+	let isEnvironment: Bool
+	let distanceFilter: Bool
+	let distanceBounds: NodeDistanceFilterBounds?
+	let activeNodeNum: Int64?
+
+	@MainActor init(_ f: NodeFilterParameters, activeNodeNum: Int64?) {
+		predicate = NodePredicateInputs(f)
+		normalizedSearchText = f.searchText.lowercased()
+		roleFilter = f.roleFilter
+		deviceRoles = f.deviceRoles
+		onlineThreshold = f.isOnline ? Date().addingTimeInterval(-7_200) : nil
+		isPkiEncrypted = f.isPkiEncrypted
+		isEnvironment = f.isEnvironment
+		distanceFilter = f.distanceFilter
+		distanceBounds = f.currentDistanceBounds
+		self.activeNodeNum = activeNodeNum
+	}
+}
+
+/// Equatable key over every result-affecting filter field; a change fires a recompute.
+private struct NodeListFilterKey: Equatable {
+	let search: String
+	let isOnline: Bool
+	let isPkiEncrypted: Bool
+	let isFavorite: Bool
+	let isIgnored: Bool
+	let isEnvironment: Bool
+	let distanceFilter: Bool
+	let roleFilter: Bool
+	let maxDistance: Double
+	let hopsAway: Double
+	let deviceRoles: Set<Int>
+	let viaLora: Bool
+	let viaMqtt: Bool
+	let activeNodeNum: Int64?
+
+	@MainActor init(_ f: NodeFilterParameters, active: Int64?) {
+		search = f.searchText
+		isOnline = f.isOnline
+		isPkiEncrypted = f.isPkiEncrypted
+		isFavorite = f.isFavorite
+		isIgnored = f.isIgnored
+		isEnvironment = f.isEnvironment
+		distanceFilter = f.distanceFilter
+		roleFilter = f.roleFilter
+		maxDistance = f.maxDistance
+		hopsAway = f.hopsAway
+		deviceRoles = f.deviceRoles
+		viaLora = f.viaLora
+		viaMqtt = f.viaMqtt
+		activeNodeNum = active
+	}
+}
+
+/// Cheap signature of the node set; a change (insert/delete/reorder/new packet at top) fires a recompute.
+private struct NodeListSetSignature: Equatable {
+	let count: Int
+	let topNum: Int64?
+	let topHeard: Date?
+}
+
+/// Holds the recompute driver's stream continuation so `onChange` handlers can poke it. A reference
+/// type kept in `@State` so the identity stays stable across body re-evaluations.
+private final class NodeListRecomputeTrigger {
+	var continuation: AsyncStream<Void>.Continuation?
+}
+
+/// The off-main scan (Fix 1): fetch + match, returning the matching node nums in lastHeard-desc order
+/// as Sendable `[Int64]`. Runs on a fresh `ModelContext` created and fully consumed here with no
+/// `await`, so nothing non-Sendable can escape. Moving OFF the main actor is the decisive win — the
+/// O(N) search scan (which faults `\.user`) no longer blocks input, regardless of its absolute cost.
+///
+/// Deliberately does NOT partition into connected/favorite/regular: that ordering depends on
+/// `node.favorite` and the active device, which the caller applies on the main actor from the LIVE
+/// @Query objects. Otherwise an in-place favorite toggle (possibly not yet saved to the store this
+/// background context reads) would be invisible until the write committed.
+private func computeNodeOrder(container: ModelContainer, snapshot s: FilterSnapshot) -> [Int64] {
+	let context = ModelContext(container)
+	let descriptor = FetchDescriptor<NodeInfoEntity>(
+		predicate: makeNodeListPredicate(s.predicate),
+		sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)]
+	)
+	guard let nodes = try? context.fetch(descriptor) else { return [] }
+
+	let lookup = NodeListFilterLookup(
+		nodes: nodes,
+		needsEnvironment: s.isEnvironment,
+		distanceBounds: s.distanceFilter ? s.distanceBounds : nil,
+		context: context
+	)
+	var seen = Set<Int64>()
+	seen.reserveCapacity(nodes.count)
+	var matching: [Int64] = []
+	matching.reserveCapacity(nodes.count)
+	for node in nodes where matchesPostPredicate(node, snapshot: s, lookup: lookup) {
+		let num = node.num
+		if seen.insert(num).inserted { matching.append(num) }
+	}
+	return matching
+}
+
 private struct FilteredNodeList: View {
 	@EnvironmentObject var accessoryManager: AccessoryManager
 	@EnvironmentObject var router: Router
 	@Query(sort: \NodeInfoEntity.lastHeard, order: .reverse)
 	private var allNodes: [NodeInfoEntity]
 	@Environment(\.modelContext) private var context
-	/// Throttled snapshot of the filtered/sorted nodes actually shown. Recomputed on a gentle
-	/// cadence (see `.task`) instead of in `body`, so the full-node-set scan in `displayNodes`
-	/// doesn't run on every SwiftData write — which pegged the CPU on reconnect with a large DB.
+	/// Snapshot of the filtered/sorted nodes actually shown. Recomputed OFF the main actor by
+	/// `recompute()`, driven by real change signals (filter/search edits + node-set changes) and
+	/// coalesced — replacing the old unconditional poll. See the `.task` driver in `body`.
 	@State private var displayedNodes: [NodeListEntry] = []
+	/// Stable continuation holder for the recompute driver; `onChange` handlers poke it to request a pass.
+	@State private var recomputeTrigger = NodeListRecomputeTrigger()
+	/// False until the first off-main recompute lands, so the view shows a loading indicator instead of
+	/// flashing an empty "Nodes (0)" list during the initial off-main fetch on a cold, large DB.
+	@State private var hasCompletedFirstRecompute = false
 
 	var connectedNode: NodeInfoEntity?
 	@Binding var isPresentingDeleteNodeAlert: Bool
@@ -249,79 +417,75 @@ private struct FilteredNodeList: View {
 		self._nodeListDensity = nodeListDensity
 		self._selectedNodeNum = selectedNodeNum
 
-		// Push simple filters into the SwiftData predicate to reduce in-memory work
-		let showIgnored = withFilters.isIgnored
-		let showFavorite = withFilters.isFavorite
-		let filterViaLoraOnly = withFilters.viaLora && !withFilters.viaMqtt
-		let filterViaMqttOnly = !withFilters.viaLora && withFilters.viaMqtt
-		let filterHopsDirect = withFilters.hopsAway == 0.0
-		let filterHopsMax = withFilters.hopsAway > 0.0
-		let maxHops = Int32(withFilters.hopsAway)
-
+		// Push simple filters into the SwiftData predicate to reduce in-memory work. The SAME
+		// predicate feeds both this @Query and the off-main computeNodeOrder (see
+		// makeNodeListPredicate), so the two fetched sets can never drift.
 		_allNodes = Query(
-			filter: #Predicate<NodeInfoEntity> { node in
-				// Ignored filter (always applied)
-				(showIgnored || !node.ignored) &&
-				(!showIgnored || node.ignored) &&
-				// Favorite filter
-				(!showFavorite || node.favorite) &&
-				// Via LoRa only (exclude MQTT)
-				(!filterViaLoraOnly || !node.viaMqtt) &&
-				// Via MQTT only
-				(!filterViaMqttOnly || node.viaMqtt) &&
-				// Direct nodes only
-				(!filterHopsDirect || node.hopsAway == 0) &&
-				// Hops within range
-				(!filterHopsMax || (node.hopsAway > 0 && node.hopsAway <= maxHops))
-			},
+			filter: makeNodeListPredicate(NodePredicateInputs(withFilters)),
 			sort: \NodeInfoEntity.lastHeard,
 			order: .reverse
 		)
 	}
 
-	private func displayNodes(activeNodeNum: Int64?) -> [NodeListEntry] {
-		let searchText = filters.searchText.lowercased()
-		let onlineThreshold = filters.isOnline ? Date().addingTimeInterval(-7_200) : nil
-		let distanceBounds = filters.currentDistanceBounds
-		let filterLookup = NodeListFilterLookup(
-			nodes: allNodes,
-			needsEnvironment: filters.isEnvironment,
-			distanceBounds: filters.distanceFilter ? distanceBounds : nil,
-			context: context
-		)
-		var seenNodeNums = Set<Int64>()
-		seenNodeNums.reserveCapacity(allNodes.count)
-		var connectedNode: NodeInfoEntity?
-		var favoriteNodes: [NodeInfoEntity] = []
-		var regularNodes: [NodeInfoEntity] = []
-		favoriteNodes.reserveCapacity(allNodes.count / 20)
-		regularNodes.reserveCapacity(allNodes.count)
+	/// Equatable key over every result-affecting filter field; drives a recompute on change.
+	private var filterKey: NodeListFilterKey {
+		NodeListFilterKey(filters, active: accessoryManager.activeDeviceNum)
+	}
 
-		for node in allNodes where filters.matchesPostPredicate(
-			node,
-			normalizedSearchText: searchText,
-			onlineThreshold: onlineThreshold,
-			distanceBounds: distanceBounds,
-			lookup: filterLookup
-		) {
-			guard seenNodeNums.insert(node.num).inserted else { continue }
-			if let activeNodeNum, node.num == activeNodeNum {
-				connectedNode = node
+	/// Cheap node-set signature; fires an instant recompute on insert/delete and on a new packet
+	/// reaching the top of the list. Coarse by design (reading every node's fields here would re-fault
+	/// the whole set on the main actor on each body eval); non-top reorders and in-place edits are
+	/// picked up by the periodic off-main refresh in the `.task` driver instead.
+	private var nodeSetSignature: NodeListSetSignature {
+		NodeListSetSignature(count: allNodes.count, topNum: allNodes.first?.num, topHeard: allNodes.first?.lastHeard)
+	}
+
+	/// Recompute the displayed list. The expensive fetch + search match runs OFF the main actor on a
+	/// fresh, confined `ModelContext` and returns only matching `[Int64]` node nums (Sendable). Back on
+	/// the main actor those nums are mapped onto the LIVE `@Query` objects the `List` renders and
+	/// partitioned into connected → favorites → regular using their CURRENT state — so no
+	/// background-context model ever reaches the List (SIGTRAP hardening) and in-place favorite/connect
+	/// changes re-section immediately without waiting for the background store read to catch up.
+	@MainActor private func recompute() async {
+		let snapshot = FilterSnapshot(filters, activeNodeNum: accessoryManager.activeDeviceNum)
+		// Use the @Query's own container (via the environment context) rather than a hard-coded global,
+		// so the off-main fetch always reads the SAME store the List renders from (previews/tests/any
+		// injected container included).
+		let container = context.container
+		let matching = await Task.detached(priority: .userInitiated) {
+			computeNodeOrder(container: container, snapshot: snapshot)
+		}.value
+		guard !Task.isCancelled else { return }
+
+		// Map matching nums onto the LIVE @Query objects and partition using their current favorite /
+		// active-device state (cheap scalar reads — no relationship fault). The `modelContext != nil`
+		// guard keeps the existing SIGTRAP hardening; transient byNum misses self-heal on the next pass.
+		let activeNodeNum = accessoryManager.activeDeviceNum
+		var byNum = [Int64: NodeInfoEntity](minimumCapacity: allNodes.count)
+		for node in allNodes { byNum[node.num] = node }
+		var connected: NodeListEntry?
+		var favorites: [NodeListEntry] = []
+		var regular: [NodeListEntry] = []
+		favorites.reserveCapacity(matching.count / 20)
+		regular.reserveCapacity(matching.count)
+		for num in matching {
+			guard let node = byNum[num], node.modelContext != nil else { continue }
+			let entry = NodeListEntry(id: num, node: node)
+			if let activeNodeNum, num == activeNodeNum {
+				connected = entry
 			} else if node.favorite {
-				favoriteNodes.append(node)
+				favorites.append(entry)
 			} else {
-				regularNodes.append(node)
+				regular.append(entry)
 			}
 		}
-
-		var nodes: [NodeInfoEntity] = []
-		nodes.reserveCapacity((connectedNode == nil ? 0 : 1) + favoriteNodes.count + regularNodes.count)
-		if let connectedNode {
-			nodes.append(connectedNode)
-		}
-		nodes.append(contentsOf: favoriteNodes)
-		nodes.append(contentsOf: regularNodes)
-		return nodes.map { NodeListEntry(id: $0.num, node: $0) }
+		var entries: [NodeListEntry] = []
+		entries.reserveCapacity((connected == nil ? 0 : 1) + favorites.count + regular.count)
+		if let connected { entries.append(connected) }
+		entries.append(contentsOf: favorites)
+		entries.append(contentsOf: regular)
+		replaceDisplayedNodesIfNeeded(with: entries)
+		hasCompletedFirstRecompute = true
 	}
 
 	private func replaceDisplayedNodesIfNeeded(with newNodes: [NodeListEntry]) {
@@ -365,16 +529,56 @@ private struct FilteredNodeList: View {
 				}
 			}
 		}
-		.navigationTitle(String.localizedStringWithFormat("Nodes (%@)".localized, String(displayedNodes.count)))
-		.task {
-			// Recompute the displayed list on a gentle cadence instead of inside `body`.
-			// During live ingestion the node @Query invalidates on every packet; running
-			// displayNodes (a scan over the whole node set) per write pegged the main thread
-			// on reconnect with a large DB. ~3/sec is imperceptible and keeps CPU sane.
-			while !Task.isCancelled {
-				replaceDisplayedNodesIfNeeded(with: displayNodes(activeNodeNum: accessoryManager.activeDeviceNum))
-				try? await Task.sleep(for: .milliseconds(350))
+		.overlay {
+			// Avoid flashing an empty "Nodes (0)" list while the first off-main recompute is in flight
+			// on a cold, large DB.
+			if !hasCompletedFirstRecompute && displayedNodes.isEmpty {
+				ProgressView()
 			}
+		}
+		.navigationTitle(hasCompletedFirstRecompute
+			? String.localizedStringWithFormat("Nodes (%@)".localized, String(displayedNodes.count))
+			: "Nodes".localized)
+		.task {
+			// Change-driven, coalesced recompute — replaces the old unconditional 350ms poll.
+			// A single long-lived consumer drains a bufferingNewest(1) stream: a burst (e.g. a reconnect
+			// nodeDB dump firing thousands of node-set changes) collapses to one pending pass, and the
+			// 300ms throttle caps recompute at ~3/sec. The heavy scan runs off the main actor, so even
+			// during the storm the main thread stays ~idle. The stream is created HERE (not in @State)
+			// so it is rebuilt cleanly on every disappear/reappear.
+			let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
+			recomputeTrigger.continuation = continuation
+			defer { continuation.finish() }
+			// Periodic off-main refresh for inputs that fire NO change signal: device GPS movement (with
+			// the distance filter on), wall-clock crossing a node's online window, non-top lastHeard
+			// reorders, and in-place favorite toggles. The old 350ms MAIN-thread poll covered these by
+			// brute force; this is the same idea but off-main and gentler (~1.5s). Interactive changes
+			// (search/filter edits, node inserts/deletes) still refresh instantly via the onChange
+			// triggers below — this only backstops the un-observable inputs.
+			let backstop = Task {
+				while !Task.isCancelled {
+					try? await Task.sleep(for: .milliseconds(1500))
+					continuation.yield(())
+				}
+			}
+			defer { backstop.cancel() }
+			await recompute()   // first paint
+			var last = ContinuousClock.now
+			for await _ in stream {
+				let elapsed = ContinuousClock.now - last
+				if elapsed < .milliseconds(300) {
+					try? await Task.sleep(for: .milliseconds(300) - elapsed)
+				}
+				if Task.isCancelled { break }
+				await recompute()
+				last = .now
+			}
+		}
+		.onChange(of: filterKey) { _, _ in
+			recomputeTrigger.continuation?.yield(())
+		}
+		.onChange(of: nodeSetSignature) { _, _ in
+			recomputeTrigger.continuation?.yield(())
 		}
 		.onAppear {
 			router.updateNodeIndex(from: allNodes)
@@ -524,60 +728,55 @@ private struct NodeListFilterLookup {
 //  Meshtastic
 //
 
-fileprivate extension NodeFilterParameters {
-	/// Filters already pushed into the @Query predicate: ignored, favorite, viaLora/viaMqtt, hopsAway.
-	func matchesPostPredicate(
-		_ node: NodeInfoEntity,
-		normalizedSearchText: String,
-		onlineThreshold: Date?,
-		distanceBounds: NodeDistanceFilterBounds?,
-		lookup: NodeListFilterLookup
-	) -> Bool {
-		// Search text (requires relationship traversal)
-		if !normalizedSearchText.isEmpty {
-			let matchesSearch = [
-				node.user?.userId,
-				node.user?.numString,
-				node.user?.hwModel,
-				node.user?.hwDisplayName,
-				node.user?.longName,
-				node.user?.shortName
-			].compactMap { $0 }.contains { $0.localizedCaseInsensitiveContains(normalizedSearchText) }
-			if !matchesSearch { return false }
-		}
-
-		// Role filter (requires relationship traversal)
-		if roleFilter && !deviceRoles.isEmpty {
-			guard let role = node.user?.role else { return false }
-			if !deviceRoles.contains(Int(role)) { return false }
-		}
-
-		// Online filter (requires date computation)
-		if isOnline {
-			guard let lastHeard = node.lastHeard,
-				  let threshold = onlineThreshold else {
-				return false
-			}
-			if lastHeard < threshold { return false }
-		}
-
-		// Encrypted filter (requires relationship traversal)
-		if isPkiEncrypted {
-			if node.user?.pkiEncrypted != true { return false }
-		}
-
-		// Environment filter (requires to-many relationship traversal)
-		if isEnvironment {
-			if !lookup.hasEnvironmentMetrics(node) { return false }
-		}
-
-		// Distance filter (requires latest position lookup)
-		if distanceFilter, distanceBounds != nil {
-			guard lookup.isWithinDistance(node) else {
-				return false
-			}
-		}
-
-		return true
+/// The in-memory post-predicate match (search + role/online/pki/environment/distance), reading a
+/// Sendable `FilterSnapshot` so it can run OFF the main actor. Mirrors the filters NOT pushed into
+/// the @Query predicate. (Was a `NodeFilterParameters` extension; converted to a free function so
+/// the off-main scan doesn't touch the @MainActor filter object.)
+private func matchesPostPredicate(
+	_ node: NodeInfoEntity,
+	snapshot s: FilterSnapshot,
+	lookup: NodeListFilterLookup
+) -> Bool {
+	// Search text (requires relationship traversal)
+	if !s.normalizedSearchText.isEmpty {
+		let matchesSearch = [
+			node.user?.userId,
+			node.user?.numString,
+			node.user?.hwModel,
+			node.user?.hwDisplayName,
+			node.user?.longName,
+			node.user?.shortName
+		].compactMap { $0 }.contains { $0.localizedCaseInsensitiveContains(s.normalizedSearchText) }
+		if !matchesSearch { return false }
 	}
+
+	// Role filter (requires relationship traversal)
+	if s.roleFilter && !s.deviceRoles.isEmpty {
+		guard let role = node.user?.role else { return false }
+		if !s.deviceRoles.contains(Int(role)) { return false }
+	}
+
+	// Online filter (threshold is non-nil only when the online filter is active)
+	if let threshold = s.onlineThreshold {
+		guard let lastHeard = node.lastHeard, lastHeard >= threshold else { return false }
+	}
+
+	// Encrypted filter (requires relationship traversal)
+	if s.isPkiEncrypted {
+		if node.user?.pkiEncrypted != true { return false }
+	}
+
+	// Environment filter (requires to-many relationship traversal)
+	if s.isEnvironment {
+		if !lookup.hasEnvironmentMetrics(node) { return false }
+	}
+
+	// Distance filter (requires latest position lookup)
+	if s.distanceFilter, s.distanceBounds != nil {
+		guard lookup.isWithinDistance(node) else {
+			return false
+		}
+	}
+
+	return true
 }

--- a/MeshtasticTests/NodeListFilteringTests.swift
+++ b/MeshtasticTests/NodeListFilteringTests.swift
@@ -1,0 +1,319 @@
+//
+//  NodeListFilteringTests.swift
+//  Meshtastic
+//
+//  Coverage for the off-main node-list filtering path introduced in
+//  "perf: move node-list filtering off the main thread" (PR #2055).
+//
+//  The node LIST view no longer routes through `NodeFilterParameters.matches(...)`
+//  (which still backs UserList / MeshMap and is covered by NodeFilterParametersTests).
+//  It now uses a separate pipeline in `NodeList.swift`:
+//
+//    • `makeNodeListPredicate` — the SwiftData `#Predicate` shared by the live `@Query`
+//      and the off-main fetch, so the two sets can't drift.
+//    • `computeNodeOrder` — runs that fetch off the main actor on a fresh `ModelContext`
+//      and returns the matching node `num`s in `lastHeard`-descending order.
+//
+//  These tests exercise that pipeline directly. Two of them pin the review fixes from
+//  the PR:
+//
+//    • `makeNodeListPredicate(_:applyFavoriteFilter:)` — the off-main fetch drops the
+//      `favorite` gate (`applyFavoriteFilter: false`) so it stays a SUPERSET; a node just
+//      toggled favorite in the live context can't be hidden by the background context
+//      lagging the save. The live `@Query` re-applies the filter.
+//    • `computeNodeOrder` returns `[Int64]?` — `nil` only on a fetch throw (so the caller
+//      preserves the current list); an empty match set is `[]`, not `nil`.
+//
+//  The suite shares `sharedModelContainer` with every other SwiftData test, so it never
+//  asserts on global counts — only on membership / relative order of its own unique `num`
+//  range (8_15x_xxx). `computeNodeOrder` reads through a fresh `ModelContext`, so seeded
+//  rows are always saved before the call.
+//
+
+import CoreLocation
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Meshtastic
+
+/// Isolated `UserDefaults` suite so the `@AppStorage`-backed filter flags start empty and
+/// don't collide with other suites running in parallel.
+@MainActor
+private func makeIsolatedDefaults(_ suiteName: String) -> UserDefaults {
+	let defaults = UserDefaults(suiteName: suiteName)!
+	defaults.removePersistentDomain(forName: suiteName)
+	return defaults
+}
+
+@MainActor
+@Suite("Node list off-main filtering", .serialized)
+struct NodeListFilteringTests {
+
+	let defaults: UserDefaults
+
+	init() {
+		defaults = makeIsolatedDefaults("NodeListFilteringTests")
+	}
+
+	// MARK: - Fixtures
+
+	/// Inserts a node with the given scalar attributes into the shared container's main context.
+	@discardableResult
+	private func makeNode(
+		num: Int64,
+		favorite: Bool = false,
+		ignored: Bool = false,
+		viaMqtt: Bool = false,
+		hopsAway: Int32 = 0,
+		lastHeard: Date? = nil
+	) -> NodeInfoEntity {
+		let node = NodeInfoEntity()
+		node.num = num
+		node.id = num
+		node.favorite = favorite
+		node.ignored = ignored
+		node.viaMqtt = viaMqtt
+		node.hopsAway = hopsAway
+		node.lastHeard = lastHeard
+		sharedModelContainer.mainContext.insert(node)
+		return node
+	}
+
+	/// Attaches a `UserEntity` (search fields / role / pki state) to a node.
+	private func attachUser(
+		to node: NodeInfoEntity,
+		longName: String? = nil,
+		shortName: String? = nil,
+		role: Int32 = 0,
+		pkiEncrypted: Bool = false
+	) {
+		let user = UserEntity()
+		user.num = node.num
+		user.userId = "!\(String(node.num, radix: 16))"
+		user.longName = longName
+		user.shortName = shortName
+		user.role = role
+		user.pkiEncrypted = pkiEncrypted
+		sharedModelContainer.mainContext.insert(user)
+		node.user = user
+	}
+
+	/// Persists seeded rows so the off-main / fresh-context fetches see them.
+	private func save() throws {
+		try sharedModelContainer.mainContext.save()
+	}
+
+	/// Fetches the `num`s matching a predicate through a fresh context, mirroring how both the
+	/// `@Query` and `computeNodeOrder` consume `makeNodeListPredicate`.
+	private func fetchNums(_ predicate: Predicate<NodeInfoEntity>) throws -> Set<Int64> {
+		let context = ModelContext(sharedModelContainer)
+		return Set(try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: predicate)).map(\.num))
+	}
+
+	// MARK: - makeNodeListPredicate: favorite superset (review fix)
+
+	@Test("Favorite filter: applyFavoriteFilter false keeps the fetch a superset")
+	func favoriteFilterSupersetWhenNotApplied() throws {
+		let favNum: Int64 = 8_150_001
+		let plainNum: Int64 = 8_150_002
+		makeNode(num: favNum, favorite: true)
+		makeNode(num: plainNum, favorite: false)
+		try save()
+
+		let filters = NodeFilterParameters(store: defaults)
+		filters.isFavorite = true
+		let inputs = NodePredicateInputs(filters)
+
+		// Live @Query behavior: favorite gate applied — non-favorite excluded.
+		let applied = try fetchNums(makeNodeListPredicate(inputs, applyFavoriteFilter: true))
+		#expect(applied.contains(favNum))
+		#expect(!applied.contains(plainNum))
+
+		// Off-main fetch behavior: favorite gate dropped — result is a SUPERSET so a just-toggled
+		// favorite can never be hidden by the background context lagging the save.
+		let superset = try fetchNums(makeNodeListPredicate(inputs, applyFavoriteFilter: false))
+		#expect(superset.contains(favNum))
+		#expect(superset.contains(plainNum))
+	}
+
+	@Test("Favorite filter is applied by default")
+	func favoriteFilterAppliedByDefault() throws {
+		let favNum: Int64 = 8_150_011
+		let plainNum: Int64 = 8_150_012
+		makeNode(num: favNum, favorite: true)
+		makeNode(num: plainNum, favorite: false)
+		try save()
+
+		let filters = NodeFilterParameters(store: defaults)
+		filters.isFavorite = true
+
+		let result = try fetchNums(makeNodeListPredicate(NodePredicateInputs(filters)))
+		#expect(result.contains(favNum))
+		#expect(!result.contains(plainNum))
+	}
+
+	// MARK: - makeNodeListPredicate: other filters
+
+	@Test("Ignored filter partitions ignored from non-ignored nodes")
+	func ignoredFilterPartitions() throws {
+		let normalNum: Int64 = 8_151_001
+		let ignoredNum: Int64 = 8_151_002
+		makeNode(num: normalNum, ignored: false)
+		makeNode(num: ignoredNum, ignored: true)
+		try save()
+
+		let showNormal = NodeFilterParameters(store: defaults) // isIgnored defaults false
+		let normals = try fetchNums(makeNodeListPredicate(NodePredicateInputs(showNormal)))
+		#expect(normals.contains(normalNum))
+		#expect(!normals.contains(ignoredNum))
+
+		let showIgnored = NodeFilterParameters(store: defaults)
+		showIgnored.isIgnored = true
+		let ignored = try fetchNums(makeNodeListPredicate(NodePredicateInputs(showIgnored)))
+		#expect(ignored.contains(ignoredNum))
+		#expect(!ignored.contains(normalNum))
+	}
+
+	@Test("Via LoRa only excludes MQTT nodes; Via MQTT only excludes LoRa nodes")
+	func viaTransportFilters() throws {
+		let loraNum: Int64 = 8_152_001
+		let mqttNum: Int64 = 8_152_002
+		makeNode(num: loraNum, viaMqtt: false)
+		makeNode(num: mqttNum, viaMqtt: true)
+		try save()
+
+		let loraOnly = NodeFilterParameters(store: defaults)
+		loraOnly.viaLora = true
+		loraOnly.viaMqtt = false
+		let lora = try fetchNums(makeNodeListPredicate(NodePredicateInputs(loraOnly)))
+		#expect(lora.contains(loraNum))
+		#expect(!lora.contains(mqttNum))
+
+		let mqttOnly = NodeFilterParameters(store: defaults)
+		mqttOnly.viaLora = false
+		mqttOnly.viaMqtt = true
+		let mqtt = try fetchNums(makeNodeListPredicate(NodePredicateInputs(mqttOnly)))
+		#expect(mqtt.contains(mqttNum))
+		#expect(!mqtt.contains(loraNum))
+	}
+
+	@Test("Hops filter: direct-only keeps 0-hop nodes; max keeps nodes within range")
+	func hopsFilters() throws {
+		let directNum: Int64 = 8_153_001
+		let twoHopNum: Int64 = 8_153_002
+		let fiveHopNum: Int64 = 8_153_003
+		makeNode(num: directNum, hopsAway: 0)
+		makeNode(num: twoHopNum, hopsAway: 2)
+		makeNode(num: fiveHopNum, hopsAway: 5)
+		try save()
+
+		// hopsAway == 0.0 -> direct nodes only.
+		let directOnly = NodeFilterParameters(store: defaults)
+		directOnly.hopsAway = 0.0
+		let direct = try fetchNums(makeNodeListPredicate(NodePredicateInputs(directOnly)))
+		#expect(direct.contains(directNum))
+		#expect(!direct.contains(twoHopNum))
+		#expect(!direct.contains(fiveHopNum))
+
+		// hopsAway == 3.0 -> 0 < hops <= 3 (direct excluded).
+		let maxThree = NodeFilterParameters(store: defaults)
+		maxThree.hopsAway = 3.0
+		let within = try fetchNums(makeNodeListPredicate(NodePredicateInputs(maxThree)))
+		#expect(within.contains(twoHopNum))
+		#expect(!within.contains(directNum))
+		#expect(!within.contains(fiveHopNum))
+	}
+
+	// MARK: - computeNodeOrder: ordering & post-predicate
+
+	@Test("computeNodeOrder returns matches in lastHeard-descending order")
+	func ordersByLastHeardDescending() throws {
+		let now = Date()
+		let newNum: Int64 = 8_154_001
+		let midNum: Int64 = 8_154_002
+		let oldNum: Int64 = 8_154_003
+		makeNode(num: newNum, lastHeard: now)
+		makeNode(num: midNum, lastHeard: now.addingTimeInterval(-3_600))
+		makeNode(num: oldNum, lastHeard: now.addingTimeInterval(-7_200))
+		try save()
+
+		let snapshot = FilterSnapshot(NodeFilterParameters(store: defaults), activeNodeNum: nil)
+		let result = try #require(computeNodeOrder(container: sharedModelContainer, snapshot: snapshot))
+
+		let mine = result.filter { [newNum, midNum, oldNum].contains($0) }
+		#expect(mine == [newNum, midNum, oldNum])
+	}
+
+	@Test("computeNodeOrder narrows by search term against user fields")
+	func searchNarrowsByUserFields() throws {
+		let matchNum: Int64 = 8_155_001
+		let otherNum: Int64 = 8_155_002
+		let match = makeNode(num: matchNum, lastHeard: Date())
+		attachUser(to: match, longName: "Zephyr Ridge Repeater")
+		let other = makeNode(num: otherNum, lastHeard: Date())
+		attachUser(to: other, longName: "Downtown Base")
+		try save()
+
+		let filters = NodeFilterParameters(store: defaults)
+		filters.searchText = "zephyr" // case-insensitive
+		let snapshot = FilterSnapshot(filters, activeNodeNum: nil)
+		let result = try #require(computeNodeOrder(container: sharedModelContainer, snapshot: snapshot))
+
+		#expect(result.contains(matchNum))
+		#expect(!result.contains(otherNum))
+	}
+
+	@Test("computeNodeOrder keeps the favorite fetch a superset end-to-end")
+	func computeNodeOrderFavoriteSuperset() throws {
+		let favNum: Int64 = 8_156_001
+		let plainNum: Int64 = 8_156_002
+		makeNode(num: favNum, favorite: true, lastHeard: Date())
+		makeNode(num: plainNum, favorite: false, lastHeard: Date())
+		try save()
+
+		let filters = NodeFilterParameters(store: defaults)
+		filters.isFavorite = true
+		let snapshot = FilterSnapshot(filters, activeNodeNum: nil)
+		let result = try #require(computeNodeOrder(container: sharedModelContainer, snapshot: snapshot))
+
+		// The off-main pass intentionally returns BOTH (the live @Query enforces the favorite gate
+		// when recompute() maps these nums onto live objects) — so a favorite toggled in the live
+		// context can't be dropped by a lagging background save.
+		#expect(result.contains(favNum))
+		#expect(result.contains(plainNum))
+	}
+
+	@Test("computeNodeOrder online filter excludes stale nodes")
+	func onlineFilterExcludesStale() throws {
+		let recentNum: Int64 = 8_157_001
+		let staleNum: Int64 = 8_157_002
+		makeNode(num: recentNum, lastHeard: Date())
+		makeNode(num: staleNum, lastHeard: Date().addingTimeInterval(-10_000)) // older than the 2h window
+		try save()
+
+		let filters = NodeFilterParameters(store: defaults)
+		filters.isOnline = true
+		let snapshot = FilterSnapshot(filters, activeNodeNum: nil)
+		let result = try #require(computeNodeOrder(container: sharedModelContainer, snapshot: snapshot))
+
+		#expect(result.contains(recentNum))
+		#expect(!result.contains(staleNum))
+	}
+
+	@Test("computeNodeOrder returns an empty match set as [], not nil")
+	func emptyMatchSetIsNonNil() throws {
+		let hiddenNum: Int64 = 8_158_001
+		let node = makeNode(num: hiddenNum, lastHeard: Date())
+		attachUser(to: node, longName: "Findable Node")
+		try save()
+
+		let filters = NodeFilterParameters(store: defaults)
+		// A term no seeded node contains — matches nothing, which must be [] (non-nil).
+		filters.searchText = "zzz-no-such-node-zzz"
+		let snapshot = FilterSnapshot(filters, activeNodeNum: nil)
+		let result = try #require(computeNodeOrder(container: sharedModelContainer, snapshot: snapshot))
+
+		#expect(!result.contains(hiddenNum))
+	}
+}


### PR DESCRIPTION
## What changed?

Moves node-list filtering off the main thread. `FilteredNodeList` previously ran an unconditional 350 ms poll that recomputed the filtered/sorted list on the **main actor** — an O(N) scan doing 6 relationship traversals (each a potential SwiftData fault) plus locale-aware string compares per node, ~3×/sec, forever.

The poll is replaced with a change-driven, coalesced recompute:

- The scan (`computeNodeOrder`) runs **off the main actor** on a `Task.detached` with a fresh, confined `ModelContext`, returning only Sendable `[Int64]` node nums.
- Those nums are mapped back onto the live `@Query` objects and partitioned into connected → favorites → regular **on the main actor from current state**, so no background-context model ever reaches the `List` (preserving the existing SIGTRAP hardening against faulting pruned rows).
- A single long-lived consumer drains a `bufferingNewest(1)` stream: filter/search edits and node-set changes fire an **instant** recompute; a reconnect nodeDB dump collapses to one pending pass (300 ms throttle → ~3/sec cap). A 1.5 s **off-main** backstop refreshes the inputs nothing notifies us about (GPS location with the distance filter, the online-window wall-clock crossing, non-top `lastHeard` reorders, favorite toggles).
- One `makeNodeListPredicate` source feeds both the `@Query` and the off-main fetch, so the two node sets can't drift.
- First paint shows a loading indicator instead of flashing an empty "Nodes (0)" list during the initial off-main fetch.

## Why did it change?

A user reported multi-second keypress lag and **dropped** keystrokes when searching the node list on a large mesh, worsening the longer the app ran. That signature — dropped input events — is the main thread being seized synchronously while UIKit tries to service the keyboard.

Profiling (iPhone 16 Pro Max simulator, seeded DBs) confirmed the poll's per-tick scan on the main actor:

| Nodes | Cold first-keystroke tick | Warm steady-state tick |
|------:|--------------------------:|-----------------------:|
| 1,000 | 113 ms | 11 ms |
| 5,000 | **514 ms** | 52 ms |

The scan is cleanly O(N) (~10.6 µs/node warm, ~100 µs/node cold from faulting `user`), and with `purgeStaleNodeDays` defaulting to 0 the node set grows unbounded — so it strictly worsens over time, on a device 3–4× slower than the sim. Running the identical scan on a `Task.detached` removes it from the main thread entirely; typing stays responsive regardless of the scan's absolute cost.

## How is this tested?

- Built (Debug) and run on the iPhone 16 Pro Max simulator against a 5,000-node seeded store (75k telemetry / 25k position / ~400 message rows). Node list renders correctly (4,948 after the 52 ignored are filtered), rows fully populated, no SIGTRAP.
- Compiles under Swift 6 strict concurrency (Sendable snapshot in, `[Int64]` out; the confined `ModelContext` never escapes the synchronous `computeNodeOrder`).
- Verified filter-match parity: the refactored predicate + post-predicate produce the same result count as the previous in-memory path.
- Reviewed for the change-detection regressions inherent in replacing a brute-force poll (device location, online-window crossing, favorite re-sectioning, non-top reorders) and addressed them via the 1.5 s off-main backstop + on-main partition.

Note: `relationshipKeyPathsForPrefetching = [\.user]` was evaluated as a way to cut the cold fault cost but measured no effect on this platform (SwiftData to-one prefetch appears ineffective), so it is not included. The durable cold-latency win — denormalizing a lowercased `searchIndex` and pushing search into the `#Predicate` so SQLite filters — is a separate follow-up (needs a migration).

## Screenshots/Videos (when applicable)

_Node list rendering 4,948 nodes from a 5,000-node seeded DB via the new off-main path (available on request)._

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. This is an internal performance refactor of the node list with no user-facing behavior change, so no doc update is needed — requesting the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node lists now refresh using an off-main, change-driven pipeline for smoother filtering and ordering.
  * A brief loading indicator may appear while the first refreshed results are computed.

* **Bug Fixes**
  * Improved filter consistency so visible nodes more reliably match the selected criteria, including online and distance-related effects.
  * Reduced unnecessary polling while keeping results timely with an automatic backstop refresh.

* **Tests**
  * Added unit tests covering the node list filtering and ordering behavior, including favorite/search/online semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->