### PR TITLE
Remove satellites-in-view row from map position popover

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/PositionPopover.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/PositionPopover.swift
@@ -111,19 +111,6 @@ struct PositionPopover: View {
 						}
 						.padding(.bottom, 5)
 						let pf = PositionFlags(rawValue: Int(position.nodePosition?.metadata?.positionFlags ?? 3))
-						/// Sats in view
-						if pf.contains(.Satsinview) {
-							Label {
-								Text("Sats in view: \(String(position.satsInView))")
-									.foregroundColor(.primary)
-									.font(idiom == .phone ? .callout : .body)
-							} icon: {
-								Image(systemName: "sparkles")
-									.symbolRenderingMode(.hierarchical)
-									.frame(width: 35)
-							}
-							.padding(.bottom, 5)
-						}
 						/// Sequence Number
 						if pf.contains(.SeqNo) {
 							Label {


### PR DESCRIPTION
## What changed?

Removed the "Sats in view: N" row from the map position popover (`Meshtastic/Views/Nodes/Helpers/Map/PositionPopover.swift`). The `PositionFlags` declaration is retained since it's still used by the Sequence Number and other flag-gated rows in the same popover.

## Why did it change?

Per [meshtastic/design#44](https://github.com/meshtastic/design/issues/44), satellites-in-view is not a useful/reliable metric to surface in primary, at-a-glance UI — it's commonly misread as a proxy for GPS position quality, which it isn't. The map popover is a primary/at-a-glance surface, so this value should not appear there.

The value intentionally **remains** available in the raw-data surfaces that are allowed to show it:
- Raw Position Log view (`PositionLog.swift`)
- CSV export (`WriteCsvFile.swift`)

These were left untouched.

This aligns iOS with the cross-platform effort tracked in meshtastic/design#44 (Android counterpart: [meshtastic/Meshtastic-Android#6089](https://github.com/meshtastic/Meshtastic-Android/issues/6089)).

Fixes #2038

## How is this tested?

- Verified the popover no longer renders the "Sats in view" row while other flag-gated rows (Sequence, Heading, etc.) still display correctly.
- Confirmed `satsInView` remains referenced and displayed in `PositionLog.swift` and exported by `WriteCsvFile.swift`.
- SourceKit-LSP reports no diagnostics for the changed file; SwiftLint reports no violations.

## Screenshots/Videos (when applicable)

N/A — removal of a single info row.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the “Sats in view” detail from node position popovers.
  * Other available position details, including altitude and sequence number, continue to display as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->