### PR TITLE
fix(pax): create the sending node instead of orphaning the reading

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -799,6 +799,9 @@ actor MeshPackets {
 			let fetchedNode = try modelContext.fetch(fetchDescriptor)
 
 			if let paxMessage = try? Paxcount(serializedBytes: packet.decoded.payload) {
+				// Create the sending node when unheard, same as deviceMetadataPacket and
+				// telemetryPacket — an unlinked reading would persist as an orphan row.
+				let node = fetchedNode.first ?? findOrCreateNode(num: packetFrom, context: modelContext)
 
 				let newPax = PaxCounterEntity()
 				modelContext.insert(newPax)
@@ -806,13 +809,8 @@ actor MeshPackets {
 				newPax.wifi = Int32(truncatingIfNeeded: paxMessage.wifi)
 				newPax.uptime = Int32(truncatingIfNeeded: paxMessage.uptime)
 				newPax.time = Date()
-
-				if fetchedNode.count > 0 {
-					newPax.paxNode = fetchedNode[0]
-					scheduleDebouncedSave()
-				} else {
-					Logger.data.info("Node Info Not Found")
-				}
+				newPax.paxNode = node
+				scheduleDebouncedSave()
 			}
 		} catch {
 

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -908,6 +908,77 @@ struct TelemetryPacketIngestTests {
 	}
 }
 
+// MARK: - PAX counter ingestion
+
+@Suite("PAX counter ingestion", .serialized)
+@MainActor
+struct PaxCounterPacketIngestTests {
+	private func makePaxPacket(from nodeNum: UInt32) throws -> MeshPacket {
+		var paxCounter = Paxcount()
+		paxCounter.wifi = 4
+		paxCounter.ble = 7
+		paxCounter.uptime = 60
+
+		var dataMessage = DataMessage()
+		dataMessage.payload = try paxCounter.serializedData()
+		dataMessage.portnum = .paxcounterApp
+
+		var packet = MeshPacket()
+		packet.from = nodeNum
+		packet.decoded = dataMessage
+		return packet
+	}
+
+	@Test func unknownSender_createsNodeAndLinksReading() async throws {
+		let nodeNum: UInt32 = 0x20DE_FC03
+		let persistedNodeNum = Int64(nodeNum)
+		let context = ModelContext(sharedModelContainer)
+		let orphansBefore = try context.fetchCount(FetchDescriptor<PaxCounterEntity>(
+			predicate: #Predicate { $0.paxNode == nil }
+		))
+
+		let mesh = MeshPackets(modelContainer: sharedModelContainer)
+		await mesh.paxCounterPacket(packet: try makePaxPacket(from: nodeNum))
+		await mesh.flushDebouncedSaves()
+
+		// Hearing the packet created the sender, and the reading is linked to it.
+		#expect(try context.fetchCount(FetchDescriptor<NodeInfoEntity>(
+			predicate: #Predicate { $0.num == persistedNodeNum }
+		)) == 1)
+		let readings = try context.fetch(FetchDescriptor<PaxCounterEntity>(
+			predicate: #Predicate { $0.paxNode?.num == persistedNodeNum }
+		))
+		#expect(readings.count == 1)
+		#expect(readings.first?.wifi == 4)
+		#expect(readings.first?.ble == 7)
+		// The original bug: an unlinked row swept in by the next debounced save.
+		#expect(try context.fetchCount(FetchDescriptor<PaxCounterEntity>(
+			predicate: #Predicate { $0.paxNode == nil }
+		)) == orphansBefore)
+	}
+
+	@Test func knownSender_persistsLinkedReading() async throws {
+		let nodeNum: UInt32 = 0x20DE_FC02
+		let persistedNodeNum = Int64(nodeNum)
+		let context = ModelContext(sharedModelContainer)
+		let node = NodeInfoEntity()
+		node.num = persistedNodeNum
+		context.insert(node)
+		try context.save()
+
+		let mesh = MeshPackets(modelContainer: sharedModelContainer)
+		await mesh.paxCounterPacket(packet: try makePaxPacket(from: nodeNum))
+		await mesh.flushDebouncedSaves()
+
+		let readings = try context.fetch(FetchDescriptor<PaxCounterEntity>(
+			predicate: #Predicate { $0.paxNode?.num == persistedNodeNum }
+		))
+		#expect(readings.count == 1)
+		#expect(readings.first?.wifi == 4)
+		#expect(readings.first?.ble == 7)
+	}
+}
+
 @Suite("device metadata ingestion")
 @MainActor
 struct DeviceMetadataIngestTests {


### PR DESCRIPTION
## What changed?

`paxCounterPacket` now resolves the sender with `fetchedNode.first ?? findOrCreateNode(...)` — the same idiom `deviceMetadataPacket` and `telemetryPacket` already use — and always links the reading. Two regression tests: a PAX packet from an unheard node creates the node (with user stub) and persists one linked reading with no orphan rows; a known sender persists a linked reading as before.

## Why did it change?

Hearing a packet from an unheard node is how the app learns the node exists. The old code instead inserted the `PaxCounterEntity` first and only linked it if the sender was already in the database — an unknown sender left a permanently unlinked row that the next debounced save (from any packet type) swept into the store. Orphans are unreachable by any query (readings are fetched through `paxNode`) and untouchable by node purge, so noisy traffic grew dead data forever.

Replaces #2193, which guarded against the orphan by dropping the packet — the opposite of the pipeline's create-on-hear convention (see `findOrCreateNode`'s doc comment and `environmentTelemetryFromUnknownNode_createsNodeAndLinksReading` in the existing suite).

## How is this tested?

- New `PaxCounterPacketIngestTests` (2 tests) pass, alongside the neighboring `TelemetryPacketIngestTests` and `DeviceMetadataIngestTests` suites — 7/7.
- SwiftLint: no new warnings on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PAX counter telemetry processing for previously unknown nodes.
  - Automatically creates and links node information when needed.
  - Ensures readings are saved correctly without creating duplicate or orphaned records.
  - Preserves accurate Wi-Fi and Bluetooth counter values for known nodes.

- **Tests**
  - Added coverage for PAX counter ingestion with both new and existing nodes.
  - Verified correct persistence, linking, and debounced saving behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->