### PR TITLE
a11y: use translated doc title in DocPageView VoiceOver label/hint

### DIFF
--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocPageView.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocPageView.swift
@@ -139,8 +139,8 @@ struct DocPageView: View {
 		.navigationTitle(translatedTitle ?? page.title)
 		.navigationBarTitleDisplayMode(.inline)
 		.askChirpyToolbar()
-		.accessibilityLabel(String(localized: "\(page.title) documentation page", comment: "VoiceOver label for a documentation page"))
-		.accessibilityHint(String(localized: "Web view showing the \(page.title) documentation", comment: "VoiceOver hint for the documentation web view"))
+		.accessibilityLabel(String(localized: "\(translatedTitle ?? page.title) documentation page", comment: "VoiceOver label for a documentation page"))
+		.accessibilityHint(String(localized: "Web view showing the \(translatedTitle ?? page.title) documentation", comment: "VoiceOver hint for the documentation web view"))
 		.onAppear {
 			startTranslation()
 		}


### PR DESCRIPTION
## What & why

Follow-up to the a11y series (resolves the one actionable CodeRabbit comment on #2117).

[`DocPageView`](Meshtastic/Views/Settings/HelpAndDocumentation/DocPageView.swift) sets its `navigationTitle` to `translatedTitle ?? page.title`, but the `accessibilityLabel`/`accessibilityHint` interpolated the raw English `page.title`. On a translated documentation page, VoiceOver announced the English title while the visible title was translated.

This uses the same `translatedTitle ?? page.title` fallback (already in scope) in both accessibility strings so the spoken and visible titles match.

Two-line change, no behavior change when docs aren't translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)