### PR TITLE
Use design-library amber for the message search highlight

### DIFF
--- a/Meshtastic/Assets.xcassets/Colors/MeshtasticHighlight.colorset/Contents.json
+++ b/Meshtastic/Assets.xcassets/Colors/MeshtasticHighlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.910",
+          "green" : "0.639",
+          "blue" : "0.243",
+          "alpha" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.910",
+          "green" : "0.639",
+          "blue" : "0.243",
+          "alpha" : "0.320"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Meshtastic/Extensions/Color+Brand.swift
+++ b/Meshtastic/Extensions/Color+Brand.swift
@@ -46,4 +46,10 @@ extension Color {
 	/// Branded blue — shadows SwiftUI `Color.blue`
 	/// Info #5C6BC0 both modes
 	static let blue = Color("Colors/MeshtasticInfo")
+
+	/// Message search/jump highlight wash — warning amber #E8A33E with baked
+	/// per-mode alpha (0.20 light / 0.32 dark) so it composites to a warm cream
+	/// on light lists and a readable gold on dark, instead of the muddy olive
+	/// that translucent system yellow produced over black.
+	static let messageHighlight = Color("Colors/MeshtasticHighlight")
 }

--- a/Meshtastic/Views/Messages/ChannelMessageRow.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageRow.swift
@@ -205,7 +205,7 @@ struct ChannelMessageRow: View {
 		.id(message.messageId) // ID for scrolling/highlighting
 		.background(
 			RoundedRectangle(cornerRadius: 8)
-				.fill(Color.yellow.opacity(messageToHighlight == message.messageId ? 0.18 : 0))
+				.fill(Color.messageHighlight.opacity(messageToHighlight == message.messageId ? 1 : 0))
 				.padding(.horizontal, 4)
 		)
 		.animation(.easeInOut(duration: 0.3), value: messageToHighlight)

--- a/Meshtastic/Views/Messages/UserMessageRow.swift
+++ b/Meshtastic/Views/Messages/UserMessageRow.swift
@@ -205,7 +205,7 @@ struct UserMessageRow: View {
 		.id(message.messageId)
 		.background(
 			RoundedRectangle(cornerRadius: 8)
-				.fill(Color.yellow.opacity(messageToHighlight == message.messageId ? 0.18 : 0))
+				.fill(Color.messageHighlight.opacity(messageToHighlight == message.messageId ? 1 : 0))
 				.padding(.horizontal, 4)
 		)
 		.animation(.easeInOut(duration: 0.3), value: messageToHighlight)


### PR DESCRIPTION
## What

Replaces the hardcoded `Color.yellow.opacity(0.18)` search-match / jump-to-message flash in `UserMessageRow` and `ChannelMessageRow` with a brand token colorset.

## Colors (from meshtastic/design `tokens/tokens.json`)

Built from the **semantic warning amber `#E8A33E`** — the palette's highlight-family hue, already mapped to `Color.orange` in `Color+Brand.swift`:

| Mode | Value | Composites to |
|---|---|---|
| Light | `#E8A33E` @ 20% | warm cream, in the family of the `warning-light #FFF3E0` token |
| Dark | `#E8A33E` @ 32% | readable warm gold — replaces the muddy olive translucent system yellow produced over dark lists |

- New `Colors/MeshtasticHighlight.colorset` with per-mode alpha baked in
- `Color.messageHighlight` accessor in `Color+Brand.swift`, doc-commented like its siblings
- Both row call sites switch to the token; the fade animation is unchanged

## Testing

- iOS Simulator build succeeds; Debug device build installed and verified on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated message highlights with a branded amber color.
  * Improved highlight appearance across light and dark modes.
  * Applied highlights consistently to channel and direct messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->