### PR TITLE
fix(messages): actually delete direct-message conversations (fixes #2147)

### DIFF
--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -131,15 +131,24 @@ extension MeshPackets {
 		}
 	}
 	
-	public func deleteUserMessages(user: UserEntity) {
-		let messages = (user.sentMessages ?? []) + (user.receivedMessages ?? [])
-		let filtered = messages.filter { msg in
-			msg.toUser != nil && msg.fromUser != nil && !msg.isEmoji && !msg.admin && msg.portNum != 10
-		}
-		for object in filtered {
-			modelContext.delete(object)
-		}
+	public func deleteUserMessages(userNum: Int64) {
+		// Fetch in this actor's OWN ModelContext (mirrors deleteChannelMessages and the DM message
+		// list's own query), keyed on the scalar `num`. The previous version read
+		// `user.sentMessages`/`receivedMessages` off a UserEntity handed in from the view's context:
+		// across the actor/context boundary those relationships resolved empty, and deleting
+		// foreign-context objects through this context was a no-op — so deleting a DM did nothing.
+		let descriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> { msg in
+				msg.toUser != nil &&
+				(msg.fromUser?.num == userNum || msg.toUser?.num == userNum) &&
+				msg.isEmoji == false && msg.admin == false && msg.portNum != 10
+			}
+		)
 		do {
+			let objects = try modelContext.fetch(descriptor)
+			for object in objects {
+				modelContext.delete(object)
+			}
 			try modelContext.save()
 		} catch {
 			Logger.data.error("💥 [MessageEntity] Error deleting user messages: \(error.localizedDescription, privacy: .public)")

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -368,7 +368,10 @@ private struct DirectMessageUserRow: View {
 			Button(role: .destructive) {
 				Task {
 					if let userToDelete = userToDeleteMessages {
-						await MeshPackets.shared.deleteUserMessages(user: userToDelete)
+						await MeshPackets.shared.deleteUserMessages(userNum: userToDelete.num)
+						await MainActor.run {
+							userToDeleteMessages = nil
+						}
 					}
 				}
 			} label: {


### PR DESCRIPTION
## What & why

Fixes #2147 — tapping **Delete Messages** on a direct-message conversation did nothing, even though deleting a **channel's** messages (or the whole node) worked.

### Root cause
`MeshPackets` is an `actor` with its **own** `ModelContext`, separate from the view's `@Environment(\.modelContext)`.

- `deleteChannelMessages` (works) **fetches** the messages with a predicate inside MeshPackets' own context, then deletes and saves — all context-consistent.
- `deleteUserMessages` (broken) instead read `user.sentMessages` / `user.receivedMessages` off a `UserEntity` **passed in from the view's context**. Reading a non-`Sendable` model's relationship arrays across the actor/context boundary resolved empty, and deleting foreign-context objects through this context was a no-op — so nothing was deleted or saved.

That's exactly why the whole-node delete cleared DMs (it runs in-context) but the per-conversation delete didn't.

### Fix
- Rewrite `deleteUserMessages` to fetch by predicate in its own context, keyed on the scalar node `num` (safe across the actor boundary), mirroring `deleteChannelMessages` and the DM message list's own query: `msg.toUser != nil && (msg.fromUser?.num == num || msg.toUser?.num == num)`, excluding emoji/admin/detection-sensor rows — DMs only.
- Change the call site to pass `userToDelete.num`.
- Reset `userToDeleteMessages = nil` after the delete, matching the channel path (folded-in cleanup).

## Testing
- SwiftLint clean (the one `function_body_length` warning is pre-existing on `clearDatabase`, unchanged).
- Not build/run-verified locally (the `Meshtastic` scheme requires the watchOS 26.5 simulator runtime, absent here). To verify: open a DM conversation with messages, Delete Messages → confirm, and the conversation's messages should now be removed (as channels already do). Version-agnostic; no 2.8 firmware needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion of direct messages for a selected contact.
  * Ensured only eligible direct messages are removed while preserving other message types.
  * Improved UI state handling after message deletion completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->