### PR TITLE
fix(swiftdata): preserve device metadata entity during updates

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -306,7 +306,7 @@ actor MeshPackets {
 	func myInfoPacket (myInfo: MyNodeInfo, peripheralId: String) -> PersistentIdentifier? {
 		let logString = String.localizedStringWithFormat("MyInfo received: %@".localized, String(myInfo.myNodeNum))
 		Logger.admin.info("ℹ️ \(logString, privacy: .public)")
-		
+
 		let myNodeNum = Int64(myInfo.myNodeNum)
 		let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == myNodeNum })
 
@@ -350,7 +350,7 @@ actor MeshPackets {
 		if channel.isInitialized && channel.hasSettings && channel.role != Channel.Role.disabled {
 			let logString = String.localizedStringWithFormat("Channel received: %d %@".localized, channel.index, String(fromNum))
 			Logger.admin.info("🎛️ \(logString, privacy: .public)")
-			
+
 			let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == fromNum })
 
 			do {
@@ -398,38 +398,22 @@ actor MeshPackets {
 		if metadata.isInitialized {
 			let logString = String.localizedStringWithFormat("Device Metadata received from: %@".localized, fromNum.toHex())
 			Logger.admin.info("🏷️ \(logString, privacy: .public)")
-			
+
 			let fetchDescriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == fromNum })
 
 			do {
 				let fetchedNode = try modelContext.fetch(fetchDescriptor)
-				let newMetadata = DeviceMetadataEntity()
-				modelContext.insert(newMetadata)
-				newMetadata.time = Date()
-				newMetadata.deviceStateVersion = Int32(metadata.deviceStateVersion)
-				newMetadata.canShutdown = metadata.canShutdown
-				newMetadata.hasWifi = metadata.hasWifi_p
-				newMetadata.hasBluetooth = metadata.hasBluetooth_p
-				newMetadata.hasEthernet	= metadata.hasEthernet_p
-				newMetadata.role = Int32(metadata.role.rawValue)
-				newMetadata.positionFlags = Int32(truncatingIfNeeded: metadata.positionFlags)
-				newMetadata.excludedModules = Int32(truncatingIfNeeded: metadata.excludedModules)
-				// Swift does strings weird, this does work to get the version without the github hash
-				let lastDotIndex = metadata.firmwareVersion.lastIndex(of: ".")
-				var version = metadata.firmwareVersion[...(lastDotIndex ?? String.Index(utf16Offset: 6, in: metadata.firmwareVersion))]
-				version = version.dropLast()
-				newMetadata.firmwareVersion = String(version)
-				if fetchedNode.count > 0 {
-					fetchedNode[0].metadata = newMetadata
-					if sessionPasskey?.count != 0 {
-						fetchedNode[0].sessionPasskey = sessionPasskey
-						fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
-					}
-				} else {
-					if fromNum > 0 {
-						let newNode = findOrCreateNode(num: Int64(fromNum), context: modelContext)
-						newNode.metadata = newMetadata
-					}
+				guard fromNum > 0 else { return }
+				let node = fetchedNode.first ?? findOrCreateNode(num: fromNum, context: modelContext)
+				let storedMetadata = node.metadata ?? DeviceMetadataEntity()
+				if node.metadata == nil {
+					modelContext.insert(storedMetadata)
+					node.metadata = storedMetadata
+				}
+				storedMetadata.update(from: metadata)
+				if sessionPasskey?.count != 0 {
+					node.sessionPasskey = sessionPasskey
+					node.sessionExpiration = Date().addingTimeInterval(300)
 				}
 				savePendingChanges()
 				Logger.data.info("💾 Updated Device Metadata from Admin App Packet For: \(fromNum.toHex(), privacy: .public)")
@@ -699,7 +683,7 @@ actor MeshPackets {
 				if let cmmc = try? CannedMessageModuleConfig(serializedBytes: packet.decoded.payload) {
 					let logString = String.localizedStringWithFormat("Canned Messages Messages Received For: %@".localized, packet.from.toHex())
 					Logger.admin.info("🥫 \(logString, privacy: .public)")
-					
+
 					let packetFrom = Int64(packet.from)
 					let fetchDescriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == packetFrom })
 

--- a/Meshtastic/Model/DeviceMetadataEntity.swift
+++ b/Meshtastic/Model/DeviceMetadataEntity.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftData
+import MeshtasticProtobufs
 
 @Model
 final class DeviceMetadataEntity {
@@ -25,4 +26,21 @@ final class DeviceMetadataEntity {
 	var metadataNode: NodeInfoEntity?
 
 	init() {}
+
+	func update(from metadata: DeviceMetadata) {
+		time = Date()
+		deviceStateVersion = Int32(metadata.deviceStateVersion)
+		canShutdown = metadata.canShutdown
+		hasWifi = metadata.hasWifi_p
+		hasBluetooth = metadata.hasBluetooth_p
+		hasEthernet = metadata.hasEthernet_p
+		role = Int32(metadata.role.rawValue)
+		positionFlags = Int32(truncatingIfNeeded: metadata.positionFlags)
+		excludedModules = Int32(truncatingIfNeeded: metadata.excludedModules)
+
+		let lastDotIndex = metadata.firmwareVersion.lastIndex(of: ".")
+		var version = metadata.firmwareVersion[...(lastDotIndex ?? String.Index(utf16Offset: 6, in: metadata.firmwareVersion))]
+		version = version.dropLast()
+		firmwareVersion = String(version)
+	}
 }

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -907,3 +907,34 @@ struct TelemetryPacketIngestTests {
 		#expect(latest?.nodeTelemetry?.num == Int64(nodeNum))
 	}
 }
+
+@Suite("device metadata ingestion")
+@MainActor
+struct DeviceMetadataIngestTests {
+	private func makeMetadata(version: String) -> DeviceMetadata {
+		var metadata = DeviceMetadata()
+		metadata.firmwareVersion = version
+		metadata.deviceStateVersion = 1
+		return metadata
+	}
+
+	@Test func repeatedMetadataForNode_reusesExistingEntity() async throws {
+		let nodeNum: Int64 = 0x2004_AA05
+		let mesh = MeshPackets(modelContainer: sharedModelContainer)
+
+		await mesh.deviceMetadataPacket(metadata: makeMetadata(version: "2.7.17.abcdef"), fromNum: nodeNum)
+		let context = ModelContext(sharedModelContainer)
+		let node = try #require(
+			context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == nodeNum })).first
+		)
+		let firstMetadataID = try #require(node.metadata).persistentModelID
+
+		await mesh.deviceMetadataPacket(metadata: makeMetadata(version: "2.7.18.abcdef"), fromNum: nodeNum)
+
+		let refreshedNode = try #require(
+			context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == nodeNum })).first
+		)
+		#expect(refreshedNode.metadata?.persistentModelID == firstMetadataID)
+		#expect(refreshedNode.metadata?.firmwareVersion == "2.7.18")
+	}
+}


### PR DESCRIPTION
## Summary

- Update an existing node metadata entity in place when a newer `DeviceMetadata` packet arrives.
- Keep the session-passkey update behavior unchanged.
- Add a regression test covering two metadata packets for one node.

## Root cause

The admin-packet path always inserted a new `DeviceMetadataEntity` and replaced `node.metadata`. SwiftUI could retain the previous relationship target, then fault that invalid entity when rendering the firmware version. A redacted TestFlight 2.7.17 (2153) crash showed `DeviceMetadataEntity.firmwareVersion` followed by SwiftData `_InvalidFutureBackingData`.

This is separate from the recently merged [position-cache stale-handle repair](https://github.com/meshtastic/Meshtastic-Apple/commit/cb1a6515d9954acad279870d847a35ff68c12898): this path replaces the metadata relationship rather than a position. An open-PR search for the metadata/SwiftData crash terms found no duplicate.

## Validation

```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /private/tmp/meshtastic-metadata-test -only-testing:MeshtasticTests/DeviceMetadataIngestTests\n```\n\nPasses: the second metadata packet retains the first entity persistent ID and updates the firmware version. The same test failed before the fix because the relationship changed from `DeviceMetadataEntity/p1` to `DeviceMetadataEntity/p2`.\n\nNo crash reports or tester data are included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device metadata handling when multiple updates are received for the same device.
  * Ensured refreshed metadata, including firmware version and device capabilities, is displayed correctly.
  * Improved handling of device session information during metadata updates.
  * Added safeguards for invalid device identifiers.

* **Tests**
  * Added coverage confirming repeated metadata updates retain existing device information while applying the latest values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->