### PR TITLE
fix(swiftdata): guard stale node hardware users

### DIFF
--- a/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift
@@ -10,6 +10,17 @@ import Foundation
 
 extension NodeInfoEntity {
 
+	/// Returns this node's user only while both sides of the relationship are still backed by
+	/// SwiftData. A node detail view can outlive `clearDatabase`, which removes users before it
+	/// removes nodes; reading a persisted property from that deleted user traps in SwiftData.
+	var liveUser: UserEntity? {
+		guard modelContext != nil, !isDeleted,
+			let user,
+			user.modelContext != nil, !user.isDeleted
+		else { return nil }
+		return user
+	}
+
 	// MARK: - Targeted Fetch Helpers
 	// These use FetchDescriptor with fetchLimit to avoid loading entire relationship arrays.
 

--- a/Meshtastic/Views/Nodes/Helpers/NodeInfoItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeInfoItem.swift
@@ -15,10 +15,12 @@ struct NodeInfoItem: View {
 	@Bindable var node: NodeInfoEntity
 	@Query var hardware: [DeviceHardwareEntity]
 	@EnvironmentObject var meshtasticAPI: MeshtasticAPI
+	private let hardwareModel: Int64
 
 	init(node: NodeInfoEntity) {
 		self.node = node
-		let hwModel = Int64(node.user?.hwModelId ?? 0)
+		let hwModel = Int64(node.liveUser?.hwModelId ?? 0)
+		hardwareModel = hwModel
 		_hardware = Query(filter: #Predicate<DeviceHardwareEntity> { hw in
 			hw.hwModel == hwModel
 		}, sort: [SortDescriptor(\.hwModelSlug)])
@@ -33,7 +35,7 @@ struct NodeInfoItem: View {
 	}
 
 	private var hardwarePresentation: HardwareCatalogPresentation? {
-		HardwareCatalogResolver.presentation(for: Int64(node.user?.hwModelId ?? 0), in: hardware)
+		HardwareCatalogResolver.presentation(for: hardwareModel, in: hardware)
 	}
 
 	private var supportRosette: some View {
@@ -41,12 +43,12 @@ struct NodeInfoItem: View {
 			.foregroundStyle(isActivelySupported ? .green : .secondary)
 	}
 
-	private var modelName: String {
-		hardwarePresentation?.displayName ?? node.user?.hwModel ?? "Unknown"
+	private func modelName(for user: UserEntity) -> String {
+		hardwarePresentation?.displayName ?? user.hwModel ?? "Unknown"
 	}
 
-	private var isPortduino: Bool {
-		node.user?.hwModel == "PORTDUINO"
+	private func isPortduino(_ user: UserEntity) -> Bool {
+		user.hwModel == "PORTDUINO"
 	}
 
 	private var supportLevel: SupportLevel? {
@@ -62,9 +64,9 @@ struct NodeInfoItem: View {
 			: "Hardware model information is unavailable."
 	}
 
-	private var sectionTitle: String {
-		if node.user?.hwModel == "UNSET" { return "Hardware" }
-		if isPortduino { return "Community Hardware" }
+	private func sectionTitle(for user: UserEntity) -> String {
+		if user.hwModel == "UNSET" { return "Hardware" }
+		if isPortduino(user) { return "Community Hardware" }
 		guard let supportLevel else { return "Hardware" }
 		switch supportLevel {
 		case .flagship:
@@ -79,108 +81,108 @@ struct NodeInfoItem: View {
 	}
 
 	var body: some View {
-		Section(sectionTitle) {
-		if let user = node.user {
-			if user.hwModel == "UNSET" {
-				// MARK: - Unset / Incomplete
-				HStack {
-					Image(systemName: "flipphone")
-						.symbolRenderingMode(.hierarchical)
-						.font(.title2)
-						.foregroundStyle(.secondary)
-					Text("Incomplete")
-						.foregroundStyle(.secondary)
-				}
-			} else if meshtasticAPI.isLoadingDeviceList && !hasDevice {
-				// MARK: - Loading
-				HStack {
-					ProgressView()
-					Text("Loading hardware info…")
-						.font(.subheadline)
-						.foregroundStyle(.secondary)
-				}
-				.listRowSeparator(.hidden)
-			} else if hasDevice && supportLevel == .flagship {
-				// MARK: - Flagship Device (Hero Layout)
-				VStack(spacing: 12) {
-					ZStack(alignment: .bottomTrailing) {
+		if let user = node.liveUser {
+			Section(sectionTitle(for: user)) {
+				if user.hwModel == "UNSET" {
+					// MARK: - Unset / Incomplete
+					HStack {
+						Image(systemName: "flipphone")
+							.symbolRenderingMode(.hierarchical)
+							.font(.title2)
+							.foregroundStyle(.secondary)
+						Text("Incomplete")
+							.foregroundStyle(.secondary)
+					}
+				} else if meshtasticAPI.isLoadingDeviceList && !hasDevice {
+					// MARK: - Loading
+					HStack {
+						ProgressView()
+						Text("Loading hardware info…")
+							.font(.subheadline)
+							.foregroundStyle(.secondary)
+					}
+					.listRowSeparator(.hidden)
+				} else if hasDevice && supportLevel == .flagship {
+					// MARK: - Flagship Device (Hero Layout)
+					VStack(spacing: 12) {
+						ZStack(alignment: .bottomTrailing) {
+							DeviceHardwareImage(hwId: user.hwModelId)
+								.frame(maxWidth: .infinity)
+								.frame(height: 200)
+								.cornerRadius(12)
+							supportRosette
+								.font(.title2)
+								.padding(8)
+						}
+						Text(modelName(for: user))
+							.font(.headline)
+							.frame(maxWidth: .infinity, alignment: .center)
+					}
+					.listRowSeparator(.hidden)
+				} else if hasDevice && (supportLevel == .niche || supportLevel == .legacy) {
+					// MARK: - Niche / Legacy Device
+					HStack(spacing: 16) {
 						DeviceHardwareImage(hwId: user.hwModelId)
-							.frame(maxWidth: .infinity)
-							.frame(height: 200)
-							.cornerRadius(12)
+							.frame(width: 60, height: 60)
+							.cornerRadius(8)
+							.opacity(0.6)
+						Text(modelName(for: user))
+							.font(.subheadline)
+							.foregroundStyle(.secondary)
+						Spacer()
 						supportRosette
 							.font(.title2)
-							.padding(8)
 					}
-					Text(modelName)
-						.font(.headline)
-						.frame(maxWidth: .infinity, alignment: .center)
-				}
-				.listRowSeparator(.hidden)
-			} else if hasDevice && (supportLevel == .niche || supportLevel == .legacy) {
-				// MARK: - Niche / Legacy Device
-				HStack(spacing: 16) {
-					DeviceHardwareImage(hwId: user.hwModelId)
-						.frame(width: 60, height: 60)
-						.cornerRadius(8)
-						.opacity(0.6)
-					Text(modelName)
-						.font(.subheadline)
-						.foregroundStyle(.secondary)
-					Spacer()
-					supportRosette
-						.font(.title2)
-				}
-				.listRowSeparator(.hidden)
-			} else if isPortduino {
-				// MARK: - Portduino / Linux (community-supported, no firmware)
-				HStack(spacing: 16) {
-					DeviceHardwareImage(platformioTarget: "native")
-						.frame(width: 60, height: 60)
-						.cornerRadius(8)
-					VStack(alignment: .leading, spacing: 4) {
-						Text(modelName)
-							.font(.subheadline)
-							.foregroundStyle(.secondary)
-						Text("Community supported Linux device.")
-							.font(.caption)
-							.foregroundStyle(.tertiary)
-					}
-					Spacer()
-					supportRosette
-						.font(.title2)
-				}
-				.listRowSeparator(.hidden)
-			} else {
-				// MARK: - Discontinued / Unknown Device
-				HStack(spacing: 16) {
-					if hardwarePresentation?.activelySupported == nil {
-						Image(systemName: "questionmark.circle.fill")
-							.font(.system(size: 40))
-							.foregroundStyle(.secondary)
-					} else {
+					.listRowSeparator(.hidden)
+				} else if isPortduino(user) {
+					// MARK: - Portduino / Linux (community-supported, no firmware)
+					HStack(spacing: 16) {
+						DeviceHardwareImage(platformioTarget: "native")
+							.frame(width: 60, height: 60)
+							.cornerRadius(8)
+						VStack(alignment: .leading, spacing: 4) {
+							Text(modelName(for: user))
+								.font(.subheadline)
+								.foregroundStyle(.secondary)
+							Text("Community supported Linux device.")
+								.font(.caption)
+								.foregroundStyle(.tertiary)
+						}
+						Spacer()
 						supportRosette
-							.font(.system(size: 40))
+							.font(.title2)
 					}
-					VStack(alignment: .leading, spacing: 4) {
-						Text(modelName)
-							.font(.subheadline)
-							.foregroundStyle(.secondary)
-						Text(hardwareDescription)
-							.font(.caption)
-							.foregroundStyle(.tertiary)
+					.listRowSeparator(.hidden)
+				} else {
+					// MARK: - Discontinued / Unknown Device
+					HStack(spacing: 16) {
+						if hardwarePresentation?.activelySupported == nil {
+							Image(systemName: "questionmark.circle.fill")
+								.font(.system(size: 40))
+								.foregroundStyle(.secondary)
+						} else {
+							supportRosette
+								.font(.system(size: 40))
+						}
+						VStack(alignment: .leading, spacing: 4) {
+							Text(modelName(for: user))
+								.font(.subheadline)
+								.foregroundStyle(.secondary)
+							Text(hardwareDescription)
+								.font(.caption)
+								.foregroundStyle(.tertiary)
+						}
+						Spacer()
 					}
-					Spacer()
+					.listRowSeparator(.hidden)
 				}
-				.listRowSeparator(.hidden)
 			}
-		}
-		}
-		.accessibilityElement(children: .combine)
+			.accessibilityElement(children: .combine)
 
-		// Device links section (shown only when device has a platformioTarget)
-		if let target = hardwarePresentation?.platformioTarget {
-			DeviceLinksSection(platformioTarget: target)
+			// Device links section (shown only when device has a platformioTarget)
+			if let target = hardwarePresentation?.platformioTarget {
+				DeviceLinksSection(platformioTarget: target)
+			}
 		}
 	}
 }

--- a/MeshtasticTests/NodeInfoEntityLivenessTests.swift
+++ b/MeshtasticTests/NodeInfoEntityLivenessTests.swift
@@ -1,0 +1,37 @@
+//
+//  NodeInfoEntityLivenessTests.swift
+//  MeshtasticTests
+//
+
+import SwiftData
+import Testing
+@testable import Meshtastic
+
+@Suite("Node info liveness")
+@MainActor
+struct NodeInfoEntityLivenessTests {
+
+	@Test("A node does not expose a deleted user relationship")
+	func deletedUserIsNotLive() throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = container.mainContext
+
+		let node = NodeInfoEntity()
+		node.num = 1
+		let user = UserEntity()
+		user.num = 1
+		user.hwModel = "HELTEC_V3"
+		node.user = user
+		context.insert(node)
+		try context.save()
+
+		context.delete(user)
+		try context.save()
+
+		#expect(node.liveUser == nil)
+		#expect(NodeInfoItem(node: node).hardware.isEmpty)
+	}
+}


### PR DESCRIPTION
## Summary
- Prevent the node-details hardware card from reading a deleted SwiftData `UserEntity`.
- Add a `NodeInfoEntity.liveUser` liveness guard and use it for the card's query setup and rendering.
- Add a regression test that deletes the user while retaining its node, then initializes `NodeInfoItem` safely.

## Why
TestFlight build 2.7.17 (2165) crashed in `UserEntity.hwModel` from `NodeInfoItem.sectionTitle`. During a database clear, a detail view can retain the node after its related user has been deleted; accessing that user's persisted properties causes SwiftData to trap.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -quiet -project Meshtastic.xcodeproj -scheme Meshtastic -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /private/tmp/meshtastic-nodeinfoitem-liveness-final -resultBundlePath /private/tmp/meshtastic-nodeinfoitem-liveness-final-2-20260723.xcresult -only-testing:MeshtasticTests/NodeInfoEntityLivenessTests` — passed (1/1)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint Meshtastic/Extensions/SwiftData/NodeInfoEntityExtension.swift Meshtastic/Views/Nodes/Helpers/NodeInfoItem.swift MeshtasticTests/NodeInfoEntityLivenessTests.swift` — 0 violations

No screenshot: this is a crash-only lifecycle guard with no intended visual change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node details handling when related device records are deleted or cleared.
  * Prevented stale hardware information from appearing after a device is removed.
  * Avoided potential crashes when viewing node details during database cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->