### PR TITLE
fix(build): main doesn't compile — ua868 stragglers from #2151 and an over-budget #Predicate from #2150

### DIFF
--- a/Meshtastic/Enums/LoraConfigEnums.swift
+++ b/Meshtastic/Enums/LoraConfigEnums.swift
@@ -275,8 +275,6 @@ enum RegionCodes: Int, CaseIterable, Identifiable {
 			return 100
 		case .ua433:
 			return 10
-		case .ua868:
-			return 10
 		case .lora24:
 			return 100
 		case .my433:
@@ -354,8 +352,6 @@ enum RegionCodes: Int, CaseIterable, Identifiable {
 		case .th:
 			return true
 		case .ua433:
-			return true
-		case .ua868:
 			return true
 		case .lora24:
 			return false
@@ -436,8 +432,6 @@ enum RegionCodes: Int, CaseIterable, Identifiable {
 			return Config.LoRaConfig.RegionCode.th
 		case .ua433:
 			return Config.LoRaConfig.RegionCode.ua433
-		case .ua868:
-			return Config.LoRaConfig.RegionCode.ua868
 		case .lora24:
 			return Config.LoRaConfig.RegionCode.lora24
 		case .my433:

--- a/Meshtastic/Helpers/LoRaChannelCalculator.swift
+++ b/Meshtastic/Helpers/LoRaChannelCalculator.swift
@@ -259,8 +259,6 @@ struct RegionInfo {
 			self.init(freqStart: 920.0, freqEnd: 925.0)
 		case .ua433:
 			self.init(freqStart: 433.0, freqEnd: 434.7)
-		case .ua868:
-			self.init(freqStart: 868.0, freqEnd: 868.6)
 		case .my433:
 			self.init(freqStart: 433.0, freqEnd: 435.0)
 		case .my919:

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -138,15 +138,19 @@ extension MeshPackets {
 		// `user.sentMessages`/`receivedMessages` off a UserEntity handed in from the view's context:
 		// across the actor/context boundary those relationships resolved empty, and deleting
 		// foreign-context objects through this context was a no-op — so deleting a DM did nothing.
+		// Keep only the selective OR in the #Predicate: the full five-term compound (two
+		// optional-chained comparisons + three scalar tests) blows the #Predicate macro's
+		// type-check budget — the same limit documented in UserMessageList's ACK counts.
+		// The scalar screens run in-memory over the (small) single-conversation result.
 		let descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> { msg in
-				msg.toUser != nil &&
-				(msg.fromUser?.num == userNum || msg.toUser?.num == userNum) &&
-				msg.isEmoji == false && msg.admin == false && msg.portNum != 10
+				msg.fromUser?.num == userNum || msg.toUser?.num == userNum
 			}
 		)
 		do {
-			let objects = try modelContext.fetch(descriptor)
+			let objects = try modelContext.fetch(descriptor).filter { msg in
+				msg.toUser != nil && msg.isEmoji == false && msg.admin == false && msg.portNum != 10
+			}
 			for object in objects {
 				modelContext.delete(object)
 			}

--- a/MeshtasticTests/LoraDeviceEnumTests.swift
+++ b/MeshtasticTests/LoraDeviceEnumTests.swift
@@ -677,7 +677,7 @@ struct LoRaRegionPresetMapTests {
 			group([.tinyFast, .tinySlow], .tinyFast, true),
 			group([.narrowFast, .narrowSlow], .narrowSlow, true)
 		]
-		let group0Regions: [Region] = [.us, .eu433, .cn, .jp, .anz, .anz433, .ru, .kr, .tw, .in, .nz865, .th, .ua433, .ua868, .my433, .my919, .sg923, .ph433, .ph868, .ph915, .kz433, .kz863, .np865, .br902, .lora24]
+		let group0Regions: [Region] = [.us, .eu433, .cn, .jp, .anz, .anz433, .ru, .kr, .tw, .in, .nz865, .th, .ua433, .my433, .my919, .sg923, .ph433, .ph868, .ph915, .kz433, .kz863, .np865, .br902, .lora24]
 		map.regionGroups = group0Regions.map { entry($0, 0) }
 		map.regionGroups.append(entry(.eu868, 1))
 		map.regionGroups.append(entry(.eu866, 2))

--- a/MeshtasticTests/RegionCodesFirmwareLocaleTests.swift
+++ b/MeshtasticTests/RegionCodesFirmwareLocaleTests.swift
@@ -31,7 +31,7 @@ struct RegionCodesFirmwareLocaleTests {
 
 	@Test("Non-Latin regions prefer locale firmware")
 	func nonLatinRegionsPreferLocale() {
-		let nonLatinRegions: [RegionCodes] = [.ru, .ua433, .ua868, .cn, .jp, .kr, .tw, .th]
+		let nonLatinRegions: [RegionCodes] = [.ru, .ua433, .cn, .jp, .kr, .tw, .th]
 		for region in nonLatinRegions {
 			#expect(region.prefersLocalizedFontFirmware, "\(region) should be non-Latin")
 		}
@@ -68,7 +68,7 @@ struct RegionCodesFirmwareLocaleTests {
 	/// latinScriptRegions exhaustiveness — the "new region" trap
 	@Test("All non-unset regions are explicitly classified as Latin or non-Latin")
 	func allRegionsAreExplicitlyClassified() {
-		let knownNonLatin: Set<RegionCodes> = [.ru, .ua433, .ua868, .cn, .jp, .kr, .tw, .th]
+		let knownNonLatin: Set<RegionCodes> = [.ru, .ua433, .cn, .jp, .kr, .tw, .th]
 		let allNonUnset = Set(RegionCodes.allCases.filter { $0 != .unset })
 		#expect(RegionCodes.latinScriptRegions.union(knownNonLatin) == allNonUnset,
 				"A region is missing from latinScriptRegions or knownNonLatin")


### PR DESCRIPTION
Current main fails to build for device and simulator, from two independent merges landing together:

## 1. `ua868` stragglers (#2151)

#2151 removed `case ua868` from the app's `RegionCodes` enum, but four `RegionCodes`-typed references survived, so every switch over the enum stopped compiling:
- the duty-cycle and channel-support switches in `LoraConfigEnums.swift`
- the `toProto` mapping arm
- the frequency table in `LoRaChannelCalculator.swift`
- `.ua868` entries in two test arrays

All removed. The protobuf enum keeps `UA_868` (wire format unchanged); the app simply no longer offers or maps it — matching #2151's intent, since UA_868 is now identical to EU_868.

## 2. `deleteUserMessages` predicate over the type-check budget (#2150)

The five-term compound `#Predicate` (two optional-chained `num` comparisons in an OR, plus three scalar screens) fails with "the compiler is unable to type-check this expression in reasonable time" — the same `#Predicate` macro budget this codebase already documents in `UserMessageList`'s ACK-count fetches. The selective OR stays in the predicate; the scalar screens (`toUser != nil`, `isEmoji`, `admin`, `portNum != 10`) now run in-memory over the single-conversation result. Semantics unchanged.

## Verification

- `generic/platform=iOS` device build: succeeds
- `build-for-testing` (app + test targets) on simulator: succeeds
- Both failures reproduced deterministically on this machine before the fixes (Xcode 26.x); the type-check budget one may be toolchain/machine-sensitive, which would explain green CI on #2150.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unsupported UA868 region option from regional configuration and locale handling.
  * Preserved existing frequency and channel calculations for all remaining regions.
  * Improved deletion of user messages while retaining existing filtering behavior.

* **Tests**
  * Updated region presets and locale classifications to reflect the removal of UA868.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->