### PR TITLE
Fix CarPlay unread staleness and channel reply routing

### DIFF
--- a/Meshtastic/AppState.swift
+++ b/Meshtastic/AppState.swift
@@ -13,6 +13,17 @@ struct PendingContact: Identifiable {
 	let base64UrlString: String
 }
 
+extension NSNotification.Name {
+	/// Posted whenever message read-state changes anywhere (new message saved,
+	/// messages marked read in a list, Siri/CarPlay read-aloud). Observers that
+	/// display unread state (badge counts, the CarPlay list templates) refresh on
+	/// it — before this existed the CarPlay templates only refreshed on
+	/// connect/disconnect and went stale for the whole drive.
+	/// (NSNotification.Name, not Notification.Name — the app defines its own
+	/// `Notification` model type which shadows Foundation's in some files.)
+	static let meshMessagesDidChange = NSNotification.Name("MeshMessagesDidChange")
+}
+
 class AppState: ObservableObject {
 
 	@Published var router: Router

--- a/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
+++ b/Meshtastic/CarPlay/CarPlaySceneDelegate.swift
@@ -27,9 +27,20 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 	// Retained template references so we can call updateSections rather than replacing the whole tree.
 	private var channelsTemplate: CPListTemplate?
 	private var directMessagesTemplate: CPListTemplate?
-	// Tracks which conversation identifiers have already had a contact intent donated
-	// during this CarPlay session so we don't re-donate on every refresh.
-	private var donatedConversationIds = Set<String>()
+	// Tracks which conversation identifiers have already had a compose-contact
+	// intent donated during this CarPlay session so we don't re-donate on every
+	// refresh.
+	//
+	// NOTE: this set is intentionally separate from `donatedReadKeys`. They were
+	// once a single set, which meant whichever donation happened first (compose
+	// intent for a read conversation vs. communication notification for an unread
+	// one) permanently blocked the other — a channel that started read and later
+	// received a message could never get its read-back notification, so tapping it
+	// composed instead of reading.
+	private var donatedComposeIds = Set<String>()
+	// Tracks communication-notification donations keyed by conversation AND
+	// message, so a newer unread message re-donates and stays readable by Siri.
+	private var donatedReadKeys = Set<String>()
 
 	private lazy var context: ModelContext = PersistenceController.shared.context
 
@@ -72,6 +83,17 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 			}
 			.store(in: &cancellables)
 
+		// Refresh rows whenever read-state changes anywhere — messages arriving,
+		// being read in the phone app, or Siri read-aloud completing. Without this
+		// the templates were frozen between connection changes and unread counts
+		// went stale for the whole drive.
+		NotificationCenter.default.publisher(for: .meshMessagesDidChange)
+			.debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+			.sink { [weak self] _ in
+				self?.refreshSections()
+			}
+			.store(in: &cancellables)
+
 		// Start Live Activity immediately if already connected
 		if AccessoryManager.shared.isConnected {
 			startLiveActivityIfNeeded()
@@ -85,7 +107,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 		Logger.services.info("🚗 [CarPlay] Disconnected")
 		endLiveActivity()
 		cancellables.removeAll()
-		donatedConversationIds.removeAll()
+		donatedComposeIds.removeAll()
+		donatedReadKeys.removeAll()
 		channelsTemplate = nil
 		directMessagesTemplate = nil
 		self.interfaceController = nil
@@ -404,7 +427,12 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 		)
 		let results = (try? context.fetch(descriptor)) ?? []
 		var counts = [Int64: Int]()
-		for message in results {
+		// toUser != nil: only direct messages count toward a DM row. Without the
+		// filter, unread CHANNEL messages from the same sender inflated that
+		// sender's DM badge — diverging from the in-app DM counts, which have
+		// always excluded channel traffic. (Checked in Swift, not the predicate:
+		// optional-relationship nil compares in #Predicate crash on iOS 26.)
+		for message in results where message.toUser != nil {
 			if let num = message.fromUser?.num, nodeNumSet.contains(num) {
 				counts[num, default: 0] += 1
 			}
@@ -436,7 +464,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 	/// Donates a contact intent for a DM conversation the first time it is seen this session.
 	/// Subsequent renders are no-ops, avoiding repeated IPC calls to the intents daemon.
 	private func donateMessageIntentIfNeeded(conversationId: String, toNodeNum: Int64, name: String) {
-		guard donatedConversationIds.insert(conversationId).inserted else { return }
+		guard donatedComposeIds.insert(conversationId).inserted else { return }
 
 		let handleValue = "\(toNodeNum)@meshtastic.local"
 		let person = INPerson(
@@ -468,7 +496,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 
 	/// Donates a contact intent for a channel conversation the first time it is seen this session.
 	private func donateChannelIntentIfNeeded(conversationId: String, channelIndex: Int, channelName: String) {
-		guard donatedConversationIds.insert(conversationId).inserted else { return }
+		guard donatedComposeIds.insert(conversationId).inserted else { return }
 
 		let channelHandle = "channel-\(channelIndex)@meshtastic.local"
 		let recipient = INPerson(
@@ -504,8 +532,6 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 	/// Posts a Communication Notification for the most recent unread channel message.
 	/// This is required for CarPlay to offer read-back instead of compose when tapped.
 	private func donateLatestIncomingChannelMessage(channelIndex: Int32, conversationId: String, channelName: String) {
-		guard donatedConversationIds.insert(conversationId).inserted else { return }
-
 		var descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate { message in
 				message.read == false &&
@@ -521,6 +547,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 
 		guard let message = (try? context.fetch(descriptor))?.first(where: { $0.toUser == nil }),
 			  let fromUser = message.fromUser else { return }
+		// Dedup AFTER resolving the message, keyed by conversation + message, so a
+		// newer unread message re-donates and stays readable by Siri.
+		guard donatedReadKeys.insert("\(conversationId)#\(message.messageId)").inserted else { return }
 
 		postCommunicationNotification(
 			message: message,
@@ -532,8 +561,6 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 
 	/// Posts a Communication Notification for the most recent unread DM.
 	private func donateLatestIncomingDM(nodeNum: Int64, conversationId: String, name: String) {
-		guard donatedConversationIds.insert(conversationId).inserted else { return }
-
 		var descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate { message in
 				message.read == false &&
@@ -543,10 +570,16 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 			},
 			sortBy: [SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse)]
 		)
-		descriptor.fetchLimit = 1
+		// Small batch + toUser filter in Swift (see channel variant): this donation
+		// must read back a DIRECT message — the sender's unread channel messages
+		// don't belong to this conversation.
+		descriptor.fetchLimit = 5
 
-		guard let message = (try? context.fetch(descriptor))?.first,
+		guard let message = (try? context.fetch(descriptor))?.first(where: { $0.toUser != nil }),
 			  let fromUser = message.fromUser else { return }
+		// Dedup AFTER resolving the message, keyed by conversation + message, so a
+		// newer unread message re-donates and stays readable by Siri.
+		guard donatedReadKeys.insert("\(conversationId)#\(message.messageId)").inserted else { return }
 
 		postCommunicationNotification(
 			message: message,
@@ -675,6 +708,10 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate, CPI
 						attachments: nil
 					)
 				}
+
+				// Shared dedup with the per-row donations: skip if this exact
+				// message has already been donated this session (e.g. a reconnect).
+				guard donatedReadKeys.insert("\(conversationId)#\(message.messageId)").inserted else { continue }
 
 				// Donate the interaction
 				let interaction = INInteraction(intent: intent, response: nil)

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1401,6 +1401,10 @@ actor MeshPackets {
 						CarPlayIntentDonation.donateReceivedMessage(newMessage)
 						#endif
 
+						// Let unread-displaying surfaces (badge, CarPlay templates) refresh.
+						// Observers debounce, so posting per saved message is cheap.
+						NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
+
 						if packet.decoded.portnum == PortNum.detectionSensorApp && !UserDefaults.enableDetectionNotifications {
 							return
 						}

--- a/Meshtastic/Intents/IntentMessageConverters.swift
+++ b/Meshtastic/Intents/IntentMessageConverters.swift
@@ -77,8 +77,28 @@ enum IntentMessageConverters {
 		}
 	}
 
-	/// Looks up a `ChannelEntity` by matching name.
+	/// Looks up a `ChannelEntity` by matching name, scoped to the connected
+	/// node's channel table.
+	///
+	/// Scoping matters: `ChannelEntity` rows exist per `MyInfoEntity`, so anyone
+	/// who has ever connected more than one radio has duplicate rows per index.
+	/// Unscoped, "Channel 2" matched several identical channels and Siri replied
+	/// with a disambiguation between indistinguishable options (or failed) —
+	/// breaking channel replies from CarPlay.
+	@MainActor
 	static func findChannels(matching name: String, in context: ModelContext) -> [ChannelEntity] {
+		let connectedNum = AccessoryManager.shared.activeDeviceNum
+
+		// Filter to the connected node's myInfo in Swift, not the predicate —
+		// optional-relationship comparisons in #Predicate crash SwiftData on iOS 26.
+		func scoped(_ channels: [ChannelEntity]) -> [ChannelEntity] {
+			guard let connectedNum else { return channels }
+			let mine = channels.filter { $0.myInfoChannel?.myNodeNum == connectedNum }
+			// Fall back to the unscoped list if the connected node has no matching
+			// row (e.g. channel DB not yet synced) rather than failing outright.
+			return mine.isEmpty ? channels : mine
+		}
+
 		if let explicitIndex = channelIndex(fromHandleOrName: name) {
 			let explicitIndex32 = Int32(explicitIndex)
 			let descriptor = FetchDescriptor<ChannelEntity>(
@@ -86,25 +106,34 @@ enum IntentMessageConverters {
 					channel.index == explicitIndex32
 				}
 			)
-			return (try? context.fetch(descriptor)) ?? []
+			// The duplicates are interchangeable for index-addressed lookups —
+			// return at most one so resolution never disambiguates identical rows.
+			return Array(scoped((try? context.fetch(descriptor)) ?? []).prefix(1))
 		}
 
 		let normalized = name.lowercased()
 		let channels = (try? context.fetch(FetchDescriptor<ChannelEntity>())) ?? []
-		return channels.filter { channel in
+		let matches = scoped(channels.filter { channel in
 			guard let channelName = channel.name, !channelName.isEmpty else { return false }
 			return channelName.lowercased().contains(normalized)
-		}
+		})
+		// Collapse duplicate (index, name) rows left over from other radios.
+		var seen = Set<Int32>()
+		return matches.filter { seen.insert($0.index).inserted }
 	}
 
-	/// Resolves a channel index from a spoken group name, defaulting to the primary channel.
-	static func channelIndex(for name: String, in context: ModelContext) -> Int {
+	/// Resolves a channel index from a spoken group name. Returns nil when the
+	/// name matches nothing — callers must fail rather than fall back: the old
+	/// default of 0 silently sent channel replies to Primary when Siri's
+	/// transcription didn't match any channel name.
+	@MainActor
+	static func channelIndex(for name: String, in context: ModelContext) -> Int? {
 		if let explicitIndex = channelIndex(fromHandleOrName: name) {
 			return explicitIndex
 		}
 
 		let channels = findChannels(matching: name, in: context)
-		return channels.first.map { Int($0.index) } ?? 0
+		return channels.first.map { Int($0.index) }
 	}
 
 	static func directMessageNodeNum(from value: String) -> Int64? {

--- a/Meshtastic/Intents/IntentMessageConverters.swift
+++ b/Meshtastic/Intents/IntentMessageConverters.swift
@@ -155,7 +155,7 @@ enum IntentMessageConverters {
 		}
 
 		if value.hasPrefix("Channel "), let index = Int(value.dropFirst("Channel ".count)) {
-			return index
+			return validChannelIndex(index)
 		}
 
 		let channelPrefix = "channel-"
@@ -164,10 +164,18 @@ enum IntentMessageConverters {
 			let rawIndex = remainder.hasSuffix(meshtasticDomain)
 				? String(remainder.dropLast(meshtasticDomain.count))
 				: remainder
-			return Int(rawIndex)
+			return Int(rawIndex).flatMap(validChannelIndex)
 		}
 
 		return nil
+	}
+
+	/// The mesh supports at most 8 channels (indices 0–7). Rejecting anything
+	/// outside that range here also protects the `Int32(_:)` conversions at
+	/// every caller — an unbounded parse let a malformed handle like
+	/// "channel-2147483648" through as an `Int` and trapped on the send path.
+	private static func validChannelIndex(_ index: Int) -> Int? {
+		(0...7).contains(index) ? index : nil
 	}
 
 	static func channelDisplayName(for index: Int32, named name: String?) -> String {

--- a/Meshtastic/Intents/SendMessageIntentHandler.swift
+++ b/Meshtastic/Intents/SendMessageIntentHandler.swift
@@ -128,6 +128,26 @@ final class SendMessageIntentHandler: NSObject, INSendMessageIntentHandling {
 					let context = PersistenceController.shared.context
 					return IntentMessageConverters.channelIndex(for: groupName.spokenPhrase, in: context)
 				}
+				// A group name that matches no channel is a failure — the old
+				// fallback to index 0 silently sent the reply to Primary instead.
+				guard let channelIndex else {
+					Logger.services.error("CarPlay/Siri: No channel matches group name \(groupName.spokenPhrase, privacy: .public)")
+					return INSendMessageIntentResponse(code: .failure, userActivity: nil)
+				}
+				try await AccessoryManager.shared.sendMessage(
+					message: content,
+					toUserNum: 0,
+					channel: Int32(channelIndex),
+					isEmoji: false,
+					replyID: 0
+				)
+			} else if let conversationId = intent.conversationIdentifier,
+					  let channelIndex = IntentMessageConverters.channelIndex(fromHandleOrName: conversationId) {
+				// Channel reply where Siri dropped the speakable group name (seen on
+				// notification replies): the conversation identifier still carries
+				// "channel-<N>". Route by it — before this, the reply fell through to
+				// the recipient handle below, which is the message's SENDER, and the
+				// channel reply went out as a DM to that person.
 				try await AccessoryManager.shared.sendMessage(
 					message: content,
 					toUserNum: 0,

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -274,6 +274,16 @@ struct MeshtasticAppleApp: App {
 
 						dispatchIncomingURL(url, fromActivity: false)
 					})
+					// Keep the badge in sync with read-state changes that happen outside
+					// the message lists (Siri/CarPlay read-aloud, background ingest) —
+					// previously those only reconciled on the next scene-active pass.
+					.onReceive(
+						NotificationCenter.default.publisher(for: .meshMessagesDidChange)
+							.debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+					) { _ in
+						guard let persistenceController else { return }
+						appState.refreshBadgeCount(context: persistenceController.container.mainContext)
+					}
 				.task {
 					// Skip TipKit entirely during marketing screenshot capture so tip popovers never
 					// appear in the shots (unconfigured TipKit displays nothing).

--- a/Meshtastic/MeshtasticAppDelegate.swift
+++ b/Meshtastic/MeshtasticAppDelegate.swift
@@ -67,6 +67,7 @@ class MeshtasticAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificat
 	private func markCarPlayMessagesAsRead(conversationId: String) {
 		let context = PersistenceController.shared.context
 		do {
+			var readMessageIDs = [Int64]()
 			if conversationId.hasPrefix("dm-"), let nodeNum = Int64(conversationId.replacingOccurrences(of: "dm-", with: "")) {
 				let descriptor = FetchDescriptor<MessageEntity>(
 					predicate: #Predicate { message in
@@ -74,8 +75,12 @@ class MeshtasticAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificat
 					}
 				)
 				let messages = try context.fetch(descriptor)
-				for message in messages {
+				// toUser != nil: this is a DM conversation — without the filter,
+				// reading a DM aloud also silently marked the sender's unread
+				// CHANNEL messages as read.
+				for message in messages where message.toUser != nil {
 					message.read = true
+					readMessageIDs.append(message.messageId)
 				}
 			} else if conversationId.hasPrefix("channel-"), let channelIndex = Int32(conversationId.replacingOccurrences(of: "channel-", with: "")) {
 				let descriptor = FetchDescriptor<MessageEntity>(
@@ -86,11 +91,19 @@ class MeshtasticAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificat
 				let messages = try context.fetch(descriptor)
 				for message in messages where message.toUser == nil {
 					message.read = true
+					readMessageIDs.append(message.messageId)
 				}
 			}
 			if context.hasChanges {
 				try context.save()
 				Logger.services.info("🚗 [CarPlay] Marked messages as read for \(conversationId, privacy: .public)")
+				// Match the in-app mark-read paths: clear delivered notifications for
+				// the read messages and tell unread surfaces (app badge via
+				// MeshtasticApp's observer, CarPlay templates) to refresh — this
+				// previously left the badge and CarPlay rows stale until the app
+				// next became active.
+				LocalNotificationManager().cancelNotificationsForMessageIds(readMessageIDs)
+				NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
 			}
 		} catch {
 			Logger.services.error("🚗 [CarPlay] Failed to mark messages as read: \(error.localizedDescription, privacy: .public)")

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -100,6 +100,8 @@ struct ChannelMessageList: View {
 			}
 			Logger.data.info("📖 [App] All unread messages marked as read.")
 			appState.unreadChannelMessages = myInfo.unreadMessages
+			// Refresh other unread surfaces (CarPlay templates) too.
+			NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
 		} catch {
 			Logger.data.error("Failed to read messages: \(error.localizedDescription, privacy: .public)")
 		}

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -97,6 +97,8 @@ struct UserMessageList: View {
 			   let connectedUser = connectedNode.user {
 				appState.unreadDirectMessages = connectedUser.unreadMessages(context: context, skipLastMessageCheck: true) // skipLastMessageCheck=true because we don't update lastMessage on our own connected node
 			}
+			// Refresh other unread surfaces (CarPlay templates) too.
+			NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
 		} catch {
 			Logger.data.error("Failed to read direct messages: \(error.localizedDescription, privacy: .public)")
 		}


### PR DESCRIPTION
## What

Full audit of the CarPlay flow surfaced structural causes for the two reported symptoms — stale/wrong unread counts, and channel replies failing or landing in the wrong place. Two commits, one per symptom.

## Commit 1 — live unread refresh and correct unread accounting

**Root cause:** the CarPlay `CPListTemplate`s only refreshed on connect/disconnect, so rows were frozen for the whole drive. Several DM counting paths were also wrong.

- New `.meshMessagesDidChange` notification posted from message ingest, both in-app mark-read paths, and the CarPlay read-aloud mark-read. The CarPlay scene observes it (debounced 500 ms) and refreshes sections in place; `MeshtasticApp` observes it (debounced 1 s) so the app badge tracks read-state changes that happen outside the message lists.
- CarPlay's DM unread counter now filters `toUser != nil` — unread **channel** messages from a sender were inflating that sender's **DM** badge (the in-app counts have always excluded channel traffic).
- `markCarPlayMessagesAsRead` gets the same filter (reading a DM aloud was silently marking the sender's channel messages read) and now cancels delivered notifications, matching the in-app paths.
- Donation dedup split: compose intents dedup per conversation; read-back communication notifications dedup per conversation **and message**, guarded after the fetch. They previously shared one set, so whichever donated first permanently blocked the other — a conversation gaining unread mid-session could never get its read-back notification (tap → compose instead of read).

## Commit 2 — channel reply resolution and routing

- `findChannels` matched `ChannelEntity` rows across **every radio ever connected** (rows are per-`MyInfoEntity`), so "Channel 2" resolved to several identical channels and Siri offered a disambiguation between indistinguishable options or failed. Lookups are now scoped to the connected node's channel table (duplicates collapsed, unscoped fallback if not yet synced).
- `channelIndex(for:)` silently defaulted to **0** on no match — a mis-transcribed channel name sent the reply to Primary. It now returns nil and the intent fails instead.
- When Siri drops the speakable group name on a notification reply, the intent's `conversationIdentifier` ("channel-N") now routes the send — previously the handler fell through to the recipient handle, which is the message's *sender*, turning a channel reply into a DM to that person.

## Testing

- iOS Simulator build succeeds.
- Suggested manual verification: CarPlay simulator (I/O ▸ External Displays ▸ CarPlay) with a connected node — watch a channel row's unread count bump live on message arrival, clear after reading in the phone app; reply to a channel message by voice on a device with 2+ historically connected radios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unread message counts and app badges now refresh automatically when new messages arrive or when messages are marked as read (with a brief debounce).
  - CarPlay message lists and read/unread state stay synchronized during drives, with improved coordination to prevent duplicate announcements.

- **Bug Fixes**
  - Direct-message unread counts no longer include channel traffic.
  - Siri channel replies now fail safely when the requested channel can’t be resolved, rather than routing to the primary channel.
  - Channel selection is more accurate when multiple radios are connected, preventing duplicate/disambiguation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->