### PR TITLE
Remove MQTT cloud status icons from the channel list rows

### DIFF
--- a/Meshtastic/Views/Helpers/Help/ChannelsHelp.swift
+++ b/Meshtastic/Views/Helpers/Help/ChannelsHelp.swift
@@ -35,24 +35,6 @@ struct ChannelsHelp: View {
 						title: String(localized: "Location Sharing"),
 						subtitle: String(localized: "Marks the channel currently used for position broadcasts.")
 					)
-					HelpItem(
-						symbol: AnyView(
-							Image(systemName: "icloud.and.arrow.up")
-								.font(.title3)
-								.foregroundColor(.blue)
-						),
-						title: String(localized: "MQTT Uplink"),
-						subtitle: String(localized: "Packets from this channel can be forwarded to MQTT when MQTT is configured.")
-					)
-					HelpItem(
-						symbol: AnyView(
-							Image(systemName: "icloud.and.arrow.down")
-								.font(.title3)
-								.foregroundColor(.blue)
-						),
-						title: String(localized: "MQTT Downlink"),
-						subtitle: String(localized: "MQTT packets for this channel can be sent back over LoRa when MQTT is configured.")
-					)
 				} header: {
 					Text("Channel Icons")
 				}

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -523,28 +523,16 @@ private struct ChannelRow: View {
 					.foregroundStyle(.secondary)
 			}
 			Spacer(minLength: 0)
-			HStack(spacing: 8) {
-				if sharesLocation {
-					ChannelStatusIcon(
-						systemImage: "location.fill",
-						color: .green,
-						accessibilityLabel: String(localized: "Position sharing", comment: "VoiceOver: this channel shares location")
-					)
-				}
-				if channel.uplinkEnabled {
-					ChannelStatusIcon(
-						systemImage: "icloud.and.arrow.up",
-						color: .blue,
-						accessibilityLabel: String(localized: "MQTT uplink enabled", comment: "VoiceOver: this channel uplinks to MQTT")
-					)
-				}
-				if channel.downlinkEnabled {
-					ChannelStatusIcon(
-						systemImage: "icloud.and.arrow.down",
-						color: .blue,
-						accessibilityLabel: String(localized: "MQTT downlink enabled", comment: "VoiceOver: this channel downlinks from MQTT")
-					)
-				}
+			// MQTT uplink/downlink cloud icons used to render here too, but downlink is
+			// commonly enabled by default, so nearly every channel row carried a cloud
+			// that read as a download button rather than status — removed. The uplink/
+			// downlink toggles remain visible in the channel editor itself.
+			if sharesLocation {
+				ChannelStatusIcon(
+					systemImage: "location.fill",
+					color: .green,
+					accessibilityLabel: String(localized: "Position sharing", comment: "VoiceOver: this channel shares location")
+				)
 			}
 		}
 		.padding(.vertical, 4)


### PR DESCRIPTION
## What changed?

Removes the `icloud.and.arrow.up` / `icloud.and.arrow.down` MQTT status icons from the channel rows on the Channels screen, and drops the two matching entries from the in-app Channels help legend. The green `location.fill` position-sharing indicator stays.

## Why?

The downlink cloud is enabled on many primary-channel configs, so it sat at the trailing edge of the row on essentially every radio looking like a tappable "download" affordance rather than passive status. Both clouds removed rather than just the visible one — an uplink-only cloud surviving would be the same visual noise, and an MQTT legend describing one direction but not the other makes no sense. The uplink/downlink toggles themselves are unchanged and remain visible when editing a channel.

These icons arrived in #1927 as part of the Android status-overview alignment; this deliberately walks that piece back for iOS.

## How is this tested?

- `xcodebuild build` (Debug, simulator) succeeds; SwiftLint clean on both touched files (the one `vertical_whitespace` warning in ChannelsHelp.swift is pre-existing, verified via stash).
- No snapshot coverage renders these row icons (`channelForm_primary` renders the editor form with uplink/downlink off), so no snapshot churn.
- No user-doc pages documented the row clouds (only the in-app help legend, updated here) — hence `skip-docs-check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed MQTT uplink and downlink status icons from channel list entries.
  * Simplified channel help by removing MQTT uplink and downlink help items.
  * MQTT uplink and downlink settings remain available in the channel editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->