### PR TITLE
fix(map): precision-bits range, redundant distance filter, close-button consistency

### DIFF
--- a/Meshtastic/Extensions/SwiftData/PositionEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/PositionEntityExtension.swift
@@ -73,9 +73,13 @@ extension PositionEntity {
 
 	/// `precisionBits` range for reduced-precision positions. These are rendered at a fuzzed
 	/// coordinate with a translucent accuracy circle on the map (as opposed to `isPreciseLocation`,
-	/// which renders at the exact coordinate). Centralized here so the map's filter/render/snapshot
-	/// paths can't drift if the range ever changes.
-	static let reducedPrecisionBits: ClosedRange<Int32> = 12...15
+	/// which renders at the exact coordinate). Matches the full range of configurable position
+	/// precision levels in `PositionPrecision` (2...24) — a narrower 12...15 window previously left
+	/// nodes broadcasting any other configured precision level (e.g. a channel set to a coarser or
+	/// finer precision than the default) neither precise nor reduced-precision, so they were dropped
+	/// from the map entirely instead of showing as a fuzzed pin. Centralized here so the map's
+	/// filter/render/snapshot paths can't drift if the range ever changes.
+	static let reducedPrecisionBits: ClosedRange<Int32> = 2...24
 
 	var isReducedPrecision: Bool {
 		Self.reducedPrecisionBits ~= precisionBits

--- a/Meshtastic/Extensions/UserDefaults.swift
+++ b/Meshtastic/Extensions/UserDefaults.swift
@@ -46,7 +46,6 @@ extension UserDefaults {
 		case provideLocation
 		case provideLocationInterval
 		case mapLayer
-		case meshMapDistance
 		case enableMapWaypoints
 		case meshMapRecentering
 		case meshMapShowNodeHistory
@@ -85,6 +84,7 @@ extension UserDefaults {
 		case purgeStaleNodeDays
 		case manualConnections
 		case testIntEnum
+		case testDoubleValue
 		case lastDeviceAPIUpdate
 		case lastFirmwareAPIUpdate
 		case firmwareUpdateNotificationKeys
@@ -112,9 +112,6 @@ extension UserDefaults {
 
 	@UserDefault(.mapLayer, defaultValue: .standard)
 	static var mapLayer: MapLayer
-
-	@UserDefault(.meshMapDistance, defaultValue: 800000)
-	static var meshMapDistance: Double
 
 	@UserDefault(.enableMapWaypoints, defaultValue: true)
 	static var enableMapWaypoints: Bool

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -64,12 +64,8 @@ struct CoverageEstimateForm: View {
 						runner.reset()
 						dismiss()
 					} label: {
-						Image(systemName: "xmark.circle.fill")
-							.font(.title2)
-							.symbolRenderingMode(.palette)
-							.foregroundStyle(.white, Color(.systemGray3))
+						Image(systemName: "xmark")
 					}
-					.buttonStyle(.plain)
 					.accessibilityLabel(String(localized: "Close", comment: "VoiceOver label for the close button"))
 				}
 				ToolbarItem(placement: .confirmationAction) {

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
@@ -31,7 +31,6 @@ struct MapSettingsForm: View {
 	@Binding var traffic: Bool
 	@Binding var pointsOfInterest: Bool
 	@Binding var mapLayer: MapLayer
-	@AppStorage("meshMapDistance") private var meshMapDistance: Double = 800000
 	@Binding var meshMap: Bool
 	@Binding var enabledOverlayConfigs: Set<UUID>
 
@@ -55,21 +54,6 @@ struct MapSettingsForm: View {
 						UserDefaults.mapLayer = newMapLayer
 					}
 					if meshMap {
-					if LocationsHandler.currentPreciseLocation != nil {
-							HStack {
-								Label("Distance", systemImage: "lines.measurement.horizontal")
-								Picker("", selection: $meshMapDistance) {
-									ForEach(MeshMapDistances.allCases) { di in
-										Text(di.description)
-											.tag(di.id)
-									}
-								}
-								.pickerStyle(DefaultPickerStyle())
-							}
-							.onChange(of: meshMapDistance) { _, newMeshMapDistance in
-								UserDefaults.meshMapDistance = newMeshMapDistance
-							}
-						}
 						Toggle(isOn: $enableMapWaypoints) {
 							Label {
 								Text("Waypoints")

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -48,7 +48,6 @@ struct MeshMapMK: View {
 	@State private var enabledOverlayConfigs: Set<UUID> = []
 	// Map Configuration
 	@Namespace var mapScope
-	@AppStorage("meshMapDistance") private var meshMapDistance: Double = 800000
 	// Persisted last-viewed camera region, so the map reopens where the user left it -- independent of
 	// GPS / connected device / node availability at launch. This is what fixes the cold-open default
 	// (0,0) "South Atlantic" view for a location-denied user with no positioned nodes. Stored as four
@@ -1593,7 +1592,11 @@ struct MeshMapMK: View {
 				position.fuzzedNodeCoordinate ?? LocationsHandler.DefaultLocation
 			}
 			let precisionBits = position.precisionBits
-			guard PositionEntity.reducedPrecisionBits ~= precisionBits || precisionBits == 32 else { return nil }
+			// Was `reducedPrecisionBits ~= precisionBits || precisionBits == 32`, which silently
+			// dropped positions with precisionBits == 0 (isPreciseLocation's other "precise" sentinel)
+			// from the map entirely. Use the same two predicates the rest of the file already relies
+			// on so this can't drift from isPreciseLocation / isReducedPrecision again.
+			guard position.isPreciseLocation || position.isReducedPrecision else { return nil }
 			let node = position.nodePosition
 			let nodeNum = node?.num ?? 0
 				return MeshMapPositionSnapshot(

--- a/MeshtasticTests/AppSettingsAndFirmwareTests.swift
+++ b/MeshtasticTests/AppSettingsAndFirmwareTests.swift
@@ -361,7 +361,7 @@ struct UserDefaultPropertyWrapperTests {
 
 	@Test func readDefaultValue() {
 		// Create a UserDefault with a known-unused key pattern
-		let wrapper = UserDefault(.meshMapDistance, defaultValue: 8046.72)
+		let wrapper = UserDefault(.testDoubleValue, defaultValue: 8046.72)
 		// Should return defaultValue or whatever is stored
 		let value = wrapper.wrappedValue
 		#expect(value > 0)

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -740,6 +740,35 @@ struct PositionEntityComputedTests {
 		#expect(pos.isPreciseLocation == false)
 	}
 
+	// `reducedPrecisionBits` previously only covered 12...15, so a node configured with any other
+	// valid PositionPrecision level (2...24) was neither precise nor reduced-precision and got
+	// dropped from the map entirely (see makePositionSnapshots' guard). Range is now 2...24 to
+	// match every value PositionPrecision actually defines.
+	@Test @MainActor func isReducedPrecision_16bits_isReduced() throws {
+		let pos = try makePosition(precisionBits: 16)
+		#expect(pos.isReducedPrecision == true)
+	}
+
+	@Test @MainActor func isReducedPrecision_8bits_isReduced() throws {
+		let pos = try makePosition(precisionBits: 8)
+		#expect(pos.isReducedPrecision == true)
+	}
+
+	@Test @MainActor func isReducedPrecision_13bits_isReduced() throws {
+		let pos = try makePosition(precisionBits: 13)
+		#expect(pos.isReducedPrecision == true)
+	}
+
+	@Test @MainActor func isReducedPrecision_32bits_isNotReduced() throws {
+		let pos = try makePosition(precisionBits: 32)
+		#expect(pos.isReducedPrecision == false)
+	}
+
+	@Test @MainActor func isReducedPrecision_0bits_isNotReduced() throws {
+		let pos = try makePosition(precisionBits: 0)
+		#expect(pos.isReducedPrecision == false)
+	}
+
 	@Test @MainActor func annotation_returnsPointAnnotation() throws {
 		let pos = try makePosition(latI: 374_000_000, lonI: -1_220_000_000)
 		let ann = pos.annotaton


### PR DESCRIPTION
## What changed?

Three small, related Map Options fixes found while testing on-device:

**1. Nodes with certain precision levels were dropped from the map entirely**

`PositionEntity.reducedPrecisionBits` only covered `12...15`, but the app's own `PositionPrecision` setting supports the full `2...24` range. A node broadcasting any precision level outside that narrow window (and not exactly 32 or 0) was neither "precise" nor "reduced-precision" by these checks, so `makePositionSnapshots`'s guard silently dropped it from the map — not shown as a pin at all, regardless of the Precise Locations Only toggle state. This is very likely what made the toggle feel unreliable: nodes at those levels never appeared either way.

Widened the range to `2...24` to match every level `PositionPrecision` actually defines, and pointed the snapshot guard at `isPreciseLocation`/`isReducedPrecision` directly instead of a separately hand-rolled check, so it can't drift from those again.

**2. Removed the redundant Distance control from Map Options**

The Map Options sheet had its own Distance picker bound to a `meshMapDistance` value that turned out to be dead — `MeshMapMK.swift` declared it but never read it anywhere. The actual, working distance filter lives in the Node/Map Filters sheet (`NodeListFilter.swift`, `filters.maxDistance`). Removed the dead control and its now-fully-unused storage plumbing (`UserDefaults.meshMapDistance`, the `.meshMapDistance` key).

**3. Coverage Estimate sheet's close button now matches the app-wide pattern**

Was using an older `xmark.circle.fill` palette-rendered icon; switched to the plain `xmark` style used everywhere else sheets have a title-bar close button.

## How is this tested?

- Added regression tests for `isReducedPrecision` across the widened range (`MeshtasticTests/EntityTests.swift`) — including the specific 8/13/16-bit cases that were previously misclassified.
- Full build succeeded; ran the affected test suites (`PositionEntityComputedTests`, `UserDefaultPropertyWrapperTests`) — all pass.
- Installed to a physical device for manual verification of the Map Options sheet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for reduced-precision location data across the full supported range.
  * Map rendering now includes both precise and reduced-precision positions more consistently.

* **Bug Fixes**
  * Removed the map distance setting and its Distance control from map options.
  * Simplified the coverage form’s close button appearance.
  * Improved handling of precision values during map display.

* **Tests**
  * Added coverage for multiple reduced-precision location values and boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->