### PR TITLE
fix: accept interoperable QR URL hosts

### DIFF
--- a/Meshtastic/AppIntents/AddContactIntent.swift
+++ b/Meshtastic/AppIntents/AddContactIntent.swift
@@ -22,7 +22,7 @@ struct AddContactIntent: AppIntent {
 			throw AppIntentErrors.AppIntentError.notConnected
 		}
 
-		if contactUrl.absoluteString.lowercased().contains("meshtastic.org/v/#") {
+		if ContactURLHandler.canHandle(contactUrl) {
 			let components = self.contactUrl.absoluteString.components(separatedBy: "#")
 			// Extract contact information from the URL
 			if let contactData = components.last {

--- a/Meshtastic/Helpers/ContactURLHandler.swift
+++ b/Meshtastic/Helpers/ContactURLHandler.swift
@@ -14,6 +14,15 @@ struct ContactURLHandler {
 
 	static var minimumContactVersion = "2.6.9"
 
+	static func canHandle(_ url: URL) -> Bool {
+		guard let host = url.host?.lowercased(), ["meshtastic.org", "www.meshtastic.org"].contains(host) else {
+			return false
+		}
+		guard let fragment = url.fragment, !fragment.isEmpty else { return false }
+		let pathSegments = url.pathComponents.filter { $0 != "/" }.map { $0.lowercased() }
+		return pathSegments == ["v"]
+	}
+
 	@MainActor
 	static func handleContactUrl(url: URL, accessoryManager: AccessoryManager) {
 		let supportedVersion = accessoryManager.checkIsVersionSupported(forVersion: minimumContactVersion)

--- a/Meshtastic/Helpers/MeshtasticChannelURL.swift
+++ b/Meshtastic/Helpers/MeshtasticChannelURL.swift
@@ -121,7 +121,8 @@ struct MeshtasticChannelURL: Sendable {
 			return url.host?.lowercased() == channelPathSegment && pathSegments.isEmpty
 		}
 
-		guard url.host?.lowercased() == Self.host else { return false }
+		let supportedHosts = [Self.host, "www.\(Self.host)"]
+		guard let host = url.host?.lowercased(), supportedHosts.contains(host) else { return false }
 		return pathSegments(for: url) == [channelPathSegment]
 	}
 

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -217,7 +217,7 @@ struct MeshtasticAppleApp: App {
 						self.saveChannelLink = nil
 
 						if let url = userActivity.webpageURL {
-							if url.absoluteString.lowercased().contains("meshtastic.org/v/#") == true {
+							if ContactURLHandler.canHandle(url) {
 								ContactURLHandler.handleContactUrl(url: url, accessoryManager: accessoryManager)
 							} else if MeshtasticChannelURL.canHandle(url) {
 								// **Consolidated Call for User Activity**
@@ -237,7 +237,7 @@ struct MeshtasticAppleApp: App {
 							// "Open in Meshtastic" from the Share Sheet / Files app / drag-and-drop —
 							// distinct from the meshtastic:// scheme handled below.
 							appState.router.importMapFile(url: url)
-						} else if url.absoluteString.lowercased().contains("meshtastic.org/v/#") {
+						} else if ContactURLHandler.canHandle(url) {
 							ContactURLHandler.handleContactUrl(url: url, accessoryManager: accessoryManager)
 						} else if MeshtasticChannelURL.canHandle(url) {
 							// **Consolidated Call for Open URL**

--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -297,19 +297,19 @@
             "tap",
             "recipient",
             "node",
+            "meshtastic",
             "conversation",
             "after",
             "selection",
             "bold",
             "radio",
             "public",
+            "links",
             "field",
             "button",
-            "symbol",
-            "preview",
-            "press"
+            "symbol"
         ],
-        "charCount": 11637
+        "charCount": 11883
     },
     {
         "id": "mqtt",

--- a/Meshtastic/Resources/docs/markdown/user/messages.md
+++ b/Meshtastic/Resources/docs/markdown/user/messages.md
@@ -145,7 +145,7 @@ The message status row combines a short label, SF Symbol icon, and color. Color 
 
 ## Link Appearance
 
-Links in message bubbles — including URLs, Meshtastic channel links, and markdown `[text](url)` links — are styled with an underline and the design standards Link color (Blue 400). This makes links visually distinct from regular message text in both light and dark mode. Tapping a link opens it in the browser, or for Meshtastic channel/contact URLs, opens the appropriate in-app handler.
+Links in message bubbles — including URLs, Meshtastic channel links, and markdown `[text](url)` links — are styled with an underline and the design standards Link color (Blue 400). This makes links visually distinct from regular message text in both light and dark mode. Tapping a link opens it in the system browser (Safari on the standard/default setup), except for Meshtastic channel links and contact links in the exact `meshtastic.org/v/#...` or `www.meshtastic.org/v/#...` form, which open the appropriate in-app import flow. Meshtastic documentation links, including `meshtastic.org/docs/...`, continue to open in the system browser.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/messageText_link_dark.png">

--- a/Meshtastic/Resources/docs/user/messages.html
+++ b/Meshtastic/Resources/docs/user/messages.html
@@ -265,7 +265,7 @@ Send channel broadcasts and direct messages. Long press any message for actions 
 </table>
 <hr />
 <h2>Link Appearance</h2>
-<p>Links in message bubbles — including URLs, Meshtastic channel links, and markdown <code>[text](url)</code> links — are styled with an underline and the design standards Link color (Blue 400). This makes links visually distinct from regular message text in both light and dark mode. Tapping a link opens it in the browser, or for Meshtastic channel/contact URLs, opens the appropriate in-app handler.</p>
+<p>Links in message bubbles — including URLs, Meshtastic channel links, and markdown <code>[text](url)</code> links — are styled with an underline and the design standards Link color (Blue 400). This makes links visually distinct from regular message text in both light and dark mode. Tapping a link opens it in the system browser (Safari on the standard/default setup), except for Meshtastic channel links and contact links in the exact <code>meshtastic.org/v/#...</code> or <code>www.meshtastic.org/v/#...</code> form, which open the appropriate in-app import flow. Meshtastic documentation links, including <code>meshtastic.org/docs/...</code>, continue to open in the system browser.</p>
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/messageText_link_dark.png">
   <img src="../assets/screenshots/messageText_link.png" alt="Message bubble with styled link">

--- a/Meshtastic/Views/Messages/MessageText.swift
+++ b/Meshtastic/Views/Messages/MessageText.swift
@@ -194,7 +194,7 @@ struct MessageText: View {
 	private func handleURL(_ url: URL) -> OpenURLAction.Result {
 		saveChannelLink = nil
 		var addChannels = false
-		if url.absoluteString.lowercased().contains("meshtastic.org/v/#") {
+		if ContactURLHandler.canHandle(url) {
 			// Handle contact URL
 			ContactURLHandler.handleContactUrl(url: url, accessoryManager: AccessoryManager.shared)
 			return .handled // Prevent default browser opening

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -303,6 +303,12 @@ struct ShareContactQRTests {
 		#expect(ContactURLHandler.canHandle(www))
 	}
 
+	@Test func leavesMeshtasticDocumentationURLsForTheSystemBrowser() throws {
+		let documentation = try #require(URL(string: "https://meshtastic.org/docs/configuration"))
+
+		#expect(!ContactURLHandler.canHandle(documentation))
+	}
+
 	@Test func decodesAndroidSharedContactPayload() throws {
 		let payload = "CAE="
 		let data = try #require(Data(base64Encoded: payload.base64urlToBase64()))

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -295,6 +295,22 @@ struct ShareContactQRTests {
 		#expect(contact.manuallyVerified)
 	}
 
+	@Test func recognizesAndroidCompatibleContactURLForms() throws {
+		let canonical = try #require(URL(string: "https://meshtastic.org/v/#CAE="))
+		let www = try #require(URL(string: "https://www.meshtastic.org/v/#CAE="))
+
+		#expect(ContactURLHandler.canHandle(canonical))
+		#expect(ContactURLHandler.canHandle(www))
+	}
+
+	@Test func decodesAndroidSharedContactPayload() throws {
+		let payload = "CAE="
+		let data = try #require(Data(base64Encoded: payload.base64urlToBase64()))
+		let contact = try SharedContact(serializedBytes: data)
+
+		#expect(contact.nodeNum == 1)
+	}
+
 	@Test func contactURLUnavailableForUnmessagableNode() {
 		let node = makeNodeInfo(unmessagable: true)
 

--- a/MeshtasticTests/MeshtasticChannelURLTests.swift
+++ b/MeshtasticTests/MeshtasticChannelURLTests.swift
@@ -18,6 +18,26 @@ struct MeshtasticChannelURLTests {
 		#expect(parsed.channelSet.loraConfig.hopLimit == 5)
 	}
 
+	@Test func acceptsAndroidCompatibleWWWChannelURL() throws {
+		let payload = try MeshtasticChannelURL.payloadString(for: makeChannelSet())
+		let parsed = try MeshtasticChannelURL.parse("https://www.meshtastic.org/e/?add=true#\(payload)")
+
+		#expect(parsed.addChannels)
+		#expect(parsed.channelSet.settings.first?.name == "Alpha")
+		#expect(!parsed.channelSet.hasLoraConfig)
+	}
+
+	@Test func decodesAndroidChannelReplaceAndAddVectors() throws {
+		let replace = try MeshtasticChannelURL.parse("https://meshtastic.org/e/#CgMSAQESBggBQANIAQ")
+		let add = try MeshtasticChannelURL.parse("https://meshtastic.org/e/?add=true#CgMSAQESBggBQANIAQ")
+
+		#expect(replace.channelSet.settings.count == 1)
+		#expect(replace.channelSet.hasLoraConfig)
+		#expect(add.channelSet.settings.count == 1)
+		#expect(add.addChannels)
+		#expect(!add.channelSet.hasLoraConfig)
+	}
+
 	@Test(arguments: [
 		"HTTPS://MESHTASTIC.ORG/E/#",
 		"https://meshtastic.org/e#",

--- a/MeshtasticTests/MeshtasticChannelURLTests.swift
+++ b/MeshtasticTests/MeshtasticChannelURLTests.swift
@@ -38,17 +38,16 @@ struct MeshtasticChannelURLTests {
 		#expect(!add.channelSet.hasLoraConfig)
 	}
 
-	@Test func allSupportedChannelCountsPreserveSettingsForReplaceAndAdd() throws {
-		for channelCount in 1 ... 8 {
-			let channelSet = makeChannelSet(channelCount: channelCount)
-			let replace = try MeshtasticChannelURL.parse(MeshtasticChannelURL.urlString(for: channelSet))
-			let add = try MeshtasticChannelURL.parse(MeshtasticChannelURL.urlString(for: channelSet, addChannels: true))
+	@Test(arguments: 1 ... 8)
+	func allSupportedChannelCountsPreserveSettingsForReplaceAndAdd(channelCount: Int) throws {
+		let channelSet = makeChannelSet(channelCount: channelCount)
+		let replace = try MeshtasticChannelURL.parse(MeshtasticChannelURL.urlString(for: channelSet))
+		let add = try MeshtasticChannelURL.parse(MeshtasticChannelURL.urlString(for: channelSet, addChannels: true))
 
-			#expect(replace.channelSet.settings == channelSet.settings, "\(channelCount)-channel replace settings")
-			#expect(replace.channelSet.loraConfig == channelSet.loraConfig, "\(channelCount)-channel replace LoRa config")
-			#expect(add.channelSet.settings == channelSet.settings, "\(channelCount)-channel add settings")
-			#expect(!add.channelSet.hasLoraConfig, "\(channelCount)-channel add must not retune")
-		}
+		#expect(replace.channelSet.settings == channelSet.settings, "\(channelCount)-channel replace settings")
+		#expect(replace.channelSet.loraConfig == channelSet.loraConfig, "\(channelCount)-channel replace LoRa config")
+		#expect(add.channelSet.settings == channelSet.settings, "\(channelCount)-channel add settings")
+		#expect(!add.channelSet.hasLoraConfig, "\(channelCount)-channel add must not retune")
 	}
 
 	@Test(arguments: [

--- a/MeshtasticTests/MeshtasticChannelURLTests.swift
+++ b/MeshtasticTests/MeshtasticChannelURLTests.swift
@@ -38,6 +38,19 @@ struct MeshtasticChannelURLTests {
 		#expect(!add.channelSet.hasLoraConfig)
 	}
 
+	@Test func allSupportedChannelCountsPreserveSettingsForReplaceAndAdd() throws {
+		for channelCount in 1 ... 8 {
+			let channelSet = makeChannelSet(channelCount: channelCount)
+			let replace = try MeshtasticChannelURL.parse(MeshtasticChannelURL.urlString(for: channelSet))
+			let add = try MeshtasticChannelURL.parse(MeshtasticChannelURL.urlString(for: channelSet, addChannels: true))
+
+			#expect(replace.channelSet.settings == channelSet.settings, "\(channelCount)-channel replace settings")
+			#expect(replace.channelSet.loraConfig == channelSet.loraConfig, "\(channelCount)-channel replace LoRa config")
+			#expect(add.channelSet.settings == channelSet.settings, "\(channelCount)-channel add settings")
+			#expect(!add.channelSet.hasLoraConfig, "\(channelCount)-channel add must not retune")
+		}
+	}
+
 	@Test(arguments: [
 		"HTTPS://MESHTASTIC.ORG/E/#",
 		"https://meshtastic.org/e#",
@@ -111,18 +124,25 @@ struct MeshtasticChannelURLTests {
 		}
 	}
 
-	private func makeChannelSet() -> ChannelSet {
+	private func makeChannelSet(channelCount: Int = 1) -> ChannelSet {
 		var lora = Config.LoRaConfig()
 		lora.hopLimit = 5
 		lora.modemPreset = .longFast
-
-		var settings = ChannelSettings()
-		settings.name = "Alpha"
-		settings.psk = Data([1, 2, 3, 4])
+		lora.region = .us
+		lora.channelNum = 13
+		lora.txPower = 20
+		lora.usePreset = true
 
 		var channelSet = ChannelSet()
 		channelSet.loraConfig = lora
-		channelSet.settings = [settings]
+		channelSet.settings = (0 ..< channelCount).map { index in
+			var settings = ChannelSettings()
+			settings.name = index == 0 ? "Alpha" : "Conference-\(index)"
+			settings.psk = Data([UInt8(index), UInt8(index + 16)])
+			settings.id = UInt32(index + 1)
+			settings.moduleSettings.positionPrecision = UInt32(index)
+			return settings
+		}
 		return channelSet
 	}
 }

--- a/docs/user/messages.md
+++ b/docs/user/messages.md
@@ -145,7 +145,7 @@ The message status row combines a short label, SF Symbol icon, and color. Color 
 
 ## Link Appearance
 
-Links in message bubbles — including URLs, Meshtastic channel links, and markdown `[text](url)` links — are styled with an underline and the design standards Link color (Blue 400). This makes links visually distinct from regular message text in both light and dark mode. Tapping a link opens it in the browser, or for Meshtastic channel/contact URLs, opens the appropriate in-app handler.
+Links in message bubbles — including URLs, Meshtastic channel links, and markdown `[text](url)` links — are styled with an underline and the design standards Link color (Blue 400). This makes links visually distinct from regular message text in both light and dark mode. Tapping a link opens it in Safari, except for Meshtastic channel links and contact links in the exact `meshtastic.org/v/#...` or `www.meshtastic.org/v/#...` form, which open the appropriate in-app import flow. Meshtastic documentation links, including `meshtastic.org/docs/...`, continue to open in Safari.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/messageText_link_dark.png">

--- a/docs/user/messages.md
+++ b/docs/user/messages.md
@@ -145,7 +145,7 @@ The message status row combines a short label, SF Symbol icon, and color. Color 
 
 ## Link Appearance
 
-Links in message bubbles — including URLs, Meshtastic channel links, and markdown `[text](url)` links — are styled with an underline and the design standards Link color (Blue 400). This makes links visually distinct from regular message text in both light and dark mode. Tapping a link opens it in Safari, except for Meshtastic channel links and contact links in the exact `meshtastic.org/v/#...` or `www.meshtastic.org/v/#...` form, which open the appropriate in-app import flow. Meshtastic documentation links, including `meshtastic.org/docs/...`, continue to open in Safari.
+Links in message bubbles — including URLs, Meshtastic channel links, and markdown `[text](url)` links — are styled with an underline and the design standards Link color (Blue 400). This makes links visually distinct from regular message text in both light and dark mode. Tapping a link opens it in the system browser (Safari on the standard/default setup), except for Meshtastic channel links and contact links in the exact `meshtastic.org/v/#...` or `www.meshtastic.org/v/#...` form, which open the appropriate in-app import flow. Meshtastic documentation links, including `meshtastic.org/docs/...`, continue to open in the system browser.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../assets/screenshots/messageText_link_dark.png">


### PR DESCRIPTION
## Summary
- Accept canonical and www Meshtastic hosts for channel QR links.
- Route contact QR links structurally instead of relying on a raw URL substring.
- Cover Android channel replace, channel add, and shared-contact payload vectors in Apple tests.

## Root cause
Android accepts both meshtastic.org and www.meshtastic.org for channel and contact links. Apple only accepted the bare host for channels and routed contacts with a literal meshtastic.org/v/# substring, so valid links using the alternate host were not imported.

## Evidence
- The shared channel vector exercises replace with LoRa preserved and add with LoRa removed.
- The shared-contact vector CAE= decodes to node 1.
- Focused simulator verification passed:
  xcodebuild test -quiet -project Meshtastic.xcodeproj -scheme Meshtastic -only-testing:MeshtasticTests/MeshtasticChannelURLTests -only-testing:MeshtasticTests/ShareContactQRTests

No UI layout changes: this is URL routing and protocol regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Meshtastic contact and channel links (including `www.meshtastic.org`), and tightened in-app importing to the supported URL formats only.
  * Updated URL routing across app launch, shared content, and message interactions so supported contact links consistently use the in-app import flow.
* **Documentation**
  * Refined “Link Appearance” guidance to clearly distinguish in-app import URLs (exact contact/channel formats) from system-browser links (including Meshtastic docs).
* **Tests**
  * Expanded coverage for Android-compatible link/QR payload handling and add-versus-replace parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->