### PR TITLE
Fix: BLE 'Enable Bluetooth' alert dismiss/reappear loop on launch (#2139)

### DIFF
--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -51,7 +51,7 @@ actor BLETransport: Transport {
 		if CBCentralManager.authorization != .notDetermined {
 			centralManager = CBCentralManager(delegate: delegate,
 											  queue: centralQueue,
-											  options: [CBCentralManagerOptionRestoreIdentifierKey: kCentralRestoreID]
+											  options: Self.centralManagerOptions(restoreIdentifier: kCentralRestoreID)
 			)
 		}
 		self.delegate.setTransport(self)
@@ -64,8 +64,31 @@ actor BLETransport: Transport {
 	private func createCentralManager() {
 		centralManager = CBCentralManager(delegate: delegate,
 										  queue: centralQueue,
-										  options: [CBCentralManagerOptionRestoreIdentifierKey: kCentralRestoreID]
+										  options: Self.centralManagerOptions(restoreIdentifier: kCentralRestoreID)
 		)
+	}
+
+	/// The options CBCentralManager is created with, factored out so the contents are testable
+	/// without standing up a real CoreBluetooth stack (static + value-out, same pattern as
+	/// `Connect.liveNode`).
+	///
+	/// `CBCentralManagerOptionShowPowerAlertKey` is explicitly `false`. BLE is one of several
+	/// transports — discovery starts unconditionally on all of them at launch
+	/// (`AccessoryManager.startDiscovery()`) regardless of which transport the user actually
+	/// connects with — so leaving the (default-`true`) system "Bluetooth is turned off" alert
+	/// enabled meant a TCP/WiFi-only user saw it on every launch. Worse, presenting that alert
+	/// blips `scenePhase` (inactive/background then active), and `appDidBecomeActive()` restarts
+	/// BLE discovery whenever there's no active connection yet — which re-triggers the alert,
+	/// producing the dismiss/reappear loop reported in #2139. Suppressing the system alert here
+	/// doesn't change BLE functionality: `BLETransport` already reacts to `.poweredOff` in
+	/// `handleCentralState` and surfaces it as transport status, and the explicit onboarding
+	/// "enable Bluetooth" flow (`BluetoothAuthorizationHelper`) uses its own default-options
+	/// manager, so that user-initiated prompt still appears where it belongs.
+	static func centralManagerOptions(restoreIdentifier: String) -> [String: Any] {
+		[
+			CBCentralManagerOptionRestoreIdentifierKey: restoreIdentifier,
+			CBCentralManagerOptionShowPowerAlertKey: false
+		]
 	}
 
 	func discoverDevices() -> AsyncStream<DiscoveryEvent> {

--- a/MeshtasticTests/BLETransportCentralManagerOptionsTests.swift
+++ b/MeshtasticTests/BLETransportCentralManagerOptionsTests.swift
@@ -1,3 +1,4 @@
+// MARK: BLETransportCentralManagerOptionsTests
 //
 //  BLETransportCentralManagerOptionsTests.swift
 //  MeshtasticTests

--- a/MeshtasticTests/BLETransportCentralManagerOptionsTests.swift
+++ b/MeshtasticTests/BLETransportCentralManagerOptionsTests.swift
@@ -1,0 +1,52 @@
+//
+//  BLETransportCentralManagerOptionsTests.swift
+//  MeshtasticTests
+//
+//  Covers the fix for issue #2139: the app initializes BLE discovery unconditionally on
+//  every launch (AccessoryManager.startDiscovery() fans out to every transport, regardless
+//  of which one the user actually connects with), so a TCP/WiFi-only user with Bluetooth
+//  off on the device was seeing the system "Bluetooth is turned off" alert every launch —
+//  and, because presenting that alert blips scenePhase and appDidBecomeActive() re-arms BLE
+//  discovery, in a tight dismiss/reappear loop.
+//
+//  These tests pin down the options CBCentralManager is created with (BLETransport.
+//  centralManagerOptions), since that's the only piece of the fix that's cheaply testable
+//  without standing up a real CoreBluetooth stack.
+//
+
+import CoreBluetooth
+import Testing
+
+@testable import Meshtastic
+
+@Suite("BLETransport central manager options")
+struct BLETransportCentralManagerOptionsTests {
+
+	@Test func suppressesTheSystemPowerAlert() {
+		let options = BLETransport.centralManagerOptions(restoreIdentifier: "com.meshtastic.central")
+
+		let showPowerAlert = options[CBCentralManagerOptionShowPowerAlertKey] as? Bool
+		#expect(showPowerAlert == false, "CBCentralManagerOptionShowPowerAlertKey must be false, or the system 'Bluetooth is turned off' alert reappears every launch for TCP/WiFi-only users (#2139)")
+	}
+
+	@Test func preservesStateRestoration() {
+		let restoreId = "com.meshtastic.central"
+		let options = BLETransport.centralManagerOptions(restoreIdentifier: restoreId)
+
+		let restoredIdentifier = options[CBCentralManagerOptionRestoreIdentifierKey] as? String
+		#expect(restoredIdentifier == restoreId, "Suppressing the power alert must not disable state restoration for backgrounded BLE connections")
+	}
+
+	@Test func passesThroughTheGivenRestoreIdentifier() {
+		let options = BLETransport.centralManagerOptions(restoreIdentifier: "some-other-id")
+
+		let restoredIdentifier = options[CBCentralManagerOptionRestoreIdentifierKey] as? String
+		#expect(restoredIdentifier == "some-other-id")
+	}
+
+	@Test func containsExactlyTheExpectedKeys() {
+		let options = BLETransport.centralManagerOptions(restoreIdentifier: "com.meshtastic.central")
+
+		#expect(Set(options.keys) == Set([CBCentralManagerOptionRestoreIdentifierKey, CBCentralManagerOptionShowPowerAlertKey]))
+	}
+}


### PR DESCRIPTION
## What changed?

`Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift`: factored the duplicated `CBCentralManager` options dictionary (previously built inline in both `init()` and `createCentralManager()`) into a single `static func centralManagerOptions(restoreIdentifier:)`, and added `CBCentralManagerOptionShowPowerAlertKey: false` to it.

Also adds `MeshtasticTests/BLETransportCentralManagerOptionsTests.swift`.

## Why did it change?

Fixes #2139: a TCP/WiFi-only user with Bluetooth off on the device reported the system "Enable Bluetooth" alert appearing on every app launch and reappearing within ~1s of being dismissed, over and over, blocking interaction with the Connect tab.

Root cause, confirmed by reading the code rather than guessing: `AccessoryManager.startDiscovery()` fans out to *every* registered transport (BLE, TCP, Serial) unconditionally at launch (`MeshtasticApp.swift`) and again on every `scenePhase -> .active` transition (`appDidBecomeActive()`, when there's no active connection yet and `discoveryTask == nil`) — regardless of which transport the user actually connects with. `BLETransport.discoverDevices()` creates/uses a `CBCentralManager` and calls `scanForPeripherals` on it. `CBCentralManagerOptionShowPowerAlertKey` was never set anywhere in the codebase, so it defaulted to `true` — showing the system "Bluetooth is turned off" alert any time the manager is `.poweredOff`.

Presenting that alert blips `scenePhase` (inactive/background then active again), and `appDidBecomeActive()` restarts BLE discovery in that state, which calls `scanForPeripherals` on the still-off manager again — retriggering the alert. That's the dismiss/reappear loop from the report, and it happens even though the user has no intention of using BLE this session.

Suppressing the system alert doesn't change BLE functionality: `handleCentralState`'s `.poweredOff` case still runs (status update, active-connection cleanup) — only the OS-level alert is suppressed. The explicit onboarding "enable Bluetooth" flow (`BluetoothAuthorizationHelper.requestAuthorization()`) constructs its own `CBCentralManager` with default options (no options dict at all), so that user-initiated prompt is untouched.

## How is this tested?

`MeshtasticTests/BLETransportCentralManagerOptionsTests.swift` — 4 cases on the pure options builder:
- power alert is suppressed (`ShowPowerAlertKey == false`)
- restore identifier is preserved (guards against breaking BLE state restoration while fixing the alert)
- pass-through of an arbitrary restore identifier is genuine, not hardcoded
- the dict contains exactly the two expected keys (no silent future additions/omissions)

```
xcodebuild test -scheme Meshtastic -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -only-testing:MeshtasticTests/BLETransportCentralManagerOptionsTests
```
4/4 passed.

Reviewed via the project's `meshtastic-swift-reviewer` agent: approved. Verified via sourcekit-lsp diagnostics (clean) and swiftlint (clean) on both changed files, confirmed the `static func` on the actor has no isolation concerns (pure function, no actor-state access), and confirmed both `CBCentralManager` construction sites (including the deferred-creation path when authorization was `.notDetermined` at init) route through the new helper.

Also filed #2161 as a follow-up: `handleCentralState`'s `.poweredOff` case sets `status = .error(...)` then immediately overwrites it with `.ready` in the same branch, so the transport's in-app status never actually settles on the off-state. That's pre-existing and out of scope for this PR, but worth tracking since this fix removes the system alert that was previously an accidental backstop signal for BLE-primary users. (Fixed separately in #2163.)

## Screenshots/Videos (when applicable)

Not applicable — no UI change. The observable effect is the absence of the repeated system alert, not something a screenshot captures well; the behavior was reproduced by reading the discovery/scenePhase code path (see root-cause explanation above) rather than a device repro.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label. — `docs/developer/transport.md` doesn't describe the power-alert behavior; no update needed. `skip-docs-check` label applied.
- [x] I have tested the change to ensure that it works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary Bluetooth power alerts during connection and state restoration.
  * Preserved Bluetooth state restoration while using more consistent connection settings.

* **Tests**
  * Added coverage to verify Bluetooth configuration values and ensure no unexpected options are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->