### PR TITLE
Remove Ukraine 868MHz region code

### DIFF
--- a/Meshtastic/Enums/LoraConfigEnums.swift
+++ b/Meshtastic/Enums/LoraConfigEnums.swift
@@ -25,7 +25,6 @@ enum RegionCodes: Int, CaseIterable, Identifiable {
 	case nz865 = 11
 	case th = 12
 	case ua433 = 14
-	case ua868 = 15
 	case my433 = 16
 	case my919 = 17
 	case sg923 = 18
@@ -122,8 +121,6 @@ enum RegionCodes: Int, CaseIterable, Identifiable {
 			"TH"
 		case .ua433:
 			"UA_433"
-		case .ua868:
-			"UA_868"
 		case .my433:
 			"MY_433"
 		case .my919:
@@ -202,8 +199,6 @@ enum RegionCodes: Int, CaseIterable, Identifiable {
 			return "Thailand".localized
 		case .ua433:
 			return "Ukraine 433MHz".localized
-		case .ua868:
-			return "Ukraine 868MHz".localized
 		case .my433:
 			return "Malaysia 433MHz".localized
 		case .my919:


### PR DESCRIPTION
Ukrainian legislation[1] was harmonised with the EU's, and UA_868 is now obsolete as it is identical to the EU_868, so it was removed from the firmware.[2]

[1] http://zakon.rada.gov.ua/laws/show/262-2026-%D0%BF
[2] meshtastic/firmware#10994

## What changed?
<!-- Provide a clear description for the change -->

## Why did it change?
* http://zakon.rada.gov.ua/laws/show/262-2026-%D0%BF
* https://github.com/meshtastic/firmware/pull/10994

## How is this tested?
<!-- Describe your approach to testing the feature. -->

## Screenshots/Videos (when applicable)

<!-- Attach screenshots or videos demonstrating the new feature in action. -->

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [ ] I have tested the change to ensure that it works as intended.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ordering and mapping of regional LoRa configuration codes.
  * Ensured regional labels and identifiers remain aligned across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->