### PR TITLE
fix(messages): bound the tapback reaction pill to available width

### DIFF
--- a/Meshtastic/Views/Messages/TapbackResponses.swift
+++ b/Meshtastic/Views/Messages/TapbackResponses.swift
@@ -3,10 +3,40 @@ import SwiftUI
 struct TapbackResponses: View {
 	let tapbacks: [MessageEntity]
 
+	/// Each reaction chip is a fixed width instead of sizing to its own emoji/name — this makes
+	/// the pill's total content width exactly computable (see `pillWidth`) without any runtime
+	/// measurement. (A `GeometryReader`-based measurement of the grid's natural size, taken
+	/// inside the `ScrollView`'s content, did not resolve reliably — it read back 0 every time —
+	/// and a plain `.fixedSize()` + `.frame(maxWidth:)` chain on the `ScrollView` itself always
+	/// resolved to the cap width regardless of content, since a `ScrollView`'s ideal size along
+	/// its scroll axis isn't content-driven the way a stack's is. Fixed-width items sidestep
+	/// both: the total is arithmetic, not measured.)
+	private static let itemWidth: CGFloat = 40
+	private static let itemSpacing: CGFloat = 12
+	private static let gridPadding: CGFloat = 10
+
+	/// Caps the pill at roughly the same width budget a message bubble gets: screen width minus
+	/// the avatar circle (50pt + 10pt padding), the opposite-side spacer (50pt), and the row's
+	/// own horizontal padding (16pt/side). A few reactions still hug tightly well under this; a
+	/// long run (e.g. a popular broadcast) clips to it and scrolls horizontally instead of
+	/// overflowing past the screen edge with the rounded border pushed off-screen.
+	private static let maxWidth: CGFloat = UIScreen.main.bounds.width - 142
+
 	/// One row for a handful of reactions, two once there are several — then scroll
 	/// horizontally instead of overflowing the screen (matches the emoji picker styling).
+	private var rowCount: Int { tapbacks.count > 6 ? 2 : 1 }
+
 	private var rows: [GridItem] {
-		Array(repeating: GridItem(.fixed(38), spacing: 4), count: tapbacks.count > 6 ? 2 : 1)
+		Array(repeating: GridItem(.fixed(38), spacing: 4), count: rowCount)
+	}
+
+	/// Exact content width from the fixed item width, capped at `maxWidth`.
+	private var pillWidth: CGFloat {
+		let columnCount = Int((Double(tapbacks.count) / Double(rowCount)).rounded(.up))
+		let contentWidth = CGFloat(columnCount) * Self.itemWidth
+			+ CGFloat(max(0, columnCount - 1)) * Self.itemSpacing
+			+ 2 * Self.gridPadding
+		return min(contentWidth, Self.maxWidth)
 	}
 
 	@ViewBuilder
@@ -14,27 +44,27 @@ struct TapbackResponses: View {
 		if !tapbacks.isEmpty {
 			VStack(alignment: .trailing) {
 				ScrollView(.horizontal, showsIndicators: false) {
-					LazyHGrid(rows: rows, spacing: 12) {
+					LazyHGrid(rows: rows, spacing: Self.itemSpacing) {
 						ForEach(tapbacks) { (tapback: MessageEntity) in
 							VStack(spacing: 1) {
 								Text(tapback.messagePayload ?? "")
 									.font(.system(size: 20))
 									.lineLimit(1)
-									.fixedSize()
+									.minimumScaleFactor(0.7)
 								Text("\(tapback.fromUser?.shortName ?? "?")")
 									.font(.caption2)
 									.foregroundColor(.gray)
-									.fixedSize()
+									.lineLimit(1)
+									.minimumScaleFactor(0.7)
 							}
+							.frame(width: Self.itemWidth)
 							.accessibilityElement(children: .combine)
 							.accessibilityLabel(String(localized: "Reaction \(tapback.messagePayload ?? "") from \(tapback.fromUser?.shortName ?? "?")", comment: "VoiceOver: a single emoji reaction and who sent it. First value is the emoji, second is the sender"))
 						}
 					}
-					.padding(10)
+					.padding(Self.gridPadding)
 				}
-				// Hug the reactions so the border wraps the content instead of leaving
-				// empty space; the up-to-two-rows layout keeps realistic counts on-screen.
-				.fixedSize(horizontal: true, vertical: false)
+				.frame(width: pillWidth, alignment: .trailing)
 				.overlay(
 					RoundedRectangle(cornerRadius: 18)
 						.stroke(Color.gray, lineWidth: 1)


### PR DESCRIPTION
A message with enough reactions rendered its emoji-reaction pill full-bleed across the screen — no visible rounded border, no horizontal scroll — instead of a properly bounded, scrollable pill (screenshot from a stress-replay conversation with ~20 reactions on one message).

## Root cause

The pill's `ScrollView` used `.fixedSize(horizontal: true, vertical: false)` so it would hug tightly for the common case (a handful of reactions). But a `ScrollView`'s ideal size along its *scroll axis* isn't content-driven the way a stack's is — with enough reactions to need scrolling, it reported its ideal width as the full unclipped content width, so the rounded-rect border (sized to match) ended up mostly off-screen.

## What I tried and rejected (left as a code comment for the next person)

- A `GeometryReader` measuring the grid's natural width from inside the `ScrollView`'s content — the preference never resolved past 0.
- Layering `.frame(maxWidth:)` after `.fixedSize()` — this resolved to the cap width *unconditionally*, even for 3-5 reactions, producing a visual regression (a big pill with a wasted gap before the first reaction).

## The fix

Give each reaction chip a fixed, known width instead of sizing to its own emoji/name — the pill's total content width becomes exact arithmetic (column count × item width + spacing + padding) instead of something measured at runtime. That total is capped at roughly the same width budget a message bubble gets (screen width minus the avatar circle, the opposite-side spacer, and row padding):

- A handful of reactions hugs tightly (no wasted space).
- A long run clips to the cap, both rows fully visible, rounded border on-screen, with the rest reachable by scrolling horizontally.

## Verification

Built and tested against a stress-replay conversation with a realistic mix of reaction counts:
- 2-5 reactions: tight pill, no wasted space (confirmed this didn't regress from an earlier iteration of the fix, which forced full cap width even here).
- ~20 reactions: bounded to the cap, rounded border fully visible, horizontally scrollable.

Full test suite: no new failures (compared against the existing known-flaky/machine-specific set on this machine).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reaction picker layout consistency by using predictable chip sizing.
  * Prevented reaction options from overflowing on narrower screens.
  * Improved text fitting within reaction chips by allowing labels to scale when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->