### PR TITLE
Fix read messages leaving notifications visible

### DIFF
--- a/Meshtastic/Helpers/LocalNotificationManager.swift
+++ b/Meshtastic/Helpers/LocalNotificationManager.swift
@@ -9,9 +9,16 @@ import OSLog
 class LocalNotificationManager {
 
     var notifications = [Notification]()
+	private let removeDeliveredNotifications: ([String]) -> Void
 	let thumbsUpAction = UNNotificationAction(identifier: "messageNotification.thumbsUpAction", title: "👍 \(Tapbacks.thumbsUp.description)", options: [])
 	let thumbsDownAction = UNNotificationAction(identifier: "messageNotification.thumbsDownAction", title: "👎  \(Tapbacks.thumbsDown.description)", options: [])
 	let replyInputAction =  UNTextInputNotificationAction(identifier: "messageNotification.replyInputAction", title: "Reply".localized, options: [])
+
+	init(removeDeliveredNotifications: @escaping ([String]) -> Void = { identifiers in
+		UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: identifiers)
+	}) {
+		self.removeDeliveredNotifications = removeDeliveredNotifications
+	}
 
     // Step 1 Request Permissions for notifications
     private func requestAuthorization() async {
@@ -124,6 +131,12 @@ class LocalNotificationManager {
 	func cancelNotificationsForMessageIds(_ messageIds: [Int64]) {
 		let messageIDSet = Set(messageIds)
 		guard !messageIDSet.isEmpty else { return }
+		let deliveredNotificationIdentifiers = messageIds.map { "notification.id.\($0)" }
+
+		// Pending requests have not surfaced to the user yet; delivered notifications may
+		// still be visible on the Lock Screen or in Notification Center. Remove both when
+		// their messages have been read in the app.
+		removeDeliveredNotifications(deliveredNotificationIdentifiers)
 
 		UNUserNotificationCenter.current().getPendingNotificationRequests { notifications in
 			let identifiers = notifications.compactMap { notification -> String? in

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -69,6 +69,23 @@ struct GenerateMessageMarkdownTests {
 	}
 }
 
+// MARK: - Local Message Notification Cleanup
+
+@Suite("Local message notification cleanup")
+@MainActor
+struct LocalMessageNotificationCleanupTests {
+	@Test func readingMessages_removesTheirDeliveredNotifications() {
+		var removedIdentifiers = [String]()
+		let manager = LocalNotificationManager { identifiers in
+			removedIdentifiers = identifiers
+		}
+
+		manager.cancelNotificationsForMessageIds([123, 456])
+
+		#expect(removedIdentifiers == ["notification.id.123", "notification.id.456"])
+	}
+}
+
 // MARK: - TelemetryEnums Aqi
 
 @Suite("Local stats telemetry export")


### PR DESCRIPTION
## Summary
- remove delivered Meshtastic message notifications when their messages are read in-app
- retain the existing cancellation of pending requests
- cover the delivered-notification identifier cleanup with a focused regression test

## Root cause
The read path only removed pending local notification requests. Once a notification had already been delivered, iOS continued showing it on the Lock Screen and in Notification Center.

## Validation
- `xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic -destination platform=iOS\ Simulator,id=5669CB03-8FA2-4A97-BE04-A8566204116D -only-testing:MeshtasticTests/LocalMessageNotificationCleanupTests -derivedDataPath /private/tmp/meshtastic-notification-dismiss-derived-data CODE_SIGNING_ALLOWED=NO`
  - 1 test passed

## Notes
The local SwiftLint pre-commit hook could not run because its installed SourceKit bridge crashes with the active Xcode (`sourcekitdInProc` load failure). The focused Xcode simulator test completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canceling notifications by message ID now also removes notifications that have already been delivered, preventing stale notifications from remaining visible.

* **Tests**
  * Added coverage verifying that notifications for multiple message IDs are canceled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->