### PR TITLE
a11y: Honor Reduce Motion for continuous animations

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/AnimatedNodePin.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/AnimatedNodePin.swift
@@ -73,6 +73,7 @@ struct AnimatedNodePin: View, Equatable {
 /// recycles/reconfigures the annotation view (which it does constantly on pan/zoom/declutter). The
 /// per-node `calculatedDelay` phase-shifts each node so they don't all pulse in unison.
 struct PulsingCircle: View {
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	let nodeColor: UIColor
 	let calculatedDelay: Double
 
@@ -80,6 +81,17 @@ struct PulsingCircle: View {
 	private let period: Double = 2.4
 
 	var body: some View {
+		if reduceMotion {
+			// Static halo (no breathing) when Reduce Motion is enabled.
+			Circle()
+				.fill(Color(nodeColor.lighter()).opacity(0.3))
+				.frame(width: 50, height: 50)
+		} else {
+			animatedHalo
+		}
+	}
+
+	private var animatedHalo: some View {
 		// Cap the clock to ~20 fps: a slow 2.4s breath looks identical, but with many ONLINE pins each
 		// hosted in an MKAnnotationView, an uncapped `.animation` clock re-renders every pin every
 		// display frame and never lets the map go idle (janky at rest on Mac Catalyst).

--- a/Meshtastic/Views/Settings/Discovery/RadarSweepView.swift
+++ b/Meshtastic/Views/Settings/Discovery/RadarSweepView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct RadarSweepView: View {
 	var isActive: Bool
 
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	@State private var startDate = Date()
 
 	/// Seconds for one full 360° rotation
@@ -24,7 +25,8 @@ struct RadarSweepView: View {
 
 	var body: some View {
 		if isActive {
-			TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+			// Freeze the sweep on a single static frame when Reduce Motion is enabled.
+			TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: reduceMotion)) { timeline in
 				let elapsed = timeline.date.timeIntervalSince(startDate)
 				let rotation = (elapsed / rotationDuration).truncatingRemainder(dividingBy: 1.0) * 360.0
 

--- a/Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift
+++ b/Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift
@@ -23,6 +23,7 @@ struct CircularProgressView: View {
 	var subtitleText: String?
 	
 	@State private var rotation: Double = 0
+	@Environment(\.accessibilityReduceMotion) private var reduceMotion
 	
 	private var isComplete: Bool {
 		// Complete only if 100%, not indeterminate, and NOT an error
@@ -71,11 +72,13 @@ struct CircularProgressView: View {
 		// Monitor both Indeterminate and Error to stop/start animations
 		.onChange(of: isIndeterminate) { _, _ in updateAnimationStatus() }
 		.onChange(of: isError) { _, _ in updateAnimationStatus() }
+		.onChange(of: reduceMotion) { _, _ in updateAnimationStatus() }
 	}
 	
 	private func updateAnimationStatus() {
-		// Only spin if Indeterminate AND we are not in an Error state
-		if isIndeterminate && !isError {
+		// Only spin if Indeterminate AND we are not in an Error state. Respect Reduce Motion by
+		// leaving the indeterminate segment static instead of spinning it forever.
+		if isIndeterminate && !isError && !reduceMotion {
 			rotation = 0
 			withAnimation(.linear(duration: 2.0).repeatForever(autoreverses: false)) {
 				rotation = 360


### PR DESCRIPTION
## What changed?

Three continuously-running animations now honor the system **Reduce Motion** accessibility setting via `@Environment(\.accessibilityReduceMotion)`; when it's enabled they stop or render statically.

- **RadarSweepView** (Discovery) — the `TimelineView`-driven Canvas sweep freezes via `paused: reduceMotion`.
- **CircularProgressView** (firmware update) — the indeterminate spinner (`repeatForever` rotation) stops and leaves the segment static; re-evaluated on `onChange(of: reduceMotion)`.
- **PulsingCircle** (map node halo) — renders a static halo instead of the breathing `scaleEffect` (a map full of online nodes otherwise pulses many halos at once).
- 3 files changed, +20 / −3.

**Scope note:** This PR was trimmed to the clearly motion-based cases (sweep / spin / scale-pulse). The earlier revision also gated several `.symbolEffect(.variableColor)` sites (Connect, Wi-Fi provisioning, position popover, sensor pin), but `.variableColor` is a color/opacity shimmer rather than positional motion, so those were dropped as out-of-scope for Reduce Motion. Opacity cross-fades (e.g. `LEDIndicator`) are likewise left alone — Apple recommends cross-fade as the *substitute* for motion.

## Why did it change?

The app had 0 uses of `accessibilityReduceMotion` against a continuously-sweeping radar, an infinitely-spinning firmware loader, and breathing map-pin halos. Users who enable Reduce Motion (often for vestibular / motion sensitivity) were still shown all of them.

## How is this tested?

Built the `Meshtastic` scheme for iOS Simulator (iPhone 17 Pro, Xcode 26) → `** BUILD SUCCEEDED **`. SwiftLint clean. Verified on-simulator with Reduce Motion enabled: recorded before/after clips of all three and confirmed via frame-diff that the "after" display stops updating entirely (0 pixel change) while "before" keeps animating. A focused Swift/SwiftUI review earlier confirmed the Reduce Motion toggle reaches live map pins through the `UIHostingConfiguration` trait bridge (EquatableView memoization does not swallow environment-driven invalidation).

## Screenshots/Videos (when applicable)

https://github.com/user-attachments/assets/d50fb222-35f5-4765-90cf-03fd46e78b20

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. No doc update is needed (motion-only accessibility change, no UI/flow change) — `skip-docs-check` applied.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Respected the system’s Reduce Motion setting across map pins, radar sweeps, and firmware progress indicators.
  * Disabled or paused animations when Reduce Motion is enabled, including when the setting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->