### PR TITLE
fix(canned-messages): stop writing deprecated allow_input_source (#2022)

### DIFF
--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -188,13 +188,10 @@ struct CannedMessagesConfig: View {
 						cmc.sendBell = sendBell
 						cmc.rotary1Enabled = rotary1Enabled
 						cmc.updown1Enabled = updown1Enabled
-						if rotary1Enabled {
-							cmc.allowInputSource = "rotEnc1"
-						} else if updown1Enabled {
-							cmc.allowInputSource = "upDown1"
-						} else {
-							cmc.allowInputSource = "_any"
-						}
+						// allow_input_source is deprecated with no successor — the input
+						// source is governed by the rotary1Enabled / updown1Enabled flags
+						// above. Intentionally not written; inbound values from older
+						// firmware are ignored (never persisted). (#2022)
 						cmc.inputbrokerPinA = UInt32(inputbrokerPinA)
 						cmc.inputbrokerPinB = UInt32(inputbrokerPinB)
 						cmc.inputbrokerPinPress = UInt32(inputbrokerPinPress)


### PR DESCRIPTION
## What changed?

Stopped writing the deprecated `CannedMessageConfig.allow_input_source` field (`allow_input_source = 10`) when saving Canned Messages module config.

- Removed the derived `if/else` block in the save closure of `CannedMessagesConfig.swift` that set `cmc.allowInputSource` to `"rotEnc1"` / `"upDown1"` / `"_any"`.
- There was **no dedicated UI control** for this field — it was derived from the existing `rotary1Enabled` / `updown1Enabled` toggles, which are still written. So no visible control was removed.

Fixes #2022

## Why did it change?

`allow_input_source` is deprecated upstream (`[deprecated = true]`, since v2.7.4) and removed from active use with **no successor**. The input source is governed by the `rotary1_enabled` / `updown1_enabled` flags, which the app still sends. The field should simply no longer be written.

## How is this tested?

- Repo-wide scan confirms `allowInputSource` no longer appears anywhere in the app or tests except the explanatory comment — no other write, read, UI control, or `DeviceProfile`/AppIntents/CarPlay site.
- **Read-side is already backward-compatible:** the field is absent from the SwiftData model (`CannedMessageConfigEntity`) and from `UpdateSwiftData`'s canned-message upsert, so values arriving from older firmware deserialize into the protobuf struct and are silently ignored — no crash, nothing to change.
- `hasChanges`/save-button behavior is unaffected (no `@State`/`onChange`/load tied to this field).
- SourceKit-LSP: no diagnostics on the changed file.
- Reviewed with the project's Swift reviewer — approved, no blocking issues.

## Screenshots/Videos (when applicable)

N/A — no user-visible UI change (no control existed for this field; the Canned Messages screen is unchanged).

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. No doc update is needed (no user-visible control/label/navigation change) — `skip-docs-check` label applies.
- [x] I have tested the change to ensure that it works as intended.

## Note for reviewers

Residual (low/theoretical) risk: truly ancient firmware that both enforced `allow_input_source` by exact-string match *and* treated an absent value as "no source" would now receive no source hint. This is discounted because the field is upstream-deprecated, was never persisted by the app, and the old `"upDown1"` value the app used to send isn't even in the proto's documented value set (`"upDownEnc1"`) — strong evidence the string was already non-authoritative and the flags drive behavior. Separately, `CannedMessageConfig.enabled` is also `[deprecated]` but is intentionally left in place here — it still has current effect and its removal wasn't requested in #2022.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saving of canned-message input controls by relying on the current rotary and up/down control settings.
  * Prevented deprecated input-source values from being unintentionally persisted when saving configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->