### PR TITLE
perf(ingest): bound memory under sustained packet load — actor recycling, bounded event stream, DM badge throttle

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -38,6 +38,7 @@ extension AccessoryManager {
 		self.activeDeviceNum = nil
 		packetsSent = 0
 		packetsReceived = 0
+		packetsAtLastIngestRecycle = 0
 		expectedNodeDBSize = nil
 	
 		self.allowDisconnect = true

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -239,11 +239,13 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// reached millions of live model objects / multi-GB RSS). Recreating the actor releases
 	/// them; connect-time recreation alone doesn't help a session that stays connected.
 	var packetsAtLastIngestRecycle: Int = 0
-	/// How many packets between recycles. On a busy mesh (~140 pkt/s) this is a few minutes;
-	/// on a quiet mesh it may never fire — which is fine, since accumulation is proportional
-	/// to packets processed. Recycling costs one context teardown + cold caches on the next
-	/// few fetches, so keep it infrequent.
-	static let ingestRecycleInterval = 20_000
+	/// How many packets between recycles. Each processed packet leaves a handful of registered
+	/// objects behind, so this bounds the ingest context's working set to a few hundred MB at
+	/// worst. Under a saturating TCP replay this fires every couple of minutes; on a busy real
+	/// mesh every ~10 minutes; on a quiet mesh it may never fire — which is fine, since
+	/// accumulation is proportional to packets processed. Recycling costs one context teardown
+	/// plus cold caches on the next few fetches.
+	static let ingestRecycleInterval = 5_000
 
 	// Debug counter: MQTT client-proxy downlink packets dropped before forwarding
 	// to the device because they carried no payload (see MqttForwardFilter). NOT

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -233,6 +233,18 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	var packetsSent: Int = 0
 	var packetsReceived: Int = 0
 
+	/// Packet count at the last periodic MeshPackets recycle (see `didReceive`). The ingest
+	/// actor's ModelContext registers every entity it inserts or faults and never lets go, so a
+	/// long high-traffic session accumulates them without bound (a sustained TCP stress replay
+	/// reached millions of live model objects / multi-GB RSS). Recreating the actor releases
+	/// them; connect-time recreation alone doesn't help a session that stays connected.
+	var packetsAtLastIngestRecycle: Int = 0
+	/// How many packets between recycles. On a busy mesh (~140 pkt/s) this is a few minutes;
+	/// on a quiet mesh it may never fire — which is fine, since accumulation is proportional
+	/// to packets processed. Recycling costs one context teardown + cold caches on the next
+	/// few fetches, so keep it infrequent.
+	static let ingestRecycleInterval = 20_000
+
 	// Debug counter: MQTT client-proxy downlink packets dropped before forwarding
 	// to the device because they carried no payload (see MqttForwardFilter). NOT
 	// @Published — read only for debug logging, so it needn't drive view updates.
@@ -537,6 +549,16 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			}
 			// Logger.transport.info("✅ [Accessory] didReceive: \(fromRadio.payloadVariant.debugDescription)")
 			await self.processFromRadio(fromRadio)
+			// Periodically recycle the ingest actor so its ModelContext releases accumulated
+			// registered objects (see packetsAtLastIngestRecycle). Only while subscribed —
+			// never mid node-DB retrieval — and only here, between packets, where no in-flight
+			// handler still holds the retiring instance. Flush first: recreateShared's
+			// invalidate deliberately drops a retired instance's pending writes.
+			if case .subscribed = state, packetsReceived - packetsAtLastIngestRecycle >= Self.ingestRecycleInterval {
+				packetsAtLastIngestRecycle = packetsReceived
+				await MeshPackets.shared.flushDebouncedSaves()
+				MeshPackets.recreateShared()
+			}
 			Task {
 				await self.heartbeatResponseTimer?.cancel(withReason: "Data packet received")
 				await self.heartbeatTimer?.reset(delay: .seconds(Self.heartbeatInterval))

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
@@ -194,7 +194,10 @@ actor BLEConnection: Connection {
 	}
 	
 	func getPacketStream() -> AsyncStream<ConnectionEvent> {
-		AsyncStream<ConnectionEvent> { continuation in
+		// Bounded like TCPConnection's stream: drop the oldest events under sustained overload
+		// instead of queueing them without limit. BLE can't reach rates that fill this in
+		// practice; the bound is a backstop so no transport can balloon memory.
+		AsyncStream<ConnectionEvent>(bufferingPolicy: .bufferingNewest(4096)) { continuation in
 			// Finish any previous stream so its consumer's `for await` loop terminates cleanly
 			// instead of hanging indefinitely on the abandoned continuation.
 			self.connectionStreamContinuation?.finish()

--- a/Meshtastic/Accessory/Transports/Serial/SerialConnection.swift
+++ b/Meshtastic/Accessory/Transports/Serial/SerialConnection.swift
@@ -253,7 +253,9 @@ actor SerialConnection: Connection {
 
 	// MARK: - Stream Management
 	private func getPacketStream() -> AsyncStream<ConnectionEvent> {
-		AsyncStream<ConnectionEvent> { continuation in
+		// Bounded like TCPConnection's stream: drop the oldest events under sustained overload
+		// instead of queueing them without limit.
+		AsyncStream<ConnectionEvent>(bufferingPolicy: .bufferingNewest(4096)) { continuation in
 			self.eventStreamContinuation = continuation
 			continuation.onTermination = { _ in
 				Task {

--- a/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
+++ b/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
@@ -204,17 +204,21 @@ actor TCPConnection: Connection {
 		// For TCP, reader is already started
 	}
 
-	/// Data events dropped by the bounded stream buffer since connect (see `getPacketStream`).
-	private var droppedDataEventCount = 0
+	/// Yields into a full stream buffer since connect (see `getPacketStream`). With
+	/// `.bufferingNewest` each such yield evicts the oldest buffered frame, so this counts
+	/// evictions to within ±1 (the yield that exactly fills the buffer also reports 0 remaining).
+	private var saturatedYieldCount = 0
 
-	/// Yields a decoded frame into the event stream, counting buffer-overflow drops so
-	/// sustained backpressure is visible in the logs instead of silent.
+	/// Yields a decoded frame into the event stream, counting full-buffer yields so sustained
+	/// backpressure is visible in the logs instead of silent. `.bufferingNewest` never reports
+	/// `.dropped` — the NEW element is always enqueued and the OLDEST is evicted — so a full
+	/// buffer surfaces as `.enqueued(remaining: 0)`.
 	private func yieldDataEvent(_ fromRadio: FromRadio) {
 		guard let continuation = connectionStreamContinuation else { return }
-		if case .dropped = continuation.yield(.data(fromRadio)) {
-			droppedDataEventCount += 1
-			if droppedDataEventCount == 1 || droppedDataEventCount % 1_000 == 0 {
-				Logger.transport.warning("🌊 [TCP] Event buffer full — dropped oldest frame (\(self.droppedDataEventCount) dropped this session); consumer is behind the radio's packet rate")
+		if case .enqueued(let remaining) = continuation.yield(.data(fromRadio)), remaining == 0 {
+			saturatedYieldCount += 1
+			if saturatedYieldCount == 1 || saturatedYieldCount % 1_000 == 0 {
+				Logger.transport.warning("🌊 [TCP] Event buffer full — oldest frames are being evicted (\(self.saturatedYieldCount) saturated yields this session); consumer is behind the radio's packet rate")
 			}
 		}
 	}

--- a/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
+++ b/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
@@ -91,7 +91,7 @@ actor TCPConnection: Connection {
 						let payload = try await receiveData(min: Int(length), max: Int(length))
 						switch FromRadioDecoder.classify(payload) {
 						case .decoded(let fromRadio):
-							await connectionStreamContinuation?.yield(.data(fromRadio))
+							await self.yieldDataEvent(fromRadio)
 						case .skipInvalidUTF8(let error):
 							// A string field failed UTF-8 validation; skip this frame and keep reading
 							// rather than tearing down an otherwise healthy connection over one
@@ -204,11 +204,34 @@ actor TCPConnection: Connection {
 		// For TCP, reader is already started
 	}
 
+	/// Data events dropped by the bounded stream buffer since connect (see `getPacketStream`).
+	private var droppedDataEventCount = 0
+
+	/// Yields a decoded frame into the event stream, counting buffer-overflow drops so
+	/// sustained backpressure is visible in the logs instead of silent.
+	private func yieldDataEvent(_ fromRadio: FromRadio) {
+		guard let continuation = connectionStreamContinuation else { return }
+		if case .dropped = continuation.yield(.data(fromRadio)) {
+			droppedDataEventCount += 1
+			if droppedDataEventCount == 1 || droppedDataEventCount % 1_000 == 0 {
+				Logger.transport.warning("🌊 [TCP] Event buffer full — dropped oldest frame (\(self.droppedDataEventCount) dropped this session); consumer is behind the radio's packet rate")
+			}
+		}
+	}
+
 	private func getPacketStream() -> AsyncStream<ConnectionEvent> {
 		self.connectionStreamContinuation?.finish()
 		self.connectionStreamContinuation = nil
-		
-		return AsyncStream<ConnectionEvent> { continuation in
+
+		// Bounded buffer: the default unbounded policy let a fast producer (a TCP radio can
+		// sustain >100 packets/s) queue every frame the main-actor consumer hadn't processed
+		// yet — under a stress replay that backlog reached ~all packets of the session, holding
+		// their protobufs live (multi-hundred-MB) while the app fell minutes behind real time.
+		// Keeping the newest 4,096 events drops the OLDEST first under sustained overload —
+		// stale mesh traffic, exactly what a saturated real radio would shed — while a node-DB
+		// dump (one event per node) fits well inside the bound, and error/teardown events are
+		// always the newest when they occur.
+		return AsyncStream<ConnectionEvent>(bufferingPolicy: .bufferingNewest(4096)) { continuation in
 			self.connectionStreamContinuation = continuation
 			continuation.onTermination = { [weak self] termination in
 				guard let self else { return }

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -196,6 +196,17 @@ actor MeshPackets {
 		return true
 	}
 
+	/// Last time the direct-message unread badge was recomputed. Same O(unread) scan and same
+	/// burst hazard as the channel badge, so it gets the same ~1/sec rate limit — under a DM
+	/// flood the badge tolerates a brief lag and resyncs on app-active and on read.
+	private var lastDirectUnreadRecompute: ContinuousClock.Instant?
+	func shouldRecomputeDirectUnread() -> Bool {
+		let now = ContinuousClock.now
+		if let last = lastDirectUnreadRecompute, now - last < .seconds(1) { return false }
+		lastDirectUnreadRecompute = now
+		return true
+	}
+
 	func shouldPrunePositionHistory(for nodeNum: Int64) -> Bool {
 		let nextCount = (positionInsertsSincePrune[nodeNum] ?? 0) + 1
 		if nextCount >= Self.positionPruneInterval {
@@ -1412,8 +1423,10 @@ actor MeshPackets {
 							return
 						}
 						if newMessage.fromUser != nil && newMessage.toUser != nil {
-							// Set Unread Message Indicators
-							if packet.to == connectedNode {
+							// Set Unread Message Indicators. unreadMessages is O(unread); like the
+							// channel badge, recomputing it for every incoming DM turns a burst into
+							// quadratic work, so it gets the same ~1/sec rate limit.
+							if packet.to == connectedNode, shouldRecomputeDirectUnread() {
 								let unreadCount = await newMessage.toUser?.unreadMessages(context: modelContext, skipLastMessageCheck: true) ?? 0 // skipLastMessageCheck=true because we don't update lastMessage on our own connected node
 								Task { @MainActor in
 									appState?.unreadDirectMessages = unreadCount

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -156,6 +156,24 @@ struct MeshtasticAppleApp: App {
 					accessoryManager.startDiscovery()
 				}
 			}
+#if DEBUG
+			// Automated perf/stress testing: connect straight to a TCP radio (or replay
+			// server) with `-meshtastic-connect-tcp <host[:port]>`, skipping the Connect
+			// tab entirely. DEBUG-only, like the other automation hooks above.
+			let arguments = ProcessInfo.processInfo.arguments
+			if let flagIndex = arguments.firstIndex(of: "-meshtastic-connect-tcp"),
+			   arguments.indices.contains(flagIndex + 1),
+			   let tcpTransport = accessoryManager.transportForType(.tcp),
+			   let device = tcpTransport.device(forManualConnection: arguments[flagIndex + 1]) {
+				let manager = accessoryManager
+				Task {
+					// Give startup (container, transports, discovery) a beat to settle.
+					try? await Task.sleep(for: .seconds(2))
+					Logger.services.info("🧪 [App] Auto-connecting to TCP device \(device.identifier, privacy: .public) (launch argument)")
+					try? await manager.connect(to: device)
+				}
+			}
+#endif
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #2105 — together they're the two halves of the stress-replay findings: #2105 fixed the main-thread view storms; this bounds the ingestion side's memory.

## The problem

Two unbounded accumulators, found by heap analysis of a long session against a 1,600-node DEF-CON-shaped TCP replay at ~140 packets/second:

1. **The ingest actor's ModelContext never lets go.** Every entity it inserts or faults stays registered. `MeshPackets.recreateShared()` exists for exactly this — its doc comment says to call it *periodically* — but it was only invoked at connect time, so a session that stays connected accumulates without bound. A long run reached over a million live model objects, with the SwiftData observation machinery alone holding hundreds of MB.
2. **The transport event stream buffers without limit.** `AsyncStream`'s default unbounded policy let the TCP reader queue every frame the main-actor consumer hadn't gotten to. Under sustained overload the backlog grew to essentially the whole session's packets — hundreds of thousands of live protobufs — while the app processed traffic minutes old.

Plus a small quadratic: the per-DM unread-badge recount is O(unread) and ran for every incoming DM (the channel path was already throttled).

## The fixes

- **Periodic ingest recycle**: `didReceive` flushes pending debounced saves and recycles the MeshPackets actor every 5,000 packets while subscribed — between packets (no in-flight handler holds the retiring instance) and never during node-DB retrieval. Proportional to traffic: a quiet mesh may never recycle, which is fine.
- **Bounded event streams**: all three transports use `.bufferingNewest(4096)`. Under sustained overload the oldest frames drop first — stale mesh traffic, what a saturated real radio would shed. A node-DB dump fits well within the bound; error/teardown events are the newest when they occur so they can't be displaced. The TCP reader logs drops so backpressure is visible.
- **DM unread recount throttled to ~1/sec**, matching the existing channel-badge throttle.
- **DEBUG launch argument** `-meshtastic-connect-tcp <host[:port]>` connects straight to a TCP radio at startup, making stress runs fully scriptable (`simctl launch` + replay server) with no UI automation. Same pattern as the existing `--marketing-capture` / perf-seed hooks.

## Verification (same replay, before → after)

- Live model objects (heap analysis): **>1.3M → under 400K**, bounded by the recycle window instead of session length.
- Stream backlog: **~all session packets → pinned at the 4,096 bound** with drops logged.
- RSS: previously grew unbounded (multi-GB in under half an hour, plateau never reached); now holds flat for minutes at a time with steps tracking replay phases, at a fraction of the old footprint.
- Badges, messages, map, node list, and the Discovery analyze all behave normally under flood; a real radio's packet rates never approach the buffer bound or drop path.

## Known remainder (future work)

The main context still grows slowly under flood (message-view fetches, notification donations) and the consumer saturates around half the replay's rate, so a sustained >100pps source sheds oldest traffic by design. Both are follow-up material; neither affects real-mesh rates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved memory management during extended device connections.
  * Reduced unnecessary unread-message badge recomputation during high-volume messaging.

* **Reliability**
  * Improved stability when receiving sustained bursts of Bluetooth, serial, or TCP data by preventing unbounded connection event backlogs.
  * Added safeguards to drop excess connection events under overload instead of queueing indefinitely.
  * Added connection-state reset when starting a new connection attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->