### PR TITLE
Fix crashes on malformed or truncated PMTiles archives

### DIFF
--- a/Meshtastic/Helpers/Map/PMTilesArchive.swift
+++ b/Meshtastic/Helpers/Map/PMTilesArchive.swift
@@ -101,6 +101,7 @@ final class PMTilesArchive {
 
 	static func parseHeader(_ data: Data) -> PMTilesHeader? {
 		// Magic "PMTiles" + version 3.
+		guard data.count >= 127 else { return nil }
 		let magic = data.subdata(in: 0..<7)
 		guard magic == Data("PMTiles".utf8), data[7] == 3 else { return nil }
 
@@ -154,10 +155,13 @@ final class PMTilesArchive {
 
 			if entry.runLength == 0 {
 				// Leaf directory pointer — descend.
-				dirOffset = header.leafDirOffset + entry.offset
+				let (leafOffset, overflow) = header.leafDirOffset.addingReportingOverflow(entry.offset)
+				guard !overflow else { return nil }
+				dirOffset = leafOffset
 				dirLength = UInt64(entry.length)
 			} else {
-				guard let raw = slice(offset: header.tileDataOffset + entry.offset, length: entry.length) else { return nil }
+				let (tileOffset, overflow) = header.tileDataOffset.addingReportingOverflow(entry.offset)
+				guard !overflow, let raw = slice(offset: tileOffset, length: entry.length) else { return nil }
 				return decompress(raw, using: header.tileCompression)
 			}
 		}
@@ -193,9 +197,9 @@ final class PMTilesArchive {
 	// MARK: - Byte access
 
 	private func slice(offset: UInt64, length: UInt32) -> Data? {
-		let start = Int(offset)
-		let end = start + Int(length)
-		guard start >= 0, end <= data.count, length > 0 else { return nil }
+		guard let start = Int(exactly: offset), let byteCount = Int(exactly: length), length > 0 else { return nil }
+		let (end, overflow) = start.addingReportingOverflow(byteCount)
+		guard !overflow, start >= 0, end <= data.count else { return nil }
 		return data.subdata(in: start..<end)
 	}
 
@@ -203,31 +207,47 @@ final class PMTilesArchive {
 
 	static func deserializeDirectory(_ data: Data) -> [Entry] {
 		var pos = 0
-		func varint() -> UInt64 {
+		func varint() -> UInt64? {
 			var result: UInt64 = 0
 			var shift: UInt64 = 0
 			while pos < data.count {
 				let byte = data[data.startIndex + pos]; pos += 1
-				result |= UInt64(byte & 0x7F) << shift
-				if byte & 0x80 == 0 { break }
+				let value = UInt64(byte & 0x7F)
+				guard shift < 64, shift <= 56 || value <= 1 else { return nil }
+				result |= value << shift
+				if byte & 0x80 == 0 { return result }
 				shift += 7
 			}
-			return result
+			return nil
 		}
 
-		let count = Int(varint())
-		guard count > 0, count < 10_000_000 else { return [] }
+		guard let rawCount = varint(), let count = Int(exactly: rawCount), count > 0, count < 10_000_000 else { return [] }
 		var entries = [Entry](repeating: Entry(tileID: 0, offset: 0, length: 0, runLength: 0), count: count)
 
 		var lastID: UInt64 = 0
-		for index in 0..<count { lastID += varint(); entries[index].tileID = lastID }
-		for index in 0..<count { entries[index].runLength = UInt32(truncatingIfNeeded: varint()) }
-		for index in 0..<count { entries[index].length = UInt32(truncatingIfNeeded: varint()) }
 		for index in 0..<count {
-			let value = varint()
+			guard let delta = varint() else { return [] }
+			let (tileID, overflow) = lastID.addingReportingOverflow(delta)
+			guard !overflow else { return [] }
+			lastID = tileID
+			entries[index].tileID = tileID
+		}
+		for index in 0..<count {
+			guard let runLength = varint(), let value = UInt32(exactly: runLength) else { return [] }
+			entries[index].runLength = value
+		}
+		for index in 0..<count {
+			guard let length = varint(), let value = UInt32(exactly: length) else { return [] }
+			entries[index].length = value
+		}
+		for index in 0..<count {
+			guard let value = varint() else { return [] }
 			if value == 0 && index > 0 {
-				entries[index].offset = entries[index - 1].offset + UInt64(entries[index - 1].length)
+				let (offset, overflow) = entries[index - 1].offset.addingReportingOverflow(UInt64(entries[index - 1].length))
+				guard !overflow else { return [] }
+				entries[index].offset = offset
 			} else {
+				guard value > 0 else { return [] }
 				entries[index].offset = value - 1
 			}
 		}

--- a/MeshtasticTests/PMTilesExtractorTests.swift
+++ b/MeshtasticTests/PMTilesExtractorTests.swift
@@ -46,6 +46,12 @@ struct PMTilesExtractorTileMathTests {
 @Suite("PMTiles directory round-trip")
 struct PMTilesDirectoryRoundTripTests {
 
+	@Test func deserializeDirectory_rejectsZeroFirstOffset() {
+		// count=1, then tileID/runLength/length/offset values of 0. The first
+		// offset is invalid in PMTiles (zero is only a continuation marker).
+		#expect(PMTilesArchive.deserializeDirectory(Data([1, 0, 0, 0, 0])).isEmpty)
+	}
+
 	@Test func serializeDeserialize_preservesEntries() {
 		let entries: [PMTilesArchive.Entry] = [
 			.init(tileID: 5, offset: 0, length: 100, runLength: 1),
@@ -68,6 +74,12 @@ struct PMTilesDirectoryRoundTripTests {
 
 @Suite("PMTiles header round-trip")
 struct PMTilesHeaderRoundTripTests {
+
+	@Test func parseHeader_rejectsTruncatedVersionedHeader() {
+		var truncated = Data("PMTiles".utf8)
+		truncated.append(3)
+		#expect(PMTilesArchive.parseHeader(truncated) == nil)
+	}
 
 	@Test func buildParse_preservesFields() throws {
 		let bounds = GeoBounds(minLon: -122.5, minLat: 47.3, maxLon: -121.9, maxLat: 47.8)
@@ -95,6 +107,43 @@ struct PMTilesHeaderRoundTripTests {
 
 @Suite("PMTiles full file round-trip")
 struct PMTilesFullFileRoundTripTests {
+
+	@Test func archiveWithOutOfRangeDirectoryOffsetDoesNotReadTile() throws {
+		let header = PMTilesExtractor.buildHeader(
+			rootDirOffset: .max, rootDirLength: 1,
+			metadataOffset: 127, metadataLength: 0,
+			tileDataOffset: 127, tileDataLength: 0,
+			numTiles: 0,
+			bounds: GeoBounds(minLon: -1, minLat: -1, maxLon: 1, maxLat: 1),
+			minZoom: 0, maxZoom: 0, tileType: .png, tileCompression: .none
+		)
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).pmtiles")
+		try header.write(to: url)
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		let archive = try #require(PMTilesArchive(url: url))
+		#expect(archive.tileData(z: 0, x: 0, y: 0) == nil)
+	}
+
+	@Test func archiveWithOverflowingTileDataOffsetDoesNotReadTile() throws {
+		let directory = PMTilesExtractor.serializeDirectory([
+			.init(tileID: 0, offset: 1, length: 1, runLength: 1)
+		])
+		let header = PMTilesExtractor.buildHeader(
+			rootDirOffset: 127, rootDirLength: UInt64(directory.count),
+			metadataOffset: 127 + UInt64(directory.count), metadataLength: 0,
+			tileDataOffset: .max, tileDataLength: 0,
+			numTiles: 1,
+			bounds: GeoBounds(minLon: -1, minLat: -1, maxLon: 1, maxLat: 1),
+			minZoom: 0, maxZoom: 0, tileType: .png, tileCompression: .none
+		)
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).pmtiles")
+		try (header + directory).write(to: url)
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		let archive = try #require(PMTilesArchive(url: url))
+		#expect(archive.tileData(z: 0, x: 0, y: 0) == nil)
+	}
 
 	@Test func writtenArchive_readsBackTiles() throws {
 		// Build a small archive the way PMTilesExtractor.extract does, with uncompressed


### PR DESCRIPTION
## Summary
- Reject truncated or malformed PMTiles headers and directories before indexed reads.
- Make PMTiles offset arithmetic and file slicing overflow-safe.
- Add regression tests for truncated headers, invalid directories, out-of-range directories, and overflowing tile offsets.

## Why

This is a crash-robustness fix, not a security fix. The archive fetch is hardcoded HTTPS to `build.protomaps.com` with default ATS (no exceptions), so attacker-chosen bytes would require compromising Protomaps or its CDN first — that is not the concern here. And Swift integer/bounds traps are memory-safe, so the worst outcome was always a crash, never code execution.

The concern is that malformed bytes reach this parser through entirely benign paths, and the old code trapped (crashed the app) deterministically instead of returning "no tile":

- `fetchRange` validates only the HTTP status, not body length — a short 200/206 body (a range clamped at EOF, an empty error body from a misbehaving edge) reached `parseHeader` with fewer than 7 bytes, which trapped on the first `subdata` read.
- The leaf-directory path falls back to `gunzip(raw) ?? raw` — any failed decompression (e.g. a body truncated on a flaky connection) feeds raw gzip bytes into the varint parser, where values above `Int.max` trapped on integer conversion.
- An extraction interrupted mid-write leaves a corrupt archive on disk that the map reopens on every launch — a deterministic crash loop until the file is manually deleted.
- `Documents/OfflineMaps` is user-writable via the Files app (`UIFileSharingEnabled` is on), and community-shared `.pmtiles` files become ordinary inputs once offline packs circulate — corrupt or hand-assembled archives will happen.

## Verification

- The new regression tests crash **unpatched `main`** outright — verified by grafting only the test file onto main and running it: repeated test-runner crashes, including `Fatal error: Not enough bits to represent the passed value`. Each guarded path was a real, reachable trap: a 5-byte directory (`0 - 1` UInt64 underflow), an 8-byte header (out-of-range `subdata`), a `UInt64.max` offset (`Int` conversion), and overflowing offset addition.
- On this branch the same suites pass 12/12 with no crashes, and every pre-existing round-trip test still passes — valid-archive behavior is unchanged.
- Focused suites also pass on an iPhone 17 Pro simulator per the original validation run; SwiftLint clean on touched files.

## Follow-up (not in this PR)

`PMTilesExtractor` still contains the same unchecked arithmetic on remote bytes (`header.tileDataOffset + entry.offset` when planning tile reads, `offset + length` in `directory()`); the same guard treatment should be applied there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or truncated map tile archives.
  * Prevented invalid tile lookups when offsets overflow or point outside the available data.
  * Added stricter validation for directory entries, headers, and byte ranges.

* **Tests**
  * Added coverage for invalid headers, directory offsets, tile offsets, and malformed directory data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->