### PR TITLE
ci(sync-device-svgs): refresh the Resources/images catalog the app actually loads

### DIFF
--- a/.github/workflows/sync_device_svgs.yml
+++ b/.github/workflows/sync_device_svgs.yml
@@ -7,155 +7,65 @@ on:
   workflow_dispatch:
     # Allow manual triggering
 
+# Needed so the scheduled run can commit the refreshed catalog back to the repo.
+permissions:
+  contents: write
+
 jobs:
   sync-device-svgs:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        node-version: '18'
-        
-    - name: Install dependencies
+        python-version: '3.11'
+
+    - name: Sync device images and hardware catalog
+      # Reuse the exact script the Xcode "Download Node SVG Images" build phase runs,
+      # writing to the bundled resource location the app actually loads at runtime
+      # (the Bundle "images" subdirectory + DeviceHardware.json — see MeshtasticAPI).
+      # --force ignores the cached API hash so the committed snapshot always matches
+      # the upstream device hardware API instead of drifting until someone clean-builds.
       run: |
-        npm install -g svgo
-        
-    - name: Download and process SVGs
-      run: |
-        #!/bin/bash
-        set -e
-        
-        # Create temporary directory
-        mkdir -p temp_svgs
-        cd temp_svgs
-        
-        # Clone web-flasher repo (shallow clone for speed)
-        git clone --depth 1 https://github.com/meshtastic/web-flasher.git
-        
-        # Navigate to SVG directory
-        cd web-flasher/public/img/devices
-        
-        # Create output directory
-        mkdir -p ../../../../processed_svgs
-        
-        # Process each SVG file
-        for svg_file in *.svg; do
-          if [ -f "$svg_file" ]; then
-            # Get filename without extension
-            filename=$(basename "$svg_file" .svg)
-            
-            # Optimize SVG
-            svgo "$svg_file" --output "../../../../processed_svgs/${filename}.svg"
-            
-            echo "Processed: $filename"
-          fi
-        done
-        
-        cd ../../../../
-        ls -la processed_svgs/
-        
-    - name: Update Xcode Assets
-      run: |
-        #!/bin/bash
-        set -e
-        
-        ASSETS_DIR="Meshtastic/Assets.xcassets"
-        
-        # Ensure assets directory exists
-        mkdir -p "$ASSETS_DIR"
-        
-        # Process each SVG
-        for svg_file in processed_svgs/*.svg; do
-          if [ -f "$svg_file" ]; then
-            # Get filename without extension
-            filename=$(basename "$svg_file" .svg)
-            
-            # Create imageset directory
-            imageset_dir="${ASSETS_DIR}/${filename}.imageset"
-            mkdir -p "$imageset_dir"
-            
-            # Copy SVG to imageset
-            cp "$svg_file" "${imageset_dir}/${filename}.svg"
-            
-            # Create Contents.json for the imageset
-            cat > "${imageset_dir}/Contents.json" << EOF
-        {
-          "images" : [
-            {
-              "filename" : "${filename}.svg",
-              "idiom" : "universal"
-            }
-          ],
-          "info" : {
-            "author" : "xcode",
-            "version" : 1
-          },
-          "properties" : {
-            "preserves-vector-representation" : true
-          }
-        }
-        EOF
-            
-            echo "Created imageset: ${filename}"
-          fi
-        done
-        
+        python3 scripts/download_images.py \
+          --output-dir "Meshtastic/Resources/images" \
+          --output-json "Meshtastic/Resources/DeviceHardware.json" \
+          --force \
+          --verbose
+
     - name: Check for changes
       id: check_changes
       run: |
-        if git diff --quiet; then
-          echo "has_changes=false" >> $GITHUB_OUTPUT
+        if [ -z "$(git status --porcelain Meshtastic/Resources/images Meshtastic/Resources/DeviceHardware.json)" ]; then
+          echo "has_changes=false" >> "$GITHUB_OUTPUT"
         else
-          echo "has_changes=true" >> $GITHUB_OUTPUT
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
         fi
-        
+
     - name: Commit and push changes
       if: steps.check_changes.outputs.has_changes == 'true'
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git add Meshtastic/Assets.xcassets/
-        git commit -m "🤖 Sync device SVGs from web-flasher repo
-        
-        - Updated device images from meshtastic/web-flasher
-        - Automatically synced on $(date -u)
-        - Source: https://github.com/meshtastic/web-flasher/tree/main/public/img/devices"
+        # -A stages new device SVGs, updated ones, and any pruned (removed) devices.
+        git add -A Meshtastic/Resources/images Meshtastic/Resources/DeviceHardware.json
+        git commit -m "🤖 Sync device images and hardware catalog
+
+        - Refreshed from https://api.meshtastic.org/resource/deviceHardware
+        - Bundled resources: Meshtastic/Resources/images + DeviceHardware.json
+        - Automatically synced on $(date -u)"
         git push
-        
-    - name: Create PR (alternative to direct push)
-      if: steps.check_changes.outputs.has_changes == 'true' && false  # Set to true if you prefer PRs
-      uses: peter-evans/create-pull-request@v5
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "🤖 Sync device SVGs from web-flasher repo"
-        title: "Sync device SVGs from web-flasher"
-        body: |
-          This PR automatically syncs device SVG images from the [meshtastic/web-flasher](https://github.com/meshtastic/web-flasher) repository.
-          
-          **Changes:**
-          - Updated device images from web-flasher repo
-          - Source: https://github.com/meshtastic/web-flasher/tree/main/public/img/devices
-          - Automatically generated on $(date -u)
-          
-          The SVGs have been optimized and converted to Xcode asset format.
-        branch: sync-device-svgs
-        delete-branch: true
-        
-    - name: Cleanup
-      if: always()
-      run: |
-        rm -rf temp_svgs processed_svgs
-        
+
     - name: Summary
       run: |
         if [ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]; then
-          echo "✅ Device SVGs updated successfully"
+          echo "✅ Device images and hardware catalog updated"
         else
-          echo "ℹ️ No changes detected - SVGs are up to date"
+          echo "ℹ️ No changes detected - resources are up to date"
         fi

--- a/.github/workflows/sync_device_svgs.yml
+++ b/.github/workflows/sync_device_svgs.yml
@@ -50,6 +50,11 @@ jobs:
 
     - name: Commit and push changes
       if: steps.check_changes.outputs.has_changes == 'true'
+      env:
+        # actions/checkout leaves a detached HEAD, so push HEAD explicitly to the
+        # branch. Read the ref through env (not inline ${{ }}) to avoid expanding a
+        # GitHub expression inside the shell.
+        TARGET_BRANCH: ${{ github.ref_name }}
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
@@ -60,11 +65,13 @@ jobs:
         - Refreshed from https://api.meshtastic.org/resource/deviceHardware
         - Bundled resources: Meshtastic/Resources/images + DeviceHardware.json
         - Automatically synced on $(date -u)"
-        git push
+        git push origin "HEAD:${TARGET_BRANCH}"
 
     - name: Summary
+      env:
+        HAS_CHANGES: ${{ steps.check_changes.outputs.has_changes }}
       run: |
-        if [ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]; then
+        if [ "$HAS_CHANGES" == "true" ]; then
           echo "✅ Device images and hardware catalog updated"
         else
           echo "ℹ️ No changes detected - resources are up to date"


### PR DESCRIPTION
## What changed?

Retargets the nightly **Sync Device SVGs** workflow (`.github/workflows/sync_device_svgs.yml`) so it refreshes the device catalog the app actually loads.

- Replaces the old "clone `meshtastic/web-flasher` → svgo → write imagesets into `Meshtastic/Assets.xcassets`" steps with a single call to the repo's own **`scripts/download_images.py --force`**, writing to **`Meshtastic/Resources/images/`** + **`Meshtastic/Resources/DeviceHardware.json`** — the same script and output location the Xcode **"Download Node SVG Images"** build phase uses.
- Adds explicit **`permissions: contents: write`** so the scheduled job can actually commit/push the refresh.
- Stages new/updated/pruned device SVGs via `git add -A`, and detects changes (including brand-new untracked SVGs) with a path-scoped `git status --porcelain`.

Net: +37 / −127 (removes the now-unnecessary web-flasher clone, svgo install, and xcassets generation).

## Why did it change?

The app loads device images at runtime from the **bundled `images` subdirectory** and **`DeviceHardware.json`** (`MeshtasticAPI.swift` — `Bundle.main.url(forResource:withExtension:subdirectory:"images")` and the bundled hardware catalog), maintained by `scripts/download_images.py`. The device imagesets under `Assets.xcassets` are **no longer the runtime source** (the remaining imagesets there are AppIcons). So the nightly job was updating a legacy location and **not** keeping the real catalog current — it drifted until someone happened to run a clean build (which force-refreshes the catalog) and committed the result.

Concretely, this catalog is currently behind upstream: a new **RAK6421** device is present in the API but missing from the committed snapshot. Pointing the automation at the correct script + path means the bundled catalog stays in sync with `https://api.meshtastic.org/resource/deviceHardware` automatically, and contributors stop seeing spurious `DeviceHardware.json` / `image_manifest.json` diffs after clean builds.

## How is this tested?

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML validates.
- `scripts/download_images.py` is the exact script already run by the Xcode build phase (unchanged), so the workflow reproduces the same output the app bundle expects; running it locally with these args produces the expected catalog refresh (e.g. adds `rak6421.svg` + its manifest/JSON entries).
- The job is `schedule` + `workflow_dispatch` only (no untrusted/fork input), and `contents: write` is the minimum permission required for the auto-commit. It can be dry-run via **workflow_dispatch** after merge to confirm the commit/push path.

## Screenshots/Videos (when applicable)

N/A — CI workflow change only.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. This is a CI-only change with no `Meshtastic/Views/**` or `@Model` changes, so no doc update is required — adding the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked the automated device resource synchronization process.
  * Device images and the hardware catalog are now updated and pushed directly when changes are detected.
  * Improved workflow logging to clearly report whether device resources were updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->