### PR TITLE
fix(canned-messages): stop showing/writing deprecated enabled field (#2021)

### DIFF
--- a/Meshtastic/Model/ConfigModels.swift
+++ b/Meshtastic/Model/ConfigModels.swift
@@ -47,6 +47,8 @@ final class BluetoothConfigEntity {
 
 @Model
 final class CannedMessageConfigEntity {
+	/// Deprecated (no successor, removed from active use — #2021). Retained to
+	/// preserve the SwiftData schema; no longer surfaced, written, or persisted.
 	var enabled: Bool = false
 	var inputbrokerEventCcw: Int32 = 0
 	var inputbrokerEventCw: Int32 = 0

--- a/Meshtastic/Model/ConfigModels.swift
+++ b/Meshtastic/Model/ConfigModels.swift
@@ -47,8 +47,9 @@ final class BluetoothConfigEntity {
 
 @Model
 final class CannedMessageConfigEntity {
-	/// Deprecated (no successor, removed from active use — #2021). Retained to
-	/// preserve the SwiftData schema; no longer surfaced, written, or persisted.
+	/// Deprecated (no successor, removed from active use — #2021). Retained as a stored
+	/// SwiftData property to preserve the schema and keep existing persisted values readable;
+	/// it is no longer surfaced in the UI, read, or actively written by app code.
 	var enabled: Bool = false
 	var inputbrokerEventCcw: Int32 = 0
 	var inputbrokerEventCw: Int32 = 0

--- a/Meshtastic/Persistence/CoreDataMigrationService.swift
+++ b/Meshtastic/Persistence/CoreDataMigrationService.swift
@@ -477,7 +477,8 @@ private extension CoreDataMigrationService {
 			nodeMap: nodeMap
 		) { obj -> CannedMessageConfigEntity in
 			let sd = CannedMessageConfigEntity()
-			// enabled is deprecated (no successor) and no longer persisted — not migrated. (#2021)
+			// enabled is deprecated (no successor) and no longer written — not migrated; the
+			// stored property keeps its default. (#2021)
 			sd.inputbrokerEventCcw    = (obj.value(forKey: "inputbrokerEventCcw") as? Int32) ?? 0
 			sd.inputbrokerEventCw     = (obj.value(forKey: "inputbrokerEventCw") as? Int32) ?? 0
 			sd.inputbrokerEventPress  = (obj.value(forKey: "inputbrokerEventPress") as? Int32) ?? 0

--- a/Meshtastic/Persistence/CoreDataMigrationService.swift
+++ b/Meshtastic/Persistence/CoreDataMigrationService.swift
@@ -477,7 +477,7 @@ private extension CoreDataMigrationService {
 			nodeMap: nodeMap
 		) { obj -> CannedMessageConfigEntity in
 			let sd = CannedMessageConfigEntity()
-			sd.enabled                = (obj.value(forKey: "enabled") as? Bool) ?? false
+			// enabled is deprecated (no successor) and no longer persisted — not migrated. (#2021)
 			sd.inputbrokerEventCcw    = (obj.value(forKey: "inputbrokerEventCcw") as? Int32) ?? 0
 			sd.inputbrokerEventCw     = (obj.value(forKey: "inputbrokerEventCw") as? Int32) ?? 0
 			sd.inputbrokerEventPress  = (obj.value(forKey: "inputbrokerEventPress") as? Int32) ?? 0

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -1252,7 +1252,7 @@ extension MeshPackets {
 					let newCannedMessageConfig = CannedMessageConfigEntity()
 					modelContext.insert(newCannedMessageConfig)
 					// config.enabled is deprecated (no successor, removed from active use);
-					// tolerated on read but intentionally not persisted. (#2021)
+					// tolerated on read but no longer written to the stored entity. (#2021)
 					newCannedMessageConfig.sendBell = config.sendBell
 					newCannedMessageConfig.rotary1Enabled = config.rotary1Enabled
 					newCannedMessageConfig.updown1Enabled = config.updown1Enabled
@@ -1264,7 +1264,7 @@ extension MeshPackets {
 					newCannedMessageConfig.inputbrokerEventPress = Int32(config.inputbrokerEventPress.rawValue)
 					fetchedNode[0].cannedMessageConfig = newCannedMessageConfig
 				} else {
-					// config.enabled is deprecated (see above); not persisted. (#2021)
+					// config.enabled is deprecated (see above); no longer written. (#2021)
 					fetchedNode[0].cannedMessageConfig?.sendBell = config.sendBell
 					fetchedNode[0].cannedMessageConfig?.rotary1Enabled = config.rotary1Enabled
 					fetchedNode[0].cannedMessageConfig?.updown1Enabled = config.updown1Enabled

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -1251,7 +1251,8 @@ extension MeshPackets {
 				if fetchedNode[0].cannedMessageConfig == nil {
 					let newCannedMessageConfig = CannedMessageConfigEntity()
 					modelContext.insert(newCannedMessageConfig)
-					newCannedMessageConfig.enabled = config.enabled
+					// config.enabled is deprecated (no successor, removed from active use);
+					// tolerated on read but intentionally not persisted. (#2021)
 					newCannedMessageConfig.sendBell = config.sendBell
 					newCannedMessageConfig.rotary1Enabled = config.rotary1Enabled
 					newCannedMessageConfig.updown1Enabled = config.updown1Enabled
@@ -1263,7 +1264,7 @@ extension MeshPackets {
 					newCannedMessageConfig.inputbrokerEventPress = Int32(config.inputbrokerEventPress.rawValue)
 					fetchedNode[0].cannedMessageConfig = newCannedMessageConfig
 				} else {
-					fetchedNode[0].cannedMessageConfig?.enabled = config.enabled
+					// config.enabled is deprecated (see above); not persisted. (#2021)
 					fetchedNode[0].cannedMessageConfig?.sendBell = config.sendBell
 					fetchedNode[0].cannedMessageConfig?.rotary1Enabled = config.rotary1Enabled
 					fetchedNode[0].cannedMessageConfig?.updown1Enabled = config.updown1Enabled

--- a/Meshtastic/Resources/docs/developer/swiftdata.html
+++ b/Meshtastic/Resources/docs/developer/swiftdata.html
@@ -173,6 +173,29 @@ static let migrateV1toV2 = MigrationStage.custom(
 <li>Update <code>MeshtasticSchema.current</code> to point to the new version.</li>
 </ol>
 <div class="warning-callout"><strong>Warning — Never delete a <code>VersionedSchema</code>.</strong> Migration history must be preserved or the migration plan will fail on devices that skipped intermediate versions.</div>
+<h3>Deprecated Properties</h3>
+<p>When a proto field is deprecated upstream and the app stops using it, <strong>do not remove the corresponding <code>@Model</code> property</strong> — deleting a stored property is a schema change that would require a migration, and while V1 is unreleased there is nowhere to migrate from. Instead, retain the property as-is so:</p>
+<ul>
+<li>the SwiftData schema is unchanged, and</li>
+<li>any values already persisted on-device remain readable.</li>
+</ul>
+<p>The field simply stops being surfaced in the UI, read, or actively written by app code. Mark it with a doc comment noting the deprecation and the tracking issue. Current examples:</p>
+<table>
+<thead>
+<tr>
+<th>Model</th>
+<th>Property</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>CannedMessageConfigEntity</code></td>
+<td><code>enabled</code></td>
+<td>#2021 — no successor; retained for schema/value compatibility, no longer read or written</td>
+</tr>
+</tbody>
+</table>
 <h2>Query Helpers</h2>
 <p><code>QuerySwiftData.swift</code> contains helper functions for common fetches:</p>
 <pre><code class="language-swift">let node = getNodeInfo(id: nodeNum, context: context)

--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -1025,20 +1025,20 @@
             "node",
             "stats",
             "simctl",
+            "model",
             "local",
             "nodes",
+            "app",
             "store",
-            "model",
+            "schema",
             "context",
             "packet",
             "history",
             "data",
             "child",
-            "app",
             "swift",
-            "schema",
-            "launch",
             "device",
+            "launch",
             "var",
             "true",
             "telemetry",
@@ -1050,7 +1050,7 @@
             "type",
             "set"
         ],
-        "charCount": 11360
+        "charCount": 12115
     },
     {
         "id": "tak-protocol",

--- a/Meshtastic/Resources/docs/markdown/developer/swiftdata.md
+++ b/Meshtastic/Resources/docs/markdown/developer/swiftdata.md
@@ -157,6 +157,19 @@ static let migrateV1toV2 = MigrationStage.custom(
 
 > **Warning — Never delete a `VersionedSchema`.** Migration history must be preserved or the migration plan will fail on devices that skipped intermediate versions.
 
+### Deprecated Properties
+
+When a proto field is deprecated upstream and the app stops using it, **do not remove the corresponding `@Model` property** — deleting a stored property is a schema change that would require a migration, and while V1 is unreleased there is nowhere to migrate from. Instead, retain the property as-is so:
+
+- the SwiftData schema is unchanged, and
+- any values already persisted on-device remain readable.
+
+The field simply stops being surfaced in the UI, read, or actively written by app code. Mark it with a doc comment noting the deprecation and the tracking issue. Current examples:
+
+| Model | Property | Notes |
+|-------|----------|-------|
+| `CannedMessageConfigEntity` | `enabled` | #2021 — no successor; retained for schema/value compatibility, no longer read or written |
+
 ## Query Helpers
 
 `QuerySwiftData.swift` contains helper functions for common fetches:

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -17,7 +17,6 @@ struct CannedMessagesConfig: View {
 	@State var hasChanges = false
 	@State var hasMessagesChanges = false
 	@State var configPreset = 0
-	@State var enabled = false
 	/// CannedMessageModule will sends a bell character with the messages.
 	@State var sendBell: Bool = false
 	/// Enable the rotary encoder #1. This is a 'dumb' encoder sending pulses on both A and B pins while rotating.
@@ -42,12 +41,6 @@ struct CannedMessagesConfig: View {
 			ConfigHeader(title: "Canned messages", config: \.cannedMessageConfig, node: node, onAppear: setCannedMessagesValues)
 			
 			Section(header: Text("Options")) {
-				
-				Toggle(isOn: $enabled) {
-					
-					Label("Enabled", systemImage: "list.bullet.rectangle.fill")
-				}
-				.tint(.accentColor)
 				
 				Toggle(isOn: $sendBell) {
 					
@@ -184,7 +177,8 @@ struct CannedMessagesConfig: View {
 						dismiss: goBack
 					) { fromUser, toUser in
 						var cmc = ModuleConfig.CannedMessageConfig()
-						cmc.enabled = enabled
+						// enabled is deprecated with no successor and removed from active
+						// use — intentionally not written. (#2021)
 						cmc.sendBell = sendBell
 						cmc.rotary1Enabled = rotary1Enabled
 						cmc.updown1Enabled = updown1Enabled
@@ -265,9 +259,6 @@ struct CannedMessagesConfig: View {
 			
 			hasChanges = true
 		}
-		.onChange(of: enabled) { _, newEnabled in
-			if newEnabled != node?.cannedMessageConfig?.enabled { hasChanges = true }
-		}
 		.onChange(of: sendBell) { _, newSendBell in
 			if newSendBell != node?.cannedMessageConfig?.sendBell { hasChanges = true }
 		}
@@ -297,7 +288,6 @@ struct CannedMessagesConfig: View {
 		}
 	}
 	func setCannedMessagesValues() {
-		self.enabled = node?.cannedMessageConfig?.enabled ?? false
 		self.sendBell = node?.cannedMessageConfig?.sendBell ?? false
 		self.rotary1Enabled = node?.cannedMessageConfig?.rotary1Enabled ?? false
 		self.updown1Enabled = node?.cannedMessageConfig?.updown1Enabled ?? false

--- a/docs/developer/swiftdata.md
+++ b/docs/developer/swiftdata.md
@@ -157,6 +157,19 @@ static let migrateV1toV2 = MigrationStage.custom(
 
 > **Warning — Never delete a `VersionedSchema`.** Migration history must be preserved or the migration plan will fail on devices that skipped intermediate versions.
 
+### Deprecated Properties
+
+When a proto field is deprecated upstream and the app stops using it, **do not remove the corresponding `@Model` property** — deleting a stored property is a schema change that would require a migration, and while V1 is unreleased there is nowhere to migrate from. Instead, retain the property as-is so:
+
+- the SwiftData schema is unchanged, and
+- any values already persisted on-device remain readable.
+
+The field simply stops being surfaced in the UI, read, or actively written by app code. Mark it with a doc comment noting the deprecation and the tracking issue. Current examples:
+
+| Model | Property | Notes |
+|-------|----------|-------|
+| `CannedMessageConfigEntity` | `enabled` | #2021 — no successor; retained for schema/value compatibility, no longer read or written |
+
 ## Query Helpers
 
 `QuerySwiftData.swift` contains helper functions for common fetches:


### PR DESCRIPTION
## What changed?

Removed the deprecated `CannedMessageConfig.enabled` field (`enabled = 9`) from the Canned Messages module config — it is deprecated upstream with **no successor** and removed from active use.

- `CannedMessagesConfig.swift`: removed the **"Enabled" toggle** from the Options section, plus its `@State`, its `.onChange`, and the `setCannedMessagesValues()` read. Stopped writing `cmc.enabled` on save.
- `UpdateSwiftData.swift`: stopped persisting `config.enabled` in both the insert and update branches of the canned-message upsert. Inbound values from older firmware are still tolerated on read (the proto struct still decodes field 9), just never surfaced or stored.
- `CoreDataMigrationService.swift`: no longer migrates the legacy `enabled` value.
- `ConfigModels.swift`: **retained** the `CannedMessageConfigEntity.enabled` stored property (annotated as deprecated) to avoid a SwiftData schema-version change — the project uses a `VersionedSchema` + `MeshtasticMigrationPlan`, so removing the column would require a new migration stage for zero user benefit. The column is now inert (never surfaced, written, or persisted).

Fixes #2021

## Why did it change?

`enabled = 9` is `[deprecated = true]` in `module_config.proto` with no successor. Current firmware no longer gates the canned-message module on this proto field — enablement is driven by whether canned messages are configured (or a cardkb/matrix input is present). The app should therefore no longer show, write, or persist it.

## How is this tested?

- Confirmed the firmware contract: current `CannedMessageModule.cpp` gates the module on `splitConfiguredMessages()` / cardkb / matrix input, not proto field 9 (the old compile-time toggle was removed upstream in firmware #9470). Dropping the write does not disable the module on supported firmware.
- Repo-wide check: no remaining reader/writer/UI site for `cannedMessageConfig.enabled` after this change (verified absent from AppIntents, CarPlay, watch, export/import, and tests).
- `hasChanges`/save-button behavior verified: still driven by the remaining `sendBell`/`rotary1Enabled`/`updown1Enabled`/input-broker `.onChange` handlers; no dangling `enabled` reference.
- SourceKit-LSP: no diagnostics on any changed file.
- Reviewed with the project's Swift reviewer — approved, no blocking issues (it independently verified the firmware contract and the SwiftData judgment call).

## Screenshots/Videos (when applicable)

N/A — the only visible change is the removal of the deprecated "Enabled" toggle from the Canned Messages settings screen.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. No doc update is needed — `docs/user/settings.md`'s canned-messages entry is a high-level one-liner that does not document the removed toggle (so nothing becomes inaccurate), and the `Meshtastic/Model/` change is a comment only with no schema change. `skip-docs-check` label applies.
- [x] I have tested the change to ensure that it works as intended.

## Note for reviewers

Sibling of #2022 (which removes the deprecated `allow_input_source` from the same screen). This PR is scoped to `enabled` only and intentionally leaves the `allowInputSource` save block untouched. On truly ancient firmware that honored proto field 9 at runtime, the app can no longer toggle the module on/off — this is the intended behavior of #2021 and such firmware is outside the supported window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the deprecated “Enabled” option from Canned Messages settings.
  * Canned Message configuration updates and migrations no longer save or restore this setting.
  * Existing configuration data remains compatible, while the deprecated option is no longer surfaced or persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->