### PR TITLE
test: fix stale region-count assertions after ua868 removal

### DIFF
--- a/MeshtasticTests/LoraDeviceEnumTests.swift
+++ b/MeshtasticTests/LoraDeviceEnumTests.swift
@@ -48,7 +48,7 @@ struct RegionCodesTests {
 	}
 
 	@Test func totalCaseCount() {
-		#expect(RegionCodes.allCases.count == 38)
+		#expect(RegionCodes.allCases.count == 37)
 	}
 
 	@Test func eu433_hasDutyCycle10() {
@@ -749,7 +749,7 @@ struct LoRaRegionPresetMapTests {
 	}
 
 	@Test func decode_allRegionsPresent() {
-		#expect(referenceMap().decoded().count == 32)
+		#expect(referenceMap().decoded().count == 31)
 	}
 
 	@Test func absentRegion_hasNoConstraint() {
@@ -767,7 +767,7 @@ struct LoRaRegionPresetMapTests {
 		map.regionGroups.append(bad)
 		let decoded = map.decoded()
 		#expect(decoded[.eu874] == nil)   // skipped defensively (spec §4)
-		#expect(decoded.count == 32)      // unchanged
+		#expect(decoded.count == 31)      // unchanged
 	}
 
 	@Test func emptyMap_decodesEmpty() {


### PR DESCRIPTION
Found while running the full test suite to verify an unrelated change (#2157) — not a regression from that PR, just previously uncaught.

## What's wrong

Three tests assert hardcoded region counts that went stale when `ua868` was removed from `RegionCodes` (#2151, build-fixed in #2156):

- `RegionCodesTests.totalCaseCount()` — expected `38`, actual is `37`
- `LoRaRegionPresetMapTests.decode_allRegionsPresent()` — expected `32`, actual is `31`
- `LoRaRegionPresetMapTests.outOfRangeGroupIndex_isSkipped()` — same, expected `32`, actual `31`

The reference fixture these build from doesn't (and can't) reference `.ua868` any more — the case doesn't exist — so the counts were simply one too high everywhere UA_868 used to count as a distinct region. Neither #2151 nor #2156 ran the full suite (both used targeted/compile-only verification), so this went uncaught until now.

## Fix

Update the three hardcoded expectations to 37/31/31, matching current, correct behavior.

## Verification

Ran full suite before and after: these three go from failing to passing, with no change to the existing known machine-specific/flaky set (snapshot tests referencing local paths, a couple of timing-sensitive tests) on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated region and preset decoding test expectations to reflect the current set of supported regions.
  * Adjusted validation for total region counts and decoded firmware mapping entries, including out-of-range handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->