### PR TITLE
Default in-app Site Planner coverage palette to Mesh

### DIFF
--- a/Meshtastic/Helpers/SitePlanner/SitePlannerParameters.swift
+++ b/Meshtastic/Helpers/SitePlanner/SitePlannerParameters.swift
@@ -17,6 +17,7 @@ import CoreLocation
 /// The coverage-map colour palette (`color_scale` query key). Raw values are the
 /// exact planner tokens; an unknown token falls back to `plasma` planner-side.
 enum SitePlannerColorScale: String, CaseIterable, Identifiable, Hashable {
+	case mesh
 	case plasma
 	case viridis
 	case cmrmap = "CMRmap"
@@ -29,6 +30,7 @@ enum SitePlannerColorScale: String, CaseIterable, Identifiable, Hashable {
 	/// Human-facing palette name for the picker.
 	var displayName: String {
 		switch self {
+		case .mesh: return "Mesh"
 		case .plasma: return "Plasma"
 		case .viridis: return "Viridis"
 		case .cmrmap: return "CMRmap"
@@ -68,7 +70,7 @@ struct SitePlannerParameters: Equatable {
 	var highResolution: Bool = false
 
 	// MARK: Display
-	var colorScale: SitePlannerColorScale = .turbo
+	var colorScale: SitePlannerColorScale = .mesh
 
 	// MARK: - Validation bounds (mirror the planner's `store.ts` / input ranges)
 	static let frequencyRange: ClosedRange<Double> = 20...20_000


### PR DESCRIPTION
## What

Makes **Mesh** the default color palette for in-app coverage estimates that open the hosted Meshtastic Site Planner.

- Adds a `mesh` case to `SitePlannerColorScale` (planner `color_scale` token `mesh`), placed first so it leads the palette picker.
- Changes the `SitePlannerParameters.colorScale` default from `turbo` to `mesh`.

The coverage estimate sheet's picker already renders `SitePlannerColorScale.allCases`/`displayName`, so the new option appears automatically. Permalinks and any persisted params still override the default, as before.

## Why

The `mesh` palette (the Meshtastic SNR red→green scale) was added to the Site Planner upstream in meshtastic/meshtastic-site-planner#75. This makes a coverage estimate launched from the app use it by default for a consistent look.

## Testing

- Verified the palette picker builds its options from `allCases` + `displayName` and that no exhaustive switch over the enum exists elsewhere (only the enum's own `displayName`), so adding a case is safe.
- Full app build not run for this palette-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Mesh” color scale option to Site Planner.

* **Updates**
  * Site Planner now uses the “Mesh” color scale by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->