### PR TITLE
fix: iOS 17 launch crash in the Lockdown gate presentation binding

### DIFF
--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -22,6 +22,18 @@ struct ContentView: View {
 	/// non-blocking state (.none, .unlocked, .lockNowAcknowledged).
 	private var isLockdownGateActive: Bool { lockdown.isBlockingSession }
 
+	/// Plain view-state mirror of `isLockdownGateActive`, kept in sync from the
+	/// coordinator via `.onChange`. Presenting the lockdown `fullScreenCover`
+	/// through a *computed* `Binding` — getter reading the `lockdown`
+	/// `@EnvironmentObject`, setter a no-op — produced a presentation binding that
+	/// could never converge, which iOS 17's SwiftUI resolved by re-entering the
+	/// attribute graph until it tripped `_assertionFailure` at first layout (a
+	/// launch crash unique to iOS 17; iOS 18+ tolerated it). Driving the cover
+	/// from real `@State` breaks that cycle. `LockdownSheet` has no dismiss
+	/// affordance, so this stays non-dismissable — only the coordinator leaving a
+	/// blocking state clears it.
+	@State private var isShowingLockdownGate: Bool = false
+
 	init(appState: AppState, router: Router) {
 		self.appState = appState
 		self.router = router
@@ -38,16 +50,23 @@ struct ContentView: View {
 					DeviceOnboarding()
 				}
 			)
-			.fullScreenCover(isPresented: Binding(
-				get: { isLockdownGateActive },
-				set: { _ in /* non-dismissable; coordinator state controls visibility */ }
-			)) {
+			.fullScreenCover(isPresented: $isShowingLockdownGate) {
 				LockdownSheet()
 			}
 			.onAppear {
 				if UserDefaults.firstLaunch {
 					isShowingDeviceOnboardingFlow = true
 				}
+				// Present the gate if the device is already in a blocking state when
+				// this view appears.
+				isShowingLockdownGate = isLockdownGateActive
+			}
+			.onChange(of: isLockdownGateActive) { _, active in
+				// Follow the coordinator's blocking state. The gate never closes from
+				// user interaction (fullScreenCover has no interactive dismiss and
+				// LockdownSheet exposes no dismiss control), so this is the only path
+				// that shows or hides it.
+				isShowingLockdownGate = active
 			}
 			.onChange(of: UserDefaults.showDeviceOnboarding) {_, newValue in
 				isShowingDeviceOnboardingFlow = newValue


### PR DESCRIPTION
## Summary

Fixes a launch-time `SIGTRAP` that is **specific to iOS/iPadOS 17** (iOS 18+ is unaffected). It is the dominant crash for the 2.7.16 App Store release by a wide margin.

## Root cause

The Lockdown gate in `ContentView` was presented with:

```swift
.fullScreenCover(isPresented: Binding(
    get: { isLockdownGateActive },              // reads the `lockdown` @EnvironmentObject
    set: { _ in /* non-dismissable */ }          // no-op
)) { LockdownSheet() }
```

A presentation `Binding` whose getter reads observable state and whose setter is a no-op can never converge: SwiftUI's presentation machinery writes the binding, the no-op setter drops the write, and the getter still reflects the coordinator. On iOS 17's SwiftUI this re-enters the AttributeGraph until it trips `_assertionFailure` during the **first layout pass** — so affected iOS 17 users crash at launch. iOS 18+'s presentation code tolerates the same construct.

A symbolicated production crash report pins the crashed thread to `ContentView.body.getter` → the cover's binding closure → `isLockdownGateActive.getter`, recursing through AttributeGraph to `_assertionFailure`, exclusively on iOS/iPadOS 17.

The Lockdown gate shipped in 2.7.16 (#1779), which is why the crash is exclusive to this release.

## Fix

Drive the cover from a plain `@State` (`isShowingLockdownGate`) synced from the coordinator's blocking state via `.onChange` (with an initial sync in `.onAppear`) — a normal, converging presentation binding.

Behavior is unchanged: `LockdownSheet` exposes no dismiss control and `fullScreenCover` has no interactive dismiss, so the gate stays **non-dismissable** and closes only when the coordinator leaves a blocking state — exactly as before.

## Testing

- Builds clean.
- Exercised the presentation path on an iOS 17.5 simulator (gate forced active at launch): both the current build and this fix **present the lockdown gate without crashing on 17.5**, and the fix is confirmed **behavior-preserving** (the gate still presents/persists correctly via the new `@State` binding). The production crash did not reproduce on the 17.5 simulator — it is a real-device launch race (crashing samples are on iOS 17.7.x; simulator SwiftUI on 17.5 tolerates the binding).
- **Recommend a final smoke test on a real iOS 17 device (ideally 17.7.x)** before release, exercising a device that enters a lockdown-blocking state, to confirm the gate presents/dismisses correctly and the launch crash is gone.

## Risk

Low — one view, no behavior change to the gate, no API changes. Good candidate for a 2.7.17 hotfix given the iOS 17 launch impact.