### PR TITLE
fix: align channel frequency display with firmware

### DIFF
--- a/Meshtastic/Helpers/LoRaChannelCalculator.swift
+++ b/Meshtastic/Helpers/LoRaChannelCalculator.swift
@@ -16,14 +16,48 @@ import Foundation
 /// Moved out of `Channels.swift` (was `private struct`) so the Mesh Beacons join
 /// enhancement can reuse the exact same math instead of hand-rolling a second hash.
 struct LoRaChannelCalculator {
-	let config: LoRaConfigEntity?
+	private let regionCode: Int
+	private let usePreset: Bool
+	private let modemPreset: Int
+	private let channelNum: Int
+	private let bandwidth: Int
+	private let overrideFrequency: Double
+	private let frequencyOffset: Double
+
+	init(config: LoRaConfigEntity?) {
+		regionCode = Int(config?.regionCode ?? 0)
+		usePreset = config?.usePreset ?? false
+		modemPreset = Int(config?.modemPreset ?? 0)
+		channelNum = Int(config?.channelNum ?? 0)
+		bandwidth = Int(config?.bandwidth ?? 0)
+		overrideFrequency = Double(config?.overrideFrequency ?? 0)
+		frequencyOffset = Double(config?.frequencyOffset ?? 0)
+	}
+
+	init(
+		regionCode: Int,
+		usePreset: Bool,
+		modemPreset: Int,
+		channelNum: Int,
+		bandwidth: Int,
+		overrideFrequency: Double,
+		frequencyOffset: Double = 0
+	) {
+		self.regionCode = regionCode
+		self.usePreset = usePreset
+		self.modemPreset = modemPreset
+		self.channelNum = channelNum
+		self.bandwidth = bandwidth
+		self.overrideFrequency = overrideFrequency
+		self.frequencyOffset = frequencyOffset
+	}
 
 	private var region: RegionInfo? {
-		RegionInfo(regionCode: Int(config?.regionCode ?? 0))
+		RegionInfo(regionCode: regionCode)
 	}
 
 	var regionName: String {
-		guard let regionCode = RegionCodes(rawValue: Int(config?.regionCode ?? 0)) else {
+		guard let regionCode = RegionCodes(rawValue: regionCode) else {
 			return "Unknown region"
 		}
 		return regionCode.description
@@ -33,8 +67,11 @@ struct LoRaChannelCalculator {
 	/// (the firmware pins the slot when set); otherwise derives it from the primary
 	/// channel name.
 	func effectiveChannelSlot(primaryName: String) -> Int {
-		if let channelNum = config?.channelNum, channelNum != 0 {
-			return Int(channelNum)
+		if channelNum != 0 {
+			return channelNum
+		}
+		if let defaultSlot = region?.defaultSlot, defaultSlot > 0 {
+			return defaultSlot
 		}
 		let numChannels = numChannels()
 		guard numChannels > 0 else { return 0 }
@@ -51,30 +88,30 @@ struct LoRaChannelCalculator {
 	}
 
 	func radioFrequencyMHz(slot: Int) -> Double {
-		guard let config else { return 0 }
-		if config.overrideFrequency != 0 {
-			return Double(config.overrideFrequency)
+		if overrideFrequency != 0 {
+			return overrideFrequency + frequencyOffset
 		}
 		guard let region else { return 0 }
-		let bandwidth = bandwidthMHz(region: region)
-		guard bandwidth > 0, slot > 0 else { return 0 }
-		return region.freqStart + bandwidth / 2 + Double(slot - 1) * bandwidth
+		let bandwidthMHz = bandwidthMHz(region: region)
+		guard bandwidthMHz > 0, slot > 0 else { return 0 }
+		let slotWidth = region.spacing + 2 * region.padding + bandwidthMHz
+		return region.freqStart + bandwidthMHz / 2 + region.padding + Double(slot - 1) * slotWidth + frequencyOffset
 	}
 
 	private func numChannels() -> Int {
 		guard let region else { return 0 }
-		let bandwidth = bandwidthMHz(region: region)
-		guard bandwidth > 0 else { return 1 }
-		return max(Int(floor((region.freqEnd - region.freqStart) / bandwidth)), 1)
+		let bandwidthMHz = bandwidthMHz(region: region)
+		guard bandwidthMHz > 0 else { return 1 }
+		let slotWidth = region.spacing + 2 * region.padding + bandwidthMHz
+		return max(Int(((region.freqEnd - region.freqStart + region.spacing) / slotWidth).rounded()), 1)
 	}
 
 	private func bandwidthMHz(region: RegionInfo) -> Double {
-		guard let config else { return 0 }
-		if config.usePreset {
-			let presetBandwidth = ModemPresets(rawValue: Int(config.modemPreset))?.bandwidthMHz ?? 0
+		if usePreset {
+			let presetBandwidth = ModemPresets(rawValue: modemPreset)?.bandwidthMHz ?? 0
 			return presetBandwidth * (region.wideLoRa ? 3.25 : 1)
 		}
-		switch config.bandwidth {
+		switch bandwidth {
 		case 31:
 			return 0.03125
 		case 62:
@@ -88,7 +125,7 @@ struct LoRaChannelCalculator {
 		case 1600:
 			return 1.625
 		default:
-			return Double(config.bandwidth) / 1000
+			return Double(bandwidth) / 1000
 		}
 	}
 
@@ -185,6 +222,9 @@ struct RegionInfo {
 	let freqStart: Double
 	let freqEnd: Double
 	let wideLoRa: Bool
+	let spacing: Double
+	let padding: Double
+	let defaultSlot: Int
 
 	init?(regionCode: Int) {
 		guard let region = RegionCodes(rawValue: regionCode) else { return nil }
@@ -241,8 +281,10 @@ struct RegionInfo {
 			self.init(freqStart: 865.0, freqEnd: 868.0)
 		case .br902:
 			self.init(freqStart: 902.0, freqEnd: 907.5)
-		case .itu12M, .itu22M:
-			self.init(freqStart: 144.0, freqEnd: 148.0)
+		case .itu12M:
+			self.init(freqStart: 144.0, freqEnd: 146.0, padding: 0.0022, defaultSlot: 26)
+		case .itu22M:
+			self.init(freqStart: 144.0, freqEnd: 148.0, padding: 0.0022, defaultSlot: 51)
 		case .eu866:
 			self.init(freqStart: 866.0, freqEnd: 866.5)
 		case .eu874:
@@ -250,29 +292,34 @@ struct RegionInfo {
 		case .eu917:
 			self.init(freqStart: 917.0, freqEnd: 921.0)
 		case .euN868:
-			self.init(freqStart: 869.4, freqEnd: 869.65)
+			self.init(freqStart: 869.4, freqEnd: 869.65, padding: 0.0104, defaultSlot: 1)
 		case .itu32M:
-			// ITU Region 3 Amateur Radio 2m band.
-			self.init(freqStart: 144.0, freqEnd: 148.0)
+			self.init(freqStart: 144.0, freqEnd: 148.0, padding: 0.0022, defaultSlot: 33)
 		case .itu170Cm:
-			// ITU Region 1 Amateur Radio 70cm band.
-			self.init(freqStart: 430.0, freqEnd: 440.0)
+			self.init(freqStart: 430.0, freqEnd: 440.0, padding: 0.01875, defaultSlot: 37)
 		case .itu270Cm:
-			// ITU Region 2 Amateur Radio 70cm band.
-			self.init(freqStart: 420.0, freqEnd: 450.0)
+			self.init(freqStart: 420.0, freqEnd: 450.0, padding: 0.01875, defaultSlot: 137)
 		case .itu370Cm:
-			// ITU Region 3 Amateur Radio 70cm band.
-			self.init(freqStart: 430.0, freqEnd: 450.0)
+			self.init(freqStart: 430.0, freqEnd: 450.0, padding: 0.01875, defaultSlot: 37)
 		case .itu2125Cm:
-			// ITU Region 2 Amateur Radio 1.25m (125cm) band.
-			self.init(freqStart: 220.0, freqEnd: 225.0)
+			self.init(freqStart: 220.0, freqEnd: 225.0, padding: 0.01875, defaultSlot: 37)
 		}
 	}
 
-	private init(freqStart: Double, freqEnd: Double, wideLoRa: Bool = false) {
+	private init(
+		freqStart: Double,
+		freqEnd: Double,
+		wideLoRa: Bool = false,
+		spacing: Double = 0,
+		padding: Double = 0,
+		defaultSlot: Int = 0
+	) {
 		self.freqStart = freqStart
 		self.freqEnd = freqEnd
 		self.wideLoRa = wideLoRa
+		self.spacing = spacing
+		self.padding = padding
+		self.defaultSlot = defaultSlot
 	}
 }
 
@@ -299,7 +346,7 @@ extension ModemPresets {
 		case .narrowFast, .narrowSlow:
 			return 0.0625
 		case .tinyFast, .tinySlow:
-			return 0.020
+			return 0.0156
 		}
 	}
 }

--- a/MeshtasticTests/LoraDeviceEnumTests.swift
+++ b/MeshtasticTests/LoraDeviceEnumTests.swift
@@ -840,3 +840,84 @@ struct LoRaPresetSelectionTests {
 		#expect(result == nil)
 	}
 }
+
+@Suite("LoRa channel frequency calculation")
+struct LoRaChannelCalculatorTests {
+	@Test("ITU Region 2 TinyFast defaults to firmware slot 51 at 145.010 MHz")
+	func itu2TinyFastDefault() {
+		let calculator = LoRaChannelCalculator(
+			regionCode: RegionCodes.itu22M.rawValue,
+			usePreset: true,
+			modemPreset: ModemPresets.tinyFast.rawValue,
+			channelNum: 0,
+			bandwidth: 0,
+			overrideFrequency: 0
+		)
+
+		let slot = calculator.effectiveChannelSlot(primaryName: "TinyFast")
+		#expect(slot == 51)
+		#expect(abs(calculator.radioFrequencyMHz(slot: slot) - 145.010) < 0.001)
+	}
+
+	@Test("ITU Region 2 TinyFast explicit slots advance by 20 kHz")
+	func itu2TinyFastExplicitSlot() {
+		let calculator = LoRaChannelCalculator(
+			regionCode: RegionCodes.itu22M.rawValue,
+			usePreset: true,
+			modemPreset: ModemPresets.tinyFast.rawValue,
+			channelNum: 52,
+			bandwidth: 0,
+			overrideFrequency: 0
+		)
+
+		let slot = calculator.effectiveChannelSlot(primaryName: "TinyFast")
+		#expect(slot == 52)
+		#expect(abs(calculator.radioFrequencyMHz(slot: slot) - 145.030) < 0.001)
+	}
+
+	@Test("Channel frequency applies the configured offset after the firmware slot calculation")
+	func appliesFrequencyOffset() {
+		let calculator = LoRaChannelCalculator(
+			regionCode: RegionCodes.itu22M.rawValue,
+			usePreset: true,
+			modemPreset: ModemPresets.tinyFast.rawValue,
+			channelNum: 0,
+			bandwidth: 0,
+			overrideFrequency: 0,
+			frequencyOffset: 0.010
+		)
+
+		let slot = calculator.effectiveChannelSlot(primaryName: "TinyFast")
+		#expect(abs(calculator.radioFrequencyMHz(slot: slot) - 145.020) < 0.001)
+	}
+
+	@Test("ITU Region 2 1.25m uses the 100 kHz ham channel plan")
+	func itu2OnePointTwoFiveMeterDefault() {
+		let calculator = LoRaChannelCalculator(
+			regionCode: RegionCodes.itu2125Cm.rawValue,
+			usePreset: true,
+			modemPreset: ModemPresets.narrowSlow.rawValue,
+			channelNum: 0,
+			bandwidth: 0,
+			overrideFrequency: 0
+		)
+
+		let slot = calculator.effectiveChannelSlot(primaryName: "NarrowSlow")
+		#expect(slot == 37)
+		#expect(abs(calculator.radioFrequencyMHz(slot: slot) - 223.650) < 0.001)
+	}
+
+	@Test("US LongFast keeps standard channel centers")
+	func usLongFast() {
+		let calculator = LoRaChannelCalculator(
+			regionCode: RegionCodes.us.rawValue,
+			usePreset: true,
+			modemPreset: ModemPresets.longFast.rawValue,
+			channelNum: 1,
+			bandwidth: 0,
+			overrideFrequency: 0
+		)
+
+		#expect(abs(calculator.radioFrequencyMHz(slot: 1) - 902.125) < 0.001)
+	}
+}

--- a/MeshtasticTests/LoraDeviceEnumTests.swift
+++ b/MeshtasticTests/LoraDeviceEnumTests.swift
@@ -891,6 +891,21 @@ struct LoRaChannelCalculatorTests {
 		#expect(abs(calculator.radioFrequencyMHz(slot: slot) - 145.020) < 0.001)
 	}
 
+	@Test("Override frequency applies the configured offset regardless of slot")
+	func overrideFrequencyAppliesOffset() {
+		let calculator = LoRaChannelCalculator(
+			regionCode: RegionCodes.itu22M.rawValue,
+			usePreset: true,
+			modemPreset: ModemPresets.tinyFast.rawValue,
+			channelNum: 0,
+			bandwidth: 0,
+			overrideFrequency: 145.500,
+			frequencyOffset: 0.010
+		)
+
+		#expect(abs(calculator.radioFrequencyMHz(slot: 999) - 145.510) < 0.001)
+	}
+
 	@Test("ITU Region 2 1.25m uses the 100 kHz ham channel plan")
 	func itu2OnePointTwoFiveMeterDefault() {
 		let calculator = LoRaChannelCalculator(


### PR DESCRIPTION
## Summary

Fixes the iOS Channels frequency summary for firmware-managed amateur-band channel plans.

Fixes #2087.

- Mirrors the firmware slot-width calculation: modem bandwidth + per-side padding + spacing.
- Uses firmware-defined regional default slots when the device leaves `channel_num` at its default.
- Applies the configured `frequency_offset` after calculating an automatic or override frequency.
- Corrects TinyFast/TinySlow RF bandwidth from 20 kHz to 15.6 kHz.

## Root cause

The iOS calculator used a simplified `freqStart + bandwidth / 2 + (slot - 1) * bandwidth` model. For ITU Region 2 Amateur 2 m / TinyFast, that meant:

| Source | Slot | Displayed / selected frequency |
| --- | ---: | ---: |
| Current iOS calculation | 144 (hash) | 146.870 MHz |
| Firmware default | 51 | 145.010 MHz |

Firmware defines TinyFast as **15.6 kHz** RF bandwidth and turns it into 20 kHz slot spacing with **2.2 kHz padding on each side**. ITU Region 2 Amateur 2 m also has an explicit default slot of **51**. Firmware then applies `frequency_offset` to the final result.

Relevant firmware evidence:

- [Ham 20 kHz profile: 15.6 kHz + 2.2 kHz padding](https://github.com/meshtastic/firmware/blob/5b1c1a9e0492432d980e110c93875ce4037981b9/src/mesh/RadioInterface.cpp#L65-L68)
- [ITU Region 2 Amateur 2 m default slot 51 (145.010 MHz)](https://github.com/meshtastic/firmware/blob/5b1c1a9e0492432d980e110c93875ce4037981b9/src/mesh/RadioInterface.cpp#L262-L268)
- [Firmware slot and final-frequency calculation](https://github.com/meshtastic/firmware/blob/5b1c1a9e0492432d980e110c93875ce4037981b9/src/mesh/RadioInterface.cpp#L1284-L1333)

## Captured evidence

The supplied captures show the original mismatch:

1. iOS Channels showed **146.870 MHz / Slot 144** for `ITU Region 2 / Amateur 2m`.
2. The T-Beam BPF device showed `ITU2_2M TinyFast`, **145.010 MHz**.
3. Firmware serial output selected `channel_num: 51` and **145.009995 MHz**.

## Tests

`xcodebuild test -quiet -project Meshtastic.xcodeproj -scheme Meshtastic -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:MeshtasticTests/LoraDeviceEnumTests`

The new focused cases verify:

- ITU Region 2 TinyFast defaults to slot 51 / 145.010 MHz.
- Explicit TinyFast slots advance by 20 kHz.
- A `+0.010 MHz` frequency offset is applied after the slot calculation.
- The 1.25 m 100 kHz amateur plan remains aligned with firmware.
- US LongFast channel centers remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LoRa channel slot selection and frequency computations across supported regions.
  - Added region-specific channel spacing, padding, and default-slot behavior.
  - Updated frequency-offset handling, including override-frequency scenarios.
  - Adjusted TinyFast/TinySlow preset bandwidth for more accurate radio behavior.

- **Tests**
  - Added a LoRa channel frequency calculation test suite covering default/explicit slots, regional channel plans, frequency offsets, and standard channel center frequencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->