### PR TITLE
fix(i18n): correct inaccurate pt-BR translations

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -11783,8 +11783,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Uma borda que envolve todas as posições dos nós LoRa no mapeamento."
+            "state" : "translated",
+            "value" : "Um contorno que envolve todas as posições dos nós LoRa no mapeamento."
           }
         },
         "uk" : {
@@ -31500,8 +31500,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Exibir"
+            "state" : "translated",
+            "value" : "Tela"
           }
         },
         "ru" : {
@@ -73398,8 +73398,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Teste de intervalo"
+            "state" : "translated",
+            "value" : "Teste de alcance"
           }
         },
         "ru" : {
@@ -73592,8 +73592,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "A configuração de teste de intervalo não foi recebida pelo rádio. Tente reconectar ao dispositivo."
+            "state" : "translated",
+            "value" : "A configuração de teste de alcance não foi recebida pelo rádio. Tente reconectar ao dispositivo."
           }
         },
         "uk" : {
@@ -73662,8 +73662,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "O teste de faixa requer um canal privado criptografado. O canal principal deste nó está usando uma chave padrão ou vazia."
+            "state" : "translated",
+            "value" : "O teste de alcance requer um canal privado criptografado. O canal principal deste nó está usando uma chave padrão ou vazia."
           }
         },
         "uk" : {
@@ -77642,8 +77642,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Retrievendo nós"
+            "state" : "translated",
+            "value" : "Obtendo nós"
           }
         },
         "ru" : {
@@ -77718,8 +77718,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Retirando nós %lld"
+            "state" : "translated",
+            "value" : "Obtendo nós %lld"
           }
         },
         "ru" : {
@@ -77800,8 +77800,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Recarregar"
+            "state" : "translated",
+            "value" : "Tentar novamente"
           }
         },
         "uk" : {
@@ -78110,8 +78110,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Revise o aplicativo"
+            "state" : "translated",
+            "value" : "Avaliar o aplicativo"
           }
         },
         "ru" : {
@@ -78210,8 +78210,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Som"
+            "state" : "translated",
+            "value" : "Toque"
           }
         },
         "ru" : {
@@ -78316,8 +78316,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Configuração de Som"
+            "state" : "translated",
+            "value" : "Configuração de toque"
           }
         },
         "ru" : {
@@ -78410,8 +78410,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Transferência de Som"
+            "state" : "translated",
+            "value" : "Idioma de transferência de toque"
           }
         },
         "ru" : {
@@ -92466,8 +92466,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Assinado"
+            "state" : "translated",
+            "value" : "Inscrito"
           }
         },
         "ru" : {
@@ -92554,8 +92554,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Sucesso na upload '%1$@' com %2$lld sobreposições"
+            "state" : "translated",
+            "value" : "'%@' enviado com sucesso com %lld sobreposições"
           }
         },
         "ru" : {
@@ -93722,8 +93722,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Toma uma URL de contato Meshtastic e salva-a no banco de dados dos nós"
+            "state" : "translated",
+            "value" : "Recebe uma URL de contato Meshtastic e a salva no banco de dados de nós"
           }
         },
         "ru" : {
@@ -93804,8 +93804,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "To enter an emoji, tap here"
+            "state" : "translated",
+            "value" : "Toque para inserir emoji"
           }
         },
         "ru" : {
@@ -93901,8 +93901,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Toque de volta"
+            "state" : "translated",
+            "value" : "Reagir"
           }
         },
         "ru" : {
@@ -94848,8 +94848,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "O URL para as configurações do canal"
+            "state" : "translated",
+            "value" : "URL para as configurações do canal"
           }
         },
         "ru" : {
@@ -94930,8 +94930,8 @@
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "O URL para o nó de adição"
+            "state" : "translated",
+            "value" : "URL do nó a adicionar"
           }
         },
         "ru" : {


### PR DESCRIPTION
## What changed?
Reviewed and corrected 19 inaccurate or unnatural pt-BR translations in Localizable.xcstrings — fixing mistranslated technical terms (e.g. "teste de intervalo" -> "teste de alcance"), anglicisms (e.g. "Retrievendo" -> "Obtendo"), a string left untranslated in English ("Tap to enter emoji"), and awkward literal translations (e.g. "Tapback": "Toque de volta" -> "Reagir").

## Why did it change?
Several pt-BR strings were either literal/incorrect translations, anglicisms, or in one case left in English by mistake, which hurt the experience for Brazilian Portuguese-speaking users of the app.

## How is this tested?
Manual review comparing each English source string against the existing pt-BR translation.

## Screenshots/Videos (when applicable)
N/A (text-only changes)

## Checklist
- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see copilot-instructions.md#in-app-documentation for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [ ] I have tested the change to ensure that it works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated Brazilian Portuguese translations for multiple UI flows, including node mapping boundary wording, range testing labels and related error/requirements text, node retrieval progress/count messaging, retry and review prompts, interaction/tap guidance, signature/inscription wording, upload success templates, and URL labels for contact and node addition.
  * Marked revised translations as complete to ensure consistent, finalized language across screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->