### PR TITLE
feat: clear delivered iOS notifications when a channel or DM is read

### DIFF
--- a/Meshtastic/Helpers/LocalNotificationManager.swift
+++ b/Meshtastic/Helpers/LocalNotificationManager.swift
@@ -136,6 +136,57 @@ class LocalNotificationManager {
 			}
 		}
 	}
+
+	// Remove already-delivered notifications for an entire channel conversation.
+	//
+	// Called when the user opens or catches up on a channel so that notifications for messages they
+	// have now read stop piling up in Notification Center. Message notifications are tagged in
+	// `userInfo` when scheduled (see `scheduleNotifications`). Channel notifications are identified
+	// by their deep-link `path` (`?channelId=`) so direct messages that happen to share the same
+	// channel index are left untouched. Delivered notifications round-trip through the system, so the
+	// numeric `userInfo` values come back as `NSNumber`.
+	func removeDeliveredNotifications(forChannel channelIndex: Int32) {
+		UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
+			let identifiers = notifications.compactMap { notification -> String? in
+				let userInfo = notification.request.content.userInfo
+				guard let path = userInfo["path"] as? String, path.contains("?channelId="),
+					  let channel = (userInfo["channel"] as? NSNumber)?.int32Value,
+					  channel == channelIndex else {
+					return nil
+				}
+				return notification.request.identifier
+			}
+
+			if !identifiers.isEmpty {
+				Logger.services.debug("Removing \(identifiers.count, privacy: .public) delivered channel notifications")
+				UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: identifiers)
+			}
+		}
+	}
+
+	// Remove already-delivered notifications for an entire direct-message conversation.
+	//
+	// Called when the user opens or catches up on a DM thread. Direct-message notifications are
+	// identified by their deep-link `path` (`?userNum=`) and matched on the remote node number so
+	// channel notifications that carry an unrelated `userNum` value are left untouched.
+	func removeDeliveredNotifications(forDirectMessageUserNum userNum: Int64) {
+		UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
+			let identifiers = notifications.compactMap { notification -> String? in
+				let userInfo = notification.request.content.userInfo
+				guard let path = userInfo["path"] as? String, path.contains("?userNum="),
+					  let num = (userInfo["userNum"] as? NSNumber)?.int64Value,
+					  num == userNum else {
+					return nil
+				}
+				return notification.request.identifier
+			}
+
+			if !identifiers.isEmpty {
+				Logger.services.debug("Removing \(identifiers.count, privacy: .public) delivered direct message notifications")
+				UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: identifiers)
+			}
+		}
+	}
 }
 
 struct Notification {

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -91,6 +91,9 @@ struct ChannelMessageList: View {
 				readMessageIDs.append(unreadTapback.messageId)
 			}
 			notificationManager.cancelNotificationsForMessageIds(readMessageIDs)
+			// Also clear any notifications for this channel that were already delivered to Notification
+			// Center, so catching up on the channel wipes its piled-up notifications.
+			notificationManager.removeDeliveredNotifications(forChannel: channelIndex)
 			if context.hasChanges {
 				try context.save()
 			}

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -83,6 +83,9 @@ struct UserMessageList: View {
 				readMessageIDs.append(unreadTapback.messageId)
 			}
 			notificationManager.cancelNotificationsForMessageIds(readMessageIDs)
+			// Also clear any notifications for this conversation that were already delivered to
+			// Notification Center, so opening the DM wipes its piled-up notifications.
+			notificationManager.removeDeliveredNotifications(forDirectMessageUserNum: user.num)
 			if context.hasChanges {
 				try context.save()
 			}


### PR DESCRIPTION
## What

Incoming message notifications stayed in iOS Notification Center even after the user had read the messages, so they piled up indefinitely. Reading a conversation only cancelled still-**pending** notification requests (`removePendingNotificationRequests`) — it never removed the ones that had already been **delivered**.

This makes reading a conversation clear its already-delivered notifications:

- Opening / catching up on a **channel** now removes that channel's delivered notifications.
- Opening / catching up on a **DM** now removes that conversation's delivered notifications.

## Why

Users see Meshtastic notifications accumulate on the lock screen / Notification Center long after they've read the messages in-app. Catching up in the app should clear the corresponding notifications.

## How

Message notifications are already tagged in `userInfo` when scheduled (`scheduleNotifications` in `LocalNotificationManager`) with the deep-link `path`, `channel` index, and sender `userNum`. Two new helpers query delivered notifications and remove only the matching ones:

- `removeDeliveredNotifications(forChannel:)` — matches channel notifications via their `?channelId=` path plus the channel index.
- `removeDeliveredNotifications(forDirectMessageUserNum:)` — matches DM notifications via their `?userNum=` path plus the remote node number.

Because both channel and DM notifications carry a `channel` **and** a `userNum` value, the deep-link `path` is used to tell the two conversation types apart so a channel and a DM are never cleared for one another. Other notification types (waypoint, low-battery, etc.) use different paths and are untouched.

They're invoked from the existing `markMessagesAsRead()` paths in `ChannelMessageList` and `UserMessageList`, right after the existing pending-cancel call.

## Notes

- The app-icon badge is unchanged: it's still driven by the unread counts updated in the same `markMessagesAsRead()` path, so the muted-channel badge behavior from #2050 is not affected.
- Delivered notifications round-trip through the system, so the numeric `userInfo` values are read back as `NSNumber`.

## Testing

I was not able to build or run this on a device/simulator in my environment (no full Xcode available), so this has **not** yet been verified at runtime — relying on CI to compile. The change is small, follows the existing `cancelNotificationsForMessageIds` pattern in the same file, and reuses `userInfo` tags that are already populated. Runtime confirmation on a device (generate channel + DM notifications, background the app, open each conversation, confirm only that conversation's notifications clear) would be appreciated before merge. Automated coverage of `UNUserNotificationCenter` delivery isn't practical in the unit-test target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing a channel or direct-message conversation as read now also removes its already-delivered notifications.
  * Prevents previously delivered conversation alerts from remaining in Notification Center after messages have been viewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->