### PR TITLE
fix: align EU and beacon frequency slots

### DIFF
--- a/Meshtastic/Helpers/LoRaChannelCalculator.swift
+++ b/Meshtastic/Helpers/LoRaChannelCalculator.swift
@@ -78,11 +78,15 @@ struct LoRaChannelCalculator {
 		return Int(djb2Hash(primaryName) % UInt32(numChannels)) + 1
 	}
 
-	/// The slot a channel with `name` would operate on, **always** derived from the
-	/// name (ignoring any `channelNum` override). This is the slot a beacon's offered
+	/// The slot a channel with `name` would operate on. Regions with a firmware default
+	/// slot use that default when a beacon does not carry an explicit channel number;
+	/// other regions derive the slot from the name. This is the slot a beacon's offered
 	/// channel resolves to on its own mesh, used to decide whether the connected radio
 	/// (whose slot comes from `effectiveChannelSlot`) can already hear it.
 	func slotForChannelName(_ name: String) -> Int {
+		if let defaultSlot = region?.defaultSlot, defaultSlot > 0 {
+			return defaultSlot
+		}
 		let numChannels = numChannels()
 		return numChannels > 0 ? Int(djb2Hash(name) % UInt32(numChannels)) + 1 : 0
 	}
@@ -286,7 +290,7 @@ struct RegionInfo {
 		case .itu22M:
 			self.init(freqStart: 144.0, freqEnd: 148.0, padding: 0.0022, defaultSlot: 51)
 		case .eu866:
-			self.init(freqStart: 866.0, freqEnd: 866.5)
+			self.init(freqStart: 865.6, freqEnd: 867.6, spacing: 0.4, padding: 0.0375)
 		case .eu874:
 			self.init(freqStart: 873.0, freqEnd: 876.0)
 		case .eu917:

--- a/MeshtasticTests/BeaconAddVsSwitchTests.swift
+++ b/MeshtasticTests/BeaconAddVsSwitchTests.swift
@@ -25,6 +25,15 @@ struct BeaconAddVsSwitchTests {
 		return config
 	}
 
+	private func itu2TinyFastConfig(channelNum: Int32 = 0) -> LoRaConfigEntity {
+		let config = LoRaConfigEntity()
+		config.regionCode = Int32(RegionCodes.itu22M.rawValue)
+		config.modemPreset = Int32(ModemPresets.tinyFast.rawValue)
+		config.usePreset = true
+		config.channelNum = channelNum
+		return config
+	}
+
 	// MARK: .add — everything matches
 
 	@Test func addWhenSlotPresetAndRegionMatch() {
@@ -54,6 +63,21 @@ struct BeaconAddVsSwitchTests {
 		#expect(option == .add)
 	}
 
+	@Test func addWhenHamBeaconUsesFirmwareDefaultSlot() {
+		// "TinyFast" hashes to slot 144, but an unset ITU2_2M channel actually uses
+		// the firmware default slot 51 on both meshes.
+		let option = LoRaChannelCalculator.beaconJoinOption(
+			hasOfferChannel: true,
+			offerChannelName: "TinyFast",
+			offeredPreset: .tinyFast,
+			offerRegion: RegionCodes.itu22M.rawValue,
+			isConnected: true,
+			loRaConfig: itu2TinyFastConfig(),
+			primaryChannelName: "TinyFast"
+		)
+		#expect(option == .add)
+	}
+
 	// MARK: .switchOnly — mismatches
 
 	@Test func switchOnlyOnSlotMismatch() {
@@ -66,6 +90,21 @@ struct BeaconAddVsSwitchTests {
 			isConnected: true,
 			loRaConfig: usLongFastConfig(),
 			primaryChannelName: "MyMesh"
+		)
+		#expect(option == .switchOnly)
+	}
+
+	@Test func switchOnlyWhenHamRadioPinsDifferentSlot() {
+		// The beacon resolves to the region's default slot 51, while this radio is
+		// explicitly pinned to slot 52.
+		let option = LoRaChannelCalculator.beaconJoinOption(
+			hasOfferChannel: true,
+			offerChannelName: "TinyFast",
+			offeredPreset: .tinyFast,
+			offerRegion: RegionCodes.itu22M.rawValue,
+			isConnected: true,
+			loRaConfig: itu2TinyFastConfig(channelNum: 52),
+			primaryChannelName: "TinyFast"
 		)
 		#expect(option == .switchOnly)
 	}

--- a/MeshtasticTests/LoraDeviceEnumTests.swift
+++ b/MeshtasticTests/LoraDeviceEnumTests.swift
@@ -875,6 +875,23 @@ struct LoRaChannelCalculatorTests {
 		#expect(abs(calculator.radioFrequencyMHz(slot: slot) - 145.030) < 0.001)
 	}
 
+	@Test("EU_866 LiteFast uses the firmware Lite band plan")
+	func eu866LiteFast() {
+		let calculator = LoRaChannelCalculator(
+			regionCode: RegionCodes.eu866.rawValue,
+			usePreset: true,
+			modemPreset: ModemPresets.liteFast.rawValue,
+			channelNum: 0,
+			bandwidth: 0,
+			overrideFrequency: 0
+		)
+
+		// Firmware PROFILE_LITE: 400 kHz spacing + 37.5 kHz padding on either side
+		// of LiteFast's 125 kHz bandwidth → four 600 kHz slots in 865.6–867.6 MHz.
+		#expect(abs(calculator.radioFrequencyMHz(slot: 1) - 865.700) < 0.001)
+		#expect(abs(calculator.radioFrequencyMHz(slot: 4) - 867.500) < 0.001)
+	}
+
 	@Test("Channel frequency applies the configured offset after the firmware slot calculation")
 	func appliesFrequencyOffset() {
 		let calculator = LoRaChannelCalculator(


### PR DESCRIPTION
## Summary

- align the EU_866 Lite profile with the firmware's 865.6–867.6 MHz plan, 400 kHz spacing, and 37.5 kHz padding
- resolve beacon-offered channels through the firmware default slot on regions that define one
- add regression coverage for EU_866 centers and ham-region Add-versus-Switch behavior

## Root cause

EU_866 retained obsolete frequency bounds with no Lite-profile spacing or padding. The beacon join comparison used the hash-only slot helper even after the connected-radio side became default-slot-aware, producing a needless Switch recommendation for matching ham meshes.

## Validation

- `xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic -destination 'platform=iOS Simulator,id=5669CB03-8FA2-4A97-BE04-A8566204116D' -only-testing:MeshtasticTests/LoRaChannelCalculatorTests -only-testing:MeshtasticTests/BeaconAddVsSwitchTests`

Fixes #2091
Fixes #2092


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beacon channel matching by honoring firmware-defined default slots when no explicit channel is provided.
  * Updated EU866 frequency calculations to use the correct regional frequency range and spacing.
  * Improved join decisions when a device is already configured for the beacon’s default slot or a different slot.

* **Tests**
  * Added coverage for EU866 LiteFast frequency calculations and beacon join scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->