### PR TITLE
fix(migration): merge-safe Core Data migration + regression tests for #2152

### DIFF
--- a/Meshtastic/Persistence/CoreDataMigrationService.swift
+++ b/Meshtastic/Persistence/CoreDataMigrationService.swift
@@ -72,6 +72,15 @@ enum CoreDataMigrationService {
 	static func migrate(into swiftDataContainer: ModelContainer) throws {
 		Logger.data.info("⬆️ CoreDataMigrationService: beginning legacy migration")
 
+		// Reset merge state: non-empty only in the rescue scenario (#2152) — releases
+		// 2.7.13–2.7.16 shipped without the legacy model, so affected users upgraded, the
+		// migration threw, and they kept using the app. Their SwiftData store is populated
+		// while the legacy store still sits on disk. When the migration finally runs, legacy
+		// rows fill the history gaps but must not duplicate nodes/users/messages that the
+		// mesh has since re-taught the app, nor clobber their fresher configs and channels.
+		preexistingNodeNums = []
+		preexistingMyInfoNums = []
+
 		let coreDataContainer = try makeCoreDataContainer()
 		let cdContext = coreDataContainer.viewContext
 		cdContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
@@ -223,6 +232,14 @@ private extension CoreDataMigrationService {
 
 	// MARK: NodeInfoEntity
 
+	/// Node nums that already existed in the SwiftData store when the migration started.
+	/// Legacy history (positions, telemetry, messages) still attaches to these nodes, but
+	/// the node row itself, its configs, and its channels are NOT migrated — the live store's
+	/// versions are fresher. See the reset in `migrate(into:)` for the scenario.
+	private(set) static var preexistingNodeNums: Set<Int64> = []
+	/// Same, for MyInfoEntity (keyed by myNodeNum) — gates channel migration.
+	private(set) static var preexistingMyInfoNums: Set<Int64> = []
+
 	static func migrateNodes(
 		cdContext: NSManagedObjectContext,
 		sdContext: ModelContext
@@ -231,18 +248,33 @@ private extension CoreDataMigrationService {
 		let objects = try cdContext.fetch(request)
 		var map = [NSManagedObjectID: NodeInfoEntity]()
 
+		let existingByNum = Dictionary(
+			(try sdContext.fetch(FetchDescriptor<NodeInfoEntity>())).map { ($0.num, $0) },
+			uniquingKeysWith: { first, _ in first }
+		)
+
+		var migrated = 0
 		for obj in objects {
+			let num = (obj.value(forKey: "num") as? Int64) ?? 0
+			if let existing = existingByNum[num] {
+				// Rescue merge: the mesh re-taught the app this node after the failed
+				// migration. Keep the live row; legacy history will attach to it.
+				preexistingNodeNums.insert(num)
+				map[obj.objectID] = existing
+				continue
+			}
 			let sd = NodeInfoEntity()
 			sd.bleName      = obj.value(forKey: "bleName") as? String
 			sd.channel      = (obj.value(forKey: "channel") as? Int32) ?? 0
 			sd.id           = (obj.value(forKey: "id") as? Int64) ?? 0
 			sd.lastHeard    = obj.value(forKey: "lastHeard") as? Date ?? Date()
-			sd.num          = (obj.value(forKey: "num") as? Int64) ?? 0
+			sd.num          = num
 			sd.snr          = (obj.value(forKey: "snr") as? Float) ?? 0
 			sdContext.insert(sd)
 			map[obj.objectID] = sd
+			migrated += 1
 		}
-		Logger.data.info("⬆️ migrated \(objects.count) NodeInfoEntity records")
+		Logger.data.info("⬆️ migrated \(migrated) of \(objects.count) NodeInfoEntity records (\(preexistingNodeNums.count) already present)")
 		return map
 	}
 
@@ -257,24 +289,39 @@ private extension CoreDataMigrationService {
 		let objects = try cdContext.fetch(request)
 		var map = [NSManagedObjectID: UserEntity]()
 
+		let existingByNum = Dictionary(
+			(try sdContext.fetch(FetchDescriptor<UserEntity>())).map { ($0.num, $0) },
+			uniquingKeysWith: { first, _ in first }
+		)
+
+		var migrated = 0
 		for obj in objects {
+			let num = (obj.value(forKey: "num") as? Int64) ?? 0
+			if let existing = existingByNum[num] {
+				map[obj.objectID] = existing
+				continue
+			}
 			let sd = UserEntity()
 			sd.hwModel   = obj.value(forKey: "hwModel") as? String
 			sd.isLicensed = (obj.value(forKey: "isLicensed") as? Bool) ?? false
 			sd.longName  = obj.value(forKey: "longName") as? String
-			sd.num       = (obj.value(forKey: "num") as? Int64) ?? 0
+			sd.num       = num
 			sd.shortName = obj.value(forKey: "shortName") as? String
 			sd.userId    = obj.value(forKey: "userId") as? String
 			// macaddr existed in Core Data but is intentionally dropped in SwiftData
 
 			if let cdNode = obj.value(forKey: "userNode") as? NSManagedObject,
-			   let sdNode = nodeMap[cdNode.objectID] {
+			   let sdNode = nodeMap[cdNode.objectID],
+			   sdNode.user == nil {
+				// Only claim the node when it has no live user; a preexisting node keeps its
+				// (fresher) user rather than being reparented onto the legacy row.
 				sd.userNode = sdNode
 			}
 			sdContext.insert(sd)
 			map[obj.objectID] = sd
+			migrated += 1
 		}
-		Logger.data.info("⬆️ migrated \(objects.count) UserEntity records")
+		Logger.data.info("⬆️ migrated \(migrated) of \(objects.count) UserEntity records")
 		return map
 	}
 
@@ -289,11 +336,23 @@ private extension CoreDataMigrationService {
 		let objects = try cdContext.fetch(request)
 		var map = [NSManagedObjectID: MyInfoEntity]()
 
+		let existingByNum = Dictionary(
+			(try sdContext.fetch(FetchDescriptor<MyInfoEntity>())).map { ($0.myNodeNum, $0) },
+			uniquingKeysWith: { first, _ in first }
+		)
+
+		var migrated = 0
 		for obj in objects {
+			let myNodeNum = (obj.value(forKey: "myNodeNum") as? Int64) ?? 0
+			if let existing = existingByNum[myNodeNum] {
+				preexistingMyInfoNums.insert(myNodeNum)
+				map[obj.objectID] = existing
+				continue
+			}
 			let sd = MyInfoEntity()
 			sd.bleName         = obj.value(forKey: "bleName") as? String
 			sd.minAppVersion   = (obj.value(forKey: "minAppVersion") as? Int32) ?? 0
-			sd.myNodeNum       = (obj.value(forKey: "myNodeNum") as? Int64) ?? 0
+			sd.myNodeNum       = myNodeNum
 			sd.peripheralId    = obj.value(forKey: "peripheralId") as? String
 			sd.rebootCount     = (obj.value(forKey: "rebootCount") as? Int32) ?? 0
 
@@ -303,8 +362,9 @@ private extension CoreDataMigrationService {
 			}
 			sdContext.insert(sd)
 			map[obj.objectID] = sd
+			migrated += 1
 		}
-		Logger.data.info("⬆️ migrated \(objects.count) MyInfoEntity records")
+		Logger.data.info("⬆️ migrated \(migrated) of \(objects.count) MyInfoEntity records")
 		return map
 	}
 
@@ -318,7 +378,15 @@ private extension CoreDataMigrationService {
 		let request = NSFetchRequest<NSManagedObject>(entityName: "ChannelEntity")
 		let objects = try cdContext.fetch(request)
 
+		var migrated = 0
 		for obj in objects {
+			let cdInfo = obj.value(forKey: "myInfoChannel") as? NSManagedObject
+			let sdInfo = cdInfo.flatMap { infoMap[$0.objectID] }
+			if let sdInfo, preexistingMyInfoNums.contains(sdInfo.myNodeNum) {
+				// Rescue merge: this radio's MyInfo survived the failed migration and its
+				// current channel set is fresher than the legacy one — don't duplicate it.
+				continue
+			}
 			let sd = ChannelEntity()
 			sd.downlinkEnabled = (obj.value(forKey: "downlinkEnabled") as? Bool) ?? false
 			sd.id              = (obj.value(forKey: "id") as? Int32) ?? 0
@@ -328,13 +396,13 @@ private extension CoreDataMigrationService {
 			sd.role            = (obj.value(forKey: "role") as? Int32) ?? 0
 			sd.uplinkEnabled   = (obj.value(forKey: "uplinkEnabled") as? Bool) ?? false
 
-			if let cdInfo = obj.value(forKey: "myInfoChannel") as? NSManagedObject,
-			   let sdInfo = infoMap[cdInfo.objectID] {
+			if let sdInfo {
 				sd.myInfoChannel = sdInfo
 			}
 			sdContext.insert(sd)
+			migrated += 1
 		}
-		Logger.data.info("⬆️ migrated \(objects.count) ChannelEntity records")
+		Logger.data.info("⬆️ migrated \(migrated) of \(objects.count) ChannelEntity records")
 	}
 
 	// MARK: MessageEntity
@@ -347,7 +415,15 @@ private extension CoreDataMigrationService {
 		let request = NSFetchRequest<NSManagedObject>(entityName: "MessageEntity")
 		let objects = try cdContext.fetch(request)
 
+		let existingMessageIds = Set(
+			(try sdContext.fetch(FetchDescriptor<MessageEntity>())).map { $0.messageId }
+		)
+
+		var migrated = 0
 		for obj in objects {
+			let messageId = (obj.value(forKey: "messageId") as? Int64) ?? 0
+			// Rescue merge: don't duplicate a message the live store already has.
+			if existingMessageIds.contains(messageId) { continue }
 			let sd = MessageEntity()
 			sd.ackError        = (obj.value(forKey: "ackError") as? Int32) ?? 0
 			sd.ackSNR          = (obj.value(forKey: "ackSNR") as? Float) ?? 0
@@ -356,7 +432,7 @@ private extension CoreDataMigrationService {
 			sd.adminDescription = obj.value(forKey: "adminDescription") as? String
 			sd.channel         = (obj.value(forKey: "channel") as? Int32) ?? 0
 			sd.isEmoji         = (obj.value(forKey: "isEmoji") as? Bool) ?? false
-			sd.messageId       = (obj.value(forKey: "messageId") as? Int64) ?? 0
+			sd.messageId       = messageId
 			sd.messagePayload  = obj.value(forKey: "messagePayload") as? String
 			sd.messageTimestamp = (obj.value(forKey: "messageTimestamp") as? Int32) ?? 0
 			sd.receivedACK     = (obj.value(forKey: "receivedACK") as? Bool) ?? false
@@ -372,8 +448,9 @@ private extension CoreDataMigrationService {
 				sd.toUser = sdTo
 			}
 			sdContext.insert(sd)
+			migrated += 1
 		}
-		Logger.data.info("⬆️ migrated \(objects.count) MessageEntity records")
+		Logger.data.info("⬆️ migrated \(migrated) of \(objects.count) MessageEntity records")
 	}
 
 	// MARK: PositionEntity
@@ -755,15 +832,23 @@ private extension CoreDataMigrationService {
 		let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
 		let objects = try cdContext.fetch(request)
 
+		var migrated = 0
 		for obj in objects {
+			let cdNode = obj.value(forKey: nodeKey) as? NSManagedObject
+			let sdNode = cdNode.flatMap { nodeMap[$0.objectID] }
+			if let sdNode, preexistingNodeNums.contains(sdNode.num) {
+				// Rescue merge: this node survived the failed migration; its current config
+				// reflects the radio's live state and must not be replaced by the legacy one.
+				continue
+			}
 			let sd = try make(obj)
-			if let cdNode = obj.value(forKey: nodeKey) as? NSManagedObject,
-			   let sdNode = nodeMap[cdNode.objectID] {
+			if let sdNode {
 				wireNode(sdNode, sd)
 			}
 			sdContext.insert(sd)
+			migrated += 1
 		}
-		Logger.data.info("⬆️ migrated \(objects.count) \(entityName) records")
+		Logger.data.info("⬆️ migrated \(migrated) of \(objects.count) \(entityName) records")
 	}
 }
 

--- a/MeshtasticTests/CoreDataMigrationServiceTests.swift
+++ b/MeshtasticTests/CoreDataMigrationServiceTests.swift
@@ -1,0 +1,221 @@
+//
+//  CoreDataMigrationServiceTests.swift
+//  MeshtasticTests
+//
+//  Regression tests for #2152: the Core Data → SwiftData migration silently never ran in
+//  2.7.13–2.7.16 because Meshtastic.momd was dropped from the app target's Resources build
+//  phase by a hand-resolved project.pbxproj conflict (#1898). These tests guard the bundled
+//  model itself and exercise the full migration — including the "rescue" merge into a store
+//  the user has already been writing to since the failed upgrade.
+//
+
+import XCTest
+import CoreData
+import SwiftData
+@testable import Meshtastic
+
+final class CoreDataMigrationServiceTests: XCTestCase {
+
+	// Mirrors of the service's private store URLs.
+	private var applicationSupportURL: URL {
+		FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+	}
+	private var legacyStoreURL: URL {
+		applicationSupportURL.appendingPathComponent("Meshtastic-coredata-legacy.sqlite")
+	}
+	private var backupStoreURL: URL {
+		applicationSupportURL.appendingPathComponent("Meshtastic-coredata-backup.sqlite")
+	}
+
+	override func setUpWithError() throws {
+		try super.setUpWithError()
+		removeLegacyAndBackupStores()
+	}
+
+	override func tearDownWithError() throws {
+		removeLegacyAndBackupStores()
+		try super.tearDownWithError()
+	}
+
+	private func removeLegacyAndBackupStores() {
+		let fm = FileManager.default
+		for base in [legacyStoreURL, backupStoreURL] {
+			for suffix in ["", "-shm", "-wal"] {
+				let url = base.deletingPathExtension().appendingPathExtension("sqlite\(suffix)")
+				try? fm.removeItem(at: url)
+			}
+		}
+	}
+
+	// MARK: - Bundle regression guard
+
+	/// The direct #2152 regression: the compiled legacy model must ship in the app bundle,
+	/// including the exact versioned model the migration loads by name. If this fails, the
+	/// one-time migration throws `modelNotFound` on every launch and upgraders from ≤2.7.12
+	/// see an empty database.
+	func testLegacyCoreDataModelIsInAppBundle() throws {
+		let momdURL = Bundle.main.url(forResource: "Meshtastic", withExtension: "momd")
+		XCTAssertNotNil(
+			momdURL,
+			"Meshtastic.momd is missing from the app bundle — Meshtastic.xcdatamodeld must stay in the app target's Resources build phase (#2152)"
+		)
+		guard let momdURL else { return }
+
+		let v58URL = momdURL.appendingPathComponent("MeshtasticDataModelV 58.mom")
+		XCTAssertTrue(
+			FileManager.default.fileExists(atPath: v58URL.path),
+			"MeshtasticDataModelV 58.mom (the version CoreDataMigrationService loads) is missing from Meshtastic.momd"
+		)
+		XCTAssertNotNil(NSManagedObjectModel(contentsOf: v58URL), "The bundled V58 model failed to load")
+	}
+
+	// MARK: - End-to-end migration
+
+	/// Full migration into a POPULATED SwiftData store — the #2152 rescue scenario. Users on
+	/// 2.7.13–2.7.16 upgraded, the migration threw, and they kept using the app; their legacy
+	/// store still sits on disk. When the migration finally runs it must fill the gaps
+	/// (old nodes, users, messages, configs) without duplicating rows the mesh has since
+	/// re-taught the app, and without replacing their fresher configs/channels. A fresh
+	/// install is the degenerate case (nothing preexisting), so this covers both paths:
+	/// node 111 exists only in the legacy store, node 222 exists in both.
+	@MainActor
+	func testMigrationFillsGapsWithoutDuplicatingLiveData() throws {
+		try buildLegacyStore()
+		XCTAssertTrue(CoreDataMigrationService.legacyStoreExists())
+
+		// Destination store, as the rescued user's app would have it: node 222 re-taught by
+		// the mesh (with a fresher bleName and a live device config), message 1002 re-received.
+		let schema = Schema(versionedSchema: MeshtasticSchema.current)
+		let config = ModelConfiguration("MigrationTest", schema: schema, isStoredInMemoryOnly: true, allowsSave: true)
+		let container = try ModelContainer(for: schema, configurations: config)
+		let context = container.mainContext
+
+		let liveNode = NodeInfoEntity()
+		liveNode.num = 222
+		liveNode.bleName = "live-222"
+		context.insert(liveNode)
+		let liveUser = UserEntity()
+		liveUser.num = 222
+		liveUser.longName = "Live User 222"
+		liveUser.userNode = liveNode
+		context.insert(liveUser)
+		let liveConfig = DeviceConfigEntity()
+		liveConfig.role = 1
+		context.insert(liveConfig)
+		liveNode.deviceConfig = liveConfig
+		let liveMessage = MessageEntity()
+		liveMessage.messageId = 1002
+		liveMessage.messagePayload = "live copy"
+		context.insert(liveMessage)
+		try context.save()
+
+		try CoreDataMigrationService.migrate(into: container)
+
+		// Node 111 migrated with its user and config; node 222 kept, not duplicated.
+		let nodes = try context.fetch(FetchDescriptor<NodeInfoEntity>())
+		XCTAssertEqual(nodes.count, 2, "expected legacy node 111 + live node 222, no duplicates")
+		let node111 = try XCTUnwrap(nodes.first(where: { $0.num == 111 }))
+		XCTAssertEqual(node111.bleName, "legacy-111")
+		XCTAssertEqual(node111.user?.longName, "Legacy User 111")
+		XCTAssertEqual(node111.deviceConfig?.role, 5, "legacy config should migrate for a legacy-only node")
+		let node222 = try XCTUnwrap(nodes.first(where: { $0.num == 222 }))
+		XCTAssertEqual(node222.bleName, "live-222", "live node must not be overwritten by the legacy row")
+		XCTAssertEqual(node222.user?.longName, "Live User 222", "live node must keep its fresher user")
+		XCTAssertEqual(node222.deviceConfig?.role, 1, "live node must keep its fresher config")
+
+		// Users deduped by num.
+		let users = try context.fetch(FetchDescriptor<UserEntity>())
+		XCTAssertEqual(users.filter { $0.num == 222 }.count, 1, "user 222 must not be duplicated")
+
+		// Message 1001 fills the gap; 1002 is not duplicated and keeps the live payload.
+		let messages = try context.fetch(FetchDescriptor<MessageEntity>())
+		XCTAssertEqual(messages.count, 2)
+		XCTAssertEqual(messages.first(where: { $0.messageId == 1001 })?.messagePayload, "legacy hello")
+		let dupes = messages.filter { $0.messageId == 1002 }
+		XCTAssertEqual(dupes.count, 1)
+		XCTAssertEqual(dupes.first?.messagePayload, "live copy")
+
+		// MyInfo + its channel migrate (they only existed in the legacy store).
+		let infos = try context.fetch(FetchDescriptor<MyInfoEntity>())
+		XCTAssertEqual(infos.count, 1)
+		XCTAssertEqual(infos.first?.myNodeNum, 111)
+		let channels = try context.fetch(FetchDescriptor<ChannelEntity>())
+		XCTAssertEqual(channels.count, 1)
+		XCTAssertEqual(channels.first?.name, "LegacyChan")
+
+		// The legacy store is retired so the migration never runs again.
+		XCTAssertFalse(CoreDataMigrationService.legacyStoreExists(), "legacy store should be renamed after a successful migration")
+		XCTAssertTrue(FileManager.default.fileExists(atPath: backupStoreURL.path), "renamed backup store should exist")
+	}
+
+	// MARK: - Legacy store construction
+
+	/// Builds a real V58 Core Data store at the service's legacy URL using the bundled model,
+	/// exactly as a 2.7.12 install would have left it (after `prepareForMigration()` renamed it).
+	private func buildLegacyStore() throws {
+		let momdURL = try XCTUnwrap(Bundle.main.url(forResource: "Meshtastic", withExtension: "momd"))
+		let modelURL = momdURL.appendingPathComponent("MeshtasticDataModelV 58.mom")
+		let model = try XCTUnwrap(NSManagedObjectModel(contentsOf: modelURL))
+
+		let container = NSPersistentContainer(name: "Meshtastic", managedObjectModel: model)
+		let description = NSPersistentStoreDescription(url: legacyStoreURL)
+		description.shouldAddStoreAsynchronously = false
+		container.persistentStoreDescriptions = [description]
+		var loadError: Error?
+		container.loadPersistentStores { _, error in loadError = error }
+		if let loadError { throw loadError }
+
+		let ctx = container.viewContext
+
+		func insert(_ entity: String, _ values: [String: Any]) -> NSManagedObject {
+			let obj = NSEntityDescription.insertNewObject(forEntityName: entity, into: ctx)
+			for (key, value) in values { obj.setValue(value, forKey: key) }
+			return obj
+		}
+
+		let node111 = insert("NodeInfoEntity", ["num": Int64(111), "bleName": "legacy-111", "lastHeard": Date()])
+		let node222 = insert("NodeInfoEntity", ["num": Int64(222), "bleName": "legacy-222", "lastHeard": Date()])
+
+		let user111 = insert("UserEntity", [
+			"num": Int64(111), "longName": "Legacy User 111", "shortName": "L111",
+			"hwModel": "TBEAM", "userId": "!0000006f"
+		])
+		user111.setValue(node111, forKey: "userNode")
+		let user222 = insert("UserEntity", [
+			"num": Int64(222), "longName": "Legacy User 222", "shortName": "L222",
+			"hwModel": "TBEAM", "userId": "!000000de"
+		])
+		user222.setValue(node222, forKey: "userNode")
+
+		let myInfo = insert("MyInfoEntity", ["myNodeNum": Int64(111)])
+		myInfo.setValue(node111, forKey: "myInfoNode")
+
+		let channel = insert("ChannelEntity", ["index": Int32(0), "name": "LegacyChan", "role": Int32(1)])
+		channel.setValue(myInfo, forKey: "myInfoChannel")
+
+		let message1001 = insert("MessageEntity", [
+			"messageId": Int64(1001), "messagePayload": "legacy hello",
+			"messageTimestamp": Int32(Date().timeIntervalSince1970), "receivedACK": false
+		])
+		message1001.setValue(user111, forKey: "fromUser")
+		let message1002 = insert("MessageEntity", [
+			"messageId": Int64(1002), "messagePayload": "legacy copy of 1002",
+			"messageTimestamp": Int32(Date().timeIntervalSince1970), "receivedACK": false
+		])
+		message1002.setValue(user222, forKey: "fromUser")
+
+		// Configs: one on the legacy-only node (should migrate) and one on the node the
+		// live store also has (must be skipped in favor of the live config).
+		let config111 = insert("DeviceConfigEntity", ["role": Int32(5)])
+		config111.setValue(node111, forKey: "deviceConfigNode")
+		let config222 = insert("DeviceConfigEntity", ["role": Int32(9)])
+		config222.setValue(node222, forKey: "deviceConfigNode")
+
+		try ctx.save()
+
+		// Detach so the migration's own container gets exclusive access.
+		for store in container.persistentStoreCoordinator.persistentStores {
+			try container.persistentStoreCoordinator.remove(store)
+		}
+	}
+}


### PR DESCRIPTION
Companion to #2153 (merged), which restored the bundled legacy model so the Core Data → SwiftData migration can run again — full credit to @laconicman for finding and fixing #2152. This PR makes that migration safe for the population it now applies to, and locks both fixes in with tests.

## Why #2153 needed a companion

The migration was written for an **empty** destination store. But the affected users (2.7.13–2.7.16 upgraders) have been writing to SwiftData since their upgrade — their legacy store sat on disk while the mesh re-taught the app its nodes, users, and messages. With the model restored, the migration now runs for them **against a populated store**, and the original blind-insert logic would duplicate every re-learned row.

## What this changes

- **Nodes, users, MyInfos, and messages dedupe by natural key** (`num` / `myNodeNum` / `messageId`). Legacy rows map onto the existing entities, so legacy positions, telemetry, and messages still attach where they belong and fill the pre-upgrade history gap.
- **Configs and channels are skipped for preexisting parents** — the live versions reflect the radio's current state and must not be replaced by year-old copies.
- **Fresh installs are the degenerate case**: nothing preexists, everything migrates exactly as before.
- Per-entity logs report migrated-vs-skipped counts for diagnosing rescue runs.

## Tests (`CoreDataMigrationServiceTests`)

- `testLegacyCoreDataModelIsInAppBundle` — guards #2153's fix: fails loudly if `Meshtastic.momd` (including `MeshtasticDataModelV 58.mom`) ever falls out of the bundle again.
- `testMigrationFillsGapsWithoutDuplicatingLiveData` — builds a real V58 Core Data store from the bundled model (as a 2.7.12 install would have left it), migrates it into a pre-populated in-memory SwiftData store, and asserts: legacy-only data fills in (node, user, config, message, MyInfo, channel), nothing duplicates, live rows win over legacy ones, and the legacy store is renamed so the migration never re-runs.

Both pass on top of current main. Ideally this ships in the same release as #2153 so the first rescue run users get is the merge-safe one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data migration to preserve newer existing data and prevent duplicate nodes, users, messages, and configuration records.
  * Ensured legacy-only channels and device information are imported correctly.
  * Retired the legacy data store after migration while retaining a backup.

* **Tests**
  * Added comprehensive migration coverage for data preservation, deduplication, legacy imports, and backup creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->