### PR TITLE
perf(mqtt): drop payload-less client-proxy downlinks before BLE forward

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		DD00003ASUPPORTLVL0000001 /* SupportLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */; };
 		DD00003C000SNAP00000001 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DD00003B000SNAP00000000 /* SnapshotTesting */; };
 		DD0000CHSETST0000000001 /* ChannelSetSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000CHSETST0000000000 /* ChannelSetSaveTests.swift */; };
+		DD0000MQTTFWDFLTTST00001 /* MqttForwardFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000MQTTFWDFLTTST00000 /* MqttForwardFilterTests.swift */; };
 		DD0000DEVLNKTST000000001 /* DeviceLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */; };
 		DD1827FB0000000000000002 /* RegionCodesFirmwareLocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1827FA0000000000000002 /* RegionCodesFirmwareLocaleTests.swift */; };
 		DD007BAE2AA4E91200F5FA12 /* MyInfoEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD007BAD2AA4E91200F5FA12 /* MyInfoEntityExtension.swift */; };
@@ -473,6 +474,7 @@
 		DDC94FCE29CF55310082EA6E /* RtttlConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC94FCD29CF55310082EA6E /* RtttlConfig.swift */; };
 		DDCE4E2C2869F92900BE9F8F /* UserConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCE4E2B2869F92900BE9F8F /* UserConfig.swift */; };
 		DDD43FE32A78C8900083A3E9 /* MqttClientProxyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD43FE22A78C8900083A3E9 /* MqttClientProxyManager.swift */; };
+		DD0000MQTTFWDFLT00000001 /* MqttForwardFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000MQTTFWDFLT00000000 /* MqttForwardFilter.swift */; };
 		DDD5BB092C285DDC007E03CA /* AppLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD5BB082C285DDC007E03CA /* AppLog.swift */; };
 		DDD5BB0B2C285E45007E03CA /* LogDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD5BB0A2C285E45007E03CA /* LogDetail.swift */; };
 		DDD5BB102C285FB3007E03CA /* AppLogFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD5BB0F2C285FB3007E03CA /* AppLogFilter.swift */; };
@@ -941,6 +943,7 @@
 		DD000031FWEDTENUM0000000 /* FirmwareEditionEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareEditionEnum.swift; sourceTree = "<group>"; };
 		DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportLevel.swift; sourceTree = "<group>"; };
 		DD0000CHSETST0000000000 /* ChannelSetSaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelSetSaveTests.swift; sourceTree = "<group>"; };
+		DD0000MQTTFWDFLTTST00000 /* MqttForwardFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MqttForwardFilterTests.swift; sourceTree = "<group>"; };
 		DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLinkTests.swift; sourceTree = "<group>"; };
 		DD1827FA0000000000000002 /* RegionCodesFirmwareLocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCodesFirmwareLocaleTests.swift; sourceTree = "<group>"; };
 		DD007BAD2AA4E91200F5FA12 /* MyInfoEntityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoEntityExtension.swift; sourceTree = "<group>"; };
@@ -1130,6 +1133,7 @@
 		DDD28D372C0CD2670063CFA3 /* MeshtasticDataModelV 37.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 37.xcdatamodel"; sourceTree = "<group>"; };
 		DDD3A2B22D5127CF0045EB48 /* ci_pre_xcodebuild.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_pre_xcodebuild.sh; sourceTree = "<group>"; };
 		DDD43FE22A78C8900083A3E9 /* MqttClientProxyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MqttClientProxyManager.swift; sourceTree = "<group>"; };
+		DD0000MQTTFWDFLT00000000 /* MqttForwardFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MqttForwardFilter.swift; sourceTree = "<group>"; };
 		DDD5BB082C285DDC007E03CA /* AppLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLog.swift; sourceTree = "<group>"; };
 		DDD5BB0A2C285E45007E03CA /* LogDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogDetail.swift; sourceTree = "<group>"; };
 		DDD5BB0C2C285F00007E03CA /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -1688,6 +1692,7 @@
 				DD0000DEVLNKTST000000000 /* DeviceLinkTests.swift */,
 				BEEF00102F00000100000003 /* MeshtasticChannelURLTests.swift */,
 				DD0000CHSETST0000000000 /* ChannelSetSaveTests.swift */,
+				DD0000MQTTFWDFLTTST00000 /* MqttForwardFilterTests.swift */,
 				DD1827FA0000000000000002 /* RegionCodesFirmwareLocaleTests.swift */,
 				DD000031STATMSGDISP00000 /* StatusMessageDisplayTests.swift */,
 			);
@@ -2391,6 +2396,7 @@
 			isa = PBXGroup;
 			children = (
 				DDD43FE22A78C8900083A3E9 /* MqttClientProxyManager.swift */,
+				DD0000MQTTFWDFLT00000000 /* MqttForwardFilter.swift */,
 			);
 			path = Mqtt;
 			sourceTree = "<group>";
@@ -2770,6 +2776,7 @@
 				DD7E5750000000000000008B /* LockdownPassphraseStoreTests.swift in Sources */,
 				DD0000DEVLNKTST000000001 /* DeviceLinkTests.swift in Sources */,
 				DD0000CHSETST0000000001 /* ChannelSetSaveTests.swift in Sources */,
+				DD0000MQTTFWDFLTTST00001 /* MqttForwardFilterTests.swift in Sources */,
 				DD1827FB0000000000000002 /* RegionCodesFirmwareLocaleTests.swift in Sources */,
 				DD000031STATMSGDISP00001 /* StatusMessageDisplayTests.swift in Sources */,
 				AA009MCT0000002000000001 /* MarkdownConverterTests.swift in Sources */,
@@ -3085,6 +3092,7 @@
 				DDB8F4142A9EE5F000230ECE /* ChannelList.swift in Sources */,
 				BCB35B4F2E5FC42500B04F60 /* MessageNodeIntent.swift in Sources */,
 				DDD43FE32A78C8900083A3E9 /* MqttClientProxyManager.swift in Sources */,
+				DD0000MQTTFWDFLT00000001 /* MqttForwardFilter.swift in Sources */,
 				BCD7448D2E0F2FAA00F265A2 /* ContactURLHandler.swift in Sources */,
 				BEEF00102F00000100000002 /* MeshtasticChannelURL.swift in Sources */,
 				DD007BB02AA5981000F5FA12 /* NodeInfoEntityExtension.swift in Sources */,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
@@ -12,10 +12,12 @@ import OSLog
 import MeshtasticProtobufs
 
 // Serialises MQTT-sourced BLE writes by allowing at most one forwarded packet
-// in-flight over BLE at any time. CocoaMQTT calls its delegate on a background
-// thread; this actor gates entry and drops packets that arrive while a write is
-// already in progress rather than queuing them, preventing the device firmware
-// from being overwhelmed by global broker traffic.
+// in-flight over BLE at any time. CocoaMQTT delivers its delegate callbacks on
+// its default `delegateQueue` (DispatchQueue.main) and we never override it, so
+// the receive handler runs on the main actor; each forward still kicks off an
+// async BLE write, and this actor gates entry and drops packets that arrive
+// while a write is already in progress rather than queuing them, preventing the
+// device firmware from being overwhelmed by global broker traffic.
 actor MqttForwardGate {
 	private var busy = false
 

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
@@ -98,13 +98,31 @@ extension AccessoryManager {
 			return
 		}
 
+		let rawData = Data(message.payload)
+
+		// Parse the ServiceEnvelope once. Fail open: unparseable bytes are
+		// forwarded unchanged (nil `parsed`), exactly as before this filter existed.
+		let parsed = try? ServiceEnvelope(serializedData: rawData)
+
+		// Drop provably-undeliverable packets before spending any BLE bandwidth on
+		// them. In client-proxy mode the public broker floods payload-less stubs the
+		// node can only decrypt-fail and discard; stopping them here saves BLE
+		// airtime, a decrypt attempt, and a node-side WARN per packet.
+		if let envelope = parsed {
+			let myHex = myNodeNum == 0 ? "" : myNodeNum.toHex()
+			if MqttForwardFilter.decide(envelope: envelope, myNodeHex: myHex) == .dropNoPayload {
+				mqttProxyDroppedNoPayload += 1
+				Logger.services.debug("📲 [MQTT] drop (no payload) topic=\(message.topic, privacy: .public) count=\(self.mqttProxyDroppedNoPayload, privacy: .public)")
+				return
+			}
+		}
+
 		// Clamp hop_limit to 0 on downlink ServiceEnvelopes before forwarding to
 		// the device. Packets with hop_limit > 0 would be re-broadcast over RF,
 		// flooding the mesh with traffic that arrived via MQTT. hop_start is
 		// preserved so receivers can still compute how far the packet travelled.
-		let rawData = Data(message.payload)
 		let forwardData: Data
-		if var envelope = try? ServiceEnvelope(serializedData: rawData),
+		if var envelope = parsed,
 		   envelope.hasPacket, envelope.packet.hopLimit > 0 {
 			let original = envelope.packet.hopLimit
 			envelope.packet.hopLimit = 0

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -235,7 +235,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 	// Debug counter: MQTT client-proxy downlink packets dropped before forwarding
 	// to the device because they carried no payload (see MqttForwardFilter). NOT
-	// @Published — mutated on the MQTT delegate path, read only for debug logging.
+	// @Published — read only for debug logging, so it needn't drive view updates.
+	// Mutated on the main actor: CocoaMQTT delivers delegate callbacks on its
+	// default main delegateQueue, so onMqttMessageReceived runs on MainActor.
 	var mqttProxyDroppedNoPayload: Int = 0
 	
 	// Continuations

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -232,6 +232,11 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	// RXTXIndicatorWidget observes these via onChange polling.
 	var packetsSent: Int = 0
 	var packetsReceived: Int = 0
+
+	// Debug counter: MQTT client-proxy downlink packets dropped before forwarding
+	// to the device because they carried no payload (see MqttForwardFilter). NOT
+	// @Published — mutated on the MQTT delegate path, read only for debug logging.
+	var mqttProxyDroppedNoPayload: Int = 0
 	
 	// Continuations
 	var wantConfigContinuation: CheckedContinuation<Void, Error>?

--- a/Meshtastic/Helpers/Mqtt/MqttForwardFilter.swift
+++ b/Meshtastic/Helpers/Mqtt/MqttForwardFilter.swift
@@ -1,0 +1,66 @@
+//
+//  MqttForwardFilter.swift
+//  Meshtastic
+//
+//  Decides whether a downlink MQTT ServiceEnvelope received from the broker is
+//  worth forwarding to the connected node over BLE. In client-proxy mode the
+//  public broker delivers a large, continuous stream of packets the node cannot
+//  use — most visibly payload-less packet-header stubs on LongFast — and the app
+//  is the cheapest place to drop them (it already holds the bytes). Pure and
+//  side-effect free so the decision can be exhaustively unit-tested without an
+//  AccessoryManager, SwiftData, or the CocoaMQTT delegate thread.
+//
+
+import Foundation
+import MeshtasticProtobufs
+
+/// Why a downlink MQTT packet was (or was not) forwarded to the node.
+enum MqttForwardDecision: Equatable {
+	/// Forward the packet to the device (the default; fail-open outcome).
+	case forward
+	/// Drop: the inner MeshPacket carries no payload, so there is nothing the
+	/// node could ever act on (Tier 1).
+	case dropNoPayload
+}
+
+/// Pure decision for the MQTT client-proxy receive path. Fails open: it only
+/// returns `.dropNoPayload` for a packet it can positively prove is undeliverable;
+/// anything uncertain forwards unchanged, exactly as before the filter existed.
+enum MqttForwardFilter {
+
+	/// - Parameters:
+	///   - envelope:  the already-parsed ServiceEnvelope (unparseable bytes are
+	///                forwarded at the call site, before this runs).
+	///   - myNodeHex: the connected node's hex id (e.g. "!433e2700"); pass "" when unknown.
+	static func decide(envelope: ServiceEnvelope, myNodeHex: String) -> MqttForwardDecision {
+		// Guard: our own echoed-back packet. The node uses these as implicit ACKs
+		// to stop retransmissions, so they must never be dropped. (They carry a
+		// payload and would pass Tier 1 anyway; the explicit guard keeps a future
+		// change from breaking ACKs.)
+		if !myNodeHex.isEmpty,
+		   envelope.gatewayID.caseInsensitiveCompare(myNodeHex) == .orderedSame {
+			return .forward
+		}
+
+		// Guard: the node intentionally accepts PKC direct messages on the PKI
+		// topic without decrypting them first. Never filter PKI traffic.
+		if envelope.channelID == "PKI" {
+			return .forward
+		}
+
+		// No packet at all → nothing we can prove undeliverable; fail open.
+		// (A packet-less envelope's `.packet` is a default MeshPacket with a nil
+		// payload variant, which must NOT be treated as a Tier 1 drop.)
+		guard envelope.hasPacket else {
+			return .forward
+		}
+
+		// Tier 1: a MeshPacket with neither `decoded` nor `encrypted` set carries
+		// nothing the node can use. No legitimate Meshtastic packet is payload-less.
+		if envelope.packet.payloadVariant == nil {
+			return .dropNoPayload
+		}
+
+		return .forward
+	}
+}

--- a/MeshtasticTests/MqttForwardFilterTests.swift
+++ b/MeshtasticTests/MqttForwardFilterTests.swift
@@ -1,0 +1,107 @@
+//
+//  MqttForwardFilterTests.swift
+//  MeshtasticTests
+//
+//  Coverage for the MQTT client-proxy downlink filter (MqttForwardFilter). In
+//  client-proxy mode the public broker floods payload-less packet-header stubs
+//  the node cannot use; the filter drops those before they cost BLE bandwidth,
+//  while always forwarding real traffic and the PKI / own-echo guard cases.
+//
+
+import Testing
+import Foundation
+@testable import Meshtastic
+import MeshtasticProtobufs
+
+@Suite("MQTT Forward Filter")
+struct MqttForwardFilterTests {
+
+	/// Builds a ServiceEnvelope for the filter under test.
+	/// - `hasPacket == false` leaves the inner packet unset (envelope.hasPacket == false).
+	private func makeEnvelope(
+		gatewayID: String = "!aabbccdd",
+		channelID: String = "LongFast",
+		hasPacket: Bool = true,
+		payload: MeshPacket.OneOf_PayloadVariant? = nil,
+		channel: UInt32 = 0
+	) -> ServiceEnvelope {
+		var env = ServiceEnvelope()
+		env.gatewayID = gatewayID
+		env.channelID = channelID
+		if hasPacket {
+			var pkt = MeshPacket()
+			pkt.channel = channel
+			if let payload {
+				pkt.payloadVariant = payload
+			}
+			env.packet = pkt
+		}
+		return env
+	}
+
+	private let myHex = "!433e2700"
+
+	// MARK: - Real payloads are always forwarded
+
+	@Test("Decoded payload is forwarded")
+	func decodedForwarded() {
+		let env = makeEnvelope(payload: .decoded(DataMessage()))
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .forward)
+	}
+
+	@Test("Encrypted payload is forwarded")
+	func encryptedForwarded() {
+		let env = makeEnvelope(payload: .encrypted(Data([0x01, 0x02, 0x03])), channel: 0x08)
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .forward)
+	}
+
+	// MARK: - Tier 1: payload-less stubs are dropped
+
+	@Test("Payload-less packet is dropped")
+	func payloadlessDropped() {
+		// The observed LongFast flood: a packet with no payload variant, channel 0.
+		let env = makeEnvelope(payload: nil, channel: 0)
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .dropNoPayload)
+	}
+
+	// MARK: - Guards: never drop
+
+	@Test("PKI topic is never dropped, even when payload-less")
+	func pkiGuard() {
+		let env = makeEnvelope(channelID: "PKI", payload: nil)
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .forward)
+	}
+
+	@Test("Own echo (gateway == my node) is never dropped, even when payload-less")
+	func ownEchoGuard() {
+		let env = makeEnvelope(gatewayID: myHex, payload: nil)
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .forward)
+	}
+
+	@Test("Own-echo guard is case-insensitive")
+	func ownEchoGuardCaseInsensitive() {
+		let env = makeEnvelope(gatewayID: "!433E2700", payload: nil)
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .forward)
+	}
+
+	@Test("A different gateway's payload-less packet is still dropped")
+	func otherGatewayDropped() {
+		let env = makeEnvelope(gatewayID: "!deadbeef", payload: nil)
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .dropNoPayload)
+	}
+
+	@Test("Unknown local node id does not suppress dropping")
+	func emptyMyHexDrops() {
+		// Empty hex must never accidentally match a gateway id.
+		let env = makeEnvelope(gatewayID: "!deadbeef", payload: nil)
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: "") == .dropNoPayload)
+	}
+
+	// MARK: - Fail open
+
+	@Test("Envelope with no packet is forwarded (fail open)")
+	func noPacketForwarded() {
+		let env = makeEnvelope(hasPacket: false)
+		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .forward)
+	}
+}

--- a/MeshtasticTests/MqttForwardFilterTests.swift
+++ b/MeshtasticTests/MqttForwardFilterTests.swift
@@ -22,15 +22,13 @@ struct MqttForwardFilterTests {
 		gatewayID: String = "!aabbccdd",
 		channelID: String = "LongFast",
 		hasPacket: Bool = true,
-		payload: MeshPacket.OneOf_PayloadVariant? = nil,
-		channel: UInt32 = 0
+		payload: MeshPacket.OneOf_PayloadVariant? = nil
 	) -> ServiceEnvelope {
 		var env = ServiceEnvelope()
 		env.gatewayID = gatewayID
 		env.channelID = channelID
 		if hasPacket {
 			var pkt = MeshPacket()
-			pkt.channel = channel
 			if let payload {
 				pkt.payloadVariant = payload
 			}
@@ -51,7 +49,7 @@ struct MqttForwardFilterTests {
 
 	@Test("Encrypted payload is forwarded")
 	func encryptedForwarded() {
-		let env = makeEnvelope(payload: .encrypted(Data([0x01, 0x02, 0x03])), channel: 0x08)
+		let env = makeEnvelope(payload: .encrypted(Data([0x01, 0x02, 0x03])))
 		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .forward)
 	}
 
@@ -59,8 +57,8 @@ struct MqttForwardFilterTests {
 
 	@Test("Payload-less packet is dropped")
 	func payloadlessDropped() {
-		// The observed LongFast flood: a packet with no payload variant, channel 0.
-		let env = makeEnvelope(payload: nil, channel: 0)
+		// The observed LongFast flood: a packet with no payload variant.
+		let env = makeEnvelope(payload: nil)
 		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .dropNoPayload)
 	}
 


### PR DESCRIPTION
## Summary

When a node uses the app as its MQTT **client proxy** (`mqtt.proxy_to_client_enabled`), the app forwards **every** message it receives from the broker to the node over BLE. On the public broker a large, continuous fraction of that traffic is stuff the node **provably cannot use** — most visibly a flood of **payload-less, channel-hash-0 packet-header stubs** on `LongFast`:

```
INFO  | [NimbleBluetooth] Received MQTT topic msh/US/2/e/LongFast/!849a248c, len=50
WARN  | [NimbleBluetooth] No suitable channel found for decoding, hash was 0x0!
```

The node pays BLE bandwidth + a decrypt attempt + a `WARN` per packet, only to drop it. The app already has the bytes and everything needed to know the node can't use them, so it's the right place to stop this one hop earlier.

## What changed

In the MQTT-proxy **receive** path (`AccessoryManager+MQTT.swift` → `onMqttMessageReceived`), the inbound `ServiceEnvelope` is now parsed **once** and run through a small pure filter (`MqttForwardFilter`) **before** the `MqttClientProxyMessage`/`ToRadio` is built and before the BLE forward gate is touched.

**Tier 1 (this PR):** drop packets whose `MeshPacket` has **no payload variant** (neither `decoded` nor `encrypted`). No legitimate Meshtastic packet is payload-less, and this alone eliminated 100% of the observed flood in captures of the public US `LongFast` firehose.

**Fail open + guards — never drops anything the node can use:**
- Unparseable bytes → forwarded unchanged (behavior identical to before).
- `channel_id == "PKI"` → forwarded (the node accepts PKC DMs without decrypting).
- `gateway_id == <our own node id>` → forwarded (our echoed-back packets are implicit ACKs). These carry a payload and would pass Tier 1 anyway; the guard is explicit so a future change can't break ACKs.

A debug counter + `Logger.services` line (`📲 [MQTT] drop (no payload) …`) makes the effect observable.

## Why the app, not the node
The node can't subscribe more narrowly (the topic only wildcards on gateway-id), and it already drops these correctly — but only *after* the app spent BLE bandwidth delivering each one and the node spent a decrypt attempt + log line. All of that is avoidable one hop earlier, at no extra network cost.

## Testing
- New `MqttForwardFilterTests` (Swift Testing) — 9 cases: decoded/encrypted forwarded; payload-less dropped; PKI/own-echo (incl. case-insensitive) guards; different-gateway + empty-node-id still drop; packet-less envelope fails open. All pass.
- Full app + test target builds clean; existing suites unaffected.

## Scope
Tier 1 + guards only, default-on. The optional Tier 2 (dropping *encrypted* packets for channels the node doesn't have) from the investigation is intentionally **not** included here to keep this change zero-risk. A companion PR applies the same Tier 1 filter to Meshtastic-Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MQTT forwarding-decision layer for MQTT downlinks to reduce unnecessary forwarding.
  * Introduced unit tests that validate when MQTT downlinks are forwarded vs. dropped.

* **Bug Fixes**
  * Prevents forwarding of MQTT downlinks that are detected as having no payload (when applicable).
  * Preserves forwarding for gateway echo/implicit-ack traffic and protected channel traffic.
  * Adds debug tracking for dropped MQTT downlinks due to missing payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->