### PR TITLE
Fix Xcode Cloud iOS archive: revert NFC entitlement format to TAG

### DIFF
--- a/Meshtastic/Meshtastic-Catalyst.entitlements
+++ b/Meshtastic/Meshtastic-Catalyst.entitlements
@@ -15,7 +15,7 @@
 	<true/>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
-		<string>NDEF</string>
+		<string>TAG</string>
 	</array>
 	<key>com.apple.developer.usernotifications.critical-alerts</key>
 	<true/>

--- a/Meshtastic/Meshtastic.entitlements
+++ b/Meshtastic/Meshtastic.entitlements
@@ -17,7 +17,7 @@
 	<true/>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
-		<string>NDEF</string>
+		<string>TAG</string>
 	</array>
 	<key>com.apple.developer.usernotifications.critical-alerts</key>
 	<true/>


### PR DESCRIPTION
## What

The Xcode Cloud iOS archive has failed at **Prepare Build for App Store Connect** (1 error) on every merge since #2136. This reverts the one packaging-relevant change in that PR: `com.apple.developer.nfc.readersession.formats` goes back to `TAG` in both entitlements files.

## Why

- #2136 flipped the entitlement value `TAG` → `NDEF`. **NDEF is a deprecated value** for this entitlement; freshly generated distribution profiles may not grant it, so export/prepare requests an entitlement the profile doesn't carry.
- `TAG` + `NFCNDEFReaderSession` is the proven pairing: the app has shipped exactly that combination since 2.7.10 (#1648) with green archives and App Store submissions throughout — #2136 kept the same `NFCNDEFReaderSession` code paths and only changed the entitlement string.
- Timeline correlation: iOS archive was green on the two merges before #2136 and `action_required` on every merge at/after it, while the code itself builds clean locally (Debug/sim and Release/generic-device).

## Testing

- Release build for `generic/platform=iOS` on main HEAD succeeds locally — confirms the failure is packaging, not code.
- Local team provisioning profile grants `NDEF TAG PACE`, but cloud-managed **distribution** profiles are regenerated on demand and NDEF is deprecated — the archive prepare step is where the mismatch surfaces. Final confirmation will be the Xcode Cloud run on this merge.

No code changes — two one-line entitlement reverts.