### PR TITLE
fix(widgets): exclude Live Activity from Mac Catalyst build

### DIFF
--- a/Widgets/WidgetsBundle.swift
+++ b/Widgets/WidgetsBundle.swift
@@ -12,8 +12,10 @@ import SwiftUI
 struct WidgetsBundle: WidgetBundle {
     var body: some Widget {
         // Widgets()
+		#if !targetEnvironment(macCatalyst)
 		#if canImport(ActivityKit)
 		WidgetsLiveActivity()
+		#endif
 		#endif
 
     }

--- a/Widgets/WidgetsBundle.swift
+++ b/Widgets/WidgetsBundle.swift
@@ -10,13 +10,12 @@ import SwiftUI
 
 @main
 struct WidgetsBundle: WidgetBundle {
-    var body: some Widget {
-        // Widgets()
+	var body: some Widget {
+		// Widgets()
 		#if !targetEnvironment(macCatalyst)
 		#if canImport(ActivityKit)
 		WidgetsLiveActivity()
 		#endif
 		#endif
-
-    }
+	}
 }

--- a/Widgets/WidgetsLiveActivity.swift
+++ b/Widgets/WidgetsLiveActivity.swift
@@ -5,6 +5,7 @@
 //  Created by Garth Vander Houwen on 2/28/23.
 //
 #if os(iOS)
+#if !targetEnvironment(macCatalyst)
 #if canImport(ActivityKit)
 import ActivityKit
 import WidgetKit
@@ -370,5 +371,6 @@ struct ExpandedTrailingView: View {
 		.tint(Color("LightIndigo"))
 	}
 }
+#endif
 #endif
 #endif


### PR DESCRIPTION
## Summary

The Mac Catalyst build was failing to compile, blocking archive/App Store Connect upload:

- `cannot find 'MeshActivityAttributes' in scope`
- `result builder 'DynamicIslandExpandedContentBuilder' does not implement...`
- `'activityBackgroundTint' is unavailable in Mac Catalyst`
- `'activitySystemActionForegroundColor' is unavailable in Mac Catalyst`

`os(iOS)` evaluates to `true` under Mac Catalyst, so `Widgets/WidgetsLiveActivity.swift` and `Widgets/WidgetsBundle.swift` were being compiled for Catalyst too, even though Live Activities aren't supported there. `Shared/MeshActivityAttributes.swift` already correctly excludes itself from Catalyst with `#if os(iOS)` + `#if !targetEnvironment(macCatalyst)` + `#if canImport(ActivityKit)` — the two Widgets-target files were just missing the middle guard, so they referenced a type that no longer existed for that platform.

## Fix

Add the same `#if !targetEnvironment(macCatalyst)` guard already used consistently elsewhere in the app wherever ActivityKit/`MeshActivityAttributes` is touched (`Connect.swift`, `MeshPackets.swift`, `CarPlaySceneDelegate.swift`).

## Test plan

- [x] `xcodebuild ... -destination 'platform=macOS,variant=Mac Catalyst' -configuration Release build` — compiles clean (previously failed with the errors above)
- [x] `xcodebuild ... -destination 'generic/platform=iOS Simulator' -configuration Debug build` — still succeeds, unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Mac Catalyst builds by excluding unsupported live activity and widget features.
  * Prevented widget-related compilation issues when ActivityKit is available but the app targets Mac Catalyst.
* **Other Changes**
  * Live activity/widget support now activates only when ActivityKit is available and the build is not for Mac Catalyst.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->