### PR TITLE
Site Planner polish: radio-tower icon, standard form layout, locale-aware fields, geocoded name

### DIFF
--- a/Meshtastic/Assets.xcassets/custom.radio.tower.symbolset/Contents.json
+++ b/Meshtastic/Assets.xcassets/custom.radio.tower.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "custom.radio.tower.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Meshtastic/Assets.xcassets/custom.radio.tower.symbolset/custom.radio.tower.svg
+++ b/Meshtastic/Assets.xcassets/custom.radio.tower.symbolset/custom.radio.tower.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generator: Custom SF Symbol - Radio Tower-->
+<!DOCTYPE svg
+PUBLIC "-//W3C//DTD SVG 1.1//EN"
+       "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3300 2200">
+ <!--glyph: "radio.tower", point size: 100.0, template writer version: "138.0.0"-->
+ <style>.monochrome-0 {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:-a1b2c3d4e5f60001}
+
+.multicolor-0:tintColor {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:-a1b2c3d4e5f60001}
+
+.hierarchical-0:primary {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:-a1b2c3d4e5f60001}
+
+.SFSymbolsPreviewWireframe {fill:none;opacity:1.0;stroke:black;stroke-width:0.5}
+</style>
+ <g id="Notes">
+  <rect height="2200" id="artboard" style="fill:white;opacity:1" width="3300" x="0" y="0"/>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="292" y2="292"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 322)">Weight/Scale Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 559.711 322)">Ultralight</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1449.84 322)">Regular</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2933.4 322)">Black</text>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1903" y2="1903"/>
+  <text id="template-version" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1933)">Template v.6.0</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1951)">Requires Xcode 16 or greater</text>
+  <text id="descriptive-name" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1969)">Generated from custom.radio.tower</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1987)">Typeset at 100.0 points</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 726)">Small</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1156)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1586)">Large</text>
+ </g>
+ <g id="Guides">
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 696)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="696" y2="696"/>
+  <line id="Capline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="625.541" y2="625.541"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1126)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1126" y2="1126"/>
+  <line id="Capline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1055.54" y2="1055.54"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1556)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1556" y2="1556"/>
+  <line id="Capline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1485.54" y2="1485.54"/>
+  <line id="left-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="515.423" x2="515.423" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="604" x2="604" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1405.56" x2="1405.56" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1494.13" x2="1494.13" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2889.11" x2="2889.11" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2977.69" x2="2977.69" y1="600.785" y2="720.121"/>
+ </g>
+ <g id="Symbols">
+  <g id="Black-S" transform="matrix(1 0 0 1 2889.11 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:primary SFSymbolsPreviewWireframe" fill-rule="nonzero" d="M30.39 0.40L43.39 -44.60L40.61 -45.40L27.61 -0.40ZM60.39 -0.40L47.39 -45.40L44.61 -44.60L57.61 0.40ZM33.33 -13.80L54.67 -13.80L54.67 -16.20L33.33 -16.20ZM37.67 -28.80L50.33 -28.80L50.33 -31.20L37.67 -31.20ZM40.56 -38.80L47.44 -38.80L47.44 -41.20L40.56 -41.20ZM29.61 1.04L55.27 -13.96L54.06 -16.04L28.39 -1.04ZM59.61 -1.04L33.94 -16.04L32.73 -13.96L58.39 1.04ZM34.13 -14.10L51.13 -29.10L49.54 -30.90L32.54 -15.90ZM55.46 -15.90L38.46 -30.90L36.87 -29.10L53.87 -14.10ZM38.52 -29.16L48.30 -39.16L46.59 -40.84L36.81 -30.84ZM51.19 -30.84L41.41 -40.84L39.70 -39.16L49.48 -29.16ZM39.10 -51.00A4.90 4.90 0 1 0 48.90 -51.00A4.90 4.90 0 1 0 39.10 -51.00ZM51.94 -40.83A12.90 12.90 0 0 0 51.94 -61.17L50.22 -58.96A10.10 10.10 0 0 1 50.22 -43.04ZM36.06 -61.17A12.90 12.90 0 0 0 36.06 -40.83L37.78 -43.04A10.10 10.10 0 0 1 37.78 -58.96ZM56.25 -35.32A19.90 19.90 0 0 0 56.25 -66.68L54.53 -64.47A17.10 17.10 0 0 1 54.53 -37.53ZM31.75 -66.68A19.90 19.90 0 0 0 31.75 -35.32L33.47 -37.53A17.10 17.10 0 0 1 33.47 -64.47ZM60.56 -29.80A26.90 26.90 0 0 0 60.56 -72.20L58.84 -69.99A24.10 24.10 0 0 1 58.84 -32.01ZM27.44 -72.20A26.90 26.90 0 0 0 27.44 -29.80L29.16 -32.01A24.10 24.10 0 0 1 29.16 -69.99Z"/>
+  </g>
+  <g id="Regular-S" transform="matrix(1 0 0 1 1405.56 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:primary SFSymbolsPreviewWireframe" fill-rule="nonzero" d="M30.39 0.40L43.39 -44.60L40.61 -45.40L27.61 -0.40ZM60.39 -0.40L47.39 -45.40L44.61 -44.60L57.61 0.40ZM33.33 -13.80L54.67 -13.80L54.67 -16.20L33.33 -16.20ZM37.67 -28.80L50.33 -28.80L50.33 -31.20L37.67 -31.20ZM40.56 -38.80L47.44 -38.80L47.44 -41.20L40.56 -41.20ZM29.61 1.04L55.27 -13.96L54.06 -16.04L28.39 -1.04ZM59.61 -1.04L33.94 -16.04L32.73 -13.96L58.39 1.04ZM34.13 -14.10L51.13 -29.10L49.54 -30.90L32.54 -15.90ZM55.46 -15.90L38.46 -30.90L36.87 -29.10L53.87 -14.10ZM38.52 -29.16L48.30 -39.16L46.59 -40.84L36.81 -30.84ZM51.19 -30.84L41.41 -40.84L39.70 -39.16L49.48 -29.16ZM39.10 -51.00A4.90 4.90 0 1 0 48.90 -51.00A4.90 4.90 0 1 0 39.10 -51.00ZM51.94 -40.83A12.90 12.90 0 0 0 51.94 -61.17L50.22 -58.96A10.10 10.10 0 0 1 50.22 -43.04ZM36.06 -61.17A12.90 12.90 0 0 0 36.06 -40.83L37.78 -43.04A10.10 10.10 0 0 1 37.78 -58.96ZM56.25 -35.32A19.90 19.90 0 0 0 56.25 -66.68L54.53 -64.47A17.10 17.10 0 0 1 54.53 -37.53ZM31.75 -66.68A19.90 19.90 0 0 0 31.75 -35.32L33.47 -37.53A17.10 17.10 0 0 1 33.47 -64.47ZM60.56 -29.80A26.90 26.90 0 0 0 60.56 -72.20L58.84 -69.99A24.10 24.10 0 0 1 58.84 -32.01ZM27.44 -72.20A26.90 26.90 0 0 0 27.44 -29.80L29.16 -32.01A24.10 24.10 0 0 1 29.16 -69.99Z"/>
+  </g>
+  <g id="Ultralight-S" transform="matrix(1 0 0 1 515.423 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:primary SFSymbolsPreviewWireframe" fill-rule="nonzero" d="M30.39 0.40L43.39 -44.60L40.61 -45.40L27.61 -0.40ZM60.39 -0.40L47.39 -45.40L44.61 -44.60L57.61 0.40ZM33.33 -13.80L54.67 -13.80L54.67 -16.20L33.33 -16.20ZM37.67 -28.80L50.33 -28.80L50.33 -31.20L37.67 -31.20ZM40.56 -38.80L47.44 -38.80L47.44 -41.20L40.56 -41.20ZM29.61 1.04L55.27 -13.96L54.06 -16.04L28.39 -1.04ZM59.61 -1.04L33.94 -16.04L32.73 -13.96L58.39 1.04ZM34.13 -14.10L51.13 -29.10L49.54 -30.90L32.54 -15.90ZM55.46 -15.90L38.46 -30.90L36.87 -29.10L53.87 -14.10ZM38.52 -29.16L48.30 -39.16L46.59 -40.84L36.81 -30.84ZM51.19 -30.84L41.41 -40.84L39.70 -39.16L49.48 -29.16ZM39.10 -51.00A4.90 4.90 0 1 0 48.90 -51.00A4.90 4.90 0 1 0 39.10 -51.00ZM51.94 -40.83A12.90 12.90 0 0 0 51.94 -61.17L50.22 -58.96A10.10 10.10 0 0 1 50.22 -43.04ZM36.06 -61.17A12.90 12.90 0 0 0 36.06 -40.83L37.78 -43.04A10.10 10.10 0 0 1 37.78 -58.96ZM56.25 -35.32A19.90 19.90 0 0 0 56.25 -66.68L54.53 -64.47A17.10 17.10 0 0 1 54.53 -37.53ZM31.75 -66.68A19.90 19.90 0 0 0 31.75 -35.32L33.47 -37.53A17.10 17.10 0 0 1 33.47 -64.47ZM60.56 -29.80A26.90 26.90 0 0 0 60.56 -72.20L58.84 -69.99A24.10 24.10 0 0 1 58.84 -32.01ZM27.44 -72.20A26.90 26.90 0 0 0 27.44 -29.80L29.16 -32.01A24.10 24.10 0 0 1 29.16 -69.99Z"/>
+  </g>
+ </g>
+</svg>

--- a/Meshtastic/Helpers/SitePlanner/CoverageEstimateRunner.swift
+++ b/Meshtastic/Helpers/SitePlanner/CoverageEstimateRunner.swift
@@ -28,13 +28,23 @@ enum CoverageEstimateState: Equatable {
 	case failed(String)
 }
 
-/// The result of a successful run: the imported overlay's metadata plus the
-/// transmitter coordinate to recenter the map on. `Equatable` (by a per-result
+/// Geographic bounding box (degrees) of an imported coverage overlay, used to frame the map on it.
+struct CoverageBounds {
+	let minLatitude: Double
+	let maxLatitude: Double
+	let minLongitude: Double
+	let maxLongitude: Double
+}
+
+/// The result of a successful run: the imported overlay's metadata, the transmitter coordinate, and
+/// the coverage geometry's bounding box (to frame the map on it). `Equatable` (by a per-result
 /// token) so it can drive a SwiftUI `onChange`.
 struct CoverageEstimateResult: Equatable {
 	let token = UUID()
 	let metadata: MapDataMetadata
 	let coordinate: CLLocationCoordinate2D
+	/// Bounding box of the imported coverage geometry, when derivable from the GeoJSON.
+	let boundingBox: CoverageBounds?
 
 	static func == (lhs: CoverageEstimateResult, rhs: CoverageEstimateResult) -> Bool {
 		lhs.token == rhs.token
@@ -166,6 +176,7 @@ final class CoverageEstimateRunner: NSObject, ObservableObject {
 		let coordinate = CLLocationCoordinate2D(latitude: params.latitude, longitude: params.longitude)
 		let layerName = params.name.trimmingCharacters(in: .whitespacesAndNewlines)
 		let importName = layerName.isEmpty ? "Coverage" : layerName
+		let boundingBox = Self.boundingBox(fromGeoJSON: geoJSON)
 
 		// This method is `@MainActor`, so the Task inherits MainActor isolation — after each
 		// `await` we're back on the main actor and can assign published state directly.
@@ -173,12 +184,38 @@ final class CoverageEstimateRunner: NSObject, ObservableObject {
 			do {
 				let metadata = try await MapDataManager.shared.importFromString(geoJSON, name: importName)
 				guard let self else { return }
-				self.importedResult = CoverageEstimateResult(metadata: metadata, coordinate: coordinate)
+				self.importedResult = CoverageEstimateResult(metadata: metadata, coordinate: coordinate, boundingBox: boundingBox)
 				self.state = .imported
 			} catch {
 				self?.state = .failed(error.localizedDescription)
 			}
 		}
+	}
+
+	/// Compute the bounding box of every position in a GeoJSON string. Walks the parsed JSON
+	/// generically: any array whose first element is a number is a `[lon, lat, …]` position, and
+	/// everything else is a container to recurse into — so it works for Point / LineString / Polygon /
+	/// MultiPolygon without a schema. Returns nil when no positions are found.
+	static func boundingBox(fromGeoJSON geoJSON: String) -> CoverageBounds? {
+		guard let data = geoJSON.data(using: .utf8),
+			  let root = try? JSONSerialization.jsonObject(with: data) else { return nil }
+		var minLat = Double.infinity, maxLat = -Double.infinity
+		var minLon = Double.infinity, maxLon = -Double.infinity
+		func walk(_ node: Any) {
+			if let array = node as? [Any] {
+				if let lon = array.first as? Double, array.count >= 2, let lat = array[1] as? Double {
+					minLat = min(minLat, lat); maxLat = max(maxLat, lat)
+					minLon = min(minLon, lon); maxLon = max(maxLon, lon)
+				} else {
+					array.forEach(walk)
+				}
+			} else if let dict = node as? [String: Any] {
+				dict.values.forEach(walk)
+			}
+		}
+		walk(root)
+		guard minLat <= maxLat, minLon <= maxLon else { return nil }
+		return CoverageBounds(minLatitude: minLat, maxLatitude: maxLat, minLongitude: minLon, maxLongitude: maxLon)
 	}
 
 	/// The foreground key window to host the headless WebView.

--- a/Meshtastic/Helpers/SitePlanner/SitePlannerParameters.swift
+++ b/Meshtastic/Helpers/SitePlanner/SitePlannerParameters.swift
@@ -68,7 +68,7 @@ struct SitePlannerParameters: Equatable {
 	var highResolution: Bool = false
 
 	// MARK: Display
-	var colorScale: SitePlannerColorScale = .plasma
+	var colorScale: SitePlannerColorScale = .turbo
 
 	// MARK: - Validation bounds (mirror the planner's `store.ts` / input ranges)
 	static let frequencyRange: ClosedRange<Double> = 20...20_000

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -69,6 +69,7 @@ struct CoverageEstimateForm: View {
 							.symbolRenderingMode(.palette)
 							.foregroundStyle(.white, Color(.systemGray3))
 					}
+					.buttonStyle(.plain)
 					.accessibilityLabel("Close")
 				}
 				ToolbarItem(placement: .confirmationAction) {

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -65,7 +65,7 @@ struct CoverageEstimateForm: View {
 						dismiss()
 					} label: {
 						Image(systemName: "xmark.circle.fill")
-							.font(.title)
+							.font(.title2)
 							.symbolRenderingMode(.palette)
 							.foregroundStyle(.white, Color(.systemGray3))
 					}

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -38,6 +38,8 @@ struct CoverageEstimateForm: View {
 	@State private var simulationExpanded = false
 	@State private var displayExpanded = true
 	@State private var errorMessage: String?
+	/// In-flight reverse geocode for the chosen coordinate; cancelled when a newer coordinate is picked.
+	@State private var geocodeTask: Task<Void, Never>?
 
 	init(seed: CoverageEstimateSeed, runner: CoverageEstimateRunner) {
 		self.seed = seed
@@ -61,10 +63,14 @@ struct CoverageEstimateForm: View {
 			.navigationBarTitleDisplayMode(.inline)
 			.toolbar {
 				ToolbarItem(placement: .cancellationAction) {
-					Button("Cancel") {
+					Button {
 						runner.reset()
 						dismiss()
+					} label: {
+						Image(systemName: "xmark.circle.fill")
+							.foregroundStyle(.secondary)
 					}
+					.accessibilityLabel("Close")
 				}
 				ToolbarItem(placement: .confirmationAction) {
 					Button("Estimate") {
@@ -121,7 +127,11 @@ struct CoverageEstimateForm: View {
 				labeledNumber("Antenna height (m)", value: $params.txHeightMeters)
 				labeledNumber("Antenna gain (dBi)", value: $params.txGainDBi)
 			} label: {
-				Label("Site / Transmitter", systemImage: "antenna.radiowaves.left.and.right")
+				Label {
+					Text("Site / Transmitter")
+				} icon: {
+					Image("custom.radio.tower")
+				}
 			}
 		}
 	}
@@ -213,6 +223,44 @@ struct CoverageEstimateForm: View {
 	private func apply(_ coordinate: CLLocationCoordinate2D) {
 		params.latitude = coordinate.latitude
 		params.longitude = coordinate.longitude
+		reverseGeocodeName(for: coordinate)
+	}
+
+	/// Auto-fills the site name from the chosen coordinate's placemark. Prefers a named point of
+	/// interest (coverage sites are usually a landmark/hill/park/tower), then the placemark name,
+	/// then progressively coarser locality/street/water fields. Cancels any in-flight lookup so the
+	/// newest pick wins, and leaves the existing name untouched when the geocode yields nothing or fails.
+	private func reverseGeocodeName(for coordinate: CLLocationCoordinate2D) {
+		geocodeTask?.cancel()
+		geocodeTask = Task {
+			let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+			let placemark = try? await CLGeocoder().reverseGeocodeLocation(location).first
+			guard !Task.isCancelled, let placemark, let name = Self.siteName(from: placemark) else { return }
+			await MainActor.run { params.name = name }
+		}
+	}
+
+	/// Picks a human place name for a coordinate. Prefers a named point of interest, then the
+	/// placemark's `name` ONLY when it isn't a street address (`CLPlacemark.name` degrades to the
+	/// street address whenever there's no landmark), then neighborhood → city → street → water. This
+	/// keeps residential coordinates from filling the field with "13500 SE Newport Way".
+	static func siteName(from placemark: CLPlacemark) -> String? {
+		if let poi = placemark.areasOfInterest?.first { return poi }
+		if let name = placemark.name, !placemarkNameIsStreetAddress(name, placemark) { return name }
+		return placemark.subLocality
+			?? placemark.locality
+			?? placemark.thoroughfare
+			?? placemark.inlandWater
+			?? placemark.ocean
+	}
+
+	/// `CLPlacemark.name` is the formatted street address when the placemark resolves to a building:
+	/// a house number is present, or the name leads with a digit, or it contains the street name.
+	private static func placemarkNameIsStreetAddress(_ name: String, _ placemark: CLPlacemark) -> Bool {
+		if placemark.subThoroughfare != nil { return true }
+		if name.first?.isNumber == true { return true }
+		if let street = placemark.thoroughfare, name.localizedCaseInsensitiveContains(street) { return true }
+		return false
 	}
 
 	// MARK: - Helpers

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -33,10 +33,6 @@ struct CoverageEstimateForm: View {
 	@Environment(\.dismiss) private var dismiss
 
 	@State private var params: SitePlannerParameters
-	@State private var transmitterExpanded = true
-	@State private var receiverExpanded = false
-	@State private var simulationExpanded = false
-	@State private var displayExpanded = true
 	@State private var errorMessage: String?
 	/// In-flight reverse geocode for the chosen coordinate; cancelled when a newer coordinate is picked.
 	@State private var geocodeTask: Task<Void, Never>?
@@ -59,6 +55,7 @@ struct CoverageEstimateForm: View {
 				simulationSection
 				displaySection
 			}
+			.scrollDismissesKeyboard(.immediately)
 			.navigationTitle("Estimate Coverage")
 			.navigationBarTitleDisplayMode(.inline)
 			.toolbar {
@@ -114,65 +111,59 @@ struct CoverageEstimateForm: View {
 
 	private var transmitterSection: some View {
 		Section {
-			DisclosureGroup(isExpanded: $transmitterExpanded) {
-				TextField("Site name", text: $params.name)
-					.accessibilityLabel("Site name")
+			TextField("Site name", text: $params.name)
+				.accessibilityLabel("Site name")
 
-				locationShortcuts
+			locationShortcuts
 
-				DecimalField("Latitude", value: $params.latitude)
-				DecimalField("Longitude", value: $params.longitude)
-				labeledNumber("Transmit power (W)", value: $params.txPowerWatts)
-				labeledNumber("Frequency (MHz)", value: $params.txFrequencyMHz)
-				lengthField("Antenna height", canonical: $params.txHeightMeters, storedUnit: .meters, imperialUnit: .feet)
-				labeledNumber("Antenna gain (dBi)", value: $params.txGainDBi)
-			} label: {
-				Label {
-					Text("Site / Transmitter")
-				} icon: {
-					Image("custom.radio.tower")
-				}
+			DecimalField("Latitude", value: $params.latitude)
+			DecimalField("Longitude", value: $params.longitude)
+			labeledNumber("Transmit power (W)", value: $params.txPowerWatts)
+			labeledNumber("Frequency (MHz)", value: $params.txFrequencyMHz)
+			lengthField("Antenna height", canonical: $params.txHeightMeters, storedUnit: .meters, imperialUnit: .feet)
+			labeledNumber("Antenna gain (dBi)", value: $params.txGainDBi)
+		} header: {
+			Label {
+				Text("Site / Transmitter")
+			} icon: {
+				Image("custom.radio.tower")
 			}
 		}
 	}
 
 	private var receiverSection: some View {
 		Section {
-			DisclosureGroup(isExpanded: $receiverExpanded) {
-				DecimalField("Sensitivity (dBm)", value: $params.rxSensitivityDBm)
-			} label: {
-				Label("Receiver", systemImage: "dot.radiowaves.left.and.right")
-			}
+			DecimalField("Sensitivity (dBm)", value: $params.rxSensitivityDBm)
+		} header: {
+			Label("Receiver", systemImage: "dot.radiowaves.left.and.right")
 		}
 	}
 
 	private var simulationSection: some View {
 		Section {
-			DisclosureGroup(isExpanded: $simulationExpanded) {
-				lengthField("Max range", canonical: $params.maxRangeKm, storedUnit: .kilometers, imperialUnit: .miles)
-				Toggle("High-resolution terrain", isOn: $params.highResolution)
-					.onChange(of: params.highResolution) { _, _ in
-						// High-res caps the range at 70 km — clamp so the value stays valid.
-						let bounds = params.maxRangeBounds
-						params.maxRangeKm = min(max(params.maxRangeKm, bounds.lowerBound), bounds.upperBound)
-					}
-			} label: {
-				Label("Simulation Options", systemImage: "slider.horizontal.3")
-			}
+			lengthField("Max range", canonical: $params.maxRangeKm, storedUnit: .kilometers, imperialUnit: .miles)
+			Toggle("High-resolution terrain", isOn: $params.highResolution)
+				.onChange(of: params.highResolution) { _, _ in
+					// High-res caps the range at 70 km — clamp so the value stays valid.
+					let bounds = params.maxRangeBounds
+					params.maxRangeKm = min(max(params.maxRangeKm, bounds.lowerBound), bounds.upperBound)
+				}
+		} header: {
+			Label("Simulation Options", systemImage: "slider.horizontal.3")
+		} footer: {
+			Text("High-resolution terrain gives a more detailed estimate but caps the maximum range at 70 km.")
 		}
 	}
 
 	private var displaySection: some View {
 		Section {
-			DisclosureGroup(isExpanded: $displayExpanded) {
-				Picker("Palette", selection: $params.colorScale) {
-					ForEach(SitePlannerColorScale.allCases) { scale in
-						Text(scale.displayName).tag(scale)
-					}
+			Picker("Palette", selection: $params.colorScale) {
+				ForEach(SitePlannerColorScale.allCases) { scale in
+					Text(scale.displayName).tag(scale)
 				}
-			} label: {
-				Label("Display", systemImage: "paintpalette")
 			}
+		} header: {
+			Label("Display", systemImage: "paintpalette")
 		}
 	}
 
@@ -270,7 +261,7 @@ struct CoverageEstimateForm: View {
 			Text(title)
 			Spacer()
 			TextField("", value: value, format: .number)
-				.keyboardType(.numbersAndPunctuation)
+				.keyboardType(.decimalPad)
 				.multilineTextAlignment(.trailing)
 				.frame(maxWidth: 140)
 				.accessibilityLabel(Text(title))
@@ -294,7 +285,7 @@ struct CoverageEstimateForm: View {
 				.foregroundStyle(.secondary)
 			Spacer()
 			TextField("", value: display, format: .number.precision(.fractionLength(0...2)))
-				.keyboardType(.numbersAndPunctuation)
+				.keyboardType(.decimalPad)
 				.multilineTextAlignment(.trailing)
 				.frame(maxWidth: 140)
 				.accessibilityLabel(Text(title))

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -124,7 +124,7 @@ struct CoverageEstimateForm: View {
 				DecimalField("Longitude", value: $params.longitude)
 				labeledNumber("Transmit power (W)", value: $params.txPowerWatts)
 				labeledNumber("Frequency (MHz)", value: $params.txFrequencyMHz)
-				labeledNumber("Antenna height (m)", value: $params.txHeightMeters)
+				lengthField("Antenna height", canonical: $params.txHeightMeters, storedUnit: .meters, imperialUnit: .feet)
 				labeledNumber("Antenna gain (dBi)", value: $params.txGainDBi)
 			} label: {
 				Label {
@@ -149,7 +149,7 @@ struct CoverageEstimateForm: View {
 	private var simulationSection: some View {
 		Section {
 			DisclosureGroup(isExpanded: $simulationExpanded) {
-				labeledNumber("Max range (km)", value: $params.maxRangeKm)
+				lengthField("Max range", canonical: $params.maxRangeKm, storedUnit: .kilometers, imperialUnit: .miles)
 				Toggle("High-resolution terrain", isOn: $params.highResolution)
 					.onChange(of: params.highResolution) { _, _ in
 						// High-res caps the range at 70 km — clamp so the value stays valid.
@@ -270,6 +270,30 @@ struct CoverageEstimateForm: View {
 			Text(title)
 			Spacer()
 			TextField("", value: value, format: .number)
+				.keyboardType(.numbersAndPunctuation)
+				.multilineTextAlignment(.trailing)
+				.frame(maxWidth: 140)
+				.accessibilityLabel(Text(title))
+		}
+	}
+
+	/// An editable length field that keeps the model in its canonical unit (`storedUnit`, what the
+	/// Site Planner expects) but displays and edits in the device locale's measurement system —
+	/// `imperialUnit` for non-metric locales. `Measurement.FormatStyle` isn't `ParseableFormatStyle`,
+	/// so a converting `Binding<Double>` bridges the two rather than a `format:` on the field. The
+	/// number itself still formats per locale via `.number`.
+	private func lengthField(_ title: LocalizedStringKey, canonical: Binding<Double>, storedUnit: UnitLength, imperialUnit: UnitLength) -> some View {
+		let displayUnit = Locale.current.measurementSystem == .metric ? storedUnit : imperialUnit
+		let display = Binding<Double>(
+			get: { Measurement(value: canonical.wrappedValue, unit: storedUnit).converted(to: displayUnit).value },
+			set: { canonical.wrappedValue = Measurement(value: $0, unit: displayUnit).converted(to: storedUnit).value }
+		)
+		return HStack {
+			Text(title)
+			Text(verbatim: "(\(displayUnit.symbol))")
+				.foregroundStyle(.secondary)
+			Spacer()
+			TextField("", value: display, format: .number.precision(.fractionLength(0...2)))
 				.keyboardType(.numbersAndPunctuation)
 				.multilineTextAlignment(.trailing)
 				.frame(maxWidth: 140)

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -81,6 +81,7 @@ struct CoverageEstimateForm: View {
 					estimatingOverlay
 				}
 			}
+			.onAppear(perform: generateInitialNameIfNeeded)
 			.onDisappear {
 				// Tear down a still-running headless run if the sheet is swipe-dismissed. Safe on the
 				// success path too — the import already published its result before `dismiss()`.
@@ -221,6 +222,16 @@ struct CoverageEstimateForm: View {
 	/// interest (coverage sites are usually a landmark/hill/park/tower), then the placemark name,
 	/// then progressively coarser locality/street/water fields. Cancels any in-flight lookup so the
 	/// newest pick wins, and leaves the existing name untouched when the geocode yields nothing or fails.
+	/// On launch, if the site name is empty but the seed already carries a usable coordinate (e.g.
+	/// presented from the map toolbar), reverse-geocode it to fill the name — the same result as
+	/// tapping a location shortcut, just automatic. Skipped when a name is already set (the
+	/// node-detail hand-off prefills the node's name) or the coordinate is the 0,0 sentinel.
+	private func generateInitialNameIfNeeded() {
+		guard params.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+			  params.hasValidCoordinate else { return }
+		reverseGeocodeName(for: CLLocationCoordinate2D(latitude: params.latitude, longitude: params.longitude))
+	}
+
 	private func reverseGeocodeName(for coordinate: CLLocationCoordinate2D) {
 		geocodeTask?.cancel()
 		geocodeTask = Task {

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -65,7 +65,9 @@ struct CoverageEstimateForm: View {
 						dismiss()
 					} label: {
 						Image(systemName: "xmark.circle.fill")
-							.foregroundStyle(.secondary)
+							.font(.title)
+							.symbolRenderingMode(.palette)
+							.foregroundStyle(.white, Color(.systemGray3))
 					}
 					.accessibilityLabel("Close")
 				}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -575,18 +575,18 @@ struct NodeDetail: View {
 					}
 				}
 				.disabled(!hasPositions)
-				Button {
-					router.selectedTab = .map
-					router.mapState = .coverageEstimate(node.num)
-				} label: {
-					Label {
-						Text("Estimate Coverage")
-					} icon: {
-						Image(systemName: "cellularbars")
-							.symbolRenderingMode(.multicolor)
+				if hasPositions {
+					Button {
+						router.selectedTab = .map
+						router.mapState = .coverageEstimate(node.num)
+					} label: {
+						Label {
+							Text("Estimate Coverage")
+						} icon: {
+							Image("custom.radio.tower")
+						}
 					}
 				}
-				.disabled(!hasPositions)
 			}
 			NavigationLink {
 				PositionLog(node: node)

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -445,7 +445,7 @@ struct MeshMapMK: View {
 						Button(action: {
 							presentCoverageEstimateFromMap()
 						}) {
-							Image(systemName: "cellularbars")
+							Image("custom.radio.tower")
 						}
 						.accessibilityLabel("Estimate coverage")
 						.accessibilityHint("Runs a Site Planner coverage estimate and adds it to the map.")

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -615,12 +615,31 @@ struct MeshMapMK: View {
 		rebuildGeoJSONOverlays()
 		cameraCommand = ClusterMapCameraCommand(
 			id: UUID(),
-			region: MKCoordinateRegion(
-				center: result.coordinate,
-				span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
-			),
+			region: coverageRegion(for: result),
 			animated: true
 		)
+	}
+
+	/// Frame the map on the imported coverage: fit its bounding box with padding so the whole
+	/// overlay is visible with breathing room. Falls back to a fixed span around the transmitter
+	/// when the GeoJSON yielded no bounds.
+	private func coverageRegion(for result: CoverageEstimateResult) -> MKCoordinateRegion {
+		guard let box = result.boundingBox else {
+			return MKCoordinateRegion(
+				center: result.coordinate,
+				span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+			)
+		}
+		let padding = 1.3 // ~15% margin on each side
+		let center = CLLocationCoordinate2D(
+			latitude: (box.minLatitude + box.maxLatitude) / 2,
+			longitude: (box.minLongitude + box.maxLongitude) / 2
+		)
+		let span = MKCoordinateSpan(
+			latitudeDelta: min(max((box.maxLatitude - box.minLatitude) * padding, 0.01), 180),
+			longitudeDelta: min(max((box.maxLongitude - box.minLongitude) * padding, 0.01), 360)
+		)
+		return MKCoordinateRegion(center: center, span: span)
 	}
 
 	/// The connected radio's LoRa config, used to prefill frequency / power / sensitivity.


### PR DESCRIPTION
A batch of polish for the in-app Site Planner coverage estimate (follow-up to #2058).

## Changes

**Custom radio-tower symbol**
- New `custom.radio.tower` SF Symbol (broadcast tower + beacon + concentric wave arcs), authored in the project's symbol-template format with Ultralight/Regular/Black variants.
- Used on the map coverage-estimate button, the Site / Transmitter section header, and the Node Detail "Estimate Coverage" row (replacing the generic `cellularbars`).

**Form**
- Match the standard config-form layout (LoRa/Security/Power): flat `Section(header:)` groups instead of collapsible DisclosureGroups, decimal keypads on the numeric fields (punctuation keyboard kept on the negative-capable latitude/longitude/sensitivity fields), `scrollDismissesKeyboard`, and a footer explaining the high-resolution range cap.
- **Locale-aware length fields**: antenna height and max range now display and edit in the device locale's measurement system (feet/miles for non-metric locales) while the model stays in the planner's canonical meters/kilometers. Uses a converting `Binding<Double>` since `Measurement.FormatStyle` isn't `ParseableFormatStyle`.
- Default palette is now **Turbo**.
- Cancel button replaced with an `xmark.circle.fill` close button, matching the in-app convention.

**Reverse-geocoded site name**
- Picking a coordinate (My Location / Node / Map Center) reverse-geocodes it (`CLGeocoder`) and auto-fills the site name. Prefers a named point of interest, then the placemark name only when it isn't a street address, then neighborhood → city → street → water — so residential coordinates get a place name rather than "13500 SE Newport Way". Cancellable, and leaves an existing name untouched on failure.

**Node Detail**
- The "Estimate Coverage" row is now hidden when the node has no position (it was gated with `.disabled`, which left a dead-looking row since a disabled Button with a custom Label doesn't dim its text). Estimating a node's coverage requires its location, so the row only appears when the node has one.

## Testing
- Builds clean for device; exercised on a physical iPhone (iOS, US locale) — tower icon renders on all three surfaces, length fields show ft/mi, geocoded names resolve sensibly, form reads like the other settings forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved map framing after importing coverage by using coverage geometry bounds when available.

* **Bug Fixes**
  * Hosted Site Planner color scaling now defaults to a clearer variant.
  * Coverage estimate is now shown only when node position data is available.
  * Coordinate-to-site name auto-fill now cancels in-flight lookups so the newest coordinate wins.

* **UI Improvements**
  * Simplified the coverage estimate form layout and added a dedicated close action.
  * Updated the coverage estimate icon to a custom radio tower image.
  * Enhanced reverse-geocoding name selection and localized distance input editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->