### PR TITLE
Use update icon for firmware notice

### DIFF
--- a/Meshtastic/Model/Firmware/FirmwareUpdateNotifier.swift
+++ b/Meshtastic/Model/Firmware/FirmwareUpdateNotifier.swift
@@ -24,6 +24,8 @@ struct FirmwareUpdateNotificationSource {
 }
 
 struct FirmwareUpdateNotice: Equatable {
+	static let symbolName = "arrow.triangle.2.circlepath"
+
 	let notificationKey: String
 	let deviceName: String
 	let currentVersion: String

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -840,9 +840,9 @@ private struct FirmwareUpdateConnectNotice: View {
 	var body: some View {
 		Button(action: action) {
 			HStack(alignment: .top, spacing: 12) {
-				Image(systemName: "exclamationmark.triangle.fill")
+				Image(systemName: FirmwareUpdateNotice.symbolName)
 					.font(.title3)
-					.foregroundColor(.orange)
+					.foregroundColor(.accentColor)
 					.padding(.top, 2)
 					.accessibilityHidden(true)
 				VStack(alignment: .leading, spacing: 2) {

--- a/MeshtasticTests/FirmwareUpdateNotifierTests.swift
+++ b/MeshtasticTests/FirmwareUpdateNotifierTests.swift
@@ -151,4 +151,8 @@ struct FirmwareUpdateNotifierTests {
 		#expect(appOTANotice?.accessibilityHint == "Opens Firmware Updates")
 		#expect(flasherNotice?.accessibilityHint == "Opens Meshtastic Flasher")
 	}
+
+	@Test func updateNudgeUsesAnUpdateAffordance() {
+		#expect(FirmwareUpdateNotice.symbolName == "arrow.triangle.2.circlepath")
+	}
 }


### PR DESCRIPTION
## Summary

Replaces the stable firmware-update notice's orange warning triangle with the native update symbol (`arrow.triangle.2.circlepath`) and accent styling. The notification remains an informational nudge; its copy, destinations, and dedupe behavior are unchanged.

Closes #2103
Parent: meshtastic/design#124

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -quiet -workspace Meshtastic.xcworkspace -scheme Meshtastic -destination 'platform=iOS Simulator,id=5669CB03-8FA2-4A97-BE04-A8566204116D' -only-testing:MeshtasticTests/FirmwareUpdateNotifierTests` (pass)
- Added a focused regression test asserting the update affordance symbol.

## Hardware and visual evidence

No physical hardware is required for this presentation-only change. The draft is awaiting cross-client review; simulator rendering with a connected outdated device remains to be captured before ready-for-review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Firmware update available” notice with a refresh-style icon.
  * Applied the app’s accent color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->