### PR TITLE
a11y: Hide decorative Config-screen glyphs from VoiceOver

### DIFF
--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -108,6 +108,9 @@ struct LoRaConfig: View {
 					HStack(alignment: .top, spacing: 8) {
 						Image(systemName: licensed ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
 							.foregroundColor(licensed ? .green : .orange)
+							// Decorative status glyph; the adjacent "Licensed band" title and
+							// description already convey licensed/unlicensed state to VoiceOver.
+							.accessibilityHidden(true)
 						VStack(alignment: .leading, spacing: 2) {
 							Text("Licensed band")
 								.font(.callout).bold()
@@ -226,6 +229,8 @@ struct LoRaConfig: View {
 				HStack {
 					Image(systemName: "antenna.radiowaves.left.and.right")
 						.foregroundColor(.accentColor)
+						// Decorative icon; the Stepper carries the label for VoiceOver.
+						.accessibilityHidden(true)
 					Stepper(txPower == 0 ? "Max Transmit Power" : "\(txPower)dBm Transmit Power", value: $txPower, in: 0...30, step: 1)
 						.padding(5)
 				}

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -37,12 +37,16 @@ struct AmbientLightingConfig: View {
 				HStack {
 					Image(systemName: "eyedropper")
 						.foregroundColor(.accentColor)
+						// Decorative icon; the ColorPicker carries the label for VoiceOver.
+						.accessibilityHidden(true)
 					ColorPicker("Color", selection: $color, supportsOpacity: false)
 						.padding(5)
 				}
 				HStack {
 					Image(systemName: "directcurrent")
 						.foregroundColor(.accentColor)
+						// Decorative icon; the Stepper carries the label for VoiceOver.
+						.accessibilityHidden(true)
 					Stepper("Current: \(current)", value: $current, in: 0...31, step: 1)
 						.padding(5)
 				}


### PR DESCRIPTION
## What changed?

A conservative VoiceOver pass over the Settings → Config screens: 4 standalone decorative `Image(systemName:)` glyphs that sit beside an already-labeled control are marked `.accessibilityHidden(true)` so VoiceOver no longer announces an opaque symbol name (e.g. "checkmark seal fill").

- **LoRaConfig** — licensed-band status icon (the adjacent "Licensed band" title + state-branched description already convey licensed/unlicensed) and the `antenna.radiowaves…` icon before the Transmit-Power Stepper.
- **AmbientLightingConfig** — the `eyedropper` before the ColorPicker and `directcurrent` before the Current Stepper.
- 2 files changed, +9.

## Why did it change?

Auditing the Config screens showed that nearly every glyph is already inside `Label(text, systemImage:)`, where SwiftUI exposes the title as the accessibility label and treats the symbol as decorative — so those rows already read correctly and need no change. The only real gaps were these 4 standalone glyphs, where VoiceOver would otherwise read a meaningless symbol name. Hiding (not labeling) is correct because each is adjacent to already-spoken text; labeling would produce redundant announcements.

## How is this tested?

Built the `Meshtastic` scheme for iOS Simulator (iPhone 17 Pro, Xcode 26) → `** BUILD SUCCEEDED **`. SwiftLint clean. Passed a focused Swift/SwiftUI review (approve, no nits) confirming the licensed-band description is state-branched so hiding the glyph loses no information, and that `.accessibilityHidden` scopes only to the decorative Image without affecting sibling controls.

## Screenshots/Videos (when applicable)

N/A — no visual change; affects spoken VoiceOver output only.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. No doc update is needed (non-visual a11y annotation) — please apply the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
