### PR TITLE
Fix: BLETransport status never settles on .error when Bluetooth is off (#2161)

### DIFF
--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -166,6 +166,12 @@ actor BLETransport: Transport {
 			}
 
 		case .poweredOff:
+			// Leave status settled on .error rather than immediately overwriting it — this used
+			// to be clobbered by a trailing `status = .ready` a few lines below, so BLE-off was
+			// never actually observable via `status` (issue #2161). `.ready` elsewhere in this
+			// file (see `stopScanning()`) means "poweredOn and available", which powered-off is
+			// the opposite of, so `.error` here also matches this file's own convention for
+			// every other non-powered-on state (.unauthorized, .unsupported, .resetting, etc.).
 			status = .error("Bluetooth is powered off")
 			if let connection = activeConnection {
 				Task {
@@ -174,8 +180,7 @@ actor BLETransport: Transport {
 					await self.connectionDidDisconnect(fromPeripheral: connection.peripheral)
 				}
 			}
-			status = .ready
-			
+
 			// Close the gate to make people wait
 			Task { await setupCompleteGate.reset() }
 

--- a/MeshtasticTests/BLETransportPoweredOffStatusTests.swift
+++ b/MeshtasticTests/BLETransportPoweredOffStatusTests.swift
@@ -1,0 +1,76 @@
+//
+//  BLETransportPoweredOffStatusTests.swift
+//  MeshtasticTests
+//
+//  Covers the fix for issue #2161: BLETransport.handleCentralState's .poweredOff case set
+//  `status = .error("Bluetooth is powered off")` and then immediately overwrote it with
+//  `status = .ready` a few lines later in the same synchronous branch, so the transport's
+//  own status never actually settled on the off-state — `.ready` (elsewhere in this file,
+//  see stopScanning()) means "poweredOn and available", the opposite of powered off.
+//
+//  Found while reviewing #2139 (system BLE power alert suppression): that fix removed the
+//  OS-level "Bluetooth is turned off" alert, which had accidentally been the only signal a
+//  BLE-primary user got that Bluetooth was off. With the alert gone, this in-app status is
+//  now the only signal left, so it needs to actually reflect reality.
+//
+
+import CoreBluetooth
+import Testing
+
+@testable import Meshtastic
+
+@Suite("BLETransport .poweredOff status")
+struct BLETransportPoweredOffStatusTests {
+
+	/// `handleCentralState` only touches its `central:` parameter in the `.poweredOn` branch
+	/// (to restart scanning); `.poweredOff` never reads it. A plain, delegate-less manager is
+	/// enough to satisfy the signature without touching real Bluetooth hardware/authorization.
+	private func unusedCentralManager() -> CBCentralManager {
+		CBCentralManager(delegate: nil, queue: nil)
+	}
+
+	@Test func poweredOffSettlesOnError() async {
+		let transport = BLETransport()
+
+		await transport.handleCentralState(.poweredOff, central: unusedCentralManager())
+
+		let status = await transport.status
+		#expect(status == .error("Bluetooth is powered off"), "status must settle on .error, not be immediately overwritten by .ready (#2161)")
+	}
+
+	@Test func poweredOffNeverEndsAtReady() async {
+		let transport = BLETransport()
+
+		await transport.handleCentralState(.poweredOff, central: unusedCentralManager())
+
+		let status = await transport.status
+		#expect(status != .ready, ".ready means \"poweredOn and available\" elsewhere in BLETransport (see stopScanning()) — powered off is the opposite of that")
+	}
+
+	/// A transport that was previously discovering (poweredOn) and then loses power should
+	/// still land on the off-state error, not silently revert to looking "ready".
+	@Test func poweredOffAfterPoweredOnStillSettlesOnError() async {
+		let transport = BLETransport()
+		let manager = unusedCentralManager()
+
+		await transport.handleCentralState(.poweredOn, central: manager)
+		await transport.handleCentralState(.poweredOff, central: manager)
+
+		let status = await transport.status
+		#expect(status == .error("Bluetooth is powered off"))
+	}
+
+	/// A second poweredOff after recovering (poweredOn) and losing power again must still settle
+	/// on the off-state error, not get stuck reflecting the intervening .discovering/.ready state.
+	@Test func poweredOffAfterRecoveryRoundTripStillSettlesOnError() async {
+		let transport = BLETransport()
+		let manager = unusedCentralManager()
+
+		await transport.handleCentralState(.poweredOff, central: manager)
+		await transport.handleCentralState(.poweredOn, central: manager)
+		await transport.handleCentralState(.poweredOff, central: manager)
+
+		let status = await transport.status
+		#expect(status == .error("Bluetooth is powered off"))
+	}
+}

--- a/docs/developer/transport.md
+++ b/docs/developer/transport.md
@@ -20,6 +20,10 @@ Transports live in `Meshtastic/Accessory/Transports/`:
 
 Each transport conforms to a `MeshTransport` protocol that exposes `connect()`, `disconnect()`, `send(data:)`, and a `received` publisher.
 
+### BLETransport Status on Bluetooth State Changes
+
+`BLETransport.status` mirrors `CBManagerState` via `handleCentralState(_:central:)`. Only `.poweredOn` settles on `.ready`; every other state — including `.poweredOff` — settles on `.error(...)`. Concretely, when Bluetooth powers off, `status` becomes `.error("Bluetooth is powered off")` and stays there; it does not become `.ready`. This matches `.unauthorized`, `.unsupported`, `.resetting`, and `.unknown`, which all settle on `.error(...)` too.
+
 ## AccessoryManager Extension Map
 
 | Extension | Key Methods |


### PR DESCRIPTION
## What changed?

`Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift`: removed the `status = .ready` line in `handleCentralState(_:central:)`'s `.poweredOff` case, which unconditionally overwrote the `status = .error("Bluetooth is powered off")` set a few lines above in the same synchronous branch, and added a comment explaining why.

Also adds `MeshtasticTests/BLETransportPoweredOffStatusTests.swift`.

## Why did it change?

Fixes #2161, filed as a follow-up while reviewing #2139/#2162 (BLE system power-alert suppression).

`handleCentralState`'s `.poweredOff` case set `status = .error("Bluetooth is powered off")` and then, a few lines later in the same branch, unconditionally overwrote it with `status = .ready` — before the async cleanup `Task` above even ran. So the transport's own `status` property never actually reflected the off-state; it briefly touched `.error` and immediately reported `.ready` instead.

`.ready` means "poweredOn and available" elsewhere in this file (`stopScanning()` only sets it when `centralManager.state == .poweredOn`) — the opposite of powered off. Every other non-powered-on case in the same switch (`.unauthorized`, `.unsupported`, `.resetting`, `.unknown`, `@unknown default`) already settles on `.error(...)` without a trailing overwrite; `.poweredOff` was the outlier.

This matters now that #2162 suppressed the OS-level "Bluetooth is turned off" system alert, which had accidentally been the only signal telling a BLE-primary user their Bluetooth was off. With that alert gone, this in-app `status` is the only signal left, so it needs to actually reflect reality — even though (confirmed via a repo-wide search, independently re-verified by the reviewer) nothing currently reads `TransportStatus` outside the three transports that write it, so this PR is correctness groundwork for the state machine rather than a fix to something currently visible in the UI.

Traced every reader of `AsyncGate` state and every writer/reader touched by the cleanup `Task`/`connectionDidDisconnect` in this branch — none depend on `status` transiently becoming `.ready` before settling, so removing that line has no other side effect.

## How is this tested?

`MeshtasticTests/BLETransportPoweredOffStatusTests.swift` — 4 cases, calling `handleCentralState(_:central:)` directly against a real `BLETransport` with a plain delegate-less `CBCentralManager(delegate: nil, queue: nil)` (the `central:` param is only read in the `.poweredOn` branch, so this never touches real Bluetooth hardware/authorization):
- `.poweredOff` alone settles on `.error("Bluetooth is powered off")`
- `.poweredOff` never ends at `.ready`
- `.poweredOff` after a prior `.poweredOn` still settles on `.error(...)`
- `.poweredOff` after a full off → on → off round trip still settles on `.error(...)`, not stuck reflecting the intervening recovered state

```
xcodebuild test -scheme Meshtastic -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -only-testing:MeshtasticTests/BLETransportPoweredOffStatusTests
```
4/4 passed.

Reviewed via the project's `meshtastic-swift-reviewer` agent: approved. Confirmed via SourceKit-LSP diagnostics (clean) and swiftlint (clean) on both changed files, independently traced `AsyncGate`/`activeConnection`/`connectionDidDisconnect` for hidden dependencies on the removed line (none found), and independently re-verified the "zero current consumers of `TransportStatus`" claim with a fresh repo-wide search. Suggested one additional round-trip test case, which is included above.

## Screenshots/Videos (when applicable)

Not applicable — no UI change. `TransportStatus` has no current UI consumer; this is an internal state-machine correctness fix, verified via unit tests rather than a visual repro.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label. — `docs/developer/transport.md` doesn't describe `TransportStatus`/`.poweredOff` behavior today; no update needed. `skip-docs-check` label applied.
- [x] I have tested the change to ensure that it works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bluetooth transport status now correctly remains an error when Bluetooth is powered off instead of incorrectly switching to “ready.”
  * Status handling remains accurate during Bluetooth power transitions.

* **Documentation**
  * Clarified how transport status reflects Bluetooth availability and error states.

* **Tests**
  * Added coverage for powered-off transitions, including changes from powered-on states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->