### PR TITLE
fix: bundle the Core Data model so the SwiftData migration can run (#2152)

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		259792272C2F114500AD1659 /* TraceRouteEntityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE5B4052B227E3200FCDD05 /* TraceRouteEntityExtension.swift */; };
 		25A978BA2C13F8ED0003AAE7 /* MeshtasticProtobufs in Frameworks */ = {isa = PBXBuildFile; productRef = 25A978B92C13F8ED0003AAE7 /* MeshtasticProtobufs */; };
 		25A978BC2C13F90D0003AAE7 /* MeshtasticProtobufs in Frameworks */ = {isa = PBXBuildFile; productRef = 25A978BB2C13F90D0003AAE7 /* MeshtasticProtobufs */; };
+		6215655E4BAA48B39EAD2CA3 /* Meshtastic.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = DD3CC6BA28E366DF00FA9159 /* Meshtastic.xcdatamodeld */; };
 		25AECD4F2C2F723200862C8E /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 25AECD4E2C2F723200862C8E /* Localizable.xcstrings */; };
 		25F26B1E2C2F610D00C9CD9D /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD5BB0C2C285F00007E03CA /* Logger.swift */; };
 		25F26B1F2C2F611300C9CD9D /* AppData.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD5BB152C28B1E4007E03CA /* AppData.swift */; };
@@ -2458,6 +2459,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6215655E4BAA48B39EAD2CA3 /* Meshtastic.xcdatamodeld in Resources */,
 				DDC2E15F26CE248F0042C5E4 /* Preview Assets.xcassets in Resources */,
 				AA000401SIRI000000000002 /* AppIntentVocabulary.plist in Resources */,
 				AA000402IPLS000000000002 /* InfoPlist.strings in Resources */,


### PR DESCRIPTION
Fixes #2152.

## What changed?

Restores `Meshtastic.xcdatamodeld` to the app target's **Resources** build phase
— two lines of `project.pbxproj`.

## Why did it change?

`CoreDataMigrationService.makeCoreDataContainer()` loads the legacy model from
the bundle and throws `MigrationError.modelNotFound` without it:

```swift
guard let momdURL = Bundle.main.url(forResource: "Meshtastic", withExtension: "momd")
else { throw MigrationError.modelNotFound }
```

No `Meshtastic.momd` has shipped since #1898 (2026-06-02) dropped the model's
build-phase membership while resolving a `project.pbxproj` conflict — a week
after #1886 added the migration and wired the model in. The model stayed visible
in the navigator, so nothing looked wrong and nothing failed to build.

`Persistence.swift` catches and logs the failure ("the user will simply start
fresh on this device"), so for anyone upgrading from 2.7.12 or earlier the
migration silently does nothing and their nodes, messages and waypoints are
gone. Affects v2.7.13 → v2.7.16 and current `main`.

## How is this tested?

Built current `main` and this branch, and compared the app bundles:

| | `main` | this branch |
|---|---|---|
| build | SUCCEEDED | SUCCEEDED |
| `Meshtastic.app` entries | 493 | 554 |
| `Meshtastic.momd` | **absent** | present |
| `MeshtasticDataModelV 58.mom` | absent | present |

The only difference is the model itself — `Meshtastic.momd/` with its 58 `.mom`
files, `MeshtasticDataModel.omo` and `VersionInfo.plist`. Nothing is removed and
nothing else is added.

Note it has to be **Resources**, not Sources: putting an `.xcdatamodeld` in
Sources re-enables Core Data class generation and fails to compile against the
hand-written entity classes (`invalid redeclaration of 'MyInfoEntity'`).

I have not run an end-to-end upgrade from a real 2.7.12 store — the evidence
here is that the model now ships where `CoreDataMigrationService` looks for it.
Worth a look from whoever has a 2.7.12 device backup handy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the app’s data model resources are included in the packaged application, improving data storage reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->