### PR TITLE
fix: recover firmware releases when API proxy stalls

### DIFF
--- a/Meshtastic/API/MeshtasticAPI.swift
+++ b/Meshtastic/API/MeshtasticAPI.swift
@@ -50,14 +50,14 @@ private struct DeviceHardware: Codable {
 }
 
 /// Firmware Release Lists
-private struct FirmwareReleases: Codable {
+struct FirmwareReleases: Codable {
 	let releases: Releases
 	let pullRequests: [FirmwareRelease]
 }
-private struct Releases: Codable {
+struct Releases: Codable {
 	let stable, alpha: [FirmwareRelease]
 }
-private struct FirmwareRelease: Codable {
+struct FirmwareRelease: Codable {
 	let id, title: String
 	let pageURL: String
 	let zipURL: String
@@ -68,6 +68,59 @@ private struct FirmwareRelease: Codable {
 		case pageURL = "page_url"
 		case zipURL = "zip_url"
 		case releaseNotes = "release_notes"
+	}
+}
+
+private struct GitHubFirmwareRelease: Decodable {
+	let tagName: String
+	let name: String?
+	let htmlURL: String
+	let zipballURL: String
+	let body: String?
+	let prerelease: Bool
+	let draft: Bool
+
+	enum CodingKeys: String, CodingKey {
+		case tagName = "tag_name"
+		case name
+		case htmlURL = "html_url"
+		case zipballURL = "zipball_url"
+		case body
+		case prerelease
+		case draft
+	}
+}
+
+enum FirmwareReleaseCatalog {
+	static func decode(_ data: Data) throws -> FirmwareReleases {
+		let decoder = JSONDecoder()
+		if let meshtasticReleases = try? decoder.decode(FirmwareReleases.self, from: data) {
+			return meshtasticReleases
+		}
+
+		let githubReleases = try decoder.decode([GitHubFirmwareRelease].self, from: data)
+		let publishedReleases = githubReleases.filter { !$0.draft }
+		let stable = publishedReleases
+			.filter { !$0.prerelease }
+			.map { FirmwareRelease(gitHubRelease: $0) }
+		let alpha = publishedReleases
+			.filter(\.prerelease)
+			.map { FirmwareRelease(gitHubRelease: $0) }
+
+		return FirmwareReleases(
+			releases: Releases(stable: stable, alpha: alpha),
+			pullRequests: []
+		)
+	}
+}
+
+private extension FirmwareRelease {
+	init(gitHubRelease: GitHubFirmwareRelease) {
+		id = gitHubRelease.tagName
+		title = gitHubRelease.name ?? gitHubRelease.tagName
+		pageURL = gitHubRelease.htmlURL
+		zipURL = gitHubRelease.zipballURL
+		releaseNotes = gitHubRelease.body
 	}
 }
 
@@ -116,6 +169,7 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 	static let deviceURLEndpoint = URL(string: "https://api.meshtastic.org/resource/deviceHardware")!
 	static let imageURLPrefix = URL(string: "https://flasher.meshtastic.org/img/devices/")!
 	static let firmwareURLEndpoint = URL(string: "https://api.meshtastic.org/github/firmware/list")!
+	static let firmwareGitHubURLEndpoint = URL(string: "https://api.github.com/repos/meshtastic/firmware/releases?per_page=100")!
 	static let eventFirmwareURLEndpoint = URL(string: "https://api.meshtastic.org/resource/eventFirmware")!
 	
 	// MARK: - Private properties
@@ -154,10 +208,19 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 		await MainActor.run {
 			self.isLoadingFirmwareList = true
 		}
-		
-		let apiData = try await Self.firmwareURLEndpoint.data(timeout: 5.0)
-		
-		let decodedFirmware = try decoder.decode(FirmwareReleases.self, from: apiData)
+		defer {
+			Task { @MainActor in self.isLoadingFirmwareList = false }
+		}
+
+		let decodedFirmware: FirmwareReleases
+		do {
+			let apiData = try await Self.firmwareURLEndpoint.data(timeout: 5.0)
+			decodedFirmware = try FirmwareReleaseCatalog.decode(apiData)
+		} catch {
+			Logger.services.warning("Firmware API request failed; falling back to GitHub releases: \(error.localizedDescription, privacy: .public)")
+			let githubData = try await Self.firmwareGitHubURLEndpoint.data(timeout: 5.0)
+			decodedFirmware = try FirmwareReleaseCatalog.decode(githubData)
+		}
 		let stableVersions = Set(decodedFirmware.releases.stable.map { $0.id })
 		let alphaVersions = Set(decodedFirmware.releases.alpha.map { $0.id })
 
@@ -196,10 +259,6 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 		
 		// Save the last update date for the firmware
 		UserDefaults.lastFirmwareAPIUpdate = Date()
-		
-		await MainActor.run {
-			self.isLoadingFirmwareList = false
-		}
 	}
 
 	func refreshDevicesAPIData() async throws {

--- a/MeshtasticTests/FirmwareAndAPITests.swift
+++ b/MeshtasticTests/FirmwareAndAPITests.swift
@@ -212,6 +212,79 @@ struct URLTimeoutErrorTests {
 	}
 }
 
+// MARK: - Firmware release catalog
+
+@Suite("Firmware release catalog")
+struct FirmwareReleaseCatalogTests {
+
+	@Test func mapsGitHubReleasesIntoStableAndAlphaCatalogs() throws {
+		let data = Data("""
+		[
+		  {
+		    "tag_name": "v2.7.30",
+		    "name": "2.7.30",
+		    "html_url": "https://github.com/meshtastic/firmware/releases/tag/v2.7.30",
+		    "zipball_url": "https://api.github.com/repos/meshtastic/firmware/zipball/v2.7.30",
+		    "body": "Stable release notes",
+		    "prerelease": false,
+		    "draft": false
+		  },
+		  {
+		    "tag_name": "v2.7.31.alpha",
+		    "name": null,
+		    "html_url": "https://github.com/meshtastic/firmware/releases/tag/v2.7.31.alpha",
+		    "zipball_url": "https://api.github.com/repos/meshtastic/firmware/zipball/v2.7.31.alpha",
+		    "body": null,
+		    "prerelease": true,
+		    "draft": false
+		  },
+		  {
+		    "tag_name": "v2.7.32-draft",
+		    "name": "Draft",
+		    "html_url": "https://github.com/meshtastic/firmware/releases/tag/v2.7.32-draft",
+		    "zipball_url": "https://api.github.com/repos/meshtastic/firmware/zipball/v2.7.32-draft",
+		    "body": "Not published",
+		    "prerelease": false,
+		    "draft": true
+		  }
+		]
+		""".utf8)
+
+		let releases = try FirmwareReleaseCatalog.decode(data)
+
+		#expect(releases.releases.stable.map(\.id) == ["v2.7.30"])
+		#expect(releases.releases.alpha.map(\.id) == ["v2.7.31.alpha"])
+		#expect(releases.releases.stable.first?.releaseNotes == "Stable release notes")
+		#expect(releases.releases.alpha.first?.title == "v2.7.31.alpha")
+	}
+
+	@Test func preservesMeshtasticAPIResponseFormat() throws {
+		let data = Data("""
+		{
+		  "releases": {
+		    "stable": [
+		      {
+		        "id": "v2.7.30",
+		        "title": "2.7.30",
+		        "page_url": "https://meshtastic.org",
+		        "zip_url": "https://meshtastic.org/firmware.zip",
+		        "release_notes": "Notes"
+		      }
+		    ],
+		    "alpha": []
+		  },
+		  "pullRequests": []
+		}
+		""".utf8)
+
+		let releases = try FirmwareReleaseCatalog.decode(data)
+
+		#expect(releases.releases.stable.map(\.id) == ["v2.7.30"])
+		#expect(releases.releases.alpha.isEmpty)
+		#expect(releases.pullRequests.isEmpty)
+	}
+}
+
 // MARK: - FirmwareFile validFilenameSuffixes
 
 @Suite("FirmwareFile validFilenameSuffixes")


### PR DESCRIPTION
## Problem

The shipped firmware refresh path only requests https://api.meshtastic.org/github/firmware/list with a 5-second timeout. Its error is discarded by the startup task, and an error path leaves the firmware-loading state set to true. A first install therefore has no release catalog and stays on the updating state.

Live check on 2026-07-16:
- The Meshtastic firmware-list endpoint timed out after 10.004 seconds without receiving any bytes (HTTP 000).
- GitHub's meshtastic/firmware releases endpoint returned HTTP 200 in 0.462 seconds (44,596 bytes).

This isolates the failure to the firmware-list proxy route rather than a general iOS/network outage.

## Changes

- Keep the Meshtastic API response as the primary source.
- Fall back to GitHub's release API when that request or decode fails.
- Map published GitHub releases into the existing Stable and Alpha catalogs; drafts are excluded.
- Clear the loading state on every success or failure path, preserving the existing stored catalog if both sources fail.
- Add regression coverage for GitHub mapping and the existing Meshtastic API format.

## Validation

- Focused simulator test: 2 passed, 0 failed on iPhone 17 Pro (iOS 26.5).
- Project lint phase completed with 0 serious violations.
- git diff --check passed.

The local pre-commit SwiftLint hook could not load sourcekitd in this shell; the Xcode simulator build's lint phase and focused tests completed successfully.