### PR TITLE
Consolidate FromRadio decode and UTF-8 validation across transports

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0516B3FE2F68892000D0FC40 /* NodeFilterParametersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */; };
 		DD0000A10EDD5A00000000B1 /* XEdDSASigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000A20EDD5A00000000B2 /* XEdDSASigningTests.swift */; };
+		DD0000C10EDD5A00000000C1 /* InvalidUTF8Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000C20EDD5A00000000C2 /* InvalidUTF8Tests.swift */; };
 		05A1B2C32F70000100D0FC40 /* SettingsNodeSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */; };
 		0B9642EC0DB1B971CB26E8AE /* RadarSweepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E06A9BCC789BD452DFA9CFB /* RadarSweepView.swift */; };
 		102B5EAB2E172F41003D191E /* DatadogCore in Frameworks */ = {isa = PBXBuildFile; productRef = 102B5EAA2E172F41003D191E /* DatadogCore */; };
@@ -606,6 +607,7 @@
 /* Begin PBXFileReference section */
 		01028778B8BFD81F7A039593 /* TAKConnection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TAKConnection.swift; sourceTree = "<group>"; };
 		DD0000A20EDD5A00000000B2 /* XEdDSASigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XEdDSASigningTests.swift; sourceTree = "<group>"; };
+		DD0000C20EDD5A00000000C2 /* InvalidUTF8Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidUTF8Tests.swift; sourceTree = "<group>"; };
 		05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNodeSortTests.swift; sourceTree = "<group>"; };
 		05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeFilterParametersTests.swift; sourceTree = "<group>"; };
 		05E0BD1A81CF4F6A90D56CE3 /* MeshtasticSchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshtasticSchemaV1.swift; sourceTree = "<group>"; };
@@ -1622,6 +1624,7 @@
 				25F5D5D02C4375DF008036E3 /* RouterTests.swift */,
 				05DCA1AE2F646B3B00D0724C /* NodeFilterParametersTests.swift */,
 				DD0000A20EDD5A00000000B2 /* XEdDSASigningTests.swift */,
+				DD0000C20EDD5A00000000C2 /* InvalidUTF8Tests.swift */,
 				05A1B2C42F70000100D0FC40 /* SettingsNodeSortTests.swift */,
 				AA0120250000000000000C02 /* PacketStreamModelTests.swift */,
 				AA000301CPTST000000000001 /* CarPlayTests.swift */,
@@ -2778,6 +2781,7 @@
 				25F5D5D12C4375DF008036E3 /* RouterTests.swift in Sources */,
 				0516B3FE2F68892000D0FC40 /* NodeFilterParametersTests.swift in Sources */,
 				DD0000A10EDD5A00000000B1 /* XEdDSASigningTests.swift in Sources */,
+				DD0000C10EDD5A00000000C1 /* InvalidUTF8Tests.swift in Sources */,
 				05A1B2C32F70000100D0FC40 /* SettingsNodeSortTests.swift in Sources */,
 				AA0120250000000000000C01 /* PacketStreamModelTests.swift in Sources */,
 				AA000301CPTST000000000002 /* CarPlayTests.swift in Sources */,

--- a/Meshtastic/Accessory/Protocols/Connection.swift
+++ b/Meshtastic/Accessory/Protocols/Connection.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import MeshtasticProtobufs
+import SwiftProtobuf
 
 protocol Connection: Actor {
 	var type: TransportType { get }
@@ -29,6 +30,46 @@ enum ConnectionEvent {
 	case error(Error)
 	case errorWithoutReconnect(Error)
 	case disconnected(shouldReconnect: Bool)
+}
+
+// MARK: - Shared FromRadio decode + encoding validation
+
+/// Outcome of decoding one top-level `FromRadio` frame from raw transport bytes.
+///
+/// SwiftProtobuf validates UTF-8 while decoding and throws `BinaryDecodingError.invalidUTF8`
+/// when a string field (e.g. a node's `long_name`) carries an invalid byte sequence. That
+/// is a per-field content problem, not a transport problem, so it is surfaced separately
+/// from genuine framing failures — see `FromRadioDecoder`.
+enum FromRadioDecodeOutcome {
+	/// Frame decoded cleanly; yield `.data(_)` to the `AccessoryManager`.
+	case decoded(FromRadio)
+	/// A string field failed UTF-8 validation. Skip this frame and keep reading; the
+	/// error is carried for logging only.
+	case skipInvalidUTF8(Error)
+	/// Any other decode failure (truncation, malformed wire format, …): a genuine
+	/// framing/stream problem, which transports may recover from by reconnecting.
+	case failed(Error)
+}
+
+/// The single decode + encoding-validation path shared by every transport, so BLE, TCP,
+/// and Serial handle a malformed string field identically instead of each rolling its own.
+enum FromRadioDecoder {
+	/// Decodes and validates one `FromRadio` frame. Pure — no actor state and no I/O — so
+	/// it is safe to call synchronously from any transport actor and is directly unit-testable.
+	static func classify(_ data: Data) -> FromRadioDecodeOutcome {
+		do {
+			return .decoded(try FromRadio(serializedBytes: data))
+		} catch {
+			return isInvalidUTF8(error) ? .skipInvalidUTF8(error) : .failed(error)
+		}
+	}
+
+	/// True iff `error` is SwiftProtobuf's `.invalidUTF8` binary-decoding error.
+	/// `BinaryDecodingError` has no associated values, so it is implicitly `Equatable`
+	/// and `== .invalidUTF8` compiles via `Optional`'s conditional conformance.
+	private static func isInvalidUTF8(_ error: Error) -> Bool {
+		(error as? BinaryDecodingError) == .invalidUTF8
+	}
 }
 
 enum ConnectionState: Equatable, Codable {

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
@@ -9,7 +9,6 @@ import Foundation
 @preconcurrency import CoreBluetooth
 import OSLog
 import MeshtasticProtobufs
-import SwiftProtobuf
 
 let meshtasticServiceCBUUID = CBUUID(string: "0x6BA1B218-15A8-461F-9FA8-5DCAE273EAFD")
 let TORADIO_UUID = CBUUID(string: "0xF75C76D2-129E-4DAD-A1DD-7866124401E7")
@@ -167,32 +166,25 @@ actor BLEConnection: Connection {
 				break
 			}
 
-			do {
-				let decodedInfo = try FromRadio(serializedBytes: data)
+			switch FromRadioDecoder.classify(data) {
+			case .decoded(let decodedInfo):
 				connectionStreamContinuation?.yield(.data(decodedInfo))
-			} catch {
-				if isInvalidUTF8DecodeError(error) {
-					// Skip known invalid UTF-8 payloads to avoid reconnect loops when
-					// a remote node has corrupt string data in the node database.
-					Logger.transport.error("⚠️ [BLE] Failed to decode FromRadio packet due to invalid UTF-8 (\(data.count) bytes), skipping: \(error)")
-				} else {
-					// Other decode errors are likely transport/framing issues.
-					let decodeError = error
-					do {
-						try await self.disconnect(withError: decodeError, shouldReconnect: true)
-					} catch let disconnectError {
-						Logger.transport.error("⚠️ [BLE] Failed to disconnect after FromRadio decode failure: \(disconnectError)")
-					}
-					throw decodeError
+			case .skipInvalidUTF8(let error):
+				// A string field failed UTF-8 validation; skip this frame and keep draining
+				// rather than dropping the connection over one unparseable field.
+				Logger.transport.error("⚠️ [BLE] Skipping FromRadio frame with invalid UTF-8 (\(data.count) bytes): \(error, privacy: .public)")
+			case .failed(let error):
+				// Other decode errors are likely transport/framing issues.
+				do {
+					try await self.disconnect(withError: error, shouldReconnect: true)
+				} catch let disconnectError {
+					Logger.transport.error("⚠️ [BLE] Failed to disconnect after FromRadio decode failure: \(disconnectError)")
 				}
+				throw error
 			}
 		} while true
 	}
 
-	private func isInvalidUTF8DecodeError(_ error: Error) -> Bool {
-		(error as? BinaryDecodingError) == .invalidUTF8
-	}
-	
 	func didReceiveLogMessage(_ logMessage: String) {
 		self.connectionStreamContinuation?.yield(.logMessage(logMessage))
 	}

--- a/Meshtastic/Accessory/Transports/Serial/SerialConnection.swift
+++ b/Meshtastic/Accessory/Transports/Serial/SerialConnection.swift
@@ -80,10 +80,13 @@ actor SerialConnection: Connection {
 
 			let payload = readBuffer.subdata(in: 4..<totalPacketLength)
 
-			if let fromRadio = try? FromRadio(serializedBytes: payload) {
+			switch FromRadioDecoder.classify(payload) {
+			case .decoded(let fromRadio):
 				eventStreamContinuation?.yield(.data(fromRadio))
-			} else {
-				Logger.transport.error("🔱 [Serial] Failed to deserialize payload. Skipping packet.")
+			case .skipInvalidUTF8(let error):
+				Logger.transport.error("🔱 [Serial] Skipping FromRadio frame with invalid UTF-8 (\(payload.count) bytes): \(error, privacy: .public)")
+			case .failed(let error):
+				Logger.transport.error("🔱 [Serial] Failed to deserialize payload, skipping packet: \(error, privacy: .public)")
 			}
 
 			readBuffer.removeSubrange(0..<totalPacketLength)

--- a/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
+++ b/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
@@ -89,10 +89,19 @@ actor TCPConnection: Connection {
 
 					if let length = try? await readInteger() {
 						let payload = try await receiveData(min: Int(length), max: Int(length))
-						if let fromRadio = try? FromRadio(serializedBytes: payload) {
+						switch FromRadioDecoder.classify(payload) {
+						case .decoded(let fromRadio):
 							await connectionStreamContinuation?.yield(.data(fromRadio))
-						} else {
-							try await self.disconnect(withError: AccessoryError.disconnected("Network connection dropped"), shouldReconnect: true)
+						case .skipInvalidUTF8(let error):
+							// A string field failed UTF-8 validation; skip this frame and keep reading
+							// rather than tearing down an otherwise healthy connection over one
+							// unparseable field. receiveData(min:max:) already consumed exactly `length`
+							// bytes, so the stream stays magic-byte aligned for the next frame.
+							Logger.transport.error("🌐 [TCP] Skipping FromRadio frame with invalid UTF-8 (\(payload.count) bytes): \(error, privacy: .public)")
+						case .failed(let error):
+							// Genuine framing/stream corruption — disconnect and allow reconnect recovery.
+							Logger.transport.error("🌐 [TCP] FromRadio decode failed (framing/stream corruption): \(error, privacy: .public)")
+							try await self.disconnect(withError: error, shouldReconnect: true)
 						}
 					} else {
 						Logger.transport.debug("🌐 [TCP] startReader: EOF while waiting for length")

--- a/MeshtasticTests/InvalidUTF8Tests.swift
+++ b/MeshtasticTests/InvalidUTF8Tests.swift
@@ -2,8 +2,8 @@
 //  InvalidUTF8Tests.swift
 //  MeshtasticTests
 //
-//  Tests for CVE: invalid UTF-8 in protobuf string fields
-//  causing BLE sync failure and infinite reconnect loop.
+//  Encoding-validation tests for FromRadio decoding: a string field carrying an invalid
+//  UTF-8 sequence must be skipped, not treated as a fatal transport/stream failure.
 //
 
 import Foundation
@@ -14,10 +14,10 @@ import MeshtasticProtobufs
 @Suite("Invalid UTF-8 Protobuf Handling")
 struct InvalidUTF8Tests {
 
-	// MARK: - Demonstrating the Issue
+	// MARK: - SwiftProtobuf UTF-8 validation behavior
 
-	/// Proves that SwiftProtobuf rejects a `FromRadio` containing invalid UTF-8
-	/// in `User.long_name`. This is the root cause of the infinite BLE reconnect loop.
+	/// Confirms SwiftProtobuf rejects a `FromRadio` whose `User.long_name` contains an
+	/// invalid UTF-8 sequence — the decode-time condition the shared funnel handles.
 	@Test func fromRadioWithInvalidUTF8Throws() throws {
 		// Build a valid FromRadio.nodeInfo payload, then corrupt the long_name field
 		// to contain an incomplete multibyte UTF-8 sequence.
@@ -106,6 +106,132 @@ struct InvalidUTF8Tests {
 			#expect(throws: (any Error).self) {
 				_ = try FromRadio(serializedBytes: patched)
 			}
+		}
+	}
+
+	// MARK: - Shared decode funnel: FromRadioDecoder
+
+	/// A truncated-emoji `long_name` must classify as `.skipInvalidUTF8` so every transport
+	/// skips the frame rather than tearing down the stream.
+	@Test func classifierSkipsTruncatedEmojiLongName() throws {
+		var user = User()
+		user.id = "!aabbccdd"
+		user.longName = "Lunar Tower 🌙ok"
+		user.shortName = "LT"
+
+		var nodeInfo = NodeInfo()
+		nodeInfo.num = 0xAABBCCDD
+		nodeInfo.user = user
+
+		var fromRadio = FromRadio()
+		fromRadio.id = 1
+		fromRadio.payloadVariant = .nodeInfo(nodeInfo)
+
+		let data = try fromRadio.serializedData()
+		let validName = Array("Lunar Tower 🌙ok".utf8)
+		let corruptName = Array("Lunar Tower ".utf8) + [0xF0, 0x9F, 0x8C, 0x99] + [0xF0, 0x9F, 0x97]
+
+		let patched = patchProtobufBytes(data: data, find: validName, replace: corruptName)
+		#expect(patched != nil, "Failed to find and patch the long_name in serialized protobuf data")
+
+		if let patched {
+			guard case .skipInvalidUTF8 = FromRadioDecoder.classify(patched) else {
+				Issue.record("Expected .skipInvalidUTF8 for a truncated-emoji long_name")
+				return
+			}
+		}
+	}
+
+	/// The second real-world case (lone lead bytes `E1 F3`) must also be skipped, not
+	/// treated as a transport failure.
+	@Test func classifierSkipsLoneLeadBytesLongName() throws {
+		var user = User()
+		user.id = "!11223344"
+		user.longName = "Meshtastic 37e2"
+		user.shortName = "MS"
+
+		var nodeInfo = NodeInfo()
+		nodeInfo.num = 0x11223344
+		nodeInfo.user = user
+
+		var fromRadio = FromRadio()
+		fromRadio.id = 2
+		fromRadio.payloadVariant = .nodeInfo(nodeInfo)
+
+		let data = try fromRadio.serializedData()
+		let validName = Array("Meshtastic 37e2".utf8)
+		let corruptName: [UInt8] = Array("Mesht".utf8) + [0xE1, 0xF3] + Array("tic 37e2".utf8)
+
+		let patched = patchProtobufBytes(data: data, find: validName, replace: corruptName)
+		#expect(patched != nil, "Failed to find and patch the long_name in serialized protobuf data")
+
+		if let patched {
+			guard case .skipInvalidUTF8 = FromRadioDecoder.classify(patched) else {
+				Issue.record("Expected .skipInvalidUTF8 for lone-lead-byte long_name")
+				return
+			}
+		}
+	}
+
+	/// A valid frame (including multibyte emoji) must classify as `.decoded` — the funnel
+	/// must not over-eagerly skip legitimate names.
+	@Test func classifierDecodesValidEmoji() throws {
+		var user = User()
+		user.id = "!aabbccdd"
+		user.longName = "Lunar Tower 🌙🗼"
+		user.shortName = "LT"
+
+		var nodeInfo = NodeInfo()
+		nodeInfo.num = 0xAABBCCDD
+		nodeInfo.user = user
+
+		var fromRadio = FromRadio()
+		fromRadio.id = 1
+		fromRadio.payloadVariant = .nodeInfo(nodeInfo)
+
+		let data = try fromRadio.serializedData()
+
+		guard case .decoded(let decoded) = FromRadioDecoder.classify(data) else {
+			Issue.record("Expected .decoded for a valid emoji long_name")
+			return
+		}
+		#expect(decoded.nodeInfo.user.longName == "Lunar Tower 🌙🗼")
+	}
+
+	/// A genuinely truncated protobuf (bytes lost mid-field) must classify as `.failed`,
+	/// NOT skipped — so transports still disconnect/reconnect to recover from real
+	/// framing corruption.
+	@Test func classifierFailsOnTruncatedProtobuf() throws {
+		var user = User()
+		user.id = "!aabbccdd"
+		user.longName = "Lunar Tower"
+		user.shortName = "LT"
+
+		var nodeInfo = NodeInfo()
+		nodeInfo.num = 0xAABBCCDD
+		nodeInfo.user = user
+
+		var fromRadio = FromRadio()
+		fromRadio.id = 1
+		fromRadio.payloadVariant = .nodeInfo(nodeInfo)
+
+		let data = try fromRadio.serializedData()
+		let truncated = Data(data.prefix(data.count - 3))
+
+		guard case .failed = FromRadioDecoder.classify(truncated) else {
+			Issue.record("Expected .failed for a truncated protobuf")
+			return
+		}
+	}
+
+	/// Malformed wire bytes (invalid wire type) must classify as `.failed`, preserving
+	/// genuine-corruption recovery.
+	@Test func classifierFailsOnMalformedProtobuf() throws {
+		// 0x0F = field 1, wire type 7 (invalid). Not empty (empty decodes as a valid
+		// empty FromRadio), so this exercises the malformed-wire path.
+		guard case .failed = FromRadioDecoder.classify(Data([0x0F])) else {
+			Issue.record("Expected .failed for malformed protobuf wire bytes")
+			return
 		}
 	}
 

--- a/docs/developer/transport.md
+++ b/docs/developer/transport.md
@@ -49,6 +49,18 @@ Radio (BLE/TCP/Serial)
   → Publish changes via @Published properties (UI updates)
 ```
 
+## Frame Decoding & Encoding Validation
+
+Every transport turns raw inbound bytes into a `FromRadio` frame through one shared funnel, `FromRadioDecoder.classify(_:)` in `Accessory/Protocols/Connection.swift`, so BLE, TCP, and Serial handle a malformed frame identically instead of each rolling its own `try? FromRadio(serializedBytes:)`. It returns a `FromRadioDecodeOutcome`:
+
+| Outcome | Meaning | Transport action |
+|---------|---------|------------------|
+| `.decoded(FromRadio)` | Frame decoded cleanly | Yield `.data(_)` to `AccessoryManager` |
+| `.skipInvalidUTF8(Error)` | A string field (e.g. a node's `long_name`) failed SwiftProtobuf's UTF-8 validation | Log and **skip the frame**; the connection stays alive and keeps reading |
+| `.failed(Error)` | Genuine framing / wire corruption | BLE & TCP call `disconnect(withError:shouldReconnect:)` and reconnect; Serial logs and skips |
+
+An invalid encoding in a single string field is a per-field content problem, not a transport failure, so it must not tear down an otherwise healthy stream. SwiftProtobuf validates UTF-8 during decode and throws `BinaryDecodingError.invalidUTF8`; `FromRadioDecoder` isolates that case so only genuine framing errors trigger a reconnect.
+
 ## Packet Flow (Outbound)
 
 ```


### PR DESCRIPTION
## Summary

Each transport decoded `FromRadio` frames on its own, with inconsistent handling when a protobuf string field (e.g. a node's `long_name`) contains an invalid UTF-8 sequence that SwiftProtobuf rejects at decode time:

- **TCP** tore down the connection (`disconnect(shouldReconnect: true)`) on *any* decode miss, so a single unparseable string field would drop an otherwise healthy stream.
- **BLE** already skipped invalid-UTF-8 frames, but via bespoke inline handling.
- **Serial** skipped too, but logged a generic "failed to deserialize" message.

This consolidates all three onto one decode + validation path, `FromRadioDecoder.classify(_:)`, which returns exactly one outcome:

- `.decoded(FromRadio)` — yield to the `AccessoryManager`
- `.skipInvalidUTF8(Error)` — a string field failed UTF-8 validation: skip the frame, keep reading
- `.failed(Error)` — genuine framing/wire corruption: BLE/TCP disconnect + reconnect; Serial skips

So a malformed string encoding is handled identically across transports, and the skip-vs-reconnect policy lives in one place instead of drifting per transport.

## Changes

- Add `FromRadioDecoder` + `FromRadioDecodeOutcome` in `Connection.swift`.
- Route `BLEConnection`, `TCPConnection`, and `SerialConnection` through the shared classifier.
- TCP no longer drops the connection over an invalid-UTF-8 field; genuine decode/framing failures still reconnect.
- Register `InvalidUTF8Tests` in the `MeshtasticTests` target — it was committed but never linked into the target, so it wasn't running — and add classifier coverage for the skip / decode / fail outcomes.

## Testing

```
xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic \
  -destination 'platform=iOS Simulator,name=iPhone 17' \
  -only-testing:MeshtasticTests/InvalidUTF8Tests
```

All 8 tests pass (`** TEST SUCCEEDED **`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated incoming frame decoding to treat protobuf invalid UTF-8 in string fields as non-fatal, skipping those frames instead of disconnecting.
  * Kept normal message delivery uninterrupted while continuing to disconnect/reconnect on genuinely corrupted or unreadable payloads.
  * Applied consistent decoding behavior across Bluetooth Low Energy, Serial, and TCP transports.

* **Tests**
  * Added/expanded tests ensuring frames are classified as skipped for invalid UTF-8, decoded for valid payloads, and failed for malformed protobuf inputs.

* **Documentation**
  * Documented the shared inbound frame decoding outcomes and handling semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->