### PR TITLE
fix(swiftdata): kill the invalid-entity SIGTRAP crash family — stop deleting the latest position row per packet

### DIFF
--- a/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
@@ -14,12 +14,17 @@ extension NodeInfoEntity {
 	// These use FetchDescriptor with fetchLimit to avoid loading entire relationship arrays.
 
 	var latestPosition: PositionEntity? {
-		// Fast path: the ingest layer keeps this populated, so reads are O(1).
-		if let cached = latestPositionCache {
+		// Fast path: the ingest layer keeps this populated, so reads are O(1). Screen the cached
+		// handle's liveness first — a row the ingest context deleted can linger here until this
+		// context processes the merge, and touching a persisted property on it traps in SwiftData.
+		// (The ingest side now reuses the latest row for near-duplicate fixes, so stale caches are
+		// rare; this is the reader-side backstop.)
+		if let cached = latestPositionCache, cached.modelContext != nil, !cached.isDeleted {
 			return cached
 		}
-		// Fallback for data created without the cache (migrated / restored / seeded): a sorted
-		// limit-1 query. Runs at most once per node until the cache warms on the next position.
+		// Fallback for data created without the cache (migrated / restored / seeded), or when the
+		// cached row is stale: a sorted limit-1 query. Runs at most once per node until the cache
+		// warms on the next position.
 		guard let ctx = modelContext else { return nil }
 		let nodeNum = self.num
 		var descriptor = FetchDescriptor<PositionEntity>(

--- a/Meshtastic/Helpers/WatchSessionManager.swift
+++ b/Meshtastic/Helpers/WatchSessionManager.swift
@@ -183,8 +183,13 @@ struct WatchNode: Codable {
 	let snr: Float?
 
 	static func make(from nodeInfo: NodeInfoEntity, userLocation: CLLocation, maxDistanceMeters: Double) -> WatchNode? {
-		guard let user = nodeInfo.user else { return nil }
-		guard let pos = nodeInfo.latestPosition else { return nil }
+		// Liveness screens: this walk runs over every node with a user, often while the app is
+		// backgrounded with ingestion still churning — an entity whose row another context
+		// deleted traps in SwiftData's persisted-property accessor the moment it's read
+		// (the 2.7.17 `58e0e820` background crash). Skip anything not verifiably live.
+		guard nodeInfo.modelContext != nil, !nodeInfo.isDeleted else { return nil }
+		guard let user = nodeInfo.user, user.modelContext != nil, !user.isDeleted else { return nil }
+		guard let pos = nodeInfo.latestPosition, pos.modelContext != nil, !pos.isDeleted else { return nil }
 
 		let latI = pos.latitudeI
 		let lonI = pos.longitudeI

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -5,6 +5,7 @@
 //  Copyright(c) Garth Vander Houwen 10/3/22.
 
 @preconcurrency import SwiftData
+import CoreLocation
 import MeshtasticProtobufs
 import OSLog
 
@@ -612,10 +613,31 @@ extension MeshPackets {
 						let posNum = Int64(packet.from)
 						// Previous latest is tracked directly on the node — no PositionEntity table scan.
 						let previousLatest = fetchedNode[0].latestPosition
-						previousLatest?.latest = false
 
-						let position = PositionEntity()
-						modelContext.insert(position)
+						// Near-duplicate fixes REUSE the previous-latest row instead of insert-new +
+						// delete-old. The old per-packet delete left every main-thread holder of the
+						// node's latestPositionCache (node list rows, node detail, the Watch update
+						// walk) one merge window away from a SwiftData invalid-entity SIGTRAP — and
+						// for a stationary node that window reopened on every position packet.
+						// Updating the same row keeps every outstanding handle valid; rows are now
+						// only deleted when a node actually moves beyond the 9m near-duplicate radius.
+						let newCoordinate = CLLocationCoordinate2D(
+							latitude: Double(positionMessage.latitudeI) / 1e7,
+							longitude: Double(positionMessage.longitudeI) / 1e7
+						)
+						let reusePreviousLatest: Bool = {
+							guard let previousLatest, let prevCoord = previousLatest.nodeCoordinate else { return false }
+							return prevCoord.distance(from: newCoordinate) < 9.0
+						}()
+
+						let position: PositionEntity
+						if reusePreviousLatest, let previousLatest {
+							position = previousLatest
+						} else {
+							previousLatest?.latest = false
+							position = PositionEntity()
+							modelContext.insert(position)
+						}
 						position.latest = true
 						position.snr = packet.rxSnr
 						position.rssi = packet.rxRssi
@@ -644,17 +666,11 @@ extension MeshPackets {
 						let geofenceNodeName = fetchedNode[0].user?.longName ?? fetchedNode[0].user?.shortName ?? "\(packet.from)"
 						evaluateGeofences(nodeNum: posNum, latitudeI: positionMessage.latitudeI, longitudeI: positionMessage.longitudeI, nodeName: geofenceNodeName)
 
-						if position.precisionBits == 32 || position.precisionBits == 0 {
-							// Full precision: drop a near-duplicate of the previous latest (within 9m).
-							if let previousLatest,
-								let prevCoord = previousLatest.nodeCoordinate,
-								let positionCoord = position.nodeCoordinate,
-								prevCoord.distance(from: positionCoord) < 9.0 {
-								modelContext.delete(previousLatest)
-							}
-						} else {
-							// Reduced accuracy: keep no history. Delete this node's older positions via its own
-							// relationship (small for reduced-accuracy nodes) instead of a global table scan.
+						if !reusePreviousLatest && position.precisionBits != 32 && position.precisionBits != 0 {
+							// Reduced accuracy and the fuzzed coordinate actually moved: keep no history.
+							// Delete this node's older positions via its own relationship (small for
+							// reduced-accuracy nodes) instead of a global table scan. When the row was
+							// reused (the common, stationary case) there is nothing to delete.
 							for old in fetchedNode[0].positions where !old.latest {
 								modelContext.delete(old)
 							}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -739,7 +739,10 @@ struct NodeDetail: View {
 							node: node
 						)
 					}
-					if let latestPosition {
+					// Liveness screen: `latestPosition` is a @State handle refreshed on a cadence;
+					// if ingestion deleted the row since the last refresh, reading a persisted
+					// property on it traps in SwiftData. Skip rendering until the next refresh.
+					if let latestPosition, latestPosition.modelContext != nil, !latestPosition.isDeleted {
 					#if !targetEnvironment(macCatalyst)
 						if latestPosition.isPreciseLocation {
 							Button {

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -501,9 +501,16 @@ struct PositionConfig: View {
 	private func setFixedPosition() {
 		guard let nodeNum = accessoryManager.activeDeviceNum,
 			  nodeNum > 0 else { return }
+		// Resolve the user BEFORE the async hop and without force-unwraps: a device switch or
+		// node deletion mid-flow leaves `node`/`user` nil or invalidated, and `node!.user!`
+		// inside the Task crashed here in the field (SIGTRAP under Concurrency).
+		guard let user = node?.user, user.modelContext != nil else {
+			Logger.mesh.error("Set Position Failed — no live user for connected node")
+			return
+		}
 		Task {
 			do {
-				try await accessoryManager.setFixedPosition(fromUser: node!.user!, channel: 0)
+				try await accessoryManager.setFixedPosition(fromUser: user, channel: 0)
 			} catch {
 				Logger.mesh.error("Set Position Failed")
 			}
@@ -521,9 +528,14 @@ struct PositionConfig: View {
 	private func removeFixedPosition() {
 		guard let nodeNum = accessoryManager.activeDeviceNum,
 			  nodeNum > 0 else { return }
+		// Same guard as setFixedPosition: no force-unwraps across the async hop.
+		guard let user = node?.user, user.modelContext != nil else {
+			Logger.mesh.error("Remove Fixed Position Failed — no live user for connected node")
+			return
+		}
 		Task {
 			do {
-				try await accessoryManager.removeFixedPosition(fromUser: node!.user!, channel: 0)
+				try await accessoryManager.removeFixedPosition(fromUser: user, channel: 0)
 			} catch {
 				Logger.mesh.error("Remove Fixed Position Failed")
 			}


### PR DESCRIPTION
Fixes the dominant crash family in production and TestFlight: SwiftData invalid-entity SIGTRAPs across the node UI, the Watch update path, and the ingest actor (Error Tracking issues touching `NodeListItem.swift`, `NodeListItemCompact.swift`, `NodeDetail.swift`, `MeshPackets.swift`, `WatchSessionManager.swift`, `PositionConfig.swift`, `UpdateSwiftData.swift`, and by extension `MeshtasticApp.swift`) — including the only new crash in 2.7.17 TestFlight, the backgrounded WatchSessionManager trap.

## Root cause

The position upsert deleted a row on nearly every packet from a stationary node:

- **Full precision**: a new fix within 9m of the previous latest inserted a new row and **deleted the previous latest**.
- **Reduced accuracy**: every packet swept the node's entire non-latest history.

Any main-thread reader holding the node's `latestPositionCache` handle — a node list row rendering distance, node detail, the Watch walk over every node, a config view — was one merge window away from SwiftData's persisted-property trap, and that window **reopened on every position packet from every stationary node** (which is most of a mesh, most of the time). Different top frames, one disease.

## The fix

**Reuse the previous-latest row in place for near-duplicate fixes** (both precision classes) instead of insert-new + delete-old. All fields update on the same row, every outstanding handle stays valid, and net row state is identical to before. Deletions now happen only when a node actually moves beyond the 9m near-duplicate radius — a rare event instead of a per-packet one.

**Reader-side defense in depth**, for the residual windows (actual movement, history pruning, device switches):
- `NodeInfoEntity.latestPosition` now screens the cached handle's liveness (`modelContext`/`isDeleted`) and falls back to its sorted fetch when the row is gone — one central guard covering every caller.
- `WatchNode.make` guards node/user/position liveness before touching persisted properties (the walk runs over every node with a user, often while backgrounded with ingestion churning — the 2.7.17 regression).
- `NodeDetail` screens its held `@State` position before persisted reads.
- `PositionConfig` resolves the user with `guard let` before its async hops instead of `node!.user!` inside a `Task`.

The telemetry `latest*` accessors were audited too: they're fresh limit-1 fetches (no cache), and telemetry pruning only removes oldest rows, so they don't share the exposure.

## Verification

- Full test suite: the only failures are the machine-specific snapshot references and the two known load-sensitive timing tests — the identical set that fails on unmodified main on this machine; zero new failures.
- **10-minute soak against the 1,600-node TCP stress replay** (the same rig that reproduced the DiscoveryScanEngine trap fixed in #2105): high-rate position churn from stationary nodes — the exact traffic that used to reopen the trap window per packet — with the app connected the whole time. No crashes, no crash reports, steady CPU/memory.
- Behavior parity checked for all four upsert cases (full/reduced precision × moved/stationary): same net rows, same latest flags, same geofence evaluation.

## Notes

- The `MeshtasticApp.swift`-attributed issue has no direct entity access in that file to guard; it carries the same SIGTRAP signature and should fall with the family. Worth watching in the next build's Error Tracking before calling it closed.
- The position-history prune (oldest, non-latest rows at the 5,000/node cap) is untouched — readers don't hold old history rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when displaying node details and location-based actions after position data changes.
  * Prevented stale or deleted position records from appearing in the app or on the watch.
  * Improved handling of nearby, repeated location updates to reduce unnecessary position changes.
  * Prevented potential errors when setting or removing a fixed position.
  * Improved recovery when node or location data is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->