### PR TITLE
fix: stabilize duplicate hardware model resolution

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -487,8 +487,8 @@ actor MeshPackets {
 						let hwDescriptor = FetchDescriptor<DeviceHardwareEntity>(
 							predicate: #Predicate { $0.hwModel == hwModelValue }
 						)
-						if let hardwareEntity = try? modelContext.fetch(hwDescriptor).first {
-							newUser.hwDisplayName = hardwareEntity.displayName
+						if let hardware = try? modelContext.fetch(hwDescriptor) {
+							newUser.hwDisplayName = HardwareCatalogResolver.presentation(for: hwModelValue, in: hardware)?.displayName
 						}
 						newUser.isLicensed = nodeInfo.user.isLicensed
 						newUser.role = Int32(nodeInfo.user.role.rawValue)
@@ -612,8 +612,8 @@ actor MeshPackets {
 							let hwDescriptor2 = FetchDescriptor<DeviceHardwareEntity>(
 								predicate: #Predicate { $0.hwModel == hwModelValue2 }
 							)
-							if let hardwareEntity = try? modelContext.fetch(hwDescriptor2).first {
-								user.hwDisplayName = hardwareEntity.displayName
+							if let hardware = try? modelContext.fetch(hwDescriptor2) {
+								user.hwDisplayName = HardwareCatalogResolver.presentation(for: hwModelValue2, in: hardware)?.displayName
 							}
 						}
 					} else {

--- a/Meshtastic/Model/DeviceHardwareEntity.swift
+++ b/Meshtastic/Model/DeviceHardwareEntity.swift
@@ -39,18 +39,18 @@ final class DeviceHardwareEntity {
 /// over the mesh protocol: multiple targets can intentionally report the same `hwModel`.
 struct HardwareCatalogRecord: Equatable {
 	let hwModel: Int64
-	let hwModelSlug: String
-	let platformioTarget: String
-	let displayName: String
+	let hwModelSlug: String?
+	let platformioTarget: String?
+	let displayName: String?
 	let activelySupported: Bool
 	let supportLevel: SupportLevel
 	let architecture: String?
 
 	init(
 		hwModel: Int64,
-		hwModelSlug: String,
-		platformioTarget: String,
-		displayName: String,
+		hwModelSlug: String?,
+		platformioTarget: String?,
+		displayName: String?,
 		activelySupported: Bool,
 		supportLevel: SupportLevel,
 		architecture: String? = nil
@@ -67,9 +67,9 @@ struct HardwareCatalogRecord: Equatable {
 	init(_ entity: DeviceHardwareEntity) {
 		self.init(
 			hwModel: entity.hwModel,
-			hwModelSlug: entity.hwModelSlug ?? "",
-			platformioTarget: entity.platformioTarget ?? "",
-			displayName: entity.displayName ?? "",
+			hwModelSlug: entity.hwModelSlug,
+			platformioTarget: entity.platformioTarget,
+			displayName: entity.displayName,
 			activelySupported: entity.activelySupported,
 			supportLevel: SupportLevel(rawValue: entity.supportLevel) ?? .discontinued,
 			architecture: entity.architecture
@@ -101,8 +101,10 @@ enum HardwareCatalogResolver {
 			return presentation(for: record)
 		}
 
-		let canonicalTargets = matches.filter {
-			$0.platformioTarget == normalizedTarget(from: $0.hwModelSlug)
+		let canonicalTargets = matches.filter { record in
+			guard let target = record.platformioTarget,
+			      let slug = record.hwModelSlug else { return false }
+			return target == normalizedTarget(from: slug)
 		}
 		if canonicalTargets.count == 1, let canonical = canonicalTargets.first {
 			return presentation(for: canonical)
@@ -136,8 +138,19 @@ enum HardwareCatalogResolver {
 			return lhs.activelySupported
 		}
 		if lhs.displayName != rhs.displayName {
-			return lhs.displayName.localizedStandardCompare(rhs.displayName) == .orderedAscending
+			return isPreferred(lhs.displayName, over: rhs.displayName)
 		}
-		return lhs.platformioTarget.localizedStandardCompare(rhs.platformioTarget) == .orderedAscending
+		return isPreferred(lhs.platformioTarget, over: rhs.platformioTarget)
+	}
+
+	private static func isPreferred(_ lhs: String?, over rhs: String?) -> Bool {
+		switch (lhs, rhs) {
+		case let (lhs?, rhs?):
+			return lhs < rhs
+		case (.some, nil):
+			return true
+		case (nil, .some), (nil, nil):
+			return false
+		}
 	}
 }

--- a/Meshtastic/Model/DeviceHardwareEntity.swift
+++ b/Meshtastic/Model/DeviceHardwareEntity.swift
@@ -15,7 +15,7 @@ final class DeviceHardwareEntity {
 	var displayName: String?
 	var hasInkHud: Bool = false
 	var hasMui: Bool = false
-	@Attribute(.unique) var hwModel: Int64 = 0
+	var hwModel: Int64 = 0
 	var hwModelSlug: String?
 	var key: String?
 	var partitionScheme: String?
@@ -31,4 +31,113 @@ final class DeviceHardwareEntity {
 	var tags: [DeviceHardwareTagEntity] = []
 
 	init() {}
+}
+
+/// A target-specific entry from the device-hardware catalog.
+///
+/// Firmware targets are not a one-to-one representation of the radio hardware model reported
+/// over the mesh protocol: multiple targets can intentionally report the same `hwModel`.
+struct HardwareCatalogRecord: Equatable {
+	let hwModel: Int64
+	let hwModelSlug: String
+	let platformioTarget: String
+	let displayName: String
+	let activelySupported: Bool
+	let supportLevel: SupportLevel
+	let architecture: String?
+
+	init(
+		hwModel: Int64,
+		hwModelSlug: String,
+		platformioTarget: String,
+		displayName: String,
+		activelySupported: Bool,
+		supportLevel: SupportLevel,
+		architecture: String? = nil
+	) {
+		self.hwModel = hwModel
+		self.hwModelSlug = hwModelSlug
+		self.platformioTarget = platformioTarget
+		self.displayName = displayName
+		self.activelySupported = activelySupported
+		self.supportLevel = supportLevel
+		self.architecture = architecture
+	}
+
+	init(_ entity: DeviceHardwareEntity) {
+		self.init(
+			hwModel: entity.hwModel,
+			hwModelSlug: entity.hwModelSlug ?? "",
+			platformioTarget: entity.platformioTarget ?? "",
+			displayName: entity.displayName ?? "",
+			activelySupported: entity.activelySupported,
+			supportLevel: SupportLevel(rawValue: entity.supportLevel) ?? .discontinued,
+			architecture: entity.architecture
+		)
+	}
+}
+
+/// Safe presentation metadata for a radio that only reports a protobuf `HardwareModel`.
+///
+/// Target-specific values are omitted when the protocol cannot distinguish the catalog variants.
+struct HardwareCatalogPresentation: Equatable {
+	let displayName: String?
+	let platformioTarget: String?
+	let activelySupported: Bool?
+	let supportLevel: SupportLevel?
+	let architecture: String?
+}
+
+enum HardwareCatalogResolver {
+	static func presentation(for hwModel: Int64, in entities: [DeviceHardwareEntity]) -> HardwareCatalogPresentation? {
+		presentation(for: hwModel, in: entities.map(HardwareCatalogRecord.init))
+	}
+
+	static func presentation(for hwModel: Int64, in records: [HardwareCatalogRecord]) -> HardwareCatalogPresentation? {
+		let matches = records.filter { $0.hwModel == hwModel }
+		guard !matches.isEmpty else { return nil }
+
+		if matches.count == 1, let record = matches.first {
+			return presentation(for: record)
+		}
+
+		let canonicalTargets = matches.filter {
+			$0.platformioTarget == normalizedTarget(from: $0.hwModelSlug)
+		}
+		if canonicalTargets.count == 1, let canonical = canonicalTargets.first {
+			return presentation(for: canonical)
+		}
+
+		// The radio protocol cannot supply target-level identity. Present the most desirable
+		// catalog entry consistently instead of letting database/query order pick one at random.
+		let preferred = matches.sorted(by: isPreferred(_:over:)).first!
+		return presentation(for: preferred)
+	}
+
+	private static func presentation(for record: HardwareCatalogRecord) -> HardwareCatalogPresentation {
+		HardwareCatalogPresentation(
+			displayName: record.displayName,
+			platformioTarget: record.platformioTarget,
+			activelySupported: record.activelySupported,
+			supportLevel: record.supportLevel,
+			architecture: record.architecture
+		)
+	}
+
+	private static func normalizedTarget(from hardwareModelSlug: String) -> String {
+		hardwareModelSlug.lowercased().replacingOccurrences(of: "_", with: "-")
+	}
+
+	private static func isPreferred(_ lhs: HardwareCatalogRecord, over rhs: HardwareCatalogRecord) -> Bool {
+		if lhs.supportLevel != rhs.supportLevel {
+			return lhs.supportLevel.rawValue < rhs.supportLevel.rawValue
+		}
+		if lhs.activelySupported != rhs.activelySupported {
+			return lhs.activelySupported
+		}
+		if lhs.displayName != rhs.displayName {
+			return lhs.displayName.localizedStandardCompare(rhs.displayName) == .orderedAscending
+		}
+		return lhs.platformioTarget.localizedStandardCompare(rhs.platformioTarget) == .orderedAscending
+	}
 }

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -413,8 +413,8 @@ extension MeshPackets {
 						let hwDescriptor1 = FetchDescriptor<DeviceHardwareEntity>(
 							predicate: #Predicate { $0.hwModel == fetchHwModel1 }
 						)
-						if let hardwareEntity = try? modelContext.fetch(hwDescriptor1).first {
-							newUser.hwDisplayName = hardwareEntity.displayName
+						if let hardware = try? modelContext.fetch(hwDescriptor1) {
+							newUser.hwDisplayName = HardwareCatalogResolver.presentation(for: fetchHwModel1, in: hardware)?.displayName
 						}
 						newNode.user = newUser
 						
@@ -520,8 +520,8 @@ extension MeshPackets {
 							let hwDescriptor2 = FetchDescriptor<DeviceHardwareEntity>(
 								predicate: #Predicate { $0.hwModel == fetchHwModel2 }
 							)
-							if let hardwareEntity = try? modelContext.fetch(hwDescriptor2).first {
-								user.hwDisplayName = hardwareEntity.displayName
+							if let hardware = try? modelContext.fetch(hwDescriptor2) {
+								user.hwDisplayName = HardwareCatalogResolver.presentation(for: fetchHwModel2, in: hardware)?.displayName
 							}
 						}
 					}

--- a/Meshtastic/Views/Helpers/DeviceHardwareImage.swift
+++ b/Meshtastic/Views/Helpers/DeviceHardwareImage.swift
@@ -15,10 +15,12 @@ import SwiftDraw
 struct DeviceHardwareImage: View {
 	
 	@Query var hardwareResults: [DeviceHardwareEntity]
+	private let hardwareModel: Int64?
 	
 	// Init for Integer ID
 	init<T>(hwId: T) where T: BinaryInteger {
 		let hwModel = Int64(hwId)
+		hardwareModel = hwModel
 		_hardwareResults = Query(filter: #Predicate<DeviceHardwareEntity> { hw in
 			hw.hwModel == hwModel
 		}, sort: [SortDescriptor(\.hwModelSlug)])
@@ -26,6 +28,7 @@ struct DeviceHardwareImage: View {
 	
 	// Init for String Target
 	init(platformioTarget: String) {
+		hardwareModel = nil
 		_hardwareResults = Query(filter: #Predicate<DeviceHardwareEntity> { hw in
 			hw.platformioTarget == platformioTarget
 		}, sort: [SortDescriptor(\.hwModelSlug)])
@@ -33,7 +36,7 @@ struct DeviceHardwareImage: View {
 	
 	var body: some View {
 		// Pass the raw fetched results to the logic layer
-		DeviceHardwareImageProcessor(hardware: hardwareResults)
+		DeviceHardwareImageProcessor(hardware: hardwareResults, hardwareModel: hardwareModel)
 	}
 }
 
@@ -42,6 +45,7 @@ struct DeviceHardwareImage: View {
 // This uses .task to step out of the Layout Loop.
 private struct DeviceHardwareImageProcessor: View {
 	let hardware: [DeviceHardwareEntity]
+	let hardwareModel: Int64?
 	@EnvironmentObject var meshtasticAPI: MeshtasticAPI
 	
 	// We buffer the processed images in State.
@@ -50,7 +54,7 @@ private struct DeviceHardwareImageProcessor: View {
 	
 	/// A stable identity that changes when the actual hardware models change, not just the count.
 	private var hardwareIdentity: String {
-		hardware.map { "\($0.hwModel)" }.joined(separator: ",")
+		hardware.map { "\($0.hwModel):\($0.platformioTarget ?? "")" }.joined(separator: ",")
 	}
 
 	var body: some View {
@@ -67,10 +71,18 @@ private struct DeviceHardwareImageProcessor: View {
 	
 	// The heavy logic moved out of the computed property
 	private func processImages() -> [DeviceHardwareImageEntity] {
+		let displayedHardware: [DeviceHardwareEntity]
+		if let hardwareModel,
+		   let target = HardwareCatalogResolver.presentation(for: hardwareModel, in: hardware)?.platformioTarget {
+			displayedHardware = hardware.filter { $0.platformioTarget == target }
+		} else {
+			displayedHardware = hardware
+		}
+
 		var returnImages = [DeviceHardwareImageEntity]()
 		var seenFileNames = Set<String>()
 		
-		for item in hardware {
+		for item in displayedHardware {
 			for image in item.images {
 				if image.svgData != nil {
 					let name = image.fileName ?? ""

--- a/Meshtastic/Views/Helpers/SupportedHardwareBadge.swift
+++ b/Meshtastic/Views/Helpers/SupportedHardwareBadge.swift
@@ -25,14 +25,19 @@ struct SupportedHardwareBadge: View {
 			hw.platformioTarget == platformioTarget
 		}, sort: [SortDescriptor(\.hwModelSlug)])
 	}
+
+	private var presentation: HardwareCatalogPresentation? {
+		guard let hwModel = hardware.first?.hwModel else { return nil }
+		return HardwareCatalogResolver.presentation(for: hwModel, in: hardware)
+	}
 	
 	var body: some View {
-		if let device = hardware.first {
+		if let activelySupported = presentation?.activelySupported {
 			VStack {
-				Image(systemName: device.activelySupported ? "checkmark.seal.fill" : "x.circle")
+				Image(systemName: activelySupported ? "checkmark.seal.fill" : "x.circle")
 					.font(.largeTitle)
-					.foregroundStyle(device.activelySupported ? .green : .red)
-				Text( device.activelySupported ? "Supported" : "Unsupported")
+					.foregroundStyle(activelySupported ? .green : .red)
+				Text( activelySupported ? "Supported" : "Unsupported")
 					.foregroundStyle(.gray)
 					.font(.caption2)
 					.fixedSize()

--- a/Meshtastic/Views/Nodes/Helpers/NodeInfoItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeInfoItem.swift
@@ -25,11 +25,15 @@ struct NodeInfoItem: View {
 	}
 
 	private var hasDevice: Bool {
-		hardware.first != nil
+		hardwarePresentation != nil
 	}
 
 	private var isActivelySupported: Bool {
-		hardware.first?.activelySupported ?? false
+		hardwarePresentation?.activelySupported ?? false
+	}
+
+	private var hardwarePresentation: HardwareCatalogPresentation? {
+		HardwareCatalogResolver.presentation(for: Int64(node.user?.hwModelId ?? 0), in: hardware)
 	}
 
 	private var supportRosette: some View {
@@ -38,21 +42,30 @@ struct NodeInfoItem: View {
 	}
 
 	private var modelName: String {
-		node.user?.hwDisplayName ?? node.user?.hwModel ?? "Unknown"
+		hardwarePresentation?.displayName ?? node.user?.hwModel ?? "Unknown"
 	}
 
 	private var isPortduino: Bool {
 		node.user?.hwModel == "PORTDUINO"
 	}
 
-	private var supportLevel: SupportLevel {
-		guard let device = hardware.first else { return .discontinued }
-		return SupportLevel(rawValue: device.supportLevel) ?? .discontinued
+	private var supportLevel: SupportLevel? {
+		hardwarePresentation?.supportLevel
+	}
+
+	private var hardwareDescription: String {
+		if let supportLevel {
+			return supportLevel.description
+		}
+		return hasDevice
+			? "This hardware model has multiple indistinguishable variants."
+			: "Hardware model information is unavailable."
 	}
 
 	private var sectionTitle: String {
 		if node.user?.hwModel == "UNSET" { return "Hardware" }
 		if isPortduino { return "Community Hardware" }
+		guard let supportLevel else { return "Hardware" }
 		switch supportLevel {
 		case .flagship:
 			return "Supported Hardware"
@@ -141,13 +154,19 @@ struct NodeInfoItem: View {
 			} else {
 				// MARK: - Discontinued / Unknown Device
 				HStack(spacing: 16) {
-					supportRosette
-						.font(.system(size: 40))
+					if hardwarePresentation?.activelySupported == nil {
+						Image(systemName: "questionmark.circle.fill")
+							.font(.system(size: 40))
+							.foregroundStyle(.secondary)
+					} else {
+						supportRosette
+							.font(.system(size: 40))
+					}
 					VStack(alignment: .leading, spacing: 4) {
 						Text(modelName)
 							.font(.subheadline)
 							.foregroundStyle(.secondary)
-						Text(supportLevel.description)
+						Text(hardwareDescription)
 							.font(.caption)
 							.foregroundStyle(.tertiary)
 					}
@@ -160,7 +179,7 @@ struct NodeInfoItem: View {
 		.accessibilityElement(children: .combine)
 
 		// Device links section (shown only when device has a platformioTarget)
-		if let target = hardware.first?.platformioTarget {
+		if let target = hardwarePresentation?.platformioTarget {
 			DeviceLinksSection(platformioTarget: target)
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -123,8 +123,8 @@ struct PowerConfig: View {
 				let descriptor = FetchDescriptor<DeviceHardwareEntity>(
 					predicate: #Predicate { $0.hwModel == hwModelValue }
 				)
-				if let hardwareEntity = try? context.fetch(descriptor).first,
-				   let archString = hardwareEntity.architecture,
+				if let hardware = try? context.fetch(descriptor),
+				   let archString = HardwareCatalogResolver.presentation(for: hwModelValue, in: hardware)?.architecture,
 				   let arch = Architecture(rawValue: archString) {
 					architecture = arch
 				}

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -54,7 +54,7 @@ struct HardwareCatalogPresentationTests {
 			activelySupported: true,
 			supportLevel: .flagship
 		)
-		let tracksenger = record(
+		let smallTracksenger = record(
 			model: 48,
 			slug: "HELTEC_WIRELESS_TRACKER",
 			target: "tracksenger",
@@ -62,12 +62,69 @@ struct HardwareCatalogPresentationTests {
 			activelySupported: true,
 			supportLevel: .legacy
 		)
+		let largeTracksenger = record(
+			model: 48,
+			slug: "HELTEC_WIRELESS_TRACKER",
+			target: "tracksenger-lcd",
+			displayName: "TrackSenger (big TFT)",
+			activelySupported: false,
+			supportLevel: .legacy
+		)
+		let oledTracksenger = record(
+			model: 48,
+			slug: "HELTEC_WIRELESS_TRACKER",
+			target: "tracksenger-oled",
+			displayName: "TrackSenger (OLED)",
+			activelySupported: true,
+			supportLevel: .legacy
+		)
 
-		let presentation = HardwareCatalogResolver.presentation(for: 48, in: [tracksenger, heltec])
+		let presentation = HardwareCatalogResolver.presentation(
+			for: 48,
+			in: [oledTracksenger, largeTracksenger, smallTracksenger, heltec]
+		)
 
 		#expect(presentation?.displayName == "Heltec Wireless Tracker V1.1")
 		#expect(presentation?.platformioTarget == "heltec-wireless-tracker")
 		#expect(presentation?.supportLevel == .flagship)
+	}
+
+	@Test func preservesMissingCatalogMetadata() {
+		let entity = DeviceHardwareEntity()
+		entity.hwModel = 1
+		entity.hwModelSlug = nil
+		entity.platformioTarget = nil
+		entity.displayName = nil
+
+		let record = HardwareCatalogRecord(entity)
+
+		#expect(record.hwModelSlug == nil)
+		#expect(record.platformioTarget == nil)
+		#expect(record.displayName == nil)
+	}
+
+	@Test func usesRawStringOrderingForEqualPriorityRecords() {
+		let naturalFirst = record(
+			model: 1_000,
+			slug: "AMBIGUOUS_DEVICE",
+			target: "natural-first",
+			displayName: "Device 2",
+			activelySupported: true,
+			supportLevel: .flagship
+		)
+		let rawFirst = record(
+			model: 1_000,
+			slug: "AMBIGUOUS_DEVICE",
+			target: "raw-first",
+			displayName: "Device 10",
+			activelySupported: true,
+			supportLevel: .flagship
+		)
+
+		let presentation = HardwareCatalogResolver.presentation(for: 1_000, in: [naturalFirst, rawFirst])
+
+		#expect(presentation?.displayName == "Device 10")
+		#expect(presentation?.platformioTarget == "raw-first")
 	}
 
 	@Test func choosesPreferredVariantWhenTheProtocolCannotDistinguishIt() {

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -20,6 +20,112 @@ private func makeTestContainer() throws -> ModelContainer {
 	return sharedModelContainer
 }
 
+// MARK: - Hardware catalog presentation
+
+@Suite("Hardware catalog presentation")
+struct HardwareCatalogPresentationTests {
+
+	private func record(
+		model: Int64,
+		slug: String,
+		target: String,
+		displayName: String,
+		activelySupported: Bool,
+		supportLevel: SupportLevel,
+		architecture: String? = nil
+	) -> HardwareCatalogRecord {
+		HardwareCatalogRecord(
+			hwModel: model,
+			hwModelSlug: slug,
+			platformioTarget: target,
+			displayName: displayName,
+			activelySupported: activelySupported,
+			supportLevel: supportLevel,
+			architecture: architecture
+		)
+	}
+
+	@Test func usesCanonicalTargetForTrackerAliasesRegardlessOfCatalogOrder() {
+		let heltec = record(
+			model: 48,
+			slug: "HELTEC_WIRELESS_TRACKER",
+			target: "heltec-wireless-tracker",
+			displayName: "Heltec Wireless Tracker V1.1",
+			activelySupported: true,
+			supportLevel: .flagship
+		)
+		let tracksenger = record(
+			model: 48,
+			slug: "HELTEC_WIRELESS_TRACKER",
+			target: "tracksenger",
+			displayName: "TrackSenger (small TFT)",
+			activelySupported: true,
+			supportLevel: .legacy
+		)
+
+		let presentation = HardwareCatalogResolver.presentation(for: 48, in: [tracksenger, heltec])
+
+		#expect(presentation?.displayName == "Heltec Wireless Tracker V1.1")
+		#expect(presentation?.platformioTarget == "heltec-wireless-tracker")
+		#expect(presentation?.supportLevel == .flagship)
+	}
+
+	@Test func choosesPreferredVariantWhenTheProtocolCannotDistinguishIt() {
+		let smallDisplay = record(
+			model: 16,
+			slug: "TLORA_T3_S3",
+			target: "tlora-t3s3-v1",
+			displayName: "LILYGO T-LoRa T3-S3",
+			activelySupported: true,
+			supportLevel: .flagship,
+			architecture: "esp32-s3"
+		)
+		let eInk = record(
+			model: 16,
+			slug: "TLORA_T3_S3",
+			target: "tlora-t3s3-epaper",
+			displayName: "LILYGO T-LoRa T3-S3 E-Ink",
+			activelySupported: true,
+			supportLevel: .flagship,
+			architecture: "esp32-s3"
+		)
+
+		let presentation = HardwareCatalogResolver.presentation(for: 16, in: [eInk, smallDisplay])
+
+		#expect(presentation?.displayName == "LILYGO T-LoRa T3-S3")
+		#expect(presentation?.platformioTarget == "tlora-t3s3-v1")
+		#expect(presentation?.supportLevel == .flagship)
+		#expect(presentation?.activelySupported == true)
+		#expect(presentation?.architecture == "esp32-s3")
+	}
+
+	@Test func choosesBestSupportedVariantForFutureAmbiguousModels() {
+		let active = record(
+			model: 999,
+			slug: "FUTURE_DEVICE",
+			target: "future-device-a",
+			displayName: "Future Device A",
+			activelySupported: true,
+			supportLevel: .flagship
+		)
+		let legacy = record(
+			model: 999,
+			slug: "FUTURE_DEVICE",
+			target: "future-device-b",
+			displayName: "Future Device B",
+			activelySupported: false,
+			supportLevel: .legacy
+		)
+
+		let presentation = HardwareCatalogResolver.presentation(for: 999, in: [legacy, active])
+
+		#expect(presentation?.displayName == "Future Device A")
+		#expect(presentation?.platformioTarget == "future-device-a")
+		#expect(presentation?.supportLevel == .flagship)
+		#expect(presentation?.activelySupported == true)
+	}
+}
+
 // MARK: - createUser Tests
 
 @Suite("createUser")


### PR DESCRIPTION
## Summary

Fixes #2070.

The device-hardware catalog has multiple PlatformIO targets for one protobuf hardware model. The app persisted `hwModel` as unique and then selected `hardware.first` at model-based call sites. A catalog refresh could therefore switch a Heltec Wireless Tracker (model 48) from its canonical entry to a TrackSenger alias, which changes the support badge and device description.

## Evidence

- The [protobuf model](https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto) reports only `HardwareModel`; it has no PlatformIO-target or variant field.
- The [Heltec Wireless Tracker firmware target](https://github.com/meshtastic/firmware/blob/master/variants/esp32s3/heltec_wireless_tracker/platformio.ini) and all three [TrackSenger targets](https://github.com/meshtastic/firmware/blob/master/variants/esp32s3/tracksenger/platformio.ini) report model 48.
- The [live catalog API](https://api.meshtastic.org/resource/deviceHardware) currently contains duplicate model groups 16, 39, 47, 48, 94, and 97. Model 48 includes the flagship Heltec V1.1 entry and legacy TrackSenger aliases.

## Fix

- Allow multiple target-level catalog rows for a hardware model.
- Add one deterministic resolver for every model-based presentation lookup:
  1. use the exact canonical protobuf target when present;
  2. otherwise prefer the highest support tier;
  3. then active support;
  4. then stable display-name/target ordering.
- Use that resolver in node UI, support badges, device images, links, persisted device display names, and Power Config architecture lookup.
- Add regression coverage for model 48, current duplicate model 16, and a future ambiguous duplicate group.

Model 48 now resolves consistently to Heltec Wireless Tracker V1.1. The same resolver protects every current and future duplicate model group. The protocol/API exposes no usage or popularity signal, so the supported/active preference is the strongest available deterministic fallback for noncanonical aliases.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic -destination "platform=iOS Simulator,id=470F4F6F-D37D-4093-A40F-C0785E0E9757" -derivedDataPath /private/tmp/meshtastic-hardware-catalog-derived-3 -only-testing:MeshtasticTests/HardwareCatalogPresentationTests`
- iPhone 17 Simulator: 3 passed, 0 failed.
- `swiftc -parse` on all changed Swift sources.
- `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hardware identification and presentation (model, display name, support status, and “Discontinued/Unknown” messaging) across node details, badges, and related UI.
  - Resolved ambiguous hardware variants more consistently using the hardware catalog, including tracker aliases and legacy variants.
  - Updated power settings hardware-architecture detection to use the resolved presentation.
  - Device images now filter and select the most relevant resolved hardware variant.
- **Tests**
  - Added hardware catalog presentation tests to verify resolver selection and variant tie-breaking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->