### PR TITLE
a11y: Dynamic Type support for Compact Widget metric tiles

### DIFF
--- a/Meshtastic/Views/Helpers/Compact Widgets/DistanceCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/DistanceCompactWidget.swift
@@ -11,6 +11,9 @@ struct DistanceCompactWidget: View {
 	let distance: String
 	let unit: String
 
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 50
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 40
+
 	var body: some View {
 		VStack(alignment: .leading) {
 			HStack(alignment: .firstTextBaseline) {
@@ -23,9 +26,11 @@ struct DistanceCompactWidget: View {
 			}
 			HStack {
 				Text("\(distance)")
-					.font(distance.length < 4 ? .system(size: 50) : .system(size: 40) )
+					.font(.system(size: distance.length < 4 ? valueSizeLarge : valueSizeSmall))
+					.lineLimit(1)
+					.minimumScaleFactor(0.5)
 				Text(unit)
-					.font(.system(size: 14))
+					.font(.footnote)
 			}
 		}
 		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)

--- a/Meshtastic/Views/Helpers/Compact Widgets/ParticulateMatterCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/ParticulateMatterCompactWidget.swift
@@ -11,6 +11,9 @@ struct ParticulateMatterCompactWidget: View {
 	let label: String
 	let value: UInt32
 
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 50
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 34
+
 	private var formattedValue: String {
 		value.formatted(.number.grouping(.never))
 	}
@@ -27,9 +30,11 @@ struct ParticulateMatterCompactWidget: View {
 			}
 			HStack(alignment: .firstTextBaseline) {
 				Text(verbatim: formattedValue)
-					.font(formattedValue.count < 4 ? .system(size: 50) : .system(size: 34))
+					.font(.system(size: formattedValue.count < 4 ? valueSizeLarge : valueSizeSmall))
+					.lineLimit(1)
+					.minimumScaleFactor(0.5)
 				Text(verbatim: "µg/m³")
-					.font(.system(size: 14))
+					.font(.footnote)
 			}
 		}
 		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)

--- a/Meshtastic/Views/Helpers/Compact Widgets/PressureCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/PressureCompactWidget.swift
@@ -10,6 +10,9 @@ struct PressureCompactWidget: View {
 	let pressure: String
 	let unit: String
 	let low: Bool
+
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 35
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 30
 	var body: some View {
 		VStack(alignment: .leading) {
 			HStack(spacing: 5.0) {
@@ -21,7 +24,9 @@ struct PressureCompactWidget: View {
 					.font(.caption)
 			}
 			Text(pressure)
-				.font(pressure.length < 7 ? .system(size: 35) : .system(size: 30) )
+				.font(.system(size: pressure.length < 7 ? valueSizeLarge : valueSizeSmall))
+				.lineLimit(1)
+				.minimumScaleFactor(0.5)
 			Text(low ? "LOW" : "HIGH")
 				.padding(.bottom, 10)
 			Text(unit)

--- a/Meshtastic/Views/Helpers/Compact Widgets/RadiationCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/RadiationCompactWidget.swift
@@ -11,6 +11,9 @@ struct RadiationCompactWidget: View {
 	let radiation: String
 	let unit: String
 
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 50
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 34
+
 	var body: some View {
 		VStack(alignment: .leading) {
 			HStack(alignment: .firstTextBaseline) {
@@ -23,9 +26,11 @@ struct RadiationCompactWidget: View {
 			}
 			HStack {
 				Text("\(radiation)")
-					.font(radiation.length < 4 ? .system(size: 50) : .system(size: 34) )
+					.font(.system(size: radiation.length < 4 ? valueSizeLarge : valueSizeSmall))
+					.lineLimit(1)
+					.minimumScaleFactor(0.5)
 				Text(unit)
-					.font(.system(size: 14))
+					.font(.footnote)
 			}
 		}
 		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)

--- a/Meshtastic/Views/Helpers/Compact Widgets/RainfallCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/RainfallCompactWidget.swift
@@ -17,6 +17,9 @@ struct RainfallCompactWidget: View {
 	let rainfall: String
 	let unit: String
 
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 50
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 40
+
 	private var icon: Image {
 		if timespan == .rainfall1H {
 			return Image(systemName: "cloud.rain.fill")
@@ -35,9 +38,11 @@ struct RainfallCompactWidget: View {
 			}
 			HStack {
 				Text("\(rainfall)")
-					.font(rainfall.length < 4 ? .system(size: 50) : .system(size: 40) )
+					.font(.system(size: rainfall.length < 4 ? valueSizeLarge : valueSizeSmall))
+					.lineLimit(1)
+					.minimumScaleFactor(0.5)
 				Text(unit)
-					.font(.system(size: 14))
+					.font(.footnote)
 			}
 		}
 		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)

--- a/Meshtastic/Views/Helpers/Compact Widgets/SoilCompactWidgets.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/SoilCompactWidgets.swift
@@ -11,6 +11,9 @@ struct SoilTemperatureCompactWidget: View {
 	let temperature: String
 	let unit: String
 
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 50
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 40
+
 	var body: some View {
 		VStack(alignment: .leading) {
 			HStack(alignment: .firstTextBaseline) {
@@ -23,9 +26,11 @@ struct SoilTemperatureCompactWidget: View {
 			}
 			HStack {
 				Text("\(temperature)")
-					.font(temperature.length < 4 ? .system(size: 50) : .system(size: 40) )
+					.font(.system(size: temperature.length < 4 ? valueSizeLarge : valueSizeSmall))
+					.lineLimit(1)
+					.minimumScaleFactor(0.5)
 				Text(unit)
-					.font(.system(size: 14))
+					.font(.footnote)
 			}
 		}
 		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
@@ -37,6 +42,9 @@ struct SoilTemperatureCompactWidget: View {
 struct SoilMoistureCompactWidget: View {
 	let moisture: String
 	let unit: String
+
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 50
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 40
 
 	var body: some View {
 		VStack(alignment: .leading) {
@@ -50,9 +58,11 @@ struct SoilMoistureCompactWidget: View {
 			}
 			HStack {
 				Text("\(moisture)")
-					.font(moisture.length < 4 ? .system(size: 50) : .system(size: 40) )
+					.font(.system(size: moisture.length < 4 ? valueSizeLarge : valueSizeSmall))
+					.lineLimit(1)
+					.minimumScaleFactor(0.5)
 				Text(unit)
-					.font(.system(size: 14))
+					.font(.footnote)
 			}
 		}
 		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)

--- a/Meshtastic/Views/Helpers/Compact Widgets/WeatherConditionsCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/WeatherConditionsCompactWidget.swift
@@ -10,6 +10,9 @@ struct WeatherConditionsCompactWidget: View {
 	let temperature: String
 	let symbolName: String
 	let description: String
+
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 72
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 54
 	var body: some View {
 		VStack(alignment: .leading) {
 			HStack(spacing: 5.0) {
@@ -23,7 +26,9 @@ struct WeatherConditionsCompactWidget: View {
 					.font(.caption)
 			}
 			Text(temperature)
-				.font(temperature.length < 4 ? .system(size: 72) : .system(size: 54) )
+				.font(.system(size: temperature.length < 4 ? valueSizeLarge : valueSizeSmall))
+				.lineLimit(1)
+				.minimumScaleFactor(0.5)
 		}
 		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
 		.padding()

--- a/Meshtastic/Views/Helpers/Compact Widgets/WeightCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/WeightCompactWidget.swift
@@ -11,6 +11,9 @@ struct WeightCompactWidget: View {
 	let weight: String
 	let unit: String
 
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeLarge: CGFloat = 50
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSizeSmall: CGFloat = 40
+
 	var body: some View {
 		VStack(alignment: .leading) {
 			HStack(alignment: .firstTextBaseline) {
@@ -23,9 +26,11 @@ struct WeightCompactWidget: View {
 			}
 			HStack {
 				Text("\(weight)")
-					.font(weight.length < 4 ? .system(size: 50) : .system(size: 40) )
+					.font(.system(size: weight.length < 4 ? valueSizeLarge : valueSizeSmall))
+					.lineLimit(1)
+					.minimumScaleFactor(0.5)
 				Text(unit)
-					.font(.system(size: 14))
+					.font(.footnote)
 			}
 		}
 		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)

--- a/Meshtastic/Views/Helpers/Compact Widgets/WindCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/WindCompactWidget.swift
@@ -11,6 +11,8 @@ struct WindCompactWidget: View {
 	let gust: String?
 	let direction: String?
 
+	@ScaledMetric(relativeTo: .largeTitle) private var valueSize: CGFloat = 35
+
 	var body: some View {
 		let hasGust = ((gust ?? "").isEmpty == false)
 		VStack(alignment: .leading) {
@@ -21,7 +23,9 @@ struct WindCompactWidget: View {
 					.padding(.bottom, 10)
 			}
 			Text(speed)
-				.font(.system(size: 35))
+				.font(.system(size: valueSize))
+				.lineLimit(1)
+				.minimumScaleFactor(0.5)
 			if let gust, !gust.isEmpty {
 				Text("Gusts \(gust)")
 			}

--- a/Meshtastic/Views/Helpers/PowerMetrics.swift
+++ b/Meshtastic/Views/Helpers/PowerMetrics.swift
@@ -77,6 +77,8 @@ struct PowerMetricCompactWidget: View {
 		let type: PowerMetricType
 		let value: Float
 		let title: String
+		@ScaledMetric(relativeTo: .largeTitle) private var currentValueSize: CGFloat = 35
+		@ScaledMetric(relativeTo: .largeTitle) private var voltageValueSize: CGFloat = 30
 		var body: some View {
 				VStack(alignment: .leading) {
 						HStack(spacing: 5.0) {
@@ -87,7 +89,9 @@ struct PowerMetricCompactWidget: View {
 										.font(.caption)
 						}
 						Text("\(value, specifier: type == .current ? "%.1f" : "%.2f") \(type == .current ? "mA" : "V")")
-								.font(type == .current ? .system(size: 35) : .system(size: 30))
+								.font(.system(size: type == .current ? currentValueSize : voltageValueSize))
+								.lineLimit(1)
+								.minimumScaleFactor(0.5)
 				}
 				.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
 				.padding()


### PR DESCRIPTION
## What changed?

Adds **Dynamic Type** support to the node-detail Compact Widget metric tiles, whose large numeric readouts used hardcoded `.font(.system(size: N))` (30–72pt) that ignored the user's text-size setting and would clip inside fixed-height tiles.

- Large numeric readouts → `@ScaledMetric(relativeTo: .largeTitle) private var valueSize…: CGFloat = N` + `.font(.system(size: valueSize))`, so the font scales with Dynamic Type. Base values equal the prior hardcoded sizes → pixel-parity at the default size.
- Added `.lineLimit(1)` + `.minimumScaleFactor(0.5)` so enlarged text scales-to-fit the uniform grid tile instead of clipping (grid-row alignment preserved).
- Small unit labels `.font(.system(size: 14))` → semantic `.font(.footnote)`.
- Decorative glyphs (`aqi.medium` SF Symbol, `☢` verbatim symbol) left untouched.
- 10 files changed, +71 / −18 (Compact Widgets + `PowerMetrics.swift`).

## Why did it change?

Users who increase their system text size (or use Accessibility larger text) saw these sensor readouts stay fixed-size and, at large settings, clip. Making them scale respects Dynamic Type while keeping the tile grid aligned.

## How is this tested?

Built the `Meshtastic` scheme for iOS Simulator (iPhone 17 Pro, Xcode 26) → `** BUILD SUCCEEDED **`. SwiftLint clean. Passed a focused Swift/SwiftUI review (ship-it) confirming the `@ScaledMetric` usage/anchor is correct and does not fight `minimumScaleFactor`, default-size parity holds, the glyph-vs-text split is right, and there are no caller/layout regressions in `PowerMetrics.swift`/`SoilCompactWidgets.swift`. Verify visually via Settings → Accessibility → Display & Text Size → Larger Text.

## Screenshots/Videos (when applicable)
<img width="2412" height="2762" alt="dyntype_comparison" src="https://github.com/user-attachments/assets/925da502-bd6b-47f6-84ea-668781c6b957" />



## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`. No doc update is needed (presentational Dynamic Type change under `Views/Helpers/`, no behavior/flow change) — please apply the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Compact metric widgets now adapt numeric text sizes to the device’s Dynamic Type settings.
  * Long distance, pressure, rainfall, wind, power, soil, weather, particulate matter, radiation, and weight values fit more reliably on a single line.
  * Values can scale down automatically when space is limited, improving readability in compact layouts.
  * Measurement unit labels now use standard footnote styling for more consistent typography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->