### PR TITLE
fix(status-message): enable the editor on the connected node (fixes #2148)

### DIFF
--- a/Meshtastic/Views/Settings/Config/Module/StatusMessageConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StatusMessageConfig.swift
@@ -93,7 +93,13 @@ struct StatusMessageConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.statusMessageConfig == nil },
-				request: accessoryManager.requestStatusMessageModuleConfig
+				request: accessoryManager.requestStatusMessageModuleConfig,
+				// The status message module config isn't part of the connected node's initial config
+				// download, so it must be explicitly requested for the connected node too — otherwise
+				// `statusMessageConfig` stays nil and the editor is permanently disabled on the local
+				// node (while remote-admin nodes work, since they take the PKI-admin branch). Mirrors
+				// RangeTestConfig, the other on-demand module config.
+				requestForConnectedNode: true
 			)
 		}
 	}


### PR DESCRIPTION
## What & why

Fixes #2148 — on firmware 2.8.0, opening Settings > Status Message and editing the message on the *connected* node does nothing (the field is disabled), while editing any 2.8.0 node via remote admin works.

### Root cause
The editor is disabled whenever `node.statusMessageConfig == nil`:
```swift
.disabled(!accessoryManager.isConnected || node?.statusMessageConfig == nil)
```
That config is populated by requesting it from the node on appear. But `requestRemoteConfig(...)` only issues the request for the *connected* node when `requestForConnectedNode: true` is passed — otherwise it early-returns for the local node via the `guard node.num != deviceNum` check. `StatusMessageConfig` wasn't passing the flag, and the status message module config isn't part of the connected node's initial config download, so `statusMessageConfig` stayed `nil` and the field stayed permanently disabled.

Remote-admin nodes are unaffected because `node.num != deviceNum` routes them through the PKI-admin request branch — which is exactly the asymmetry the reporter saw.

### Fix
Pass `requestForConnectedNode: true`, mirroring `RangeTestConfig` (the existing on-demand module config that already does this). One-line behavior change plus an explanatory comment.

## Testing
- SwiftLint clean.
- Not build/run-verified locally (the `Meshtastic` scheme requires the watchOS 26.5 simulator runtime, which isn't installed in this environment). To verify on device: connect a 2.8.0 node, open Settings > Status Message, confirm the field is now editable and a value saves and broadcasts.

## Note (not changed here)
Only `RangeTestConfig` and now `StatusMessageConfig` pass `requestForConnectedNode: true`. The other 2.8-era module configs that could plausibly also be missing from the initial download — `TAKModuleConfig`, `TrafficManagementConfig` (and Mesh Beacon) — also omit the flag. They're left untouched here since this issue is specifically Status Message and I can't test them; worth a follow-up check if any show the same connected-node symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the status-message settings editor for the connected node.
  * Status-message configuration is now loaded correctly when opening the settings, ensuring the editor is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->