### PR TITLE
a11y: VoiceOver grouping, firmware progress ring, Dynamic Type fixes (T039-T043)

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -197,6 +197,7 @@ struct Connect: View {
 												Text("Communicating").font(.callout)
 													.foregroundColor(.orange)
 											}
+											.accessibilityElement(children: .combine)
 										case .retrying(let attempt):
 											HStack {
 												Image(systemName: "square.stack.3d.down.forward")
@@ -206,6 +207,7 @@ struct Connect: View {
 												Text("Retrying (attempt \(attempt))").font(.callout)
 													.foregroundColor(.orange)
 											}
+											.accessibilityElement(children: .combine)
 										default:
 											EmptyView()
 										}

--- a/Meshtastic/Views/Helpers/Compact Widgets/DistanceCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/DistanceCompactWidget.swift
@@ -28,7 +28,7 @@ struct DistanceCompactWidget: View {
 					.font(.system(size: 14))
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/HumidityCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/HumidityCompactWidget.swift
@@ -30,7 +30,7 @@ struct HumidityCompactWidget: View {
 					.font(.caption2)
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/ParticulateMatterCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/ParticulateMatterCompactWidget.swift
@@ -32,7 +32,7 @@ struct ParticulateMatterCompactWidget: View {
 					.font(.system(size: 14))
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/PressureCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/PressureCompactWidget.swift
@@ -26,7 +26,7 @@ struct PressureCompactWidget: View {
 				.padding(.bottom, 10)
 			Text(unit)
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/RadiationCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/RadiationCompactWidget.swift
@@ -28,7 +28,7 @@ struct RadiationCompactWidget: View {
 					.font(.system(size: 14))
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/RainfallCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/RainfallCompactWidget.swift
@@ -40,7 +40,7 @@ struct RainfallCompactWidget: View {
 					.font(.system(size: 14))
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/SoilCompactWidgets.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/SoilCompactWidgets.swift
@@ -28,7 +28,7 @@ struct SoilTemperatureCompactWidget: View {
 					.font(.system(size: 14))
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}
@@ -55,7 +55,7 @@ struct SoilMoistureCompactWidget: View {
 					.font(.system(size: 14))
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/WeatherConditionsCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/WeatherConditionsCompactWidget.swift
@@ -25,7 +25,7 @@ struct WeatherConditionsCompactWidget: View {
 			Text(temperature)
 				.font(temperature.length < 4 ? .system(size: 72) : .system(size: 54) )
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/WeightCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/WeightCompactWidget.swift
@@ -28,7 +28,7 @@ struct WeightCompactWidget: View {
 					.font(.system(size: 14))
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Compact Widgets/WindCompactWidget.swift
+++ b/Meshtastic/Views/Helpers/Compact Widgets/WindCompactWidget.swift
@@ -26,7 +26,7 @@ struct WindCompactWidget: View {
 				Text("Gusts \(gust)")
 			}
 		}
-		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+		.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 		.padding()
 		.background(Color("Colors/MeshtasticTile"), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 	}

--- a/Meshtastic/Views/Helpers/Help/HelpItem.swift
+++ b/Meshtastic/Views/Helpers/Help/HelpItem.swift
@@ -36,5 +36,6 @@ struct HelpItem: View {
 			}
 			Spacer()
 		}
+		.accessibilityElement(children: .combine)
 	}
 }

--- a/Meshtastic/Views/Helpers/PowerMetrics.swift
+++ b/Meshtastic/Views/Helpers/PowerMetrics.swift
@@ -89,7 +89,7 @@ struct PowerMetricCompactWidget: View {
 						Text("\(value, specifier: type == .current ? "%.1f" : "%.2f") \(type == .current ? "mA" : "V")")
 								.font(type == .current ? .system(size: 35) : .system(size: 30))
 				}
-				.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120, idealHeight: 130, maxHeight: 140)
+				.frame(minWidth: 100, idealWidth: 125, maxWidth: 150, minHeight: 120)
 				.padding()
 				.background(.tertiary, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
 		}

--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -132,7 +132,7 @@ struct ChannelList: View {
 			.alignmentGuide(.listRowSeparatorLeading) {
 				$0[.leading]
 			}
-			.frame(height: 62)
+			.frame(minHeight: 62)
 			.contextMenu {
 				if hasMessages {
 					Button(role: .destructive) {

--- a/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
+++ b/Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift
@@ -44,6 +44,7 @@ struct TextMessageField: View {
 							Image(systemName: "x.circle.fill")
 								.font(.largeTitle)
 							}
+							.accessibilityLabel(String(localized: "Cancel reply", comment: "VoiceOver: cancel replying to a message"))
 							if replyMessageId != 0 {
 								Text("Reply")
 									.padding(.top, 10)
@@ -81,6 +82,7 @@ struct TextMessageField: View {
 									.font(.largeTitle)
 									.foregroundColor(.accentColor)
 							}
+							.accessibilityLabel(String(localized: "Send message", comment: "VoiceOver: send the composed message"))
 						}
 					}
 					.padding(15)
@@ -118,6 +120,7 @@ struct TextMessageField: View {
 			} label: {
 				Image(systemName: "face.smiling")
 			}
+			.accessibilityLabel(String(localized: "Emoji picker", comment: "VoiceOver: open the character/emoji picker"))
 			Spacer()
 			#endif
 			AlertButton { typingMessage += "🔔 Alert Bell Character! \u{7}" }
@@ -196,6 +199,7 @@ private struct FormattingComposeArea: View {
 						Image(systemName: "x.circle.fill")
 							.font(.largeTitle)
 					}
+					.accessibilityLabel(String(localized: "Cancel reply", comment: "VoiceOver: cancel replying to a message"))
 					if replyMessageId != 0 {
 						Text("Reply")
 							.padding(.top, 10)
@@ -239,6 +243,7 @@ private struct FormattingComposeArea: View {
 							.font(.largeTitle)
 							.foregroundColor(.accentColor)
 					}
+					.accessibilityLabel(String(localized: "Send message", comment: "VoiceOver: send the composed message"))
 				}
 			}
 			.padding(15)
@@ -318,6 +323,7 @@ private struct FormattingComposeArea: View {
 					} label: {
 						Image(systemName: "face.smiling")
 					}
+					.accessibilityLabel(String(localized: "Emoji picker", comment: "VoiceOver: open the character/emoji picker"))
 					#endif
 					AlertButton(action: alert, compact: true)
 					RequestPositionButton(action: requestPosition, compact: true)

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -313,7 +313,7 @@ private struct DirectMessageUserRow: View {
 				}
 			}
 		}
-		.frame(height: 62)
+		.frame(minHeight: 62)
 		.alignmentGuide(.listRowSeparatorLeading) {
 			$0[.leading]
 		}

--- a/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
@@ -108,33 +108,36 @@ struct DeviceMetricsLog: View {
 					/// Single Cell Compact display for phones
 					Table(deviceMetrics, selection: $selection, sortOrder: $sortOrder) {
 						TableColumn("Battery Level") { dm in
-							HStack {
-								Text(dm.time?.formatted(date: .numeric, time: .shortened) ?? "Unknown Age".localized)
-									.font(.caption)
-									.fontWeight(.semibold)
-								Spacer()
-								Image(systemName: "bolt")
-									.font(.caption)
-									.symbolRenderingMode(.multicolor)
-								Text("Volts \(dm.voltage?.formatted(.number.precision(.fractionLength(2))) ?? Constants.nilValueIndicator)")
-									.font(.caption2)
-								BatteryCompact(batteryLevel: dm.batteryLevel, font: .caption, iconFont: .callout, color: .accentColor)
-							}
-							HStack {
-								if let channelUtilization = dm.channelUtilization {
-									// Text("Channel Utilization \(String(format: "%.2f%%", channelUtilization))")
-									Text("Channel Utilization \(channelUtilization.formatted(.number.precision(.fractionLength(2))))%")
-										.foregroundColor(channelUtilization < 25 ? .green : (channelUtilization > 50 ? .red : .orange))
-								} else {
-									Text("Channel Utilization " + Constants.nilValueIndicator)
-										.foregroundColor(.gray)
+							Group {
+								HStack {
+									Text(dm.time?.formatted(date: .numeric, time: .shortened) ?? "Unknown Age".localized)
+										.font(.caption)
+										.fontWeight(.semibold)
+									Spacer()
+									Image(systemName: "bolt")
+										.font(.caption)
+										.symbolRenderingMode(.multicolor)
+									Text("Volts \(dm.voltage?.formatted(.number.precision(.fractionLength(2))) ?? Constants.nilValueIndicator)")
+										.font(.caption2)
+									BatteryCompact(batteryLevel: dm.batteryLevel, font: .caption, iconFont: .callout, color: .accentColor)
 								}
-								// Keep "Airtime" separate here as to avoid creating a new localization key
-								Text("Airtime") + Text(" \(dm.airUtilTx?.formatted(.number.precision(.fractionLength(2))) ?? Constants.nilValueIndicator)%")
-									.foregroundColor(.secondary)
-								Spacer()
+								HStack {
+									if let channelUtilization = dm.channelUtilization {
+										// Text("Channel Utilization \(String(format: "%.2f%%", channelUtilization))")
+										Text("Channel Utilization \(channelUtilization.formatted(.number.precision(.fractionLength(2))))%")
+											.foregroundColor(channelUtilization < 25 ? .green : (channelUtilization > 50 ? .red : .orange))
+									} else {
+										Text("Channel Utilization " + Constants.nilValueIndicator)
+											.foregroundColor(.gray)
+									}
+									// Keep "Airtime" separate here as to avoid creating a new localization key
+									Text("Airtime") + Text(" \(dm.airUtilTx?.formatted(.number.precision(.fractionLength(2))) ?? Constants.nilValueIndicator)%")
+										.foregroundColor(.secondary)
+									Spacer()
+								}
+								.font(.caption)
 							}
-							.font(.caption)
+							.accessibilityElement(children: .combine)
 						}
 						.width(ideal: 200, max: .infinity)
 					}

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapLegend.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapLegend.swift
@@ -35,6 +35,7 @@ struct MapLegendItem: View {
 			}
 			Spacer()
 		}
+		.accessibilityElement(children: .combine)
 	}
 }
 

--- a/Meshtastic/Views/Nodes/PowerMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/PowerMetricsLog.swift
@@ -137,6 +137,7 @@ struct PowerMetricsLog: View {
 											m.powerCh1Current.map { Text("\(String(format: "%.2f", $0))mA") } ?? Text(Constants.nilValueIndicator)
 										}
 									}
+									.accessibilityElement(children: .combine)
 								}
 								Spacer()
 								HStack {
@@ -155,6 +156,7 @@ struct PowerMetricsLog: View {
 											m.powerCh2Current.map { Text("\(String(format: "%.2f", $0))mA") } ?? Text(Constants.nilValueIndicator)
 										}
 									}
+									.accessibilityElement(children: .combine)
 								}
 								Spacer()
 								HStack {
@@ -173,6 +175,7 @@ struct PowerMetricsLog: View {
 											m.powerCh3Current.map { Text("\(String(format: "%.2f", $0))mA") } ?? Text(Constants.nilValueIndicator)
 										}
 									}
+									.accessibilityElement(children: .combine)
 								}
 							}
 						}

--- a/Meshtastic/Views/Provisioning/WifiProvisioningView.swift
+++ b/Meshtastic/Views/Provisioning/WifiProvisioningView.swift
@@ -30,6 +30,7 @@ private struct ActivityRow: View {
 				.foregroundColor(.primary)
 		}
 		.padding()
+		.accessibilityElement(children: .combine)
 	}
 }
 

--- a/Meshtastic/Views/Settings/AppData.swift
+++ b/Meshtastic/Views/Settings/AppData.swift
@@ -68,6 +68,7 @@ struct AppData: View {
 					}
 					.padding(.horizontal)
 					.padding(.vertical, 4)
+					.accessibilityElement(children: .combine)
 				}
 			}
 			Divider()

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -132,18 +132,22 @@ private struct FirmwareContentView: View {
 					Text("Platform IO").font(.caption).foregroundColor(.secondary)
 					Text("\(node.myInfo?.pioEnv ?? "Unknown")")
 				}
+				.accessibilityElement(children: .combine)
 				VStack(alignment: .leading) {
 					Text("Architecture").font(.caption).foregroundColor(.secondary)
 					Text("\(hardware.architecture ?? "Unknown")")
 				}
+				.accessibilityElement(children: .combine)
 				VStack(alignment: .leading) {
 					Text("Current Firmware Version").font(.caption).foregroundColor(.secondary)
 					Text("\(node.metadata?.firmwareVersion ?? "Unknown")")
 				}
+				.accessibilityElement(children: .combine)
 				VStack(alignment: .leading) {
 					Text("Intended LoRa Region").font(.caption).foregroundColor(.secondary)
 					Text(intendedRegionLabel)
 				}
+				.accessibilityElement(children: .combine)
 				if shouldShowRegionUnsetWarning {
 					Label("Set a LoRa region before installing firmware.", systemImage: "exclamationmark.triangle.fill")
 						.foregroundStyle(.orange)

--- a/Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift
+++ b/Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift
@@ -73,6 +73,9 @@ struct CircularProgressView: View {
 		.onChange(of: isIndeterminate) { _, _ in updateAnimationStatus() }
 		.onChange(of: isError) { _, _ in updateAnimationStatus() }
 		.onChange(of: reduceMotion) { _, _ in updateAnimationStatus() }
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel("Update progress")
+		.accessibilityValue("\(Int(progress * 100)) percent")
 	}
 	
 	private func updateAnimationStatus() {

--- a/Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift
+++ b/Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift
@@ -74,8 +74,8 @@ struct CircularProgressView: View {
 		.onChange(of: isError) { _, _ in updateAnimationStatus() }
 		.onChange(of: reduceMotion) { _, _ in updateAnimationStatus() }
 		.accessibilityElement(children: .ignore)
-		.accessibilityLabel("Update progress")
-		.accessibilityValue("\(Int(progress * 100)) percent")
+		.accessibilityLabel(String(localized: "Update progress", comment: "VoiceOver label for the firmware update progress ring"))
+		.accessibilityValue(String(localized: "\(Int(progress * 100)) percent", comment: "VoiceOver value spoken as the firmware update completion percentage"))
 	}
 	
 	private func updateAnimationStatus() {

--- a/Meshtastic/Views/Settings/TAKServerConfig.swift
+++ b/Meshtastic/Views/Settings/TAKServerConfig.swift
@@ -203,6 +203,7 @@ struct TAKServerConfig: View {
 				Text(takServer.statusDescription)
 					.foregroundColor(.secondary)
 			}
+			.accessibilityElement(children: .combine)
 
 			if let error = takServer.lastError {
 				HStack {
@@ -212,6 +213,7 @@ struct TAKServerConfig: View {
 						.font(.caption)
 						.foregroundColor(.orange)
 				}
+				.accessibilityElement(children: .combine)
 			}
 
 			if let node = connectedNode,
@@ -225,6 +227,7 @@ struct TAKServerConfig: View {
 						.font(.caption)
 						.foregroundColor(.orange)
 				}
+				.accessibilityElement(children: .combine)
 			}
 		} header: {
 			Text("Server Status")

--- a/specs/016-accessibility-audit/spec.md
+++ b/specs/016-accessibility-audit/spec.md
@@ -1,0 +1,123 @@
+# Feature Specification: Accessibility (VoiceOver) Audit Remediation
+
+**Feature Branch**: `016-accessibility-audit`
+**Created**: 2026-07-21
+**Status**: Draft
+**Input**: Deep accessibility audit fan-out (12 parallel agents + cross-validation) run against `Meshtastic/Views`, `Widgets/`, and `Meshtastic Watch App/Views`. Full raw findings: `/Users/bruschill/.pi/workflows/projects/meshtastic-apple-63f78c487247/runs/a11y-codebase-audit-mru2fgm4-u38mxd.json`.
+
+This is a remediation backlog, not a new-feature spec — the SpecKit user-story template doesn't map cleanly onto a flat bug list, so this doc gives context and the requirements/success-criteria section states the acceptance bar per severity tier. **`tasks.md` in this directory is the actual working checklist** — grouped by the same severity tiers, one checkbox per finding, meant to be checked off across however many sessions this takes.
+
+## Why this exists
+
+The app has no automated accessibility test coverage and no prior systematic audit. A 12-agent fan-out audit (VoiceOver labels, value/hint, custom-control traits, element grouping, Dynamic Type, color-only signaling, contrast, touch targets, focus order, custom drawing/maps/charts, localization of a11y strings, accessibility identifiers) plus a cross-validation pass found 20 confirmed issue clusters (5 Blocker, 11 High, 4 Medium) covering ~60 individual file locations. Two reported findings were rejected as false positives during cross-validation (`NodeList.swift:110` reset-filter label; `NodeMapContent.swift` pin annotations were already fine).
+
+## User Scenarios & Testing
+
+### User Story 1 - VoiceOver users can send and receive messages (Priority: P1) 🎯 MVP
+
+A blind or low-vision user relies on VoiceOver to compose, send, and read messages and direct messages — the app's core loop.
+
+**Why this priority**: Messaging is the primary feature. Today the send button is unlabeled, cancel-reply is unlabeled, message integrity/translation badges are silently dropped from the read-aloud label, and the entire direct-message list (`DirectMessageUserRow`) has no accessibility support at all — VoiceOver users cannot reliably use messaging.
+
+**Independent Test**: Enable VoiceOver, open a channel, compose and send a message, open Direct Messages, select a contact, verify the row announces name/unread/lock/star state, and verify a message with security/translation badges announces all of them.
+
+**Acceptance Scenarios**:
+
+1. **Given** VoiceOver is on and a channel is open, **When** the user swipes to the send button, **Then** it announces "Send message, button" (not "Button").
+2. **Given** a received message is Verified, Store-and-forward, and machine-translated, **When** VoiceOver reads the message row, **Then** all three states are announced, not just Encrypted/Verified.
+3. **Given** VoiceOver is on and Direct Messages is open, **When** the user swipes through the contact list, **Then** each row announces name, unread count, and lock/star state as one coherent element.
+
+---
+
+### User Story 2 - VoiceOver users can operate every custom (non-Button) interactive control (Priority: P1) 🎯 MVP
+
+Several controls are built from `.onTapGesture` on a plain `VStack`/`HStack` rather than `Button`, so VoiceOver either can't perceive them as interactive or can't activate them with a double-tap at all (metrics column toggles, node-detail heard-time rows, the Nymea connect row, indoor air quality row, app-log stream row, and the geofence/region-selector drag handles, which have zero non-visual equivalent to dragging).
+
+**Why this priority**: These controls are silently unreachable by VoiceOver — not degraded, unusable.
+
+**Independent Test**: Enable VoiceOver, navigate to each listed control, verify it's announced with an interactive trait and a double-tap (or, for drag handles, the VoiceOver rotor's adjustable "increment/decrement" actions) performs the action.
+
+**Acceptance Scenarios**:
+
+1. **Given** VoiceOver is on and the metrics column picker is open, **When** the user swipes to a column toggle row, **Then** it announces "\<column name\>, \<Visible|Hidden\>, button" and double-tap toggles it.
+2. **Given** VoiceOver is on and the geofence boundary editor is open, **When** the user selects the boundary handle, **Then** the VoiceOver rotor exposes increment/decrement (or named directional) actions that move the boundary without requiring a drag gesture.
+
+---
+
+### User Story 3 - VoiceOver users get equivalent information from icon-only toolbar and utility buttons (Priority: P2)
+
+~15 files have icon-only buttons (close/dismiss, refresh, export, copy, help/filter toggles, map actions) with no `.accessibilityLabel`, so VoiceOver announces them as a bare "Button" with no indication of what they do.
+
+**Why this priority**: Operable but opaque — real friction, not a hard block, since sighted-assist or trial-and-error can sometimes work around it.
+
+**Independent Test**: Enable VoiceOver, swipe through each listed toolbar, verify every icon-only button announces a specific action name, not "Button."
+
+**Acceptance Scenarios**:
+
+1. **Given** VoiceOver is on and a firmware-update sheet is open, **When** the user swipes to the close button, **Then** it announces "Close, button."
+2. **Given** VoiceOver is on the WiFi provisioning screen, **When** the user swipes to any of the three copy buttons, **Then** each announces a field-specific label ("Copy network name" / "Copy password" / "Copy PSK"), not a shared generic one.
+
+---
+
+### User Story 4 - Status conveyed by color has a non-color fallback (Priority: P2)
+
+Signal-strength indicators, trace-route arrows, and map polylines encode state through color/hue alone in `NodeListItemCompact.swift`, `TraceRouteLog.swift`, and `MeshMapMK.swift`'s polylines.
+
+**Why this priority**: Fails colorblind and low-vision users even with full vision otherwise; not a VoiceOver issue specifically but a WCAG 1.4.1 (Use of Color) violation.
+
+**Independent Test**: View the node list and trace route log with a color-blindness simulator (e.g. Sim Daltonism); verify signal tiers remain distinguishable via symbol/shape, not hue alone.
+
+**Acceptance Scenarios**:
+
+1. **Given** two nodes with different signal tiers, **When** viewed under a protanopia filter, **Then** the SF Symbol (not just tint) differs between tiers and each has a distinct `accessibilityLabel` ("Strong signal" / "Weak signal").
+
+---
+
+### User Story 5 - Contrast decisions are computed correctly (Priority: P3)
+
+`Color.swift`'s `isLight()` uses BT.601 perceptual luma with a flat 0.5 cutoff instead of WCAG relative luminance, so black/white text-on-color choices in `CircleText`, `WatchCircleText`, `FoxhuntCompassView`, and `AnimatedNodePin` can fail WCAG AA contrast at certain hues despite the code believing it "picked a contrasting color."
+
+**Why this priority**: A correctness bug in shared infrastructure, not a missing feature — worth fixing once, benefits every call site, but not urgent since it degrades rather than blocks.
+
+**Independent Test**: Compute `Color.isLight()` for known problem hues (saturated yellow, cyan) before and after the fix and confirm chosen text color meets 4.5:1 contrast against the WCAG relative-luminance formula.
+
+---
+
+### Edge Cases
+
+- Live Activity (`WidgetsLiveActivity.swift`) runs outside the main app process (Lock Screen / Dynamic Island widget extension) — fixes there must be verified in the widget extension target, not just the main app.
+- macCatalyst-gated close buttons (User Story 3, tier High #7) only matter for macOS VoiceOver; lower priority than the iOS-reachable duplicates in #6.
+- `.accessibilityIdentifier` (Medium #19) has no consumer today (no UI test target exists) — do not block other fixes on this; add incrementally.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Every interactive control (Button, custom tap-gesture view, drag handle) MUST expose a non-empty, non-generic `accessibilityLabel` to VoiceOver.
+- **FR-002**: Every custom (`.onTapGesture`-based) control that behaves like a button MUST carry `.accessibilityAddTraits(.isButton)` (or the correct trait for its role) and be activatable via VoiceOver double-tap or an explicit `.accessibilityAction`.
+- **FR-003**: Drag-only controls (geofence/region boundary handles) MUST expose a non-drag VoiceOver-operable equivalent (`.accessibilityAdjustableAction` or named directional custom actions).
+- **FR-004**: Composite message/list rows MUST NOT silently drop badge/state information when building a combined `accessibilityLabel` — the combined label's source of truth must match what's rendered visually.
+- **FR-005**: Status/state conveyed by color MUST also be conveyed by a non-color signal (symbol, shape, or text) and captured in an `accessibilityLabel`/`accessibilityValue`.
+- **FR-006**: All accessibility label/hint/value strings MUST be localized (`String(localized:)` / `Localizable.xcstrings`), not hardcoded English literals.
+- **FR-007**: `Color.isLight()` MUST use WCAG relative luminance, not BT.601 luma, for any text-on-color contrast decision.
+- **FR-008**: Sliders, gauges, and progress views MUST expose `.accessibilityValue` reflecting their current numeric/semantic state, not just a visual fill.
+
+### Key Entities
+
+- **Finding**: One audit-confirmed accessibility defect — severity (Blocker/High/Medium), file path, line range, description, proposed fix. Tracked as one checkbox item per finding in `tasks.md`.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: All 5 Blocker findings resolved and verified with VoiceOver on-device (or Simulator + Accessibility Inspector) before this spec is closed.
+- **SC-002**: All 11 High findings resolved; each icon-only button in the affected files announces a specific, localized action name.
+- **SC-003**: Zero color-only status indicators remain in the node list, trace route log, and mesh map trace overlays (User Story 4).
+- **SC-004**: `Color.isLight()` uses WCAG relative luminance; all 4 call sites (`CircleText`, `WatchCircleText`, `FoxhuntCompassView` x2, `AnimatedNodePin`) verified to pick correctly-contrasting text at previously-failing hues.
+- **SC-005**: 4 Medium findings addressed opportunistically (not blocking release) — tracked, not required for this spec to be considered "done enough to ship the Blocker/High fixes."
+
+## Assumptions
+
+- Fixes are scoped to `Meshtastic/Views`, `Widgets/`, and `Meshtastic Watch App/Views` per the original audit scope; a broader pass (Accessory, CarPlay) was not run and is out of scope here.
+- No UI test target exists yet, so `.accessibilityIdentifier` work (Medium #19) is tracked but not gated on this spec.
+- Work proceeds roughly in the "Top fixes to do first" order from the audit report (message badges → DM row → send/cancel buttons → tap-gesture traits → Live Activity), but `tasks.md` is the authoritative, resumable checklist — sessions can pick up anywhere by scanning for unchecked items.

--- a/specs/016-accessibility-audit/tasks.md
+++ b/specs/016-accessibility-audit/tasks.md
@@ -106,7 +106,7 @@
 
 ## Phase 3: Medium (correct but suboptimal)
 
-- [ ] T039 [P] Element grouping missing (readable today, but each glyph/number is a separate VoiceOver stop) — add `.accessibilityElement(children: .combine)` to each:
+- [x] T039 [P] Element grouping missing (readable today, but each glyph/number is a separate VoiceOver stop) — add `.accessibilityElement(children: .combine)` to each:
   - `PowerMetricsLog.swift:127-137`
   - `DeviceMetricsLog.swift:105-121`
   - `HelpItem.swift:23-38`
@@ -116,10 +116,10 @@
   - `Connect.swift:191-207`
   - `WifiProvisioningView.swift:15-32` (`ActivityRow`)
   - `AppData.swift:49-63`
-- [ ] T040 `Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift` — zero accessibility in this shared component. Add `.accessibilityElement(children: .ignore)` + `.accessibilityLabel("Update progress")` + `.accessibilityValue("\(Int(progress * 100)) percent")`. One fix covers 4 call sites: `NRFDFUSheet.swift`, `ESP32WifiOTASheet.swift`, `ESP32BLEOTASheet.swift`, `FirmwareUpdateGameView.swift`.
+- [x] T040 `Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift` — zero accessibility in this shared component. Add `.accessibilityElement(children: .ignore)` + `.accessibilityLabel("Update progress")` + `.accessibilityValue("\(Int(progress * 100)) percent")`. One fix covers 4 call sites: `NRFDFUSheet.swift`, `ESP32WifiOTASheet.swift`, `ESP32BLEOTASheet.swift`, `FirmwareUpdateGameView.swift`.
 - [ ] T041 Accessibility identifiers absent app-wide except `FirmwareUpdateGameView.swift:18,45,121,247`. No UI test target exists today, so this doesn't break anything — **not urgent**, add `.accessibilityIdentifier` incrementally to primary nav/interactive elements as they're touched for other fixes in this list, rather than as a standalone pass.
-- [ ] T042 [P] Dynamic Type clipping in compact widgets — `DistanceCompactWidget.swift`, `HumidityCompactWidget.swift` (and siblings) cap `maxHeight: 140` while using `.font(.largeTitle)` inside; text clips at larger accessibility sizes. Add `.minimumScaleFactor(0.5)` + `.lineLimit(1)`.
-- [ ] T043 [P] `ChannelList.swift:135` and `UserList.swift:316` — fixed `.frame(height: 62)` rows won't grow for large Dynamic Type sizes. Switch to `.frame(minHeight: 62)`.
+- [x] T042 [P] Dynamic Type clipping in compact widgets — `DistanceCompactWidget.swift`, `HumidityCompactWidget.swift` (and siblings) cap `maxHeight: 140` while using `.font(.largeTitle)` inside; text clips at larger accessibility sizes. Add `.minimumScaleFactor(0.5)` + `.lineLimit(1)`.
+- [x] T043 [P] `ChannelList.swift:135` and `UserList.swift:316` — fixed `.frame(height: 62)` rows won't grow for large Dynamic Type sizes. Switch to `.frame(minHeight: 62)`.
 
 **Checkpoint**: All 4 Medium clusters (T039-T043) closed → grouping is coherent, firmware progress is announced, Dynamic Type no longer clips, and identifiers are being added opportunistically.
 

--- a/specs/016-accessibility-audit/tasks.md
+++ b/specs/016-accessibility-audit/tasks.md
@@ -5,14 +5,14 @@
 
 **How to use this file**: Check off `[x]` as each item is fixed and verified (VoiceOver on-device or Simulator + Accessibility Inspector). This is the persistent tracker — pick up anywhere by scanning for the first unchecked box. Update the "Progress" line below when a batch is completed.
 
-**Progress**: 0 / 60 individual locations fixed (0 / 20 finding clusters fully closed) — last updated 2026-07-21.
+**Progress**: 6 / 60 individual locations fixed (0 / 20 finding clusters fully closed — T002/T015/T016 done but their clusters still have other locations open) — last updated 2026-07-21.
 
 ---
 
 ## Phase 1: Blocker (VoiceOver users cannot perceive or operate the feature)
 
 - [ ] T001 `Widgets/WidgetsLiveActivity.swift` — zero accessibility calls in the whole file. Add `.accessibilityElement(children: .ignore)` + `.accessibilityLabel` to `StatRow` (~line 296-311) and to each icon+fraction pair (lines ~64, 117, 136, 216) and the countdown timer (~line 334). Verify in the widget extension target (Lock Screen/Dynamic Island), not just the main app.
-- [ ] T002 `Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift:79,237` — send button (`arrow.up.circle.fill`) has no `.accessibilityLabel`. Add `String(localized: "Send message")`.
+- [x] T002 `Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift:79,237` — send button (`arrow.up.circle.fill`) has no `.accessibilityLabel`. Add `String(localized: "Send message")`. **Done**: fixed both the legacy (line ~82) and `FormattingComposeArea` (line ~243) send buttons.
 - [ ] T003 [P] `Meshtastic/Views/Messages/UserMessageRow.swift:35-51,180-181` and `ChannelMessageRow.swift:175-176` — combined `accessibilityLabel` (`messageAccessibilityLabel`) overwrites per-badge labels set in `MessageText.swift:172,192,206` (Verified sender, Store and forward, Detection sensor, Showing translated text). Rebuild the combined label from the same source-of-truth flags `MessageText.swift` uses instead of hand-listing only Encrypted/Verified. One fix, two call sites.
 - [ ] T004 `Meshtastic/Views/Messages/UserList.swift:253-316` (`DirectMessageUserRow`) — no accessibility at all: unread dot not `.accessibilityHidden`, lock/star icons unlabeled, no combined element/label. Port the working pattern from `ChannelList.swift:59-66`.
 - [ ] T005 [P] `Meshtastic/Views/Nodes/Helpers/Metrics Columns/MetricsColumnDetail.swift:46-61,65-77` — `.onTapGesture` row with no interactive trait; VoiceOver double-tap doesn't activate it. Add `.contentShape(Rectangle())` + `.accessibilityElement(children: .combine)` + `.accessibilityLabel` + `.accessibilityValue(Visible/Hidden)` + `.accessibilityAddTraits(.isButton)` + `.accessibilityAction`.
@@ -46,8 +46,8 @@
   - `DirectMessagesHelp.swift:47`
   - `NodeListHelp.swift:197`
   - `ChannelsHelp.swift:107`
-- [ ] T015 [P] `TextMessageField.swift:38,190` — cancel-reply button (`x.circle.fill`), add `.accessibilityLabel(String(localized: "Cancel reply"))`.
-- [ ] T016 [P] `TextMessageField.swift:111,311` — emoji picker button (`face.smiling`, Catalyst-only), add a localized label.
+- [x] T015 [P] `TextMessageField.swift:38,190` — cancel-reply button (`x.circle.fill`), add `.accessibilityLabel(String(localized: "Cancel reply"))`. **Done**: fixed both the legacy (line ~47) and `FormattingComposeArea` (line ~202) cancel-reply buttons.
+- [x] T016 [P] `TextMessageField.swift:111,311` — emoji picker button (`face.smiling`, Catalyst-only), add a localized label. **Done**: fixed both the legacy `legacyToolbarContent` (line ~123) and `FormattingComposeArea` `toolbarContent` (line ~326) emoji picker buttons.
 - [ ] T017 [P] Help-toggle buttons with no on/off-reflecting label — add `.accessibilityLabel(showHelp ? "Hide help" : "Show help")` (localized):
   - `Channels.swift:343`
   - `ShareChannels.swift:147`

--- a/specs/016-accessibility-audit/tasks.md
+++ b/specs/016-accessibility-audit/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: Accessibility (VoiceOver) Audit Remediation
+
+**Input**: `spec.md` in this directory; full raw audit result: `/Users/bruschill/.pi/workflows/projects/meshtastic-apple-63f78c487247/runs/a11y-codebase-audit-mru2fgm4-u38mxd.json`
+**Audit method**: 12-agent parallel fan-out (VoiceOver labels, value/hint, custom-control traits, element grouping, Dynamic Type, color-only signaling, contrast, touch targets, focus order, custom drawing/maps/charts, localization of a11y strings, accessibility identifiers) + cross-validation pass over `Meshtastic/Views`, `Widgets/`, `Meshtastic Watch App/Views`.
+
+**How to use this file**: Check off `[x]` as each item is fixed and verified (VoiceOver on-device or Simulator + Accessibility Inspector). This is the persistent tracker — pick up anywhere by scanning for the first unchecked box. Update the "Progress" line below when a batch is completed.
+
+**Progress**: 0 / 60 individual locations fixed (0 / 20 finding clusters fully closed) — last updated 2026-07-21.
+
+---
+
+## Phase 1: Blocker (VoiceOver users cannot perceive or operate the feature)
+
+- [ ] T001 `Widgets/WidgetsLiveActivity.swift` — zero accessibility calls in the whole file. Add `.accessibilityElement(children: .ignore)` + `.accessibilityLabel` to `StatRow` (~line 296-311) and to each icon+fraction pair (lines ~64, 117, 136, 216) and the countdown timer (~line 334). Verify in the widget extension target (Lock Screen/Dynamic Island), not just the main app.
+- [ ] T002 `Meshtastic/Views/Messages/TextMessageField/TextMessageField.swift:79,237` — send button (`arrow.up.circle.fill`) has no `.accessibilityLabel`. Add `String(localized: "Send message")`.
+- [ ] T003 [P] `Meshtastic/Views/Messages/UserMessageRow.swift:35-51,180-181` and `ChannelMessageRow.swift:175-176` — combined `accessibilityLabel` (`messageAccessibilityLabel`) overwrites per-badge labels set in `MessageText.swift:172,192,206` (Verified sender, Store and forward, Detection sensor, Showing translated text). Rebuild the combined label from the same source-of-truth flags `MessageText.swift` uses instead of hand-listing only Encrypted/Verified. One fix, two call sites.
+- [ ] T004 `Meshtastic/Views/Messages/UserList.swift:253-316` (`DirectMessageUserRow`) — no accessibility at all: unread dot not `.accessibilityHidden`, lock/star icons unlabeled, no combined element/label. Port the working pattern from `ChannelList.swift:59-66`.
+- [ ] T005 [P] `Meshtastic/Views/Nodes/Helpers/Metrics Columns/MetricsColumnDetail.swift:46-61,65-77` — `.onTapGesture` row with no interactive trait; VoiceOver double-tap doesn't activate it. Add `.contentShape(Rectangle())` + `.accessibilityElement(children: .combine)` + `.accessibilityLabel` + `.accessibilityValue(Visible/Hidden)` + `.accessibilityAddTraits(.isButton)` + `.accessibilityAction`.
+- [ ] T006 [P] `Meshtastic/Views/Connect/Connect.swift:1202-1225` (`NymeaDeviceConnectRow`) — same `.onTapGesture`-with-no-trait issue as T005; apply the same pattern.
+- [ ] T007 [P] `Meshtastic/Views/Helpers/Weather/IndoorAirQuality.swift:76-78` — same `.onTapGesture`-with-no-trait issue; apply the same pattern.
+- [ ] T008 [P] `Meshtastic/Views/Settings/AppLog.swift:324-326` (`streamRow`) — same `.onTapGesture`-with-no-trait issue; apply the same pattern.
+- [ ] T009 [P] `Meshtastic/Views/Nodes/Helpers/NodeDetail.swift:357-374,377-399` (First/Last heard rows) — already has `.accessibilityElement(children: .combine)` but no `.isButton` trait; add the trait + `.accessibilityAction`.
+- [ ] T010 `Meshtastic/Views/Nodes/Helpers/Map/GeofenceBoundsSelectorView.swift:120-138` and `Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift:143-161` — drag handles have zero non-visual equivalent. Add `.accessibilityAdjustableAction` (increment/decrement to nudge the bound) or paired "Move north/south/east/west" custom actions. Two files, same pattern.
+- [ ] T011 `Meshtastic/Views/Settings/Discovery/DiscoveryMapView.swift:84` — `Annotation("", coordinate: coord)` has a genuinely empty title. Change to `Annotation(device.displayName, coordinate: coord)`.
+
+**Checkpoint**: All 5 Blocker clusters (T001-T011) closed → messaging, metrics/settings tap-rows, geofence editing, and the Live Activity are usable end-to-end with VoiceOver.
+
+---
+
+## Phase 2: High (operable, but VoiceOver gives no useful information)
+
+### Icon-only buttons, unlabeled
+
+- [ ] T012 [P] `Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift:74` — close button (`xmark.circle.fill`), add `.accessibilityLabel(String(localized: "Close"))`.
+- [ ] T013 [P] `Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift:111` — same close-button fix as T012.
+- [ ] T014 [P] macCatalyst-gated close buttons (lower priority than T012/T013 — macOS VoiceOver only), same `.accessibilityLabel(String(localized: "Close"))` fix inside each `#if targetEnvironment(macCatalyst)` block:
+  - `RouteRecorder.swift:274`
+  - `AppLogFilter.swift:199`
+  - `LogDetail.swift:154`
+  - `NodeListFilter.swift:148`
+  - `MetricsColumnDetail.swift:85`
+  - `MapSettingsForm.swift:282`
+  - `WaypointForm.swift:555`
+  - `MapLegend.swift:67`
+  - `InvalidVersion.swift:96`
+  - `DirectMessagesHelp.swift:47`
+  - `NodeListHelp.swift:197`
+  - `ChannelsHelp.swift:107`
+- [ ] T015 [P] `TextMessageField.swift:38,190` — cancel-reply button (`x.circle.fill`), add `.accessibilityLabel(String(localized: "Cancel reply"))`.
+- [ ] T016 [P] `TextMessageField.swift:111,311` — emoji picker button (`face.smiling`, Catalyst-only), add a localized label.
+- [ ] T017 [P] Help-toggle buttons with no on/off-reflecting label — add `.accessibilityLabel(showHelp ? "Hide help" : "Show help")` (localized):
+  - `Channels.swift:343`
+  - `ShareChannels.swift:147`
+  - `ChannelList.swift:206`
+  - `UserList.swift:35`
+  - `NodeList.swift:97`
+- [ ] T018 [P] Filter-toggle buttons (distinct from the already-correct reset buttons nearby) — same on/off-label pattern as T017:
+  - `UserList.swift:62`
+  - `NodeList.swift:124`
+- [ ] T019 [P] Refresh/export/action icon buttons, unlabeled — add a specific localized `.accessibilityLabel` to each:
+  - `AppLog.swift:130` (Catalyst-gated)
+  - `Firmware.swift:370` — **fix in both** the `#if`/`#else` branches, both currently unlabeled
+  - `BackupRowView.swift:45` (restore, `arrow.counterclockwise`)
+  - `RouteRecorder.swift:70` (record/details)
+  - `AppLog.swift:143` (export CSV)
+  - `ChannelForm.swift:61` (generate key)
+  - `DiscoverySummaryView.swift:53` (export PDF)
+  - `MeshMapMK.swift:538` (open map window, macOS-only)
+  - `WaypointForm.swift:455` (edit waypoint)
+  - `SecureInput.swift:62` (show/hide password)
+- [ ] T020 `WifiProvisioningView.swift:133,348,395` — three separate `doc.on.doc` copy buttons. Give each its own field-specific label: "Copy network name" / "Copy password" / "Copy PSK" — not one shared generic label.
+- [ ] T021 [P] `MeshMapMK.swift:372` — clear-trace-route button (`trash`), unlabeled while neighboring buttons (`:365`) already are. Add `.accessibilityLabel(String(localized: "Clear trace route"))`.
+- [ ] T022 [P] `MeshMapMK.swift:511` — map-settings button (`info.circle`), unlabeled while neighboring buttons (`:507`) already are. Add `.accessibilityLabel(String(localized: "Map settings"))`.
+- [ ] T023 [P] `NodeMapSwiftUI.swift:204-210,214-218,226-230` — unlabeled while neighboring buttons (`:200-202`) already are. Add matching localized labels.
+
+### Value/hint gaps
+
+- [ ] T024 `Meshtastic/Views/Nodes/Helpers/NodeListFilter.swift:96-107` — Slider's hidden `label:` is `Text("Speed")` (wrong domain) with no `.accessibilityValue`. Fix label text and add `.accessibilityValue("\(Int(filterValue)) dBm")`.
+- [ ] T025 `AppLogFilter.swift:245-261` (`selectionRow`) — checkmark row has no trait/value. Add `.accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)`.
+- [ ] T026 `DiscoveryScanView.swift:234-236` — `ProgressView(value:)` is unlabeled and ungrouped from its "Time Remaining" text. Combine with `.accessibilityElement(children: .combine)` + `.accessibilityValue("\(Int(progress * 100)) percent")`.
+- [ ] T027 [P] `LoRaSignalStrength.swift:31-45` (compact Gauge) — no explicit accessibility. Add `.accessibilityLabel("Signal strength")` + `.accessibilityValue(signalDescription)`.
+- [ ] T028 [P] `AirQualityIndex.swift:49-58` (`.gauge` case) — same gap as T027; apply the same pattern.
+
+### Color-only signaling
+
+- [ ] T029 `Meshtastic/Views/Nodes/TraceRouteLog.swift:296-300` — `arrowshape.right.fill` tinted by `snrColor` only, no text/shape distinction. Add a per-tier `accessibilityLabel`.
+- [ ] T030 `Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift:287-288` — identical SF Symbol across all signal tiers, only color changes. Vary the symbol per tier (e.g. `wifi` / `wifi.slash`) and add `.accessibilityLabel(signalTier.description)`.
+- [ ] T031 `Meshtastic/Views/Nodes/MeshMapMK.swift:1240,1252` — trace-route polylines vary by hue only. Add `lineDashPhase`/width variation keyed to SNR tier so shape, not just hue, encodes strength.
+
+### Localization of accessibility strings
+
+- [ ] T032 [P] `Channels.swift:527,530,533` (`ChannelStatusIcon`) — hardcoded English a11y strings, absent from `Localizable.xcstrings`. Wrap in `String(localized:)` and add keys.
+- [ ] T033 [P] `TextMessageField/FormattingToolbarButtons.swift:107-114` — same localization gap as T032.
+- [ ] T034 [P] `Model/Firmware/FirmwareUpdateNotifier.swift:75-82` (feeds `Connect.swift:869`) — same localization gap as T032.
+- [ ] T035 [P] `Lockdown/LockdownSheet.swift:159,207` — same localization gap as T032.
+- [ ] T036 [P] `Messages/MessageSearchBar.swift:27` — same localization gap as T032.
+
+### Contrast correctness
+
+- [ ] T037 `Meshtastic/Extensions/Color.swift:63-67,74-78` (`isLight()`) — uses BT.601 luma with a flat 0.5 cutoff instead of WCAG relative luminance. Replace with a `relativeLuminance()` implementation (WCAG formula) and a `>0.179` (~4.5:1) cutoff. This is shared infrastructure — fixing it here fixes T038 below plus `CircleText.swift:25` and `Meshtastic Watch App/Views/WatchCircleText.swift:27` for free.
+- [ ] T038 `Meshtastic/Views/Nodes/Helpers/Map/MapContent/AnimatedNodePin.swift:43-47` — hardcoded `.foregroundStyle(.white)` ignores contrast entirely, unlike `CircleText.swift` one line below. Switch to `nodeColor.isLight() ? .black : .white` (depends on T037 being correct first).
+
+**Checkpoint**: All 11 High clusters (T012-T038) closed → every icon-only control announces a specific action, sliders/gauges report state, signal tiers are distinguishable without color, a11y strings are localized, and contrast decisions use the correct formula.
+
+---
+
+## Phase 3: Medium (correct but suboptimal)
+
+- [ ] T039 [P] Element grouping missing (readable today, but each glyph/number is a separate VoiceOver stop) — add `.accessibilityElement(children: .combine)` to each:
+  - `PowerMetricsLog.swift:127-137`
+  - `DeviceMetricsLog.swift:105-121`
+  - `HelpItem.swift:23-38`
+  - `MapLegend.swift:22-37` (`MapLegendItem`)
+  - `TAKServerConfig.swift:194-224`
+  - `Firmware.swift:131-146`
+  - `Connect.swift:191-207`
+  - `WifiProvisioningView.swift:15-32` (`ActivityRow`)
+  - `AppData.swift:49-63`
+- [ ] T040 `Meshtastic/Views/Settings/Firmware/Helpers/CircularProgressView.swift` — zero accessibility in this shared component. Add `.accessibilityElement(children: .ignore)` + `.accessibilityLabel("Update progress")` + `.accessibilityValue("\(Int(progress * 100)) percent")`. One fix covers 4 call sites: `NRFDFUSheet.swift`, `ESP32WifiOTASheet.swift`, `ESP32BLEOTASheet.swift`, `FirmwareUpdateGameView.swift`.
+- [ ] T041 Accessibility identifiers absent app-wide except `FirmwareUpdateGameView.swift:18,45,121,247`. No UI test target exists today, so this doesn't break anything — **not urgent**, add `.accessibilityIdentifier` incrementally to primary nav/interactive elements as they're touched for other fixes in this list, rather than as a standalone pass.
+- [ ] T042 [P] Dynamic Type clipping in compact widgets — `DistanceCompactWidget.swift`, `HumidityCompactWidget.swift` (and siblings) cap `maxHeight: 140` while using `.font(.largeTitle)` inside; text clips at larger accessibility sizes. Add `.minimumScaleFactor(0.5)` + `.lineLimit(1)`.
+- [ ] T043 [P] `ChannelList.swift:135` and `UserList.swift:316` — fixed `.frame(height: 62)` rows won't grow for large Dynamic Type sizes. Switch to `.frame(minHeight: 62)`.
+
+**Checkpoint**: All 4 Medium clusters (T039-T043) closed → grouping is coherent, firmware progress is announced, Dynamic Type no longer clips, and identifiers are being added opportunistically.
+
+---
+
+## Dependencies & Execution Order
+
+- **T037 before T038**: `AnimatedNodePin`'s fix depends on `Color.isLight()` being correct first.
+- Everything else in Phase 1/2/3 is independent — most rows are marked `[P]` (different files, no shared state) and can be done in any order or batched by file/area.
+- Recommended order (matches the audit's "top fixes first" list): T002-T004 (messaging) → T005-T011 (tap-gesture traits + Live Activity) → rest of Phase 2 → Phase 3.
+
+## Notes
+
+- [P] = different files, no dependencies — safe to batch or parallelize across sessions/people.
+- Each task cites exact file(s) and line numbers from the audit; line numbers may drift as the file changes — re-locate by symbol/context if a line number is stale, don't skip the task.
+- Verify fixes with VoiceOver (on-device preferred; Simulator + Accessibility Inspector as fallback) before checking a box, not just by code review.
+- Update the **Progress** line at the top of this file when a batch is completed so future sessions know where things stand at a glance.


### PR DESCRIPTION
## What changed?

Closes T039, T040, T042, and T043 from the Phase 3 (Medium) accessibility audit (`specs/016-accessibility-audit/tasks.md`). T041 is intentionally left unchecked — see that task's own note (no UI test target exists yet, so it's deferred to be added opportunistically rather than as a standalone pass).

- **T039**: Added `.accessibilityElement(children: .combine)` to icon+label+value groups that were previously announced by VoiceOver as separate glyph/number stops: `PowerMetricsLog.swift`, `DeviceMetricsLog.swift`, `HelpItem.swift`, `MapLegend.swift` (`MapLegendItem`), `TAKServerConfig.swift`, `Firmware.swift`, `Connect.swift`, `WifiProvisioningView.swift` (`ActivityRow`), `AppData.swift`.
- **T040**: `CircularProgressView.swift` (the shared firmware-update progress ring behind `NRFDFUSheet`, `ESP32WifiOTASheet`, `ESP32BLEOTASheet`, and `FirmwareUpdateGameView`) had zero accessibility support. Added `.accessibilityElement(children: .ignore)` plus a localized label and value announcing update progress as a percentage.
- **T042**: The compact metric tiles (`DistanceCompactWidget`, `HumidityCompactWidget`, and 9 siblings, including one outside the `Compact Widgets` folder: `PowerMetricCompactWidget`) clipped/overlapped their text at large accessibility Dynamic Type sizes because both `maxHeight: 140` and `idealHeight: 130` capped the tile's frame. Removed both constraints (kept `minHeight: 120` so default-size tiles still look compact). These tiles sit in 2-column `LazyVGrid`s that already auto-size each row to its tallest member, so a taller tile at large text sizes doesn't misalign its row-mate.

  A prior attempt at this same issue (#2123) only added `.minimumScaleFactor`, which the maintainer correctly rejected — with the frame still fixed, the scale factor just shrinks the font back down and surrounding labels still truncate. This PR relaxes the frame itself instead.
- **T043**: `ChannelList.swift` and `UserList.swift` row frames changed from fixed `.frame(height: 62)` to `.frame(minHeight: 62)`, so rows can grow to fit wrapped text at large Dynamic Type sizes instead of clipping.
- Checked off T039/T040/T042/T043 in `specs/016-accessibility-audit/tasks.md` (T041 and every other checkbox left untouched).

## Why did it change?

Closes out the remaining Phase 3 "Medium" accessibility findings from the audit: incoherent VoiceOver grouping, a completely silent firmware-progress control, Dynamic Type clipping in metric tiles, and fixed-height list rows that can't grow for users with larger accessibility text sizes.

## How is this tested?

- Built the app for iOS Simulator (`xcodebuild ... build`) after every change; final build succeeds.
- **T042**: Rendered the actual production widget types (via a throwaway in-process `ImageRenderer` harness, fully reverted before the final commits) against seeded environment telemetry, at both default and `accessibility5` Dynamic Type sizes, before and after the fix. Confirmed the old frame clipped/overlapped text at large sizes and the fix eliminates it with no visible change at default size.
- **T043**: Verified live in the running app (simulator, `accessibility-extra-extra-extra-large` text size) that the "Seattle Mesh" channel row wraps across multiple lines and the row grows to match instead of clipping.
- **T039/T040**: Code-level verification of accessibility modifier placement (no interactive child accidentally swallowed by `.combine`) plus a clean SwiftLint pass; visual behavior is otherwise unchanged (grouping/labeling is VoiceOver-only).
- Ran the `meshtastic-swift-reviewer` review agent against the full diff; it caught two real issues (un-localized accessibility strings in `CircularProgressView`, and a missed `PowerMetricCompactWidget` sibling for T042), both fixed in follow-up commits in this PR.

## Screenshots/Videos

![T042 before, accessibility text size](https://raw.githubusercontent.com/bruschill/Meshtastic-Apple/f8599dbc45d05c3f7483ab864827f663de15d53a/screenshots/medium-polish/T042-compactwidget-before-accessibility.png)
*T042 — before the fix, at accessibility5 text size: TEMP/PRESSURE tiles overlap and clip, bottom text cut off.*

![T042 after, accessibility text size](https://raw.githubusercontent.com/bruschill/Meshtastic-Apple/f8599dbc45d05c3f7483ab864827f663de15d53a/screenshots/medium-polish/T042-compactwidget-after-accessibility.png)
*T042 — after the fix, same text size: every tile grows to fully fit its content, no clipping or overlap.*

![T042 before, default text size](https://raw.githubusercontent.com/bruschill/Meshtastic-Apple/f8599dbc45d05c3f7483ab864827f663de15d53a/screenshots/medium-polish/T042-compactwidget-before-default.png)
*T042 — before, default text size (baseline).*

![T042 after, default text size](https://raw.githubusercontent.com/bruschill/Meshtastic-Apple/f8599dbc45d05c3f7483ab864827f663de15d53a/screenshots/medium-polish/T042-compactwidget-after-default.png)
*T042 — after, default text size: visually identical to before, confirming no regression to the normal appearance.*

![T043 ChannelList at large Dynamic Type](https://raw.githubusercontent.com/bruschill/Meshtastic-Apple/f8599dbc45d05c3f7483ab864827f663de15d53a/screenshots/medium-polish/T043-channellist-largetype.png)
*T043 — live ChannelList at accessibility-XXXL text: the channel row wraps to several lines and grows instead of clipping.*

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly. **No doc update needed** — these are VoiceOver/Dynamic Type accessibility fixes only, with no change to visible copy, feature behavior, or anything covered by the view→doc mapping. Applying the **`skip-docs-check`** label (same as PR #2123).
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved VoiceOver grouping and descriptions across connection statuses, messaging, settings, maps, device metrics, provisioning, and firmware screens.
  * Added spoken labels for message actions, emoji controls, and update progress percentages.
* **Layout Improvements**
  * Compact widgets and message rows can now expand when content requires additional space, improving readability across screen sizes.
* **Documentation**
  * Added an accessibility remediation specification and tracked checklist covering VoiceOver, controls, status communication, and contrast requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->