### PR TITLE
feat(map): let a waypoint be sent as a DM or to a specific channel

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -382,6 +382,9 @@
 		DD457188293C7E63000C49FB /* BLESignalStrengthIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD457187293C7E63000C49FB /* BLESignalStrengthIndicator.swift */; };
 		DD4640202AFF10F4002A5ECB /* WaypointForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD46401F2AFF10F4002A5ECB /* WaypointForm.swift */; };
 		AABBCCDD0000000000000005 /* GeofenceBoundsSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDD0000000000000006 /* GeofenceBoundsSelectorView.swift */; };
+		AABBCCDD0000000000000007 /* WaypointDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDD0000000000000008 /* WaypointDestination.swift */; };
+		AABBCCDD0000000000000009 /* WaypointRecipientPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDD000000000000000A /* WaypointRecipientPicker.swift */; };
+		AABBCCDD000000000000000B /* WaypointDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDD000000000000000C /* WaypointDestinationTests.swift */; };
 		DD4756AB2E9F1A0000029299 /* SecurityVersionNag.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4756AA2E9F1A0000029299 /* SecurityVersionNag.swift */; };
 		DD47E3D626F17ED900029299 /* CircleText.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD47E3D526F17ED900029299 /* CircleText.swift */; };
 		DD4975A52B147BA90026544E /* AmbientLightingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4975A42B147BA90026544E /* AmbientLightingConfig.swift */; };
@@ -1018,6 +1021,9 @@
 		DD457BC4295D5E35004BCE4D /* MeshtasticDataModelV5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV5.xcdatamodel; sourceTree = "<group>"; };
 		DD46401F2AFF10F4002A5ECB /* WaypointForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointForm.swift; sourceTree = "<group>"; };
 		AABBCCDD0000000000000006 /* GeofenceBoundsSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceBoundsSelectorView.swift; sourceTree = "<group>"; };
+		AABBCCDD0000000000000008 /* WaypointDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointDestination.swift; sourceTree = "<group>"; };
+		AABBCCDD000000000000000A /* WaypointRecipientPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointRecipientPicker.swift; sourceTree = "<group>"; };
+		AABBCCDD000000000000000C /* WaypointDestinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointDestinationTests.swift; sourceTree = "<group>"; };
 		DD4756AA2E9F1A0000029299 /* SecurityVersionNag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityVersionNag.swift; sourceTree = "<group>"; };
 		DD47E3D526F17ED900029299 /* CircleText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleText.swift; sourceTree = "<group>"; };
 		DD4975A42B147BA90026544E /* AmbientLightingConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientLightingConfig.swift; sourceTree = "<group>"; };
@@ -1643,6 +1649,7 @@
 				DDBEAC0010000000000000C1 /* DiscoveredBeaconEntityTests.swift */,
 				DDBEAC001000000000000121 /* ModemPresetFrequencySlotTests.swift */,
 				DDBEAC001000000000000141 /* BeaconAddVsSwitchTests.swift */,
+				AABBCCDD000000000000000C /* WaypointDestinationTests.swift */,
 				DDBEAC001000000000000201 /* MeshBeaconConfigEditorTests.swift */,
 				18295AFE686247778632C6DE /* NetworkConfigIPConversionTests.swift */,
 				64C6057F9508D4356DAF411F /* DiscoveryModelTests.swift */,
@@ -2099,6 +2106,7 @@
 				DD00003ASUPPORTLVL0000000 /* SupportLevel.swift */,
 				DD994B68295F88B60013760A /* IntervalEnums.swift */,
 				D93068D42B812B700066FBC8 /* MessageDestination.swift */,
+				AABBCCDD0000000000000008 /* WaypointDestination.swift */,
 				DDA9515B2BC6631200CEA535 /* TelemetryEnums.swift */,
 				DD000031FWEDTENUM0000000 /* FirmwareEditionEnum.swift */,
 				AB6E72752E3FC85A00639328 /* LayoutEnums.swift */,
@@ -2135,6 +2143,7 @@
 				DD46401F2AFF10F4002A5ECB /* WaypointForm.swift */,
 				AABBCCDD0000000000000006 /* GeofenceBoundsSelectorView.swift */,
 				DD1933752B0835D500771CD5 /* PositionAltitudeChart.swift */,
+				AABBCCDD000000000000000A /* WaypointRecipientPicker.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -2770,6 +2779,7 @@
 				DDBEAC0010000000000000D1 /* DiscoveredBeaconEntityTests.swift in Sources */,
 				DDBEAC001000000000000131 /* ModemPresetFrequencySlotTests.swift in Sources */,
 				DDBEAC001000000000000151 /* BeaconAddVsSwitchTests.swift in Sources */,
+				AABBCCDD000000000000000B /* WaypointDestinationTests.swift in Sources */,
 				DDBEAC001000000000000211 /* MeshBeaconConfigEditorTests.swift in Sources */,
 				FDAF8808342245C4817C93EC /* NetworkConfigIPConversionTests.swift in Sources */,
 				1396606FC903D7DA662B6326 /* DiscoveryModelTests.swift in Sources */,
@@ -2987,6 +2997,7 @@
 				233E99B82D849C6500CC3A77 /* HumidityCompactWidget.swift in Sources */,
 				DD4640202AFF10F4002A5ECB /* WaypointForm.swift in Sources */,
 				AABBCCDD0000000000000005 /* GeofenceBoundsSelectorView.swift in Sources */,
+				AABBCCDD0000000000000009 /* WaypointRecipientPicker.swift in Sources */,
 				233E99C12D849D6000CC3A77 /* DistanceCompactWidget.swift in Sources */,
 				DD769E0328D18BF1001A3F05 /* DeviceMetricsLog.swift in Sources */,
 				108FFECD2DD4005600BFAA81 /* NodeInfoEntityToNodeInfo.swift in Sources */,
@@ -3221,6 +3232,7 @@
 				DDAB580D2B0DAA9E00147258 /* Routes.swift in Sources */,
 				BCB613832C672A2600485544 /* MessageChannelIntent.swift in Sources */,
 				D93068D52B812B700066FBC8 /* MessageDestination.swift in Sources */,
+				AABBCCDD0000000000000007 /* WaypointDestination.swift in Sources */,
 				BC10380F2DD4334400B00BFA /* AddContactIntent.swift in Sources */,
 				DDA9515E2BC6F56F00CEA535 /* IndoorAirQuality.swift in Sources */,
 				DDDB444E29F8AB0E00EE2349 /* Int.swift in Sources */,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -270,6 +270,34 @@ extension AccessoryManager {
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 	}
 
+	/// Applies PKC (public-key encrypted) routing to `meshPacket` when `toUser` has a known public key —
+	/// the same check `sendMessage` uses for direct messages, shared here so waypoint DMs route
+	/// identically instead of re-deriving the rule. Also proactively re-shares our contact info for
+	/// `toUser` with the device, so a peer that's rolled out of the on-device node db doesn't produce a
+	/// PKI Failed error.
+	private func applyPKCRoutingIfNeeded(to meshPacket: inout MeshPacket, toUser: UserEntity?) {
+		guard toUser?.pkiEncrypted ?? false else { return }
+		meshPacket.pkiEncrypted = true
+		meshPacket.publicKey = toUser?.publicKey ?? Data()
+		Task { @MainActor in
+			let am = AccessoryManager.shared
+			if let user = toUser {
+				var contact = SharedContact()
+				contact.manuallyVerified = false
+				contact.nodeNum = UInt32(truncatingIfNeeded: user.num)
+				user.userNode?.favorite = user.userNode?.deviceConfig?.role ?? 0 != DeviceRoles.clientBase.rawValue
+				contact.user = user.toProto()
+				do {
+					let contactString = try contact.serializedData().base64EncodedString()
+					try? await am.addContactFromURL(base64UrlString: contactString)
+					try context.save()
+				} catch {
+					Logger.services.error("Error inserting new contact and resending encrypted send failed message: \(error)")
+				}
+			}
+		}
+	}
+
 	public func sendMessage(message: String, toUserNum: Int64, channel: Int32, isEmoji: Bool, replyID: Int64) async throws {
 		guard let fromUserNum = self.activeConnection?.device.num else {
 			Logger.services.error("Error while sending CannedMessageModule request.  No active device.")
@@ -326,28 +354,7 @@ extension AccessoryManager {
 					dataMessage.portnum = dataType
 
 					var meshPacket = MeshPacket()
-					if newMessage.toUser?.pkiEncrypted ?? false {
-						meshPacket.pkiEncrypted = true
-						meshPacket.publicKey = newMessage.toUser?.publicKey ?? Data()
-						// Send a contact to the phone every time we send a dm so that any nodes that have rolled out of the db are there and we don't get a PKI Failed error
-						Task { @MainActor in
-							let am = AccessoryManager.shared
-							if let user = newMessage.toUser {
-								var contact = SharedContact()
-								contact.manuallyVerified = false
-								contact.nodeNum = UInt32(truncatingIfNeeded: user.num)
-								user.userNode?.favorite = user.userNode?.deviceConfig?.role ?? 0 != DeviceRoles.clientBase.rawValue
-								contact.user = user.toProto()
-								do {
-									let contactString = try contact.serializedData().base64EncodedString()
-									try? await am.addContactFromURL(base64UrlString: contactString)
-									try context.save()
-								} catch {
-									Logger.services.error("Error inserting new contact and resending encrypted send failed message: \(error)")
-								}
-							}
-						}
-					}
+					applyPKCRoutingIfNeeded(to: &meshPacket, toUser: newMessage.toUser)
 					meshPacket.id = UInt32(newMessage.messageId)
 					if toUserNum > 0 {
 						meshPacket.to = UInt32(toUserNum)
@@ -823,7 +830,7 @@ extension AccessoryManager {
 		Logger.mesh.info("➕ [Beacon] Added advertised channel '\(channelName, privacy: .private)' to secondary slot \(targetIndex, privacy: .public) — no reboot")
 	}
 
-	public func sendWaypoint(waypoint: Waypoint) async throws {
+	public func sendWaypoint(waypoint: Waypoint, destination: WaypointDestination = .broadcastPrimary) async throws {
 		guard let deviceNum = self.activeConnection?.device.num else {
 			Logger.services.error("Error while sending sendWaypoint request.  No active device.")
 			throw AccessoryError.ioFailed("No active device")
@@ -835,9 +842,17 @@ extension AccessoryManager {
 
 		let fromNodeNum = UInt32(deviceNum)
 		var meshPacket = MeshPacket()
-		meshPacket.to = Constants.maximumNodeNum
 		meshPacket.from	= fromNodeNum
 		meshPacket.wantAck = true
+		switch destination {
+		case let .channel(index):
+			meshPacket.to = Constants.maximumNodeNum
+			meshPacket.channel = UInt32(index)
+		case let .user(destNum):
+			meshPacket.to = UInt32(destNum)
+			let userFetch = FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == destNum })
+			applyPKCRoutingIfNeeded(to: &meshPacket, toUser: try? context.fetch(userFetch).first)
+		}
 		var dataMessage = DataMessage()
 		do {
 			dataMessage.payload = try waypoint.serializedData()
@@ -862,6 +877,7 @@ extension AccessoryManager {
 			wayPointEntity.icon	= Int64(waypoint.icon)
 			wayPointEntity.latitudeI = waypoint.latitudeI
 			wayPointEntity.longitudeI = waypoint.longitudeI
+			wayPointEntity.destination = destination
 			if waypoint.expire > 1 {
 				wayPointEntity.expire = Date.init(timeIntervalSince1970: Double(waypoint.expire))
 			} else {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -847,7 +847,11 @@ extension AccessoryManager {
 		switch destination {
 		case let .channel(index):
 			meshPacket.to = Constants.maximumNodeNum
-			meshPacket.channel = UInt32(index)
+			// truncatingIfNeeded, not UInt32(index): index round-trips from an incoming packet's
+			// channel field via Int32(truncatingIfNeeded:), which can produce a negative Int32 from a
+			// malformed/out-of-range value — a trapping UInt32(_:) here would crash on resend (e.g.
+			// "delete for everyone") for a waypoint that was never valid to begin with.
+			meshPacket.channel = UInt32(truncatingIfNeeded: index)
 		case let .user(destNum):
 			meshPacket.to = UInt32(destNum)
 			// Waypoint DMs have no source-channel context to inherit (unlike sendMessage, which is always

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -850,6 +850,11 @@ extension AccessoryManager {
 			meshPacket.channel = UInt32(index)
 		case let .user(destNum):
 			meshPacket.to = UInt32(destNum)
+			// Waypoint DMs have no source-channel context to inherit (unlike sendMessage, which is always
+			// sent from within a specific channel/DM view) — explicitly use the primary channel's PSK as
+			// the fallback encryption key for non-PKC recipients, matching sendMessage's always-set
+			// meshPacket.channel instead of relying on the protobuf zero-value default.
+			meshPacket.channel = 0
 			let userFetch = FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == destNum })
 			applyPKCRoutingIfNeeded(to: &meshPacket, toUser: try? context.fetch(userFetch).first)
 		}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -713,7 +713,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 						Logger.mesh.error("🕸️ Unable to determine connectedNodeNum for waypoint packet. Skipping.")
 						return
 					}
-					await MeshPackets.shared.waypointPacket(packet: packet, myNodeNum: UInt32(connectedNodeNum))
+					await MeshPackets.shared.waypointPacket(packet: packet, myNodeNum: UInt32(truncatingIfNeeded: connectedNodeNum))
 					// Broadcast waypoint to TAK clients
 					if let waypoint = try? Waypoint(serializedBytes: data.payload) {
 						Logger.tak.info("WAYPOINT PARSED: \(waypoint.name)")

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -705,7 +705,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 					}
 				case .waypointApp:
 					Logger.tak.info("WAYPOINT APP CASE REACHED")
-					await MeshPackets.shared.waypointPacket(packet: packet)
+					await MeshPackets.shared.waypointPacket(packet: packet, myNodeNum: self.activeDeviceNum.map(UInt32.init))
 					// Broadcast waypoint to TAK clients
 					if let waypoint = try? Waypoint(serializedBytes: data.payload) {
 						Logger.tak.info("WAYPOINT PARSED: \(waypoint.name)")

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -705,7 +705,15 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 					}
 				case .waypointApp:
 					Logger.tak.info("WAYPOINT APP CASE REACHED")
-					await MeshPackets.shared.waypointPacket(packet: packet, myNodeNum: self.activeDeviceNum.map(UInt32.init))
+					// Matches the .nodeinfoApp guard below: without a confirmed connectedNodeNum, waypointDestination
+					// can't tell whether we sent this DM ourselves or received it, and would rather skip than guess
+					// wrong (misattributing a DM we sent to ourselves instead of the real recipient). Self-healing —
+					// waypoints get rebroadcast/resynced later once we're fully connected.
+					guard let connectedNodeNum = self.activeDeviceNum else {
+						Logger.mesh.error("🕸️ Unable to determine connectedNodeNum for waypoint packet. Skipping.")
+						return
+					}
+					await MeshPackets.shared.waypointPacket(packet: packet, myNodeNum: UInt32(connectedNodeNum))
 					// Broadcast waypoint to TAK clients
 					if let waypoint = try? Waypoint(serializedBytes: data.payload) {
 						Logger.tak.info("WAYPOINT PARSED: \(waypoint.name)")

--- a/Meshtastic/Enums/WaypointDestination.swift
+++ b/Meshtastic/Enums/WaypointDestination.swift
@@ -1,0 +1,52 @@
+//
+//  WaypointDestination.swift
+//  Meshtastic
+//
+
+import Foundation
+import MeshtasticProtobufs
+
+/// Where a waypoint is addressed: broadcast on a channel (including the primary channel, index 0), or a
+/// private direct message to a specific node.
+enum WaypointDestination: Equatable {
+	case channel(Int32)
+	case user(Int64)
+
+	static let broadcastPrimary = WaypointDestination.channel(0)
+
+	var channelNum: Int32 {
+		switch self {
+		case let .channel(index): return index
+		case .user: return 0
+		}
+	}
+
+	var userNum: Int64 {
+		switch self {
+		case .channel: return 0
+		case let .user(num): return num
+		}
+	}
+}
+
+extension MeshPacket {
+	/// A packet addressed to the mesh-wide broadcast address rather than a single node.
+	var isBroadcast: Bool { to == Constants.maximumNodeNum }
+}
+
+/// The contact (channel or node) a waypoint packet was exchanged on. Used both when we send a waypoint and
+/// when we receive one, so re-editing or deleting an existing waypoint always routes back to the same
+/// conversation it was created in, instead of drifting to broadcast.
+///
+/// `packet.to` is only trustworthy as "the recipient" when we sent the packet ourselves or it was a
+/// broadcast. For a waypoint DM'd *to us* by someone else, `packet.to` is our own node number — reading it
+/// unconditionally would self-address any follow-up (re-editing, "delete for everyone") back to ourselves
+/// instead of the original sender, so the update would silently never reach them. When that's the case, fall
+/// back to `packet.from`, the sender.
+func waypointDestination(packet: MeshPacket, myNodeNum: UInt32?) -> WaypointDestination {
+	if packet.isBroadcast {
+		return .channel(Int32(packet.channel))
+	}
+	let contact = (myNodeNum != nil && packet.from == myNodeNum) ? packet.to : packet.from
+	return .user(Int64(contact))
+}

--- a/Meshtastic/Enums/WaypointDestination.swift
+++ b/Meshtastic/Enums/WaypointDestination.swift
@@ -45,7 +45,7 @@ extension MeshPacket {
 /// back to `packet.from`, the sender.
 func waypointDestination(packet: MeshPacket, myNodeNum: UInt32?) -> WaypointDestination {
 	if packet.isBroadcast {
-		return .channel(Int32(packet.channel))
+		return .channel(Int32(truncatingIfNeeded: packet.channel))
 	}
 	let contact = (myNodeNum != nil && packet.from == myNodeNum) ? packet.to : packet.from
 	return .user(Int64(contact))

--- a/Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift
@@ -67,3 +67,40 @@ extension ChannelEntity {
 		return channel
 	}
 }
+
+/// Deduped, index-sorted channels for `node`'s synced config — one entry per channel index (config sync can
+/// produce transient duplicate rows for the same index before settling). Shared by the Channels settings
+/// screen and the waypoint recipient picker so their channel lists never drift apart.
+func dedupedChannels(for node: NodeInfoEntity?) -> [ChannelEntity] {
+	guard let channels = node?.myInfo?.channels else { return [] }
+	var byIndex: [Int32: ChannelEntity] = [:]
+	for channel in channels {
+		byIndex[channel.index] = channel
+	}
+	return byIndex.values.sorted { $0.index < $1.index }
+}
+
+/// The channel treated as "primary" for display purposes: index 0, or explicitly marked role 1 — firmware
+/// can reassign which channel is primary without it being index 0.
+func primaryChannel(in channels: [ChannelEntity]) -> ChannelEntity? {
+	channels.first(where: { $0.index == 0 || $0.role == 1 })
+}
+
+/// Display name for the primary channel: its configured name if set, else "Custom" for a non-preset LoRa
+/// config, else the modem-preset's Android channel name (e.g. "LongFast"), falling back to "LongFast" if the
+/// preset can't be resolved (matching the Channels settings screen), or a generic "Broadcast" only when
+/// `node` itself is unavailable (e.g. the waypoint picker while disconnected — a case the Channels screen,
+/// which always has a node, never hits).
+func channelDisplayName(channels: [ChannelEntity], node: NodeInfoEntity?) -> String {
+	if let primary = primaryChannel(in: channels), let name = primary.name, !name.isEmpty {
+		return name
+	}
+	guard let node else { return "Broadcast".localized }
+	if node.loRaConfig?.usePreset == false {
+		return "Custom".localized
+	}
+	guard let preset = ModemPresets(rawValue: Int(node.loRaConfig?.modemPreset ?? 0)) else {
+		return "LongFast"
+	}
+	return preset.androidChannelName
+}

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1435,7 +1435,8 @@ actor MeshPackets {
 		}
 	}
 
-	func waypointPacket (packet: MeshPacket) {
+	func waypointPacket (packet: MeshPacket, myNodeNum: UInt32?) {
+		let destination = waypointDestination(packet: packet, myNodeNum: myNodeNum)
 		let waypointDetail = (try? Waypoint(serializedBytes: packet.decoded.payload)).map { w -> String in
 			var parts: [String] = []
 			let name = w.name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1478,6 +1479,7 @@ actor MeshPackets {
 					waypoint.icon = Int64(waypointMessage.icon)
 					waypoint.locked = waypointMessage.lockedTo != 0
 					waypoint.createdBy = Int64(packet.from)
+					waypoint.destination = destination
 					waypoint.applyGeofence(from: waypointMessage)
 					if waypointMessage.expire >= 1 {
 						waypoint.expire = Date(timeIntervalSince1970: TimeInterval(Int64(waypointMessage.expire)))
@@ -1523,6 +1525,7 @@ actor MeshPackets {
 							existingWaypoint.icon = Int64(waypointMessage.icon)
 							existingWaypoint.locked = waypointMessage.lockedTo != 0
 							existingWaypoint.lastUpdatedBy = Int64(packet.from)
+							existingWaypoint.destination = destination
 							existingWaypoint.applyGeofence(from: waypointMessage)
 							if waypointMessage.expire >= 1 {
 								existingWaypoint.expire = Date(timeIntervalSince1970: TimeInterval(Int64(waypointMessage.expire)))

--- a/Meshtastic/Model/WaypointEntity.swift
+++ b/Meshtastic/Model/WaypointEntity.swift
@@ -27,10 +27,13 @@ final class WaypointEntity {
 
 	/// Channel index this waypoint was broadcast on (0 = primary). Only meaningful when
 	/// `destinationNodeNum` is 0 — a DM'd waypoint's channel is irrelevant to where it's routed.
-	var destinationChannel: Int32 = 0
+	/// `private(set)`: write only through `destination` below, which keeps this and `destinationNodeNum`
+	/// mutually exclusive — setting them individually could otherwise leave both non-zero at once, an
+	/// invalid state `destination`'s getter would then have to silently pick a winner for.
+	private(set) var destinationChannel: Int32 = 0
 	/// Node this waypoint was privately sent to (or received from) as a DM. 0 means it's a channel
 	/// broadcast; see `destinationChannel`.
-	var destinationNodeNum: Int64 = 0
+	private(set) var destinationNodeNum: Int64 = 0
 
 	/// The recipient this waypoint is associated with, for re-opening it in the editor or resending it
 	/// (e.g. "delete for everyone") to the same destination it was originally exchanged on.

--- a/Meshtastic/Model/WaypointEntity.swift
+++ b/Meshtastic/Model/WaypointEntity.swift
@@ -23,6 +23,31 @@ final class WaypointEntity {
 	var longitudeI: Int32 = 0
 	var name: String?
 
+	// MARK: Send-to destination
+
+	/// Channel index this waypoint was broadcast on (0 = primary). Only meaningful when
+	/// `destinationNodeNum` is 0 — a DM'd waypoint's channel is irrelevant to where it's routed.
+	var destinationChannel: Int32 = 0
+	/// Node this waypoint was privately sent to (or received from) as a DM. 0 means it's a channel
+	/// broadcast; see `destinationChannel`.
+	var destinationNodeNum: Int64 = 0
+
+	/// The recipient this waypoint is associated with, for re-opening it in the editor or resending it
+	/// (e.g. "delete for everyone") to the same destination it was originally exchanged on.
+	var destination: WaypointDestination {
+		get { destinationNodeNum > 0 ? .user(destinationNodeNum) : .channel(destinationChannel) }
+		set {
+			switch newValue {
+			case let .channel(index):
+				destinationChannel = index
+				destinationNodeNum = 0
+			case let .user(num):
+				destinationChannel = 0
+				destinationNodeNum = num
+			}
+		}
+	}
+
 	// MARK: Geofence (mirrors the Waypoint protobuf geofence fields)
 
 	/// Circular geofence radius in meters, centred on the waypoint's own location. 0 = no circle.

--- a/Meshtastic/Persistence/NodeBackupManager+Import.swift
+++ b/Meshtastic/Persistence/NodeBackupManager+Import.swift
@@ -268,6 +268,7 @@ extension NodeBackupManager {
 			dst.longDescription = src.longDescription
 			dst.longitudeI = src.longitudeI
 			dst.name = src.name
+			dst.destination = src.destination
 			liveContext.insert(dst)
 		}
 	}

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -40,6 +40,9 @@ struct WaypointForm: View {
 	@State private var waypointFailedAlert: Bool = false
 	@State private var createdByNode: NodeInfoEntity?
 	@State private var lastUpdatedByNode: NodeInfoEntity?
+	@State private var connectedNode: NodeInfoEntity?
+	@State private var destination: WaypointDestination = .broadcastPrimary
+	@State private var showingRecipientPicker: Bool = false
 
 	var body: some View {
 		NavigationStack {
@@ -130,6 +133,16 @@ struct WaypointForm: View {
 									}
 								}
 							}
+					}
+					HStack {
+						Text("Send to")
+						Spacer()
+						Button {
+							showingRecipientPicker = true
+						} label: {
+							Text(destinationLabel)
+								.foregroundColor(.secondary)
+						}
 					}
 					Toggle(isOn: $expires) {
 						Label("Expires", systemImage: "clock.badge.xmark")
@@ -232,7 +245,7 @@ struct WaypointForm: View {
 						
 						Task {
 							do {
-								try await accessoryManager.sendWaypoint(waypoint: newWaypoint)
+								try await accessoryManager.sendWaypoint(waypoint: newWaypoint, destination: destination)
 								dismiss()
 							} catch {
 								Logger.mesh.warning("Send waypoint failed: \(error)")
@@ -298,9 +311,13 @@ struct WaypointForm: View {
 							}
 							newWaypoint.expire = UInt32(1)
 							applyGeofence(to: &newWaypoint)
+							// Route the expiry to wherever the waypoint was originally exchanged (a DM or a
+							// secondary channel) — not whatever the picker currently shows — so "delete for
+							// everyone" always reaches the waypoint's actual recipient, even if the user has
+							// the destination picker set to something else mid-edit.
 							Task {
 								do {
-									try await accessoryManager.sendWaypoint(waypoint: newWaypoint)
+									try await accessoryManager.sendWaypoint(waypoint: newWaypoint, destination: waypoint.destination)
 									Task { @MainActor in
 										context.delete(waypoint)
 										do {
@@ -517,6 +534,7 @@ struct WaypointForm: View {
 				if waypoint.locked {
 					locked = true
 				}
+				destination = waypoint.destination
 				geofenceRadius = Double(waypoint.geofenceRadius)
 				notifyOnEnter = waypoint.notifyOnEnter
 				notifyOnExit = waypoint.notifyOnExit
@@ -533,6 +551,7 @@ struct WaypointForm: View {
 				name = ""
 				description = ""
 				locked = false
+				destination = .broadcastPrimary
 				geofenceRadius = 0
 				notifyOnEnter = false
 				notifyOnExit = false
@@ -544,6 +563,9 @@ struct WaypointForm: View {
 				latitude = waypoint.mapCoordinate.latitude
 				longitude = waypoint.mapCoordinate.longitude
 			}
+		}
+		.sheet(isPresented: $showingRecipientPicker) {
+			WaypointRecipientPicker(node: connectedNode, ownNodeNum: accessoryManager.activeDeviceNum, selection: $destination)
 		}
 		.presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.85)))
 		#if !targetEnvironment(macCatalyst)
@@ -589,8 +611,33 @@ struct WaypointForm: View {
 		// No geofenceBounds -> leave boundingBox unset (cleared on the mesh).
 	}
 
+	/// Label for the "Send to" row: the destination's channel name, or a DM node's long/short name/id.
+	/// Delegates the actual fallback rules to `waypointDestinationLabel`, the same helper the recipient
+	/// picker uses, so the two never drift.
+	private var destinationLabel: String {
+		var matchedNode: [NodeInfoEntity] = []
+		if case let .user(num) = destination {
+			let descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate<NodeInfoEntity> { $0.num == num })
+			matchedNode = (try? context.fetch(descriptor)) ?? []
+		}
+		return waypointDestinationLabel(destination, channels: waypointChannels(for: connectedNode), nodes: matchedNode, node: connectedNode)
+	}
+
 	@MainActor
 	private func fetchNodeInfo() async {
+		// --- Fetch connected node (for channel names / PKC-aware routing in the recipient picker) ---
+		if let deviceNum = accessoryManager.activeDeviceNum {
+			var connectedDescriptor = FetchDescriptor<NodeInfoEntity>(
+				predicate: #Predicate<NodeInfoEntity> { $0.num == deviceNum }
+			)
+			connectedDescriptor.fetchLimit = 1
+			do {
+				connectedNode = try context.fetch(connectedDescriptor).first
+			} catch {
+				Logger.services.warning("Error fetching connected node: \(error.localizedDescription)")
+			}
+		}
+
 		// --- Fetch createdBy node ---
 		if waypoint.createdBy != 0 {
 			let createdByNum = Int64(waypoint.createdBy)

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -43,6 +43,7 @@ struct WaypointForm: View {
 	@State private var connectedNode: NodeInfoEntity?
 	@State private var destination: WaypointDestination = .broadcastPrimary
 	@State private var showingRecipientPicker: Bool = false
+	@State private var destinationLabel: String = ""
 
 	var body: some View {
 		NavigationStack {
@@ -516,6 +517,10 @@ struct WaypointForm: View {
 		}
 		.task {
 			await fetchNodeInfo()
+			updateDestinationLabel()
+		}
+		.onChange(of: destination) {
+			updateDestinationLabel()
 		}
 		.onAppear {
 			if waypoint.id > 0 {
@@ -611,16 +616,18 @@ struct WaypointForm: View {
 		// No geofenceBounds -> leave boundingBox unset (cleared on the mesh).
 	}
 
-	/// Label for the "Send to" row: the destination's channel name, or a DM node's long/short name/id.
-	/// Delegates the actual fallback rules to `waypointDestinationLabel`, the same helper the recipient
-	/// picker uses, so the two never drift.
-	private var destinationLabel: String {
+	/// Recomputes the cached "Send to" row label. Delegates the actual fallback rules to
+	/// `waypointDestinationLabel`, the same helper the recipient picker uses, so the two never drift.
+	/// Called explicitly (on destination/connectedNode changes) rather than left as a computed property,
+	/// since a computed property here would re-run this SwiftData fetch on every unrelated body
+	/// re-render (e.g. every keystroke in the name/description fields).
+	private func updateDestinationLabel() {
 		var matchedNode: [NodeInfoEntity] = []
 		if case let .user(num) = destination {
 			let descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate<NodeInfoEntity> { $0.num == num })
 			matchedNode = (try? context.fetch(descriptor)) ?? []
 		}
-		return waypointDestinationLabel(destination, channels: waypointChannels(for: connectedNode), nodes: matchedNode, node: connectedNode)
+		destinationLabel = waypointDestinationLabel(destination, channels: waypointChannels(for: connectedNode), nodes: matchedNode, node: connectedNode)
 	}
 
 	@MainActor

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
@@ -108,7 +108,7 @@ struct WaypointRecipientPicker: View {
 	var body: some View {
 		NavigationStack {
 			List {
-				Section {
+				Section("Channels") {
 					ForEach(channelIndexes, id: \.self) { index in
 						Button {
 							selection = .channel(index)
@@ -121,7 +121,7 @@ struct WaypointRecipientPicker: View {
 						}
 					}
 				}
-				Section {
+				Section("Direct Messages") {
 					ForEach(filteredNodes, id: \.num) { candidate in
 						Button {
 							selection = .user(candidate.num)

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
@@ -1,0 +1,166 @@
+//
+//  WaypointRecipientPicker.swift
+//  Meshtastic
+//
+
+import MeshtasticProtobufs
+import SwiftUI
+@preconcurrency import SwiftData
+
+/// Display label for channel `index`: its configured name, the primary channel's modem-preset name (e.g.
+/// "LongFast", matching how the firmware renders an unnamed primary channel), "Custom" for a non-preset
+/// LoRa config, "Channel N" for an unnamed secondary channel, or a generic "Broadcast" only when no channel
+/// info is available at all (e.g. while disconnected).
+func waypointChannelLabel(index: Int32, channels: [ChannelEntity], node: NodeInfoEntity?) -> String {
+	if let channel = channels.first(where: { $0.index == index }), let name = channel.name, !name.isEmpty {
+		return name
+	}
+	guard index == 0 else { return "Channel \(index)".localized }
+	guard let node else { return "Broadcast".localized }
+	if node.loRaConfig?.usePreset == false {
+		return "Custom".localized
+	}
+	guard let preset = ModemPresets(rawValue: Int(node.loRaConfig?.modemPreset ?? 0)) else {
+		return "Broadcast".localized
+	}
+	return preset.androidChannelName
+}
+
+/// Display label for a node, for the recipient picker or the "currently selected" summary: long name,
+/// short name, or a fallback derived from its node number — never blank, and never rendered as "Broadcast"
+/// just because a bare/unconfigured node has no name set yet.
+func waypointNodeLabel(_ node: NodeInfoEntity) -> String {
+	if let longName = node.user?.longName, !longName.isEmpty { return longName }
+	if let shortName = node.user?.shortName, !shortName.isEmpty { return shortName }
+	return node.num.toHex()
+}
+
+/// Display label for a waypoint's currently selected destination.
+func waypointDestinationLabel(_ destination: WaypointDestination, channels: [ChannelEntity], nodes: [NodeInfoEntity], node: NodeInfoEntity?) -> String {
+	switch destination {
+	case let .channel(index):
+		return waypointChannelLabel(index: index, channels: channels, node: node)
+	case let .user(num):
+		if let match = nodes.first(where: { $0.num == num }) {
+			return waypointNodeLabel(match)
+		}
+		return num.toHex()
+	}
+}
+
+/// The connected node's configured channels (deduped by index, ascending) — used both to render the primary
+/// channel's real name and to list secondary channels in the recipient picker.
+func waypointChannels(for node: NodeInfoEntity?) -> [ChannelEntity] {
+	guard let myInfo = node?.myInfo else { return [] }
+	var channelsByIndex: [Int32: ChannelEntity] = [:]
+	for channel in myInfo.channels {
+		channelsByIndex[channel.index] = channel
+	}
+	return channelsByIndex.values.sorted { $0.index < $1.index }
+}
+
+/// Channel rows to list in the recipient picker: the primary channel (0) always appears even if it hasn't
+/// synced into `channels` yet (config sync populates channels incrementally, one packet at a time), plus
+/// whatever secondary channels are currently known.
+func waypointChannelIndexes(channels: [ChannelEntity]) -> [Int32] {
+	Array(Set([0] + channels.map(\.index))).sorted()
+}
+
+/// Node rows to list in the recipient picker: `nodes` minus `ownNodeNum` and ignored nodes, narrowed by a
+/// case-insensitive substring match on `filterText` against each node's display label.
+func waypointFilterNodes(_ nodes: [NodeInfoEntity], excluding ownNodeNum: Int64?, matching filterText: String) -> [NodeInfoEntity] {
+	let candidates = nodes.filter { $0.num != ownNodeNum && !$0.ignored }
+	guard !filterText.isEmpty else { return candidates }
+	return candidates.filter { waypointNodeLabel($0).localizedCaseInsensitiveContains(filterText) }
+}
+
+/// Lists the primary channel (labelled by its real configured name), then any secondary channels, then a
+/// divider, then every known node — letting a waypoint be broadcast, sent to a secondary channel, or DM'd
+/// to a specific node, matching the destinations the Python Meshtastic CLI/API can already target.
+///
+/// Node rows can number in the thousands on an MQTT-bridged mesh, so a name filter narrows them; channel
+/// rows are never hidden by the filter. This is a small, purpose-built filter rather than a reuse of
+/// `NodeFilterParameters` — that type is a shared app-wide singleton (`.shared`) backing the Nodes tab's own
+/// filter UI, and driving it from this transient sheet would leak filter state into that unrelated screen.
+struct WaypointRecipientPicker: View {
+
+	let node: NodeInfoEntity?
+	/// The connected device's own node number, for excluding it from the DM list. Taken directly from
+	/// `AccessoryManager.activeDeviceNum` rather than derived from `node` — `node` is populated by an async
+	/// SwiftData fetch and can still be nil the moment this picker opens, which would otherwise let the
+	/// user "DM" themselves during that brief window.
+	let ownNodeNum: Int64?
+	@Binding var selection: WaypointDestination
+	@Environment(\.dismiss) private var dismiss
+	@State private var filterText: String = ""
+
+	@Query(sort: \NodeInfoEntity.lastHeard, order: .reverse)
+	private var allNodes: [NodeInfoEntity]
+
+	private var channels: [ChannelEntity] {
+		waypointChannels(for: node)
+	}
+
+	private var channelIndexes: [Int32] {
+		waypointChannelIndexes(channels: channels)
+	}
+
+	private var filteredNodes: [NodeInfoEntity] {
+		waypointFilterNodes(allNodes, excluding: ownNodeNum, matching: filterText)
+	}
+
+	var body: some View {
+		NavigationStack {
+			List {
+				Section {
+					ForEach(channelIndexes, id: \.self) { index in
+						Button {
+							selection = .channel(index)
+							dismiss()
+						} label: {
+							recipientRow(
+								label: waypointChannelLabel(index: index, channels: channels, node: node),
+								selected: selection == .channel(index)
+							)
+						}
+					}
+				}
+				Section {
+					ForEach(filteredNodes, id: \.num) { candidate in
+						Button {
+							selection = .user(candidate.num)
+							dismiss()
+						} label: {
+							recipientRow(
+								label: waypointNodeLabel(candidate),
+								selected: selection == .user(candidate.num)
+							)
+						}
+					}
+				}
+			}
+			.searchable(text: $filterText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Find a node")
+			.autocorrectionDisabled(true)
+			.navigationTitle("Send to")
+			.navigationBarTitleDisplayMode(.inline)
+			.toolbar {
+				ToolbarItem(placement: .cancellationAction) {
+					Button("Cancel") { dismiss() }
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	private func recipientRow(label: String, selected: Bool) -> some View {
+		HStack {
+			Text(label)
+				.foregroundColor(.primary)
+			Spacer()
+			if selected {
+				Image(systemName: "checkmark")
+					.foregroundColor(.accentColor)
+			}
+		}
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
@@ -7,23 +7,16 @@ import MeshtasticProtobufs
 import SwiftUI
 @preconcurrency import SwiftData
 
-/// Display label for channel `index`: its configured name, the primary channel's modem-preset name (e.g.
-/// "LongFast", matching how the firmware renders an unnamed primary channel), "Custom" for a non-preset
-/// LoRa config, "Channel N" for an unnamed secondary channel, or a generic "Broadcast" only when no channel
-/// info is available at all (e.g. while disconnected).
+/// Display label for channel `index`: its configured name, else — for the primary channel only —
+/// `channelDisplayName` (the same preset-name/"Custom"/"Broadcast" fallback rules the Channels settings
+/// screen uses, so the two screens never show different names for the same channel), else "Channel N" for
+/// an unnamed secondary channel.
 func waypointChannelLabel(index: Int32, channels: [ChannelEntity], node: NodeInfoEntity?) -> String {
 	if let channel = channels.first(where: { $0.index == index }), let name = channel.name, !name.isEmpty {
 		return name
 	}
 	guard index == 0 else { return "Channel \(index)".localized }
-	guard let node else { return "Broadcast".localized }
-	if node.loRaConfig?.usePreset == false {
-		return "Custom".localized
-	}
-	guard let preset = ModemPresets(rawValue: Int(node.loRaConfig?.modemPreset ?? 0)) else {
-		return "Broadcast".localized
-	}
-	return preset.androidChannelName
+	return channelDisplayName(channels: channels, node: node)
 }
 
 /// Display label for a node, for the recipient picker or the "currently selected" summary: the user's local
@@ -51,14 +44,10 @@ func waypointDestinationLabel(_ destination: WaypointDestination, channels: [Cha
 }
 
 /// The connected node's configured channels (deduped by index, ascending) — used both to render the primary
-/// channel's real name and to list secondary channels in the recipient picker.
+/// channel's real name and to list secondary channels in the recipient picker. Shares its dedup logic with
+/// the Channels settings screen via `dedupedChannels(for:)`.
 func waypointChannels(for node: NodeInfoEntity?) -> [ChannelEntity] {
-	guard let myInfo = node?.myInfo else { return [] }
-	var channelsByIndex: [Int32: ChannelEntity] = [:]
-	for channel in myInfo.channels {
-		channelsByIndex[channel.index] = channel
-	}
-	return channelsByIndex.values.sorted { $0.index < $1.index }
+	dedupedChannels(for: node)
 }
 
 /// Channel rows to list in the recipient picker: the primary channel (0) always appears even if it hasn't

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
@@ -26,10 +26,12 @@ func waypointChannelLabel(index: Int32, channels: [ChannelEntity], node: NodeInf
 	return preset.androidChannelName
 }
 
-/// Display label for a node, for the recipient picker or the "currently selected" summary: long name,
-/// short name, or a fallback derived from its node number — never blank, and never rendered as "Broadcast"
-/// just because a bare/unconfigured node has no name set yet.
+/// Display label for a node, for the recipient picker or the "currently selected" summary: the user's local
+/// custom display name if set (matching every other node label in the app), else the long name, short name,
+/// or a fallback derived from its node number — never blank, and never rendered as "Broadcast" just because
+/// a bare/unconfigured node has no name set yet.
 func waypointNodeLabel(_ node: NodeInfoEntity) -> String {
+	if let custom = NodeDisplayNameStore.displayName(for: node.num) { return custom }
 	if let longName = node.user?.longName, !longName.isEmpty { return longName }
 	if let shortName = node.user?.shortName, !shortName.isEmpty { return shortName }
 	return node.num.toHex()

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointRecipientPicker.swift
@@ -99,6 +99,11 @@ struct WaypointRecipientPicker: View {
 	@Query(sort: \NodeInfoEntity.lastHeard, order: .reverse)
 	private var allNodes: [NodeInfoEntity]
 
+	// Node rows can number in the thousands (see the type doc above), so `filteredNodes` is cached in
+	// @State and only recomputed on an actual filter/list change — not on every body re-render (e.g. a
+	// selection change toggling a checkmark) — to avoid re-scanning + re-labelling the full list needlessly.
+	@State private var filteredNodes: [NodeInfoEntity] = []
+
 	private var channels: [ChannelEntity] {
 		waypointChannels(for: node)
 	}
@@ -107,8 +112,8 @@ struct WaypointRecipientPicker: View {
 		waypointChannelIndexes(channels: channels)
 	}
 
-	private var filteredNodes: [NodeInfoEntity] {
-		waypointFilterNodes(allNodes, excluding: ownNodeNum, matching: filterText)
+	private func updateFilteredNodes() {
+		filteredNodes = waypointFilterNodes(allNodes, excluding: ownNodeNum, matching: filterText)
 	}
 
 	var body: some View {
@@ -150,6 +155,15 @@ struct WaypointRecipientPicker: View {
 					Button("Cancel") { dismiss() }
 				}
 			}
+		}
+		.onAppear {
+			updateFilteredNodes()
+		}
+		.onChange(of: filterText) {
+			updateFilteredNodes()
+		}
+		.onChange(of: allNodes.count) {
+			updateFilteredNodes()
 		}
 	}
 

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -51,12 +51,7 @@ struct Channels: View {
 	@State private var showingHelp = false
 
 	private var displayChannels: [ChannelEntity] {
-		guard let channels = node.myInfo?.channels else { return [] }
-		var byIndex: [Int32: ChannelEntity] = [:]
-		for channel in channels {
-			byIndex[channel.index] = channel
-		}
-		return byIndex.values.sorted { $0.index < $1.index }
+		dedupedChannels(for: node)
 	}
 
 	private var locationSharingChannelIndex: Int32? {
@@ -71,18 +66,7 @@ struct Channels: View {
 	}
 
 	private var primaryChannelName: String {
-		if let primary = displayChannels.first(where: { $0.index == 0 || $0.role == 1 }),
-		   let name = primary.name,
-		   !name.isEmpty {
-			return name
-		}
-		if node.loRaConfig?.usePreset == false {
-			return "Custom"
-		}
-		guard let preset = ModemPresets(rawValue: Int(node.loRaConfig?.modemPreset ?? 0)) else {
-			return "LongFast"
-		}
-		return preset.androidChannelName
+		channelDisplayName(channels: displayChannels, node: node)
 	}
 
 	private var channelFrequencySummary: ChannelFrequencySummary? {

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -75,11 +75,7 @@ struct Channels: View {
 
 	private func normalizeDuplicateChannelsIfNeeded() {
 		guard let channels = node.myInfo?.channels else { return }
-		var uniqueChannels: [Int32: ChannelEntity] = [:]
-		for channel in channels {
-			uniqueChannels[channel.index] = channel
-		}
-		let deduped = uniqueChannels.values.sorted { $0.index < $1.index }
+		let deduped = dedupedChannels(for: node)
 		guard deduped.count != channels.count else { return }
 		node.myInfo?.channels = deduped
 		do {

--- a/MeshtasticTests/WaypointDestinationTests.swift
+++ b/MeshtasticTests/WaypointDestinationTests.swift
@@ -1,0 +1,230 @@
+//
+//  WaypointDestinationTests.swift
+//  MeshtasticTests
+//
+
+import Testing
+import Foundation
+import SwiftData
+import MeshtasticProtobufs
+@testable import Meshtastic
+
+@Suite("waypointDestination contact derivation")
+struct WaypointDestinationDerivationTests {
+
+	@Test("A broadcast packet resolves to its channel")
+	func broadcastResolvesToChannel() {
+		var packet = MeshPacket()
+		packet.to = Constants.maximumNodeNum
+		packet.from = 111
+		packet.channel = 2
+
+		let destination = waypointDestination(packet: packet, myNodeNum: 111)
+		#expect(destination == .channel(2))
+	}
+
+	@Test("A DM we sent resolves to its recipient (packet.to)")
+	func sentDMResolvesToRecipient() {
+		var packet = MeshPacket()
+		packet.from = 111
+		packet.to = 222
+
+		let destination = waypointDestination(packet: packet, myNodeNum: 111)
+		#expect(destination == .user(222))
+	}
+
+	@Test(
+		"""
+		A DM sent TO us by someone else resolves to the sender (packet.from), not ourselves — otherwise a \
+		follow-up would self-address back to us instead of reaching the original sender
+		"""
+	)
+	func receivedDMResolvesToSender() {
+		var packet = MeshPacket()
+		packet.from = 333
+		packet.to = 111 // addressed to us
+
+		let destination = waypointDestination(packet: packet, myNodeNum: 111)
+		#expect(destination == .user(333))
+	}
+
+	@Test("Unknown local node number still classifies a DM as belonging to the sender")
+	func unknownLocalNodeFallsBackToSender() {
+		var packet = MeshPacket()
+		packet.from = 333
+		packet.to = 111
+
+		let destination = waypointDestination(packet: packet, myNodeNum: nil)
+		#expect(destination == .user(333))
+	}
+}
+
+@Suite("WaypointEntity.destination round trip")
+struct WaypointEntityDestinationTests {
+
+	@Test("Defaults to the primary channel broadcast")
+	func defaultsToBroadcastPrimary() {
+		let waypoint = WaypointEntity()
+		#expect(waypoint.destination == .channel(0))
+	}
+
+	@Test("Setting a channel destination clears any DM node")
+	func settingChannelClearsUser() {
+		let waypoint = WaypointEntity()
+		waypoint.destination = .user(555)
+		waypoint.destination = .channel(3)
+		#expect(waypoint.destination == .channel(3))
+		#expect(waypoint.destinationNodeNum == 0)
+	}
+
+	@Test("Setting a DM destination clears any channel")
+	func settingUserClearsChannel() {
+		let waypoint = WaypointEntity()
+		waypoint.destination = .channel(3)
+		waypoint.destination = .user(555)
+		#expect(waypoint.destination == .user(555))
+		#expect(waypoint.destinationChannel == 0)
+	}
+
+	@Test("Re-editing an existing waypoint preserves its original DM recipient rather than resetting to broadcast")
+	func editingPreservesOriginalDMDestination() {
+		let waypoint = WaypointEntity()
+		waypoint.destination = .user(42)
+
+		// Simulate re-opening the editor: the destination read back must still be the DM, not broadcast.
+		#expect(waypoint.destination == .user(42))
+	}
+}
+
+@Suite("Recipient label fallbacks")
+struct WaypointRecipientLabelTests {
+
+	@Test("A node with a long name uses it")
+	func longNameWins() {
+		let node = NodeInfoEntity()
+		node.num = 123
+		let user = UserEntity()
+		user.longName = "Field Radio"
+		user.shortName = "FLD"
+		node.user = user
+
+		#expect(waypointNodeLabel(node) == "Field Radio")
+	}
+
+	@Test("A blank long name falls through to the short name")
+	func blankLongNameFallsThroughToShortName() {
+		let node = NodeInfoEntity()
+		node.num = 123
+		let user = UserEntity()
+		user.longName = ""
+		user.shortName = "FLD"
+		node.user = user
+
+		#expect(waypointNodeLabel(node) == "FLD")
+	}
+
+	@Test("Blank long and short names fall through to a node-id-derived label, never blank or 'Broadcast'")
+	func blankNamesFallThroughToNodeId() {
+		let node = NodeInfoEntity()
+		node.num = 123
+		let user = UserEntity()
+		user.longName = ""
+		user.shortName = ""
+		node.user = user
+
+		let label = waypointNodeLabel(node)
+		#expect(!label.isEmpty)
+		#expect(label == Int64(123).toHex())
+	}
+
+	@Test("No user record at all still falls through to a node-id-derived label")
+	func noUserFallsThroughToNodeId() {
+		let node = NodeInfoEntity()
+		node.num = 456
+
+		#expect(waypointNodeLabel(node) == Int64(456).toHex())
+	}
+
+	@Test("A configured channel name is used verbatim")
+	func configuredChannelNameWins() {
+		let channel = ChannelEntity()
+		channel.index = 0
+		channel.name = "LongFast"
+
+		#expect(waypointChannelLabel(index: 0, channels: [channel], node: nil) == "LongFast")
+	}
+
+	@Test("An unnamed secondary channel falls back to 'Channel N'")
+	func unnamedSecondaryChannelFallsBackToIndex() {
+		#expect(waypointChannelLabel(index: 3, channels: [], node: nil) == "Channel 3")
+	}
+
+	@Test("No channel info at all (e.g. disconnected) falls back to a generic Broadcast label")
+	func disconnectedFallsBackToGenericBroadcast() {
+		#expect(waypointChannelLabel(index: 0, channels: [], node: nil) == "Broadcast".localized)
+	}
+}
+
+@Suite("Recipient picker filtering")
+struct WaypointRecipientPickerFilteringTests {
+
+	@Test("The primary channel is always listed even if it hasn't synced into channels yet")
+	func primaryChannelAlwaysListed() {
+		let secondary = ChannelEntity()
+		secondary.index = 1
+		secondary.name = "Secondary"
+
+		#expect(waypointChannelIndexes(channels: [secondary]) == [0, 1])
+	}
+
+	@Test("Channel indexes are deduped and sorted")
+	func channelIndexesDedupedAndSorted() {
+		let primary = ChannelEntity()
+		primary.index = 0
+		let secondary = ChannelEntity()
+		secondary.index = 2
+
+		#expect(waypointChannelIndexes(channels: [secondary, primary]) == [0, 2])
+	}
+
+	@Test("The connected device's own node never appears in the DM candidate list")
+	func ownNodeExcludedFromDMList() {
+		let me = NodeInfoEntity()
+		me.num = 111
+		let other = NodeInfoEntity()
+		other.num = 222
+
+		let filtered = waypointFilterNodes([me, other], excluding: 111, matching: "")
+		#expect(filtered.map(\.num) == [222])
+	}
+
+	@Test("An ignored node is excluded from the DM candidate list")
+	func ignoredNodeExcluded() {
+		let ignored = NodeInfoEntity()
+		ignored.num = 222
+		ignored.ignored = true
+		let visible = NodeInfoEntity()
+		visible.num = 333
+
+		let filtered = waypointFilterNodes([ignored, visible], excluding: nil, matching: "")
+		#expect(filtered.map(\.num) == [333])
+	}
+
+	@Test("A name filter narrows the node list case-insensitively")
+	func filterNarrowsByName() {
+		let match = NodeInfoEntity()
+		match.num = 111
+		let matchUser = UserEntity()
+		matchUser.longName = "Field Radio"
+		match.user = matchUser
+
+		let nonMatch = NodeInfoEntity()
+		nonMatch.num = 222
+		let nonMatchUser = UserEntity()
+		nonMatchUser.longName = "Base Station"
+		nonMatch.user = nonMatchUser
+
+		let filtered = waypointFilterNodes([match, nonMatch], excluding: nil, matching: "field")
+		#expect(filtered.map(\.num) == [111])
+	}
+}

--- a/MeshtasticTests/WaypointDestinationTests.swift
+++ b/MeshtasticTests/WaypointDestinationTests.swift
@@ -163,6 +163,29 @@ struct WaypointRecipientLabelTests {
 	func disconnectedFallsBackToGenericBroadcast() {
 		#expect(waypointChannelLabel(index: 0, channels: [], node: nil) == "Broadcast".localized)
 	}
+
+	@Test("A node with a non-preset LoRa config falls back to 'Custom'")
+	func nonPresetLoRaConfigFallsBackToCustom() {
+		let node = NodeInfoEntity()
+		node.num = 123
+		let loRaConfig = LoRaConfigEntity()
+		loRaConfig.usePreset = false
+		node.loRaConfig = loRaConfig
+
+		#expect(waypointChannelLabel(index: 0, channels: [], node: node) == "Custom".localized)
+	}
+
+	@Test("An unresolvable modemPreset rawValue falls back to 'LongFast', matching the Channels settings screen")
+	func unresolvableModemPresetFallsBackToLongFast() {
+		let node = NodeInfoEntity()
+		node.num = 123
+		let loRaConfig = LoRaConfigEntity()
+		loRaConfig.usePreset = true
+		loRaConfig.modemPreset = 99 // no ModemPresets case has this rawValue
+		node.loRaConfig = loRaConfig
+
+		#expect(waypointChannelLabel(index: 0, channels: [], node: node) == "LongFast")
+	}
 }
 
 @Suite("Recipient picker filtering")

--- a/docs/user/map.md
+++ b/docs/user/map.md
@@ -62,15 +62,25 @@ Waypoints are named points of interest you can share across the mesh.
 
 1. Long press anywhere on the map.
 2. Enter a name, optional description, and lock icon (to limit editing to the creator).
-3. Tap **Save** — the waypoint broadcasts to all nodes on the primary channel.
+3. Tap **Send to** to choose where the waypoint goes (see [Choosing a Recipient](#choosing-a-recipient) below) — it broadcasts to the primary channel by default.
+4. Tap **Save**.
+
+### Choosing a Recipient
+
+Tap **Send to** in the waypoint editor to pick a destination:
+
+- **A channel** — the primary channel (shown by its real name, e.g. "LongFast") or any secondary channel. Everyone on that channel receives the waypoint.
+- **A specific node** — sends the waypoint as a private message only that node receives. Use the search field to narrow the node list by name.
+
+Re-opening an existing waypoint for editing shows the recipient it was originally sent to (or received from), not the default broadcast.
 
 ### Editing a Waypoint
 
-Tap an existing waypoint pin, then tap **Edit**. Changes broadcast to the mesh immediately.
+Tap an existing waypoint pin, then tap **Edit**. Changes are sent to the recipient shown in **Send to**.
 
 ### Deleting a Waypoint
 
-Tap the waypoint, then tap **Delete**. The deletion broadcasts to all nodes.
+Tap the waypoint, then tap **Delete**. **For everyone** re-sends the deletion to whichever channel or node the waypoint was originally exchanged with, so it reaches the same audience the waypoint did.
 
 ### Geofences
 


### PR DESCRIPTION
## What changed?

Adds a **"Send to"** picker to the waypoint editor. A waypoint can now be sent as a broadcast on the primary channel (shown by its real configured name, e.g. "LongFast"), broadcast on any secondary channel, or sent as a private direct message to a specific node — matching the destinations already supported by the Meshtastic API.

Key pieces:
- `WaypointDestination` enum + a `destination` property persisted on `WaypointEntity`, so re-opening an existing waypoint for editing, or resending it (e.g. "delete for everyone"), always routes back to wherever it was originally exchanged instead of drifting to broadcast.
- `waypointDestination(packet:myNodeNum:)` disambiguates a DM we sent from a DM sent to us (a waypoint DM'd *to* us has `packet.to` set to our own node — reading it unconditionally would misroute follow-ups back to ourselves).
- DM routing reuses the same PKC-vs-fallback check regular direct messages already use, extracted into a shared `applyPKCRoutingIfNeeded` helper so the two send paths can't drift apart.
- New `WaypointRecipientPicker` view: channels first (deduped/index-sorted, sharing its logic with the Channels settings screen so the two never show different names for the same channel), then a filterable node list — filterable since node lists can run into the thousands on an MQTT-bridged mesh.

## Why did it change?

Waypoints previously always broadcast on the primary channel, unlike text messages, which can already be sent to any channel or DM'd to a specific node. This closes that gap.

## How is this tested?

- New Swift Testing suites in `WaypointDestinationTests.swift`: packet-to-destination derivation (including the sent-vs-received DM disambiguation), `WaypointEntity.destination` round-trip, recipient/channel label fallbacks, and recipient-picker filtering.
- Verified a full build + full test suite run on a real Xcode/iOS Simulator CI job; all new tests pass. (A handful of pre-existing, unrelated failures — snapshot-image drift and flaky async-timer tests — reproduce identically against a clean `main` baseline, confirmed separately, so they're not from this change.)
- Manually sideloaded onto a physical iPhone and exercised both the send-to-channel and send-to-node-DM flows end to end.

## Screenshots/Videos
<img width="586" height="1165" alt="wp_00" src="https://github.com/user-attachments/assets/45b609a8-4a95-41f1-9f47-13ca51e727d1" />

<img width="1170" height="1500" alt="TEMP_waypointRecipientPicker" src="https://github.com/user-attachments/assets/8807d458-52e1-4b30-9e8e-b834faf1bcd3" />

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. (`docs/user/map.md` updated.)
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Send to” options for waypoints, supporting channels or specific nodes.
  * Added recipient selection with searchable node and channel lists.
  * Preserved waypoint destinations when editing, deleting, importing, or receiving waypoints.
  * Improved channel names and recipient labels with clearer fallback handling.

* **Bug Fixes**
  * Prevented waypoint processing when no active device is connected.

* **Documentation**
  * Updated waypoint guidance for choosing recipients and managing edits or deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->