### PR TITLE
Avoid orphan PAX counter records

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -799,7 +799,7 @@ actor MeshPackets {
 			let fetchedNode = try modelContext.fetch(fetchDescriptor)
 
 			guard let node = fetchedNode.first else {
-				Logger.data.info("Node Info Not Found")
+				Logger.data.debug("🗄️ [PaxCounterEntity] Ignoring packet from unknown node \(packet.from.toHex(), privacy: .public)")
 				return
 			}
 			guard let paxMessage = try? Paxcount(serializedBytes: packet.decoded.payload) else { return }

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -798,22 +798,20 @@ actor MeshPackets {
 		do {
 			let fetchedNode = try modelContext.fetch(fetchDescriptor)
 
-			if let paxMessage = try? Paxcount(serializedBytes: packet.decoded.payload) {
-
-				let newPax = PaxCounterEntity()
-				modelContext.insert(newPax)
-				newPax.ble = Int32(truncatingIfNeeded: paxMessage.ble)
-				newPax.wifi = Int32(truncatingIfNeeded: paxMessage.wifi)
-				newPax.uptime = Int32(truncatingIfNeeded: paxMessage.uptime)
-				newPax.time = Date()
-
-				if fetchedNode.count > 0 {
-					newPax.paxNode = fetchedNode[0]
-					scheduleDebouncedSave()
-				} else {
-					Logger.data.info("Node Info Not Found")
-				}
+			guard let node = fetchedNode.first else {
+				Logger.data.info("Node Info Not Found")
+				return
 			}
+			guard let paxMessage = try? Paxcount(serializedBytes: packet.decoded.payload) else { return }
+
+			let newPax = PaxCounterEntity()
+			modelContext.insert(newPax)
+			newPax.ble = Int32(truncatingIfNeeded: paxMessage.ble)
+			newPax.wifi = Int32(truncatingIfNeeded: paxMessage.wifi)
+			newPax.uptime = Int32(truncatingIfNeeded: paxMessage.uptime)
+			newPax.time = Date()
+			newPax.paxNode = node
+			scheduleDebouncedSave()
 		} catch {
 
 		}

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -908,6 +908,62 @@ struct TelemetryPacketIngestTests {
 	}
 }
 
+// MARK: - PAX counter ingestion
+
+@Suite("PAX counter ingestion", .serialized)
+@MainActor
+struct PaxCounterPacketIngestTests {
+	private func makePaxPacket(from nodeNum: UInt32) throws -> MeshPacket {
+		var paxCounter = Paxcount()
+		paxCounter.wifi = 4
+		paxCounter.ble = 7
+		paxCounter.uptime = 60
+
+		var dataMessage = DataMessage()
+		dataMessage.payload = try paxCounter.serializedData()
+		dataMessage.portnum = .paxcounterApp
+
+		var packet = MeshPacket()
+		packet.from = nodeNum
+		packet.decoded = dataMessage
+		return packet
+	}
+
+	@Test func paxCounterFromUnknownNode_doesNotPersistOrphan() async throws {
+		let packet = try makePaxPacket(from: 0x20DE_FC01)
+		let context = ModelContext(sharedModelContainer)
+		let countBefore = try context.fetchCount(FetchDescriptor<PaxCounterEntity>())
+
+		let mesh = MeshPackets(modelContainer: sharedModelContainer)
+		await mesh.paxCounterPacket(packet: packet)
+		await mesh.flushDebouncedSaves()
+
+		let countAfter = try context.fetchCount(FetchDescriptor<PaxCounterEntity>())
+		#expect(countAfter == countBefore)
+	}
+
+	@Test func paxCounterFromKnownNode_persistsLinkedReading() async throws {
+		let nodeNum: UInt32 = 0x20DE_FC02
+		let context = ModelContext(sharedModelContainer)
+		let node = NodeInfoEntity()
+		node.num = Int64(nodeNum)
+		context.insert(node)
+		try context.save()
+
+		let mesh = MeshPackets(modelContainer: sharedModelContainer)
+		await mesh.paxCounterPacket(packet: try makePaxPacket(from: nodeNum))
+		await mesh.flushDebouncedSaves()
+
+		let persistedNodeNum = Int64(nodeNum)
+		let readings = try context.fetch(FetchDescriptor<PaxCounterEntity>(
+			predicate: #Predicate { $0.paxNode?.num == persistedNodeNum }
+		))
+		#expect(readings.count == 1)
+		#expect(readings.first?.wifi == 4)
+		#expect(readings.first?.ble == 7)
+	}
+}
+
 @Suite("device metadata ingestion")
 @MainActor
 struct DeviceMetadataIngestTests {


### PR DESCRIPTION
Summary
- Verify the sending node exists before allocating a PAX counter entity.
- Preserve PAX history for known nodes.
- Add persistence regressions for both unknown and known senders.

Why
- Unknown PAX packets previously allocated an unlinked SwiftData row; the surrounding receive path could persist these orphans, allowing noisy traffic to grow unusable local data.

Validation
- `xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath /private/tmp/meshtastic-defcon-hardening-tests -only-testing:MeshtasticTests/PaxCounterPacketIngestTests`
- Both unknown-sender rejection and known-node persistence passed on iPhone 17 Pro simulator.
- Pre-commit SwiftLint completed with no serious violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PAX counter packet handling so counter records are only persisted when the related node information is available.
  * Ensured ingested PAX counter data is correctly associated with the node and saves the expected Wi‑Fi and Bluetooth values.
* **Tests**
  * Added coverage for PAX counter ingestion, including scenarios for unknown nodes (no records persisted) and existing nodes (one correctly linked record saved).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->