### PR TITLE
security: DEF CON hardening — malformed-packet crashes, MQTT MITM, App Intent confirmation

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -186,7 +186,11 @@ extension AccessoryManager {
 			}
 			
 			// Step 5a: Wait for end of WantConfig (database)
-			Step { @MainActor _ in
+			// Bounded like its sibling steps: without a timeout, a malicious/misbehaving radio
+			// that completes config but never sends the database-complete nonce would wedge the
+			// connect flow in .retrievingDatabase forever (no watchdog until Step 8). 120s is
+			// generous for a large legitimate node-DB dump.
+			Step(timeout: .seconds(120)) { @MainActor _ in
 				guard wantDatabase else {
 					Logger.transport.info("👟 [Connect] Step 4: wantDatabase = false, skipping waitForWantDatabase")
 					return

--- a/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
+++ b/Meshtastic/Accessory/Transports/TCP/TCPConnection.swift
@@ -104,6 +104,10 @@ actor TCPConnection: Connection {
 					// Logger.transport.debug("[TCP] startReader: Found magic byte, waiting for length")
 
 					if let length = try? await readInteger() {
+						// Skip zero-length frames (e.g. a crafted `94 c3 00 00`): calling
+						// receiveData(min:0,max:0) issues an undocumented empty socket read that
+						// can stall the reader loop. A real frame always has a positive length.
+						guard length > 0 else { continue }
 						let payload = try await receiveData(min: Int(length), max: Int(length))
 						switch FromRadioDecoder.classify(payload) {
 						case .decoded(let fromRadio):

--- a/Meshtastic/AppIntents/AddContactIntent.swift
+++ b/Meshtastic/AppIntents/AddContactIntent.swift
@@ -29,6 +29,12 @@ struct AddContactIntent: AppIntent {
 				let decodedString = contactData.base64urlToBase64()
 				if Data(base64Encoded: decodedString) != nil {
 					do {
+						// Confirm before adding a contact, mirroring the in-app
+						// AddContactConfirmationView — an untrusted Shortcut should not be able to
+						// silently inject a contact (and its public key) in the background.
+						try await requestConfirmation(
+							result: .result(dialog: "Add this Meshtastic contact to your nodes?")
+						)
 						try await AccessoryManager.shared.addContactFromURL(base64UrlString: contactData)
 					} catch {
 						throw AppIntentErrors.AppIntentError.message("Failed to add/parse contact data: \(error.localizedDescription)")

--- a/Meshtastic/AppIntents/AddContactIntent.swift
+++ b/Meshtastic/AppIntents/AddContactIntent.swift
@@ -28,13 +28,15 @@ struct AddContactIntent: AppIntent {
 			if let contactData = components.last {
 				let decodedString = contactData.base64urlToBase64()
 				if Data(base64Encoded: decodedString) != nil {
+					// Confirm before adding a contact, mirroring the in-app
+					// AddContactConfirmationView — an untrusted Shortcut should not be able to
+					// silently inject a contact (and its public key) in the background.
+					// requestConfirmation throws if the user declines; let that cancellation propagate
+					// unchanged rather than mislabeling it as a parse failure.
+					try await requestConfirmation(
+						result: .result(dialog: "Add this Meshtastic contact to your nodes?")
+					)
 					do {
-						// Confirm before adding a contact, mirroring the in-app
-						// AddContactConfirmationView — an untrusted Shortcut should not be able to
-						// silently inject a contact (and its public key) in the background.
-						try await requestConfirmation(
-							result: .result(dialog: "Add this Meshtastic contact to your nodes?")
-						)
 						try await AccessoryManager.shared.addContactFromURL(base64UrlString: contactData)
 					} catch {
 						throw AppIntentErrors.AppIntentError.message("Failed to add/parse contact data: \(error.localizedDescription)")

--- a/Meshtastic/AppIntents/SaveChannelSettingsIntent.swift
+++ b/Meshtastic/AppIntents/SaveChannelSettingsIntent.swift
@@ -25,25 +25,30 @@ struct SaveChannelSettingsIntent: AppIntent {
 			throw AppIntentErrors.AppIntentError.notConnected
 		}
 
+		let channelLink: MeshtasticChannelURL
 		do {
-			let channelLink = try MeshtasticChannelURL.parse(channelUrl.absoluteString)
-			// Require explicit confirmation before mutating radio state, mirroring the in-app
-			// QR/URL flow (SaveChannelQRCode) and the destructive intents (ShutDownNodeIntent /
-			// FactoryResetNodeIntent). Without this, an untrusted Shortcut could silently replace
-			// the radio's channel list, PSKs, and LoRa config in the background.
-			let mode = channelLink.addChannels ? "add to" : "REPLACE"
-			try await requestConfirmation(
-				result: .result(dialog: "This will \(mode) the channels and LoRa settings on your connected Meshtastic radio. Continue?")
-			)
+			channelLink = try MeshtasticChannelURL.parse(channelUrl.absoluteString)
+		} catch let error as MeshtasticChannelURL.ParseError {
+			throw AppIntentErrors.AppIntentError.message(error.localizedDescription)
+		}
+		// Require explicit confirmation before mutating radio state, mirroring the in-app
+		// QR/URL flow (SaveChannelQRCode) and the destructive intents (ShutDownNodeIntent /
+		// FactoryResetNodeIntent). Without this, an untrusted Shortcut could silently replace
+		// the radio's channel list, PSKs, and LoRa config in the background.
+		// requestConfirmation throws if the user declines; let that cancellation propagate
+		// unchanged rather than mislabeling it as a save failure.
+		let mode = channelLink.addChannels ? "add to" : "REPLACE"
+		try await requestConfirmation(
+			result: .result(dialog: "This will \(mode) the channels and LoRa settings on your connected Meshtastic radio. Continue?")
+		)
+		do {
 			try await AccessoryManager.shared.saveChannelSet(
 				channelSet: channelLink.channelSet,
 				addChannels: channelLink.addChannels
 			)
-			return .result()
-		} catch let error as MeshtasticChannelURL.ParseError {
-			throw AppIntentErrors.AppIntentError.message(error.localizedDescription)
 		} catch {
 			throw AppIntentErrors.AppIntentError.message("Failed to save the channel settings.")
 		}
+		return .result()
 	}
 }

--- a/Meshtastic/AppIntents/SaveChannelSettingsIntent.swift
+++ b/Meshtastic/AppIntents/SaveChannelSettingsIntent.swift
@@ -27,6 +27,14 @@ struct SaveChannelSettingsIntent: AppIntent {
 
 		do {
 			let channelLink = try MeshtasticChannelURL.parse(channelUrl.absoluteString)
+			// Require explicit confirmation before mutating radio state, mirroring the in-app
+			// QR/URL flow (SaveChannelQRCode) and the destructive intents (ShutDownNodeIntent /
+			// FactoryResetNodeIntent). Without this, an untrusted Shortcut could silently replace
+			// the radio's channel list, PSKs, and LoRa config in the background.
+			let mode = channelLink.addChannels ? "add to" : "REPLACE"
+			try await requestConfirmation(
+				result: .result(dialog: "This will \(mode) the channels and LoRa settings on your connected Meshtastic radio. Continue?")
+			)
 			try await AccessoryManager.shared.saveChannelSet(
 				channelSet: channelLink.channelSet,
 				addChannels: channelLink.addChannels

--- a/Meshtastic/Extensions/SwiftData/UserEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/UserEntityExtension.swift
@@ -245,6 +245,22 @@ func createUser(num: Int64, context: ModelContext) throws -> UserEntity {
 		throw PersistenceError.invalidInput(message: "User number cannot be negative.")
 	}
 
+	// Return an existing user for this num rather than inserting a duplicate. UserEntity.num is
+	// @Attribute(.unique); SwiftData resolves unique collisions only against the SAVED store, so
+	// two un-saved inserts with the same num (e.g. crafted back-to-back mesh packets from a new
+	// node inside the debounced-save window) would trap with a fatal SwiftData assertion. Mirror
+	// findOrCreateUser: check the saved store AND pending inserts before creating.
+	var existingDescriptor = FetchDescriptor<UserEntity>(predicate: #Predicate<UserEntity> { $0.num == num })
+	existingDescriptor.fetchLimit = 1
+	if let existing = (try? context.fetch(existingDescriptor))?.first {
+		return existing
+	}
+	if let pending = context.insertedModelsArray.lazy
+		.compactMap({ $0 as? UserEntity })
+		.first(where: { $0.num == num }) {
+		return pending
+	}
+
 	let newUser = UserEntity()
 	newUser.num = num
 	let userId = num.toHex()

--- a/Meshtastic/Helpers/Map/MBTilesArchive.swift
+++ b/Meshtastic/Helpers/Map/MBTilesArchive.swift
@@ -70,8 +70,11 @@ final class MBTilesArchive: OfflineTileSource {
 			return String(cString: text)
 		}
 
-		tileMinZoom = UInt8(metadata("minzoom").flatMap { Int($0) } ?? 0)
-		tileMaxZoom = UInt8(metadata("maxzoom").flatMap { Int($0) } ?? 22)
+		// Clamp attacker-controlled metadata zoom strings to a valid tile-zoom range: a
+		// value like "9999" or "-1" would otherwise make UInt8(_:) trap on a malicious
+		// .mbtiles archive (the same unchecked-cast class hardened for PMTiles in #2192).
+		tileMinZoom = UInt8(min(max(metadata("minzoom").flatMap { Int($0) } ?? 0, 0), 22))
+		tileMaxZoom = UInt8(min(max(metadata("maxzoom").flatMap { Int($0) } ?? 22, 0), 22))
 		if let parts = metadata("bounds")?.split(separator: ",").compactMap({ Double($0.trimmingCharacters(in: .whitespaces)) }),
 		   parts.count == 4 {
 			geographicBounds = GeoBounds(minLon: parts[0], minLat: parts[1], maxLon: parts[2], maxLat: parts[3])

--- a/Meshtastic/Helpers/Map/PMTilesExtractor.swift
+++ b/Meshtastic/Helpers/Map/PMTilesExtractor.swift
@@ -274,10 +274,15 @@ final class PMTilesExtractor {
 			}
 			guard let entry = PMTilesArchive.find(tileID, in: entries) else { return nil }
 			if entry.runLength == 0 {
-				dirOffset = header.leafDirOffset + entry.offset
+				// Overflow-safe offset math, matching the #2192 hardening of PMTilesArchive.
+				let (leaf, overflow) = header.leafDirOffset.addingReportingOverflow(entry.offset)
+				guard !overflow else { return nil }
+				dirOffset = leaf
 				dirLength = UInt64(entry.length)
 			} else {
-				return (header.tileDataOffset + entry.offset, entry.length)
+				let (tileOffset, overflow) = header.tileDataOffset.addingReportingOverflow(entry.offset)
+				guard !overflow else { return nil }
+				return (tileOffset, entry.length)
 			}
 		}
 		return nil
@@ -286,10 +291,16 @@ final class PMTilesExtractor {
 	private func directory(at offset: UInt64, length: UInt64, compression: PMTilesCompression, sourceURL: URL, prefetched: Data?) async throws -> [PMTilesArchive.Entry] {
 		if let cached = leafCache[offset] { return cached }
 		let raw: Data
-		if let prefetched, offset + length <= UInt64(prefetched.count) {
-			raw = prefetched.subdata(in: Int(offset)..<Int(offset + length))
+		// Overflow-safe range math (matches #2192): guard the add and the Int conversions so a
+		// crafted header/directory offset can't trap while planning an extraction.
+		let (end, addOverflow) = offset.addingReportingOverflow(length)
+		if let prefetched, !addOverflow, end <= UInt64(prefetched.count),
+		   let start = Int(exactly: offset), let stop = Int(exactly: end) {
+			raw = prefetched.subdata(in: start..<stop)
+		} else if length > 0, !addOverflow {
+			raw = try await fetchRange(sourceURL, start: offset, end: end - 1)
 		} else {
-			raw = try await fetchRange(sourceURL, start: offset, end: offset + length - 1)
+			return []
 		}
 		let decompressed = compression == .gzip ? (PMTilesArchive.gunzip(raw) ?? raw) : raw
 		let entries = PMTilesArchive.deserializeDirectory(decompressed)

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -319,7 +319,7 @@ actor MeshPackets {
 				modelContext.insert(myInfoEntity)
 				myInfoEntity.peripheralId = peripheralId
 				myInfoEntity.myNodeNum = Int64(myInfo.myNodeNum)
-				myInfoEntity.rebootCount = Int32(myInfo.rebootCount)
+				myInfoEntity.rebootCount = Int32(truncatingIfNeeded: myInfo.rebootCount)
 				myInfoEntity.deviceId = myInfo.deviceID
 				if !myInfo.pioEnv.isEmpty {
 					myInfoEntity.pioEnv = myInfo.pioEnv
@@ -331,7 +331,7 @@ actor MeshPackets {
 
 				fetchedMyInfo[0].peripheralId = peripheralId
 				fetchedMyInfo[0].myNodeNum = Int64(myInfo.myNodeNum)
-				fetchedMyInfo[0].rebootCount = Int32(myInfo.rebootCount)
+				fetchedMyInfo[0].rebootCount = Int32(truncatingIfNeeded: myInfo.rebootCount)
 				if !myInfo.pioEnv.isEmpty {
 					fetchedMyInfo[0].pioEnv = myInfo.pioEnv
 				}
@@ -356,7 +356,7 @@ actor MeshPackets {
 			do {
 				let fetchedMyInfo = try modelContext.fetch(fetchDescriptor)
 				if fetchedMyInfo.count == 1 {
-					let existing = fetchedMyInfo[0].channels.first(where: { $0.index == Int32(channel.index) })
+					let existing = fetchedMyInfo[0].channels.first(where: { $0.index == Int32(truncatingIfNeeded: channel.index) })
 					let newChannel: ChannelEntity
 					if let existing {
 						newChannel = existing
@@ -365,8 +365,8 @@ actor MeshPackets {
 						modelContext.insert(newChannel)
 						fetchedMyInfo[0].channels.append(newChannel)
 					}
-					newChannel.id = Int32(channel.index)
-					newChannel.index = Int32(channel.index)
+					newChannel.id = Int32(truncatingIfNeeded: channel.index)
+					newChannel.index = Int32(truncatingIfNeeded: channel.index)
 					newChannel.uplinkEnabled = channel.settings.uplinkEnabled
 					newChannel.downlinkEnabled = channel.settings.downlinkEnabled
 					newChannel.name = channel.settings.name
@@ -445,10 +445,10 @@ actor MeshPackets {
 					modelContext.insert(newNode)
 					newNode.id = Int64(nodeInfo.num)
 					newNode.num = Int64(nodeInfo.num)
-					newNode.channel = Int32(nodeInfo.channel)
+					newNode.channel = Int32(truncatingIfNeeded: nodeInfo.channel)
 					newNode.favorite = nodeInfo.isFavorite
 					newNode.ignored = nodeInfo.isIgnored
-					newNode.hopsAway = Int32(nodeInfo.hopsAway)
+					newNode.hopsAway = Int32(truncatingIfNeeded: nodeInfo.hopsAway)
 					newNode.hasXeddsaSigned = nodeInfo.hasXeddsaSigned_p
 
 					if nodeInfo.hasDeviceMetrics {
@@ -518,13 +518,13 @@ actor MeshPackets {
 						let position = PositionEntity()
 						modelContext.insert(position)
 						position.latest = true
-						position.seqNo = Int32(nodeInfo.position.seqNumber)
+						position.seqNo = Int32(truncatingIfNeeded: nodeInfo.position.seqNumber)
 						position.latitudeI = nodeInfo.position.latitudeI
 						position.longitudeI = nodeInfo.position.longitudeI
 						position.altitude = nodeInfo.position.altitude
-						position.satsInView = Int32(nodeInfo.position.satsInView)
-						position.speed = Int32(nodeInfo.position.groundSpeed)
-						position.heading = Int32(nodeInfo.position.groundTrack)
+						position.satsInView = Int32(truncatingIfNeeded: nodeInfo.position.satsInView)
+						position.speed = Int32(truncatingIfNeeded: nodeInfo.position.groundSpeed)
+						position.heading = Int32(truncatingIfNeeded: nodeInfo.position.groundTrack)
 						position.time = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.position.time)))
 						position.nodePosition = newNode
 						newNode.latestPositionCache = position
@@ -562,10 +562,10 @@ actor MeshPackets {
 						}
 					}
 					fetchedNode[0].snr = nodeInfo.snr
-					fetchedNode[0].channel = Int32(nodeInfo.channel)
+					fetchedNode[0].channel = Int32(truncatingIfNeeded: nodeInfo.channel)
 					fetchedNode[0].favorite = nodeInfo.isFavorite
 					fetchedNode[0].ignored = nodeInfo.isIgnored
-					fetchedNode[0].hopsAway = Int32(nodeInfo.hopsAway)
+					fetchedNode[0].hopsAway = Int32(truncatingIfNeeded: nodeInfo.hopsAway)
 					// has_xeddsa_signed means the node has signed ≥1 verified broadcast and persists; latch it
 					// so a later NodeInfo that omits the bit doesn't downgrade a node we've seen sign.
 					fetchedNode[0].hasXeddsaSigned = fetchedNode[0].hasXeddsaSigned || nodeInfo.hasXeddsaSigned_p
@@ -642,7 +642,7 @@ actor MeshPackets {
 							position.latitudeI = nodeInfo.position.latitudeI
 							position.longitudeI = nodeInfo.position.longitudeI
 							position.altitude = nodeInfo.position.altitude
-							position.satsInView = Int32(nodeInfo.position.satsInView)
+							position.satsInView = Int32(truncatingIfNeeded: nodeInfo.position.satsInView)
 							position.time = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.position.time)))
 							position.nodePosition = fetchedNode[0]
 						}
@@ -1266,7 +1266,7 @@ actor MeshPackets {
 					newMessage.snr = packet.rxSnr
 					newMessage.rssi = packet.rxRssi
 					newMessage.isEmoji = packet.decoded.emoji == 1
-					newMessage.channel = Int32(packet.channel)
+					newMessage.channel = Int32(truncatingIfNeeded: packet.channel)
 					newMessage.portNum = Int32(packet.decoded.portnum.rawValue)
 					/// Radio-verified XEdDSA signature for this received broadcast. Firmware only sets this on
 					/// broadcasts, but gate on the broadcast classification too so the "verified" shield can
@@ -1336,8 +1336,10 @@ actor MeshPackets {
 							if let existingNode = existingNodes.first {
 								existingNode.user = newUser
 							} else {
-								let newNode = NodeInfoEntity()
-								modelContext.insert(newNode)
+								// findOrCreateNode, not a bare insert: num is @Attribute(.unique) and
+								// the fetch above sees only saved rows — a crafted TEXT/NODEINFO pair
+								// from a new node could otherwise double-insert and trap on save.
+								let newNode = findOrCreateNode(num: Int64(newUser.num), context: modelContext)
 								newNode.id = Int64(newUser.num)
 								newNode.num = Int64(newUser.num)
 								newNode.user = newUser

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -441,8 +441,10 @@ actor MeshPackets {
 			// Not Found Insert
 			if fetchedNode.isEmpty && nodeInfo.num > 0 {
 
-				let newNode = NodeInfoEntity()
-					modelContext.insert(newNode)
+				// findOrCreateNode (not a bare insert): NodeInfoEntity.num is @Attribute(.unique) and the
+				// fetch only sees SAVED rows, so a still-pending stub node created by an earlier POSITION
+				// packet for this num would otherwise collide on the unique num and trap on save.
+				let newNode = findOrCreateNode(num: Int64(nodeInfo.num), context: modelContext)
 					newNode.id = Int64(nodeInfo.num)
 					newNode.num = Int64(nodeInfo.num)
 					newNode.channel = Int32(truncatingIfNeeded: nodeInfo.channel)
@@ -470,8 +472,9 @@ actor MeshPackets {
 					newNode.snr = nodeInfo.snr
 					if nodeInfo.hasUser {
 
-						let newUser = UserEntity()
-						modelContext.insert(newUser)
+						// findOrCreateNode already attached a find-or-create user for this num; reuse it
+						// (or find-or-create) instead of a bare insert whose duplicate unique num would trap.
+						let newUser = newNode.user ?? findOrCreateUser(num: Int64(nodeInfo.num), context: modelContext)
 						newUser.userId = nodeInfo.num.toHex()
 						newUser.num = Int64(nodeInfo.num)
 						newUser.longName = nodeInfo.user.longName
@@ -524,7 +527,11 @@ actor MeshPackets {
 						position.altitude = nodeInfo.position.altitude
 						position.satsInView = Int32(truncatingIfNeeded: nodeInfo.position.satsInView)
 						position.speed = Int32(truncatingIfNeeded: nodeInfo.position.groundSpeed)
-						position.heading = Int32(truncatingIfNeeded: nodeInfo.position.groundTrack)
+						// Range-check the UInt32 before converting (mirrors upsertPositionPacket) so a garbage
+						// groundTrack does not persist as an invalid heading.
+						if nodeInfo.position.groundTrack <= 360 {
+							position.heading = Int32(nodeInfo.position.groundTrack)
+						}
 						position.time = Date(timeIntervalSince1970: TimeInterval(Int64(nodeInfo.position.time)))
 						position.nodePosition = newNode
 						newNode.latestPositionCache = position
@@ -572,8 +579,9 @@ actor MeshPackets {
 
 					if nodeInfo.hasUser {
 						if fetchedNode[0].user == nil {
-							let newUserEntity = UserEntity()
-							modelContext.insert(newUserEntity)
+							// findOrCreateUser (not a bare insert): a user row for this unique num may already
+							// exist (orphaned or pending), so a bare insert would trap on save.
+							let newUserEntity = findOrCreateUser(num: Int64(nodeInfo.num), context: modelContext)
 							fetchedNode[0].user = newUserEntity
 						}
 						// First-wins on the public key, consistent with the NodeInfo/User paths in UpdateSwiftData

--- a/Meshtastic/Helpers/Mqtt/MqttClientProxyManager.swift
+++ b/Meshtastic/Helpers/Mqtt/MqttClientProxyManager.swift
@@ -108,9 +108,19 @@ class MqttClientProxyManager {
 		mqttClientProxy = CocoaMQTT(clientID: clientId, host: host, port: UInt16(port))
 		if let mqttClient = mqttClientProxy {
 			mqttClient.enableSSL = useSsl
-			mqttClient.allowUntrustCACertificate = true
+			// Do NOT accept untrusted certs: the didReceive-trust callback below now honors the
+			// real evaluation result, so an on-path attacker with a self-signed cert can no longer
+			// MITM the broker connection to capture credentials or inject spoofed downlinks.
+			mqttClient.allowUntrustCACertificate = false
 			mqttClient.username =  node.mqttConfig?.username
 			mqttClient.password = node.mqttConfig?.password
+			// Credentials on a non-TLS connection are transmitted in cleartext in the MQTT
+			// CONNECT packet. We warn rather than block, since local plaintext brokers are a
+			// legitimate Meshtastic setup; a hard "require TLS for credentials" policy is left
+			// as a product decision.
+			if useSsl == false, (node.mqttConfig?.username?.isEmpty == false || node.mqttConfig?.password?.isEmpty == false) {
+				Logger.mqtt.warning("📲 [MQTT] Sending credentials over a non-TLS connection to \(host, privacy: .public):\(port, privacy: .public) — username/password are in cleartext on the wire.")
+			}
 			mqttClient.keepAlive = 60
 			mqttClient.cleanSession = true
 			if debugLog {
@@ -209,11 +219,12 @@ extension MqttClientProxyManager: CocoaMQTTDelegate {
 		let isValid = SecTrustEvaluateWithError(trust, nil)
 		if isValid {
 			Logger.mqtt.info("📲 [MQTT] TLS cert valid")
-			completionHandler(true)
 		} else {
-			Logger.mqtt.warning("📲 [MQTT] TLS cert invalid — proceeding anyway (allowUntrustCACertificate=true)")
-			completionHandler(true)
+			Logger.mqtt.error("📲 [MQTT] TLS cert invalid — rejecting connection to avoid MITM")
 		}
+		// Honor the evaluation result — an invalid/self-signed cert must fail the handshake,
+		// not be silently accepted.
+		completionHandler(isValid)
 	}
 
 	func mqttDidDisconnect(_ mqtt: CocoaMQTT, withError err: Error?) {

--- a/Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift
+++ b/Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift
@@ -238,7 +238,7 @@ final class TAKMeshtasticBridge {
 		Logger.tak.debug("CoT Input:")
 		Logger.tak.debug("  uid: \(cot.uid)")
 		Logger.tak.debug("  type: \(cot.type)")
-		Logger.tak.debug("  lat: \(cot.latitude), lon: \(cot.longitude), hae: \(cot.hae)")
+		Logger.tak.debug("  lat: \(cot.latitude, privacy: .private), lon: \(cot.longitude, privacy: .private), hae: \(cot.hae)")
 		Logger.tak.debug("  contact: \(cot.contact?.callsign ?? "nil")")
 		Logger.tak.debug("  group: \(cot.group?.name ?? "nil") / \(cot.group?.role ?? "nil")")
 		Logger.tak.debug("  status.battery: \(cot.status?.battery ?? -1)")
@@ -309,8 +309,8 @@ final class TAKMeshtasticBridge {
 			takPacket.pli = pli
 
 			Logger.tak.debug("TAKPacket.pli created:")
-			Logger.tak.debug("  latitudeI: \(pli.latitudeI) (from \(cot.latitude))")
-			Logger.tak.debug("  longitudeI: \(pli.longitudeI) (from \(cot.longitude))")
+			Logger.tak.debug("  latitudeI: \(pli.latitudeI) (from \(cot.latitude, privacy: .private))")
+			Logger.tak.debug("  longitudeI: \(pli.longitudeI) (from \(cot.longitude, privacy: .private))")
 			Logger.tak.debug("  altitude: \(pli.altitude) (from \(cot.hae))")
 			Logger.tak.debug("  speed: \(pli.speed), course: \(pli.course)")
 
@@ -776,7 +776,7 @@ final class TAKMeshtasticBridge {
 		let name = waypoint.name.isEmpty ? "Dropped Pin" : waypoint.name
 		let description = waypoint.description_p.isEmpty ? "Meshtastic Waypoint" : waypoint.description_p
 		
-		Logger.tak.info("Broadcasting waypoint: \(name) at \(latitude), \(longitude), sender: \(senderName)")
+		Logger.tak.info("Broadcasting waypoint: \(name) at \(latitude, privacy: .private), \(longitude, privacy: .private), sender: \(senderName)")
 		
 		// Map Meshtastic emoji icon to appropriate TAK icon
 		let (cotType, iconPath, colorArgb) = getTakIconForWaypoint(waypoint: waypoint)

--- a/Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift
+++ b/Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift
@@ -309,8 +309,8 @@ final class TAKMeshtasticBridge {
 			takPacket.pli = pli
 
 			Logger.tak.debug("TAKPacket.pli created:")
-			Logger.tak.debug("  latitudeI: \(pli.latitudeI) (from \(cot.latitude, privacy: .private))")
-			Logger.tak.debug("  longitudeI: \(pli.longitudeI) (from \(cot.longitude, privacy: .private))")
+			Logger.tak.debug("  latitudeI: \(pli.latitudeI, privacy: .private) (from \(cot.latitude, privacy: .private))")
+			Logger.tak.debug("  longitudeI: \(pli.longitudeI, privacy: .private) (from \(cot.longitude, privacy: .private))")
 			Logger.tak.debug("  altitude: \(pli.altitude) (from \(cot.hae))")
 			Logger.tak.debug("  speed: \(pli.speed), course: \(pli.course)")
 

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -354,9 +354,11 @@ extension MeshPackets {
 			
 			let fetchedNode = try modelContext.fetch(fetchNodeInfoAppRequest)
 			if fetchedNode.count == 0 {
-				// Not Found Insert
-				let newNode = NodeInfoEntity()
-				modelContext.insert(newNode)
+				// Not Found Insert. Use findOrCreateNode (not a bare insert): NodeInfoEntity.num is
+				// @Attribute(.unique), and the fetch above only sees SAVED rows — a crafted second
+				// NODEINFO packet arriving inside the debounced-save window would otherwise create a
+				// second un-saved node with the same num and trap with a fatal SwiftData assertion.
+				let newNode = findOrCreateNode(num: Int64(packet.from), context: modelContext)
 				newNode.id = Int64(packet.from)
 				newNode.num = Int64(packet.from)
 				newNode.favorite = favorite
@@ -372,7 +374,7 @@ extension MeshPackets {
 				newNode.viaMqtt = packet.viaMqtt
 				
 				if packet.to == Constants.maximumNodeNum || packet.to == UserDefaults.preferredPeripheralNum {
-					newNode.channel = Int32(packet.channel)
+					newNode.channel = Int32(truncatingIfNeeded: packet.channel)
 				}
 				if let nodeInfoMessage = try? NodeInfo(serializedBytes: packet.decoded.payload) {
 					newNode.favorite = nodeInfoMessage.isFavorite
@@ -487,7 +489,7 @@ extension MeshPackets {
 			} else {
 				// Update an existing node
 				if packet.to == Constants.maximumNodeNum || packet.to == UserDefaults.preferredPeripheralNum {
-					fetchedNode[0].channel = Int32(packet.channel)
+					fetchedNode[0].channel = Int32(truncatingIfNeeded: packet.channel)
 				}
 				
 				if let nodeInfoMessage = try? NodeInfo(serializedBytes: packet.decoded.payload) {
@@ -499,7 +501,7 @@ extension MeshPackets {
 					if nodeInfoMessage.hasDeviceMetrics {
 						let telemetry = TelemetryEntity()
 						modelContext.insert(telemetry)
-						telemetry.batteryLevel = Int32(nodeInfoMessage.deviceMetrics.batteryLevel)
+						telemetry.batteryLevel = Int32(truncatingIfNeeded: nodeInfoMessage.deviceMetrics.batteryLevel)
 						telemetry.voltage = nodeInfoMessage.deviceMetrics.voltage
 						telemetry.channelUtilization = nodeInfoMessage.deviceMetrics.channelUtilization
 						telemetry.airUtilTx = nodeInfoMessage.deviceMetrics.airUtilTx
@@ -654,18 +656,21 @@ extension MeshPackets {
 						position.latest = true
 						position.snr = packet.rxSnr
 						position.rssi = packet.rxRssi
-						position.seqNo = Int32(positionMessage.seqNumber)
+						// All of these protobuf fields are UInt32; convert with truncatingIfNeeded
+						// (as the rest of this file does) so an attacker-crafted value > Int32.max
+						// can't SIGTRAP the app on a single unauthenticated POSITION_APP packet.
+						position.seqNo = Int32(truncatingIfNeeded: positionMessage.seqNumber)
 						position.latitudeI = positionMessage.latitudeI
 						position.longitudeI = positionMessage.longitudeI
 						position.altitude = positionMessage.altitude
-						position.satsInView = Int32(positionMessage.satsInView)
-						position.speed = Int32(positionMessage.groundSpeed)
-						let heading = Int32(positionMessage.groundTrack)
-						// Throw out bad haeadings from the device
-						if heading >= 0 && heading <= 360 {
+						position.satsInView = Int32(truncatingIfNeeded: positionMessage.satsInView)
+						position.speed = Int32(truncatingIfNeeded: positionMessage.groundSpeed)
+						// Range-check on the UInt32 before converting — the old code converted first,
+						// so an oversized groundTrack trapped before this guard could run.
+						if positionMessage.groundTrack <= 360 {
 							position.heading = Int32(positionMessage.groundTrack)
 						}
-						position.precisionBits = Int32(positionMessage.precisionBits)
+						position.precisionBits = Int32(truncatingIfNeeded: positionMessage.precisionBits)
 						if positionMessage.timestamp != 0 {
 							position.time = Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.timestamp)))
 						} else {
@@ -710,7 +715,7 @@ extension MeshPackets {
 							}
 						}
 
-						fetchedNode[0].channel = Int32(packet.channel)
+						fetchedNode[0].channel = Int32(truncatingIfNeeded: packet.channel)
 						
 						scheduleDebouncedSave()
 						Logger.data.debug("📍 [Position] buffered for Node: \(fetchedNode[0].num.toHex(), privacy: .public)")
@@ -744,12 +749,12 @@ extension MeshPackets {
 					modelContext.insert(newBluetoothConfig)
 					newBluetoothConfig.enabled = config.enabled
 					newBluetoothConfig.mode = Int32(config.mode.rawValue)
-					newBluetoothConfig.fixedPin = Int32(config.fixedPin)
+					newBluetoothConfig.fixedPin = Int32(truncatingIfNeeded: config.fixedPin)
 					fetchedNode[0].bluetoothConfig = newBluetoothConfig
 				} else {
 					fetchedNode[0].bluetoothConfig?.enabled = config.enabled
 					fetchedNode[0].bluetoothConfig?.mode = Int32(config.mode.rawValue)
-					fetchedNode[0].bluetoothConfig?.fixedPin = Int32(config.fixedPin)
+					fetchedNode[0].bluetoothConfig?.fixedPin = Int32(truncatingIfNeeded: config.fixedPin)
 				}
 				if sessionPasskey != nil {
 					fetchedNode[0].sessionPasskey = sessionPasskey
@@ -781,8 +786,8 @@ extension MeshPackets {
 					let newDeviceConfig = DeviceConfigEntity()
 					modelContext.insert(newDeviceConfig)
 					newDeviceConfig.role = Int32(config.role.rawValue)
-					newDeviceConfig.buttonGpio = Int32(config.buttonGpio)
-					newDeviceConfig.buzzerGpio =  Int32(config.buzzerGpio)
+					newDeviceConfig.buttonGpio = Int32(truncatingIfNeeded: config.buttonGpio)
+					newDeviceConfig.buzzerGpio =  Int32(truncatingIfNeeded: config.buzzerGpio)
 					newDeviceConfig.rebroadcastMode = Int32(config.rebroadcastMode.rawValue)
 					newDeviceConfig.nodeInfoBroadcastSecs = Int32(truncating: config.nodeInfoBroadcastSecs as NSNumber)
 					newDeviceConfig.doubleTapAsButtonPress = config.doubleTapAsButtonPress
@@ -793,8 +798,8 @@ extension MeshPackets {
 					fetchedNode[0].deviceConfig = newDeviceConfig
 				} else {
 					fetchedNode[0].deviceConfig?.role = Int32(config.role.rawValue)
-					fetchedNode[0].deviceConfig?.buttonGpio = Int32(config.buttonGpio)
-					fetchedNode[0].deviceConfig?.buzzerGpio = Int32(config.buzzerGpio)
+					fetchedNode[0].deviceConfig?.buttonGpio = Int32(truncatingIfNeeded: config.buttonGpio)
+					fetchedNode[0].deviceConfig?.buzzerGpio = Int32(truncatingIfNeeded: config.buzzerGpio)
 					fetchedNode[0].deviceConfig?.rebroadcastMode = Int32(config.rebroadcastMode.rawValue)
 					fetchedNode[0].deviceConfig?.nodeInfoBroadcastSecs = Int32(truncating: config.nodeInfoBroadcastSecs as NSNumber)
 					fetchedNode[0].deviceConfig?.doubleTapAsButtonPress = config.doubleTapAsButtonPress
@@ -891,16 +896,16 @@ extension MeshPackets {
 					newLoRaConfig.regionCode = Int32(config.region.rawValue)
 					newLoRaConfig.usePreset = config.usePreset
 					newLoRaConfig.modemPreset = Int32(config.modemPreset.rawValue)
-					newLoRaConfig.bandwidth = Int32(config.bandwidth)
-					newLoRaConfig.spreadFactor = Int32(config.spreadFactor)
-					newLoRaConfig.codingRate = Int32(config.codingRate)
+					newLoRaConfig.bandwidth = Int32(truncatingIfNeeded: config.bandwidth)
+					newLoRaConfig.spreadFactor = Int32(truncatingIfNeeded: config.spreadFactor)
+					newLoRaConfig.codingRate = Int32(truncatingIfNeeded: config.codingRate)
 					newLoRaConfig.frequencyOffset = config.frequencyOffset
 					newLoRaConfig.overrideFrequency = config.overrideFrequency
 					newLoRaConfig.overrideDutyCycle = config.overrideDutyCycle
-					newLoRaConfig.hopLimit = Int32(config.hopLimit)
-					newLoRaConfig.txPower = Int32(config.txPower)
+					newLoRaConfig.hopLimit = Int32(truncatingIfNeeded: config.hopLimit)
+					newLoRaConfig.txPower = Int32(truncatingIfNeeded: config.txPower)
 					newLoRaConfig.txEnabled = config.txEnabled
-					newLoRaConfig.channelNum = Int32(config.channelNum)
+					newLoRaConfig.channelNum = Int32(truncatingIfNeeded: config.channelNum)
 					newLoRaConfig.sx126xRxBoostedGain = config.sx126XRxBoostedGain
 					newLoRaConfig.ignoreMqtt = config.ignoreMqtt
 					newLoRaConfig.okToMqtt = config.configOkToMqtt
@@ -909,16 +914,16 @@ extension MeshPackets {
 					fetchedNode[0].loRaConfig?.regionCode = Int32(config.region.rawValue)
 					fetchedNode[0].loRaConfig?.usePreset = config.usePreset
 					fetchedNode[0].loRaConfig?.modemPreset = Int32(config.modemPreset.rawValue)
-					fetchedNode[0].loRaConfig?.bandwidth = Int32(config.bandwidth)
-					fetchedNode[0].loRaConfig?.spreadFactor = Int32(config.spreadFactor)
-					fetchedNode[0].loRaConfig?.codingRate = Int32(config.codingRate)
+					fetchedNode[0].loRaConfig?.bandwidth = Int32(truncatingIfNeeded: config.bandwidth)
+					fetchedNode[0].loRaConfig?.spreadFactor = Int32(truncatingIfNeeded: config.spreadFactor)
+					fetchedNode[0].loRaConfig?.codingRate = Int32(truncatingIfNeeded: config.codingRate)
 					fetchedNode[0].loRaConfig?.frequencyOffset = config.frequencyOffset
 					fetchedNode[0].loRaConfig?.overrideFrequency = config.overrideFrequency
 					fetchedNode[0].loRaConfig?.overrideDutyCycle = config.overrideDutyCycle
-					fetchedNode[0].loRaConfig?.hopLimit = Int32(config.hopLimit)
-					fetchedNode[0].loRaConfig?.txPower = Int32(config.txPower)
+					fetchedNode[0].loRaConfig?.hopLimit = Int32(truncatingIfNeeded: config.hopLimit)
+					fetchedNode[0].loRaConfig?.txPower = Int32(truncatingIfNeeded: config.txPower)
 					fetchedNode[0].loRaConfig?.txEnabled = config.txEnabled
-					fetchedNode[0].loRaConfig?.channelNum = Int32(config.channelNum)
+					fetchedNode[0].loRaConfig?.channelNum = Int32(truncatingIfNeeded: config.channelNum)
 					fetchedNode[0].loRaConfig?.sx126xRxBoostedGain = config.sx126XRxBoostedGain
 					fetchedNode[0].loRaConfig?.ignoreMqtt = config.ignoreMqtt
 					fetchedNode[0].loRaConfig?.okToMqtt = config.configOkToMqtt
@@ -959,7 +964,7 @@ extension MeshPackets {
 					newNetworkConfig.wifiPsk = config.wifiPsk
 					newNetworkConfig.ntpServer = config.ntpServer
 					newNetworkConfig.ethEnabled = config.ethEnabled
-					newNetworkConfig.enabledProtocols = Int32(config.enabledProtocols)
+					newNetworkConfig.enabledProtocols = Int32(truncatingIfNeeded: config.enabledProtocols)
 					newNetworkConfig.addressMode = Int32(config.addressMode.rawValue)
 					newNetworkConfig.rsyslogServer = config.rsyslogServer
 					newNetworkConfig.ip = Int32(bitPattern: config.ipv4Config.ip)
@@ -973,7 +978,7 @@ extension MeshPackets {
 					fetchedNode[0].networkConfig?.wifiSsid = config.wifiSsid
 					fetchedNode[0].networkConfig?.wifiPsk = config.wifiPsk
 					fetchedNode[0].networkConfig?.ntpServer = config.ntpServer
-					fetchedNode[0].networkConfig?.enabledProtocols = Int32(config.enabledProtocols)
+					fetchedNode[0].networkConfig?.enabledProtocols = Int32(truncatingIfNeeded: config.enabledProtocols)
 					fetchedNode[0].networkConfig?.addressMode = Int32(config.addressMode.rawValue)
 					fetchedNode[0].networkConfig?.rsyslogServer = config.rsyslogServer
 					fetchedNode[0].networkConfig?.ip = Int32(bitPattern: config.ipv4Config.ip)
@@ -1070,7 +1075,7 @@ extension MeshPackets {
 					let newPowerConfig = PowerConfigEntity()
 					modelContext.insert(newPowerConfig)
 					newPowerConfig.adcMultiplierOverride = config.adcMultiplierOverride
-					newPowerConfig.deviceBatteryInaAddress = Int32(config.deviceBatteryInaAddress)
+					newPowerConfig.deviceBatteryInaAddress = Int32(truncatingIfNeeded: config.deviceBatteryInaAddress)
 					newPowerConfig.isPowerSaving = config.isPowerSaving
 					newPowerConfig.lsSecs = Int32(truncatingIfNeeded: config.lsSecs)
 					newPowerConfig.minWakeSecs = Int32(truncatingIfNeeded: config.minWakeSecs)
@@ -1079,7 +1084,7 @@ extension MeshPackets {
 					fetchedNode[0].powerConfig = newPowerConfig
 				} else {
 					fetchedNode[0].powerConfig?.adcMultiplierOverride = config.adcMultiplierOverride
-					fetchedNode[0].powerConfig?.deviceBatteryInaAddress = Int32(config.deviceBatteryInaAddress)
+					fetchedNode[0].powerConfig?.deviceBatteryInaAddress = Int32(truncatingIfNeeded: config.deviceBatteryInaAddress)
 					fetchedNode[0].powerConfig?.isPowerSaving = config.isPowerSaving
 					fetchedNode[0].powerConfig?.lsSecs = Int32(truncatingIfNeeded: config.lsSecs)
 					fetchedNode[0].powerConfig?.minWakeSecs = Int32(truncatingIfNeeded: config.minWakeSecs)
@@ -1179,21 +1184,21 @@ extension MeshPackets {
 					let newAudioConfig = AudioConfigEntity()
 					modelContext.insert(newAudioConfig)
 					newAudioConfig.codec2Enabled = config.codec2Enabled
-					newAudioConfig.pttPin = Int32(config.pttPin)
+					newAudioConfig.pttPin = Int32(truncatingIfNeeded: config.pttPin)
 					newAudioConfig.bitrate = Int32(config.bitrate.rawValue)
-					newAudioConfig.i2sWs = Int32(config.i2SWs)
-					newAudioConfig.i2sSd = Int32(config.i2SSd)
-					newAudioConfig.i2sDin = Int32(config.i2SDin)
-					newAudioConfig.i2sSck = Int32(config.i2SSck)
+					newAudioConfig.i2sWs = Int32(truncatingIfNeeded: config.i2SWs)
+					newAudioConfig.i2sSd = Int32(truncatingIfNeeded: config.i2SSd)
+					newAudioConfig.i2sDin = Int32(truncatingIfNeeded: config.i2SDin)
+					newAudioConfig.i2sSck = Int32(truncatingIfNeeded: config.i2SSck)
 					fetchedNode[0].audioConfig = newAudioConfig
 				} else {
 					fetchedNode[0].audioConfig?.codec2Enabled = config.codec2Enabled
-					fetchedNode[0].audioConfig?.pttPin = Int32(config.pttPin)
+					fetchedNode[0].audioConfig?.pttPin = Int32(truncatingIfNeeded: config.pttPin)
 					fetchedNode[0].audioConfig?.bitrate = Int32(config.bitrate.rawValue)
-					fetchedNode[0].audioConfig?.i2sWs = Int32(config.i2SWs)
-					fetchedNode[0].audioConfig?.i2sSd = Int32(config.i2SSd)
-					fetchedNode[0].audioConfig?.i2sDin = Int32(config.i2SDin)
-					fetchedNode[0].audioConfig?.i2sSck = Int32(config.i2SSck)
+					fetchedNode[0].audioConfig?.i2sWs = Int32(truncatingIfNeeded: config.i2SWs)
+					fetchedNode[0].audioConfig?.i2sSd = Int32(truncatingIfNeeded: config.i2SSd)
+					fetchedNode[0].audioConfig?.i2sDin = Int32(truncatingIfNeeded: config.i2SDin)
+					fetchedNode[0].audioConfig?.i2sSck = Int32(truncatingIfNeeded: config.i2SSck)
 				}
 				if sessionPasskey != nil {
 					fetchedNode[0].sessionPasskey = sessionPasskey
@@ -1227,10 +1232,10 @@ extension MeshPackets {
 					let newAmbientLightingConfig = AmbientLightingConfigEntity()
 					modelContext.insert(newAmbientLightingConfig)
 					newAmbientLightingConfig.ledState = config.ledState
-					newAmbientLightingConfig.current = Int32(config.current)
-					newAmbientLightingConfig.red = Int32(config.red)
-					newAmbientLightingConfig.green = Int32(config.green)
-					newAmbientLightingConfig.blue = Int32(config.blue)
+					newAmbientLightingConfig.current = Int32(truncatingIfNeeded: config.current)
+					newAmbientLightingConfig.red = Int32(truncatingIfNeeded: config.red)
+					newAmbientLightingConfig.green = Int32(truncatingIfNeeded: config.green)
+					newAmbientLightingConfig.blue = Int32(truncatingIfNeeded: config.blue)
 					fetchedNode[0].ambientLightingConfig = newAmbientLightingConfig
 				} else {
 					
@@ -1240,10 +1245,10 @@ extension MeshPackets {
 						fetchedNode[0].ambientLightingConfig = newAmbientLighting
 					}
 					fetchedNode[0].ambientLightingConfig?.ledState = config.ledState
-					fetchedNode[0].ambientLightingConfig?.current = Int32(config.current)
-					fetchedNode[0].ambientLightingConfig?.red = Int32(config.red)
-					fetchedNode[0].ambientLightingConfig?.green = Int32(config.green)
-					fetchedNode[0].ambientLightingConfig?.blue = Int32(config.blue)
+					fetchedNode[0].ambientLightingConfig?.current = Int32(truncatingIfNeeded: config.current)
+					fetchedNode[0].ambientLightingConfig?.red = Int32(truncatingIfNeeded: config.red)
+					fetchedNode[0].ambientLightingConfig?.green = Int32(truncatingIfNeeded: config.green)
+					fetchedNode[0].ambientLightingConfig?.blue = Int32(truncatingIfNeeded: config.blue)
 				}
 				if sessionPasskey != nil {
 					fetchedNode[0].sessionPasskey = sessionPasskey
@@ -1281,9 +1286,9 @@ extension MeshPackets {
 					newCannedMessageConfig.sendBell = config.sendBell
 					newCannedMessageConfig.rotary1Enabled = config.rotary1Enabled
 					newCannedMessageConfig.updown1Enabled = config.updown1Enabled
-					newCannedMessageConfig.inputbrokerPinA = Int32(config.inputbrokerPinA)
-					newCannedMessageConfig.inputbrokerPinB = Int32(config.inputbrokerPinB)
-					newCannedMessageConfig.inputbrokerPinPress = Int32(config.inputbrokerPinPress)
+					newCannedMessageConfig.inputbrokerPinA = Int32(truncatingIfNeeded: config.inputbrokerPinA)
+					newCannedMessageConfig.inputbrokerPinB = Int32(truncatingIfNeeded: config.inputbrokerPinB)
+					newCannedMessageConfig.inputbrokerPinPress = Int32(truncatingIfNeeded: config.inputbrokerPinPress)
 					newCannedMessageConfig.inputbrokerEventCw = Int32(config.inputbrokerEventCw.rawValue)
 					newCannedMessageConfig.inputbrokerEventCcw = Int32(config.inputbrokerEventCcw.rawValue)
 					newCannedMessageConfig.inputbrokerEventPress = Int32(config.inputbrokerEventPress.rawValue)
@@ -1293,9 +1298,9 @@ extension MeshPackets {
 					fetchedNode[0].cannedMessageConfig?.sendBell = config.sendBell
 					fetchedNode[0].cannedMessageConfig?.rotary1Enabled = config.rotary1Enabled
 					fetchedNode[0].cannedMessageConfig?.updown1Enabled = config.updown1Enabled
-					fetchedNode[0].cannedMessageConfig?.inputbrokerPinA = Int32(config.inputbrokerPinA)
-					fetchedNode[0].cannedMessageConfig?.inputbrokerPinB = Int32(config.inputbrokerPinB)
-					fetchedNode[0].cannedMessageConfig?.inputbrokerPinPress = Int32(config.inputbrokerPinPress)
+					fetchedNode[0].cannedMessageConfig?.inputbrokerPinA = Int32(truncatingIfNeeded: config.inputbrokerPinA)
+					fetchedNode[0].cannedMessageConfig?.inputbrokerPinB = Int32(truncatingIfNeeded: config.inputbrokerPinB)
+					fetchedNode[0].cannedMessageConfig?.inputbrokerPinPress = Int32(truncatingIfNeeded: config.inputbrokerPinPress)
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventCw = Int32(config.inputbrokerEventCw.rawValue)
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventCcw = Int32(config.inputbrokerEventCcw.rawValue)
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventPress = Int32(config.inputbrokerEventPress.rawValue)
@@ -1333,7 +1338,7 @@ extension MeshPackets {
 					newConfig.enabled = config.enabled
 					newConfig.sendBell = config.sendBell
 					newConfig.name = config.name
-					newConfig.monitorPin = Int32(config.monitorPin)
+					newConfig.monitorPin = Int32(truncatingIfNeeded: config.monitorPin)
 					newConfig.triggerType = Int32(config.detectionTriggerType.rawValue)
 					newConfig.usePullup = config.usePullup
 					newConfig.minimumBroadcastSecs = Int32(truncatingIfNeeded: config.minimumBroadcastSecs)
@@ -1343,7 +1348,7 @@ extension MeshPackets {
 					fetchedNode[0].detectionSensorConfig?.enabled = config.enabled
 					fetchedNode[0].detectionSensorConfig?.sendBell = config.sendBell
 					fetchedNode[0].detectionSensorConfig?.name = config.name
-					fetchedNode[0].detectionSensorConfig?.monitorPin = Int32(config.monitorPin)
+					fetchedNode[0].detectionSensorConfig?.monitorPin = Int32(truncatingIfNeeded: config.monitorPin)
 					fetchedNode[0].detectionSensorConfig?.usePullup = config.usePullup
 					fetchedNode[0].detectionSensorConfig?.triggerType = Int32(config.detectionTriggerType.rawValue)
 					fetchedNode[0].detectionSensorConfig?.minimumBroadcastSecs = Int32(truncatingIfNeeded: config.minimumBroadcastSecs)
@@ -1455,11 +1460,11 @@ extension MeshPackets {
 					newExternalNotificationConfig.alertMessageBuzzer = config.alertMessageBuzzer
 					newExternalNotificationConfig.alertMessageVibra = config.alertMessageVibra
 					newExternalNotificationConfig.active = config.active
-					newExternalNotificationConfig.output = Int32(config.output)
-					newExternalNotificationConfig.outputBuzzer = Int32(config.outputBuzzer)
-					newExternalNotificationConfig.outputVibra = Int32(config.outputVibra)
-					newExternalNotificationConfig.outputMilliseconds = Int32(config.outputMs)
-					newExternalNotificationConfig.nagTimeout = Int32(config.nagTimeout)
+					newExternalNotificationConfig.output = Int32(truncatingIfNeeded: config.output)
+					newExternalNotificationConfig.outputBuzzer = Int32(truncatingIfNeeded: config.outputBuzzer)
+					newExternalNotificationConfig.outputVibra = Int32(truncatingIfNeeded: config.outputVibra)
+					newExternalNotificationConfig.outputMilliseconds = Int32(truncatingIfNeeded: config.outputMs)
+					newExternalNotificationConfig.nagTimeout = Int32(truncatingIfNeeded: config.nagTimeout)
 					newExternalNotificationConfig.useI2SAsBuzzer = config.useI2SAsBuzzer
 					fetchedNode[0].externalNotificationConfig = newExternalNotificationConfig
 				} else {
@@ -1472,11 +1477,11 @@ extension MeshPackets {
 					fetchedNode[0].externalNotificationConfig?.alertMessageBuzzer = config.alertMessageBuzzer
 					fetchedNode[0].externalNotificationConfig?.alertMessageVibra = config.alertMessageVibra
 					fetchedNode[0].externalNotificationConfig?.active = config.active
-					fetchedNode[0].externalNotificationConfig?.output = Int32(config.output)
-					fetchedNode[0].externalNotificationConfig?.outputBuzzer = Int32(config.outputBuzzer)
-					fetchedNode[0].externalNotificationConfig?.outputVibra = Int32(config.outputVibra)
-					fetchedNode[0].externalNotificationConfig?.outputMilliseconds = Int32(config.outputMs)
-					fetchedNode[0].externalNotificationConfig?.nagTimeout = Int32(config.nagTimeout)
+					fetchedNode[0].externalNotificationConfig?.output = Int32(truncatingIfNeeded: config.output)
+					fetchedNode[0].externalNotificationConfig?.outputBuzzer = Int32(truncatingIfNeeded: config.outputBuzzer)
+					fetchedNode[0].externalNotificationConfig?.outputVibra = Int32(truncatingIfNeeded: config.outputVibra)
+					fetchedNode[0].externalNotificationConfig?.outputMilliseconds = Int32(truncatingIfNeeded: config.outputMs)
+					fetchedNode[0].externalNotificationConfig?.nagTimeout = Int32(truncatingIfNeeded: config.nagTimeout)
 					fetchedNode[0].externalNotificationConfig?.useI2SAsBuzzer = config.useI2SAsBuzzer
 				}
 				if sessionPasskey != nil {
@@ -1509,12 +1514,12 @@ extension MeshPackets {
 					let newConfig = NeighborInfoConfigEntity()
 					modelContext.insert(newConfig)
 					newConfig.enabled = config.enabled
-					newConfig.updateInterval = Int32(config.updateInterval)
+					newConfig.updateInterval = Int32(truncatingIfNeeded: config.updateInterval)
 					newConfig.transmitOverLora = config.transmitOverLora
 					fetchedNode[0].neighborInfoConfig = newConfig
 				} else {
 					fetchedNode[0].neighborInfoConfig?.enabled = config.enabled
-					fetchedNode[0].neighborInfoConfig?.updateInterval = Int32(config.updateInterval)
+					fetchedNode[0].neighborInfoConfig?.updateInterval = Int32(truncatingIfNeeded: config.updateInterval)
 					fetchedNode[0].neighborInfoConfig?.transmitOverLora = config.transmitOverLora
 				}
 				if sessionPasskey != nil {
@@ -1548,13 +1553,13 @@ extension MeshPackets {
 					let newPaxCounterConfig = PaxCounterConfigEntity()
 					modelContext.insert(newPaxCounterConfig)
 					newPaxCounterConfig.enabled = config.enabled
-					newPaxCounterConfig.updateInterval = Int32(config.paxcounterUpdateInterval)
+					newPaxCounterConfig.updateInterval = Int32(truncatingIfNeeded: config.paxcounterUpdateInterval)
 					newPaxCounterConfig.wifiThreshold = config.wifiThreshold
 					newPaxCounterConfig.bleThreshold = config.bleThreshold
 					fetchedNode[0].paxCounterConfig = newPaxCounterConfig
 				} else {
 					fetchedNode[0].paxCounterConfig?.enabled = config.enabled
-					fetchedNode[0].paxCounterConfig?.updateInterval = Int32(config.paxcounterUpdateInterval)
+					fetchedNode[0].paxCounterConfig?.updateInterval = Int32(truncatingIfNeeded: config.paxcounterUpdateInterval)
 					fetchedNode[0].paxCounterConfig?.wifiThreshold = config.wifiThreshold
 					fetchedNode[0].paxCounterConfig?.bleThreshold = config.bleThreshold
 				}
@@ -1634,8 +1639,8 @@ extension MeshPackets {
 					newMQTTConfig.tlsEnabled = config.tlsEnabled
 					newMQTTConfig.mapReportingEnabled = config.mapReportingEnabled
 					newMQTTConfig.mapReportingShouldReportLocation = config.mapReportSettings.shouldReportLocation
-					newMQTTConfig.mapPositionPrecision = Int32(config.mapReportSettings.positionPrecision)
-					newMQTTConfig.mapPublishIntervalSecs = Int32(config.mapReportSettings.publishIntervalSecs)
+					newMQTTConfig.mapPositionPrecision = Int32(truncatingIfNeeded: config.mapReportSettings.positionPrecision)
+					newMQTTConfig.mapPublishIntervalSecs = Int32(truncatingIfNeeded: config.mapReportSettings.publishIntervalSecs)
 					fetchedNode[0].mqttConfig = newMQTTConfig
 				} else {
 					fetchedNode[0].mqttConfig?.enabled = config.enabled
@@ -1648,8 +1653,8 @@ extension MeshPackets {
 					fetchedNode[0].mqttConfig?.jsonEnabled = config.jsonEnabled
 					fetchedNode[0].mqttConfig?.tlsEnabled = config.tlsEnabled
 					fetchedNode[0].mqttConfig?.mapReportingEnabled = config.mapReportingEnabled
-					fetchedNode[0].mqttConfig?.mapPositionPrecision = Int32(config.mapReportSettings.positionPrecision)
-					fetchedNode[0].mqttConfig?.mapPublishIntervalSecs = Int32(config.mapReportSettings.publishIntervalSecs)
+					fetchedNode[0].mqttConfig?.mapPositionPrecision = Int32(truncatingIfNeeded: config.mapReportSettings.positionPrecision)
+					fetchedNode[0].mqttConfig?.mapPublishIntervalSecs = Int32(truncatingIfNeeded: config.mapReportSettings.publishIntervalSecs)
 				}
 				if sessionPasskey != nil {
 					fetchedNode[0].sessionPasskey = sessionPasskey
@@ -1681,12 +1686,12 @@ extension MeshPackets {
 				if fetchedNode[0].rangeTestConfig == nil {
 					let newRangeTestConfig = RangeTestConfigEntity()
 					modelContext.insert(newRangeTestConfig)
-					newRangeTestConfig.sender = Int32(config.sender)
+					newRangeTestConfig.sender = Int32(truncatingIfNeeded: config.sender)
 					newRangeTestConfig.enabled = config.enabled
 					newRangeTestConfig.save = config.save
 					fetchedNode[0].rangeTestConfig = newRangeTestConfig
 				} else {
-					fetchedNode[0].rangeTestConfig?.sender = Int32(config.sender)
+					fetchedNode[0].rangeTestConfig?.sender = Int32(truncatingIfNeeded: config.sender)
 					fetchedNode[0].rangeTestConfig?.enabled = config.enabled
 					fetchedNode[0].rangeTestConfig?.save = config.save
 				}
@@ -1722,19 +1727,19 @@ extension MeshPackets {
 					modelContext.insert(newSerialConfig)
 					newSerialConfig.enabled = config.enabled
 					newSerialConfig.echo = config.echo
-					newSerialConfig.rxd = Int32(config.rxd)
-					newSerialConfig.txd = Int32(config.txd)
+					newSerialConfig.rxd = Int32(truncatingIfNeeded: config.rxd)
+					newSerialConfig.txd = Int32(truncatingIfNeeded: config.txd)
 					newSerialConfig.baudRate = Int32(config.baud.rawValue)
-					newSerialConfig.timeout = Int32(config.timeout)
+					newSerialConfig.timeout = Int32(truncatingIfNeeded: config.timeout)
 					newSerialConfig.mode = Int32(config.mode.rawValue)
 					fetchedNode[0].serialConfig = newSerialConfig
 				} else {
 					fetchedNode[0].serialConfig?.enabled = config.enabled
 					fetchedNode[0].serialConfig?.echo = config.echo
-					fetchedNode[0].serialConfig?.rxd = Int32(config.rxd)
-					fetchedNode[0].serialConfig?.txd = Int32(config.txd)
+					fetchedNode[0].serialConfig?.rxd = Int32(truncatingIfNeeded: config.rxd)
+					fetchedNode[0].serialConfig?.txd = Int32(truncatingIfNeeded: config.txd)
 					fetchedNode[0].serialConfig?.baudRate = Int32(config.baud.rawValue)
-					fetchedNode[0].serialConfig?.timeout = Int32(config.timeout)
+					fetchedNode[0].serialConfig?.timeout = Int32(truncatingIfNeeded: config.timeout)
 					fetchedNode[0].serialConfig?.mode = Int32(config.mode.rawValue)
 				}
 				if sessionPasskey != nil {
@@ -1835,17 +1840,17 @@ extension MeshPackets {
 					modelContext.insert(newConfig)
 					newConfig.enabled = config.enabled
 					newConfig.heartbeat = config.heartbeat
-					newConfig.records = Int32(config.records)
-					newConfig.historyReturnMax = Int32(config.historyReturnMax)
-					newConfig.historyReturnWindow = Int32(config.historyReturnWindow)
+					newConfig.records = Int32(truncatingIfNeeded: config.records)
+					newConfig.historyReturnMax = Int32(truncatingIfNeeded: config.historyReturnMax)
+					newConfig.historyReturnWindow = Int32(truncatingIfNeeded: config.historyReturnWindow)
 					newConfig.isRouter = config.isServer
 					fetchedNode[0].storeForwardConfig = newConfig
 				} else {
 					fetchedNode[0].storeForwardConfig?.enabled = config.enabled
 					fetchedNode[0].storeForwardConfig?.heartbeat = config.heartbeat
-					fetchedNode[0].storeForwardConfig?.records = Int32(config.records)
-					fetchedNode[0].storeForwardConfig?.historyReturnMax = Int32(config.historyReturnMax)
-					fetchedNode[0].storeForwardConfig?.historyReturnWindow = Int32(config.historyReturnWindow)
+					fetchedNode[0].storeForwardConfig?.records = Int32(truncatingIfNeeded: config.records)
+					fetchedNode[0].storeForwardConfig?.historyReturnMax = Int32(truncatingIfNeeded: config.historyReturnMax)
+					fetchedNode[0].storeForwardConfig?.historyReturnWindow = Int32(truncatingIfNeeded: config.historyReturnWindow)
 				}
 				if sessionPasskey != nil {
 					fetchedNode[0].sessionPasskey = sessionPasskey
@@ -1986,14 +1991,14 @@ extension MeshPackets {
 
 				entity.enabled = positionDedup || nodeinfoDirect || rateLimit || dropUnknown
 				entity.positionDedupEnabled = positionDedup
-				entity.positionMinIntervalSecs = Int32(config.positionMinIntervalSecs)
+				entity.positionMinIntervalSecs = Int32(truncatingIfNeeded: config.positionMinIntervalSecs)
 				entity.nodeinfoDirectResponse = nodeinfoDirect
-				entity.nodeinfoDirectResponseMaxHops = Int32(config.nodeinfoDirectResponseMaxHops)
+				entity.nodeinfoDirectResponseMaxHops = Int32(truncatingIfNeeded: config.nodeinfoDirectResponseMaxHops)
 				entity.rateLimitEnabled = rateLimit
-				entity.rateLimitWindowSecs = Int32(config.rateLimitWindowSecs)
-				entity.rateLimitMaxPackets = Int32(config.rateLimitMaxPackets)
+				entity.rateLimitWindowSecs = Int32(truncatingIfNeeded: config.rateLimitWindowSecs)
+				entity.rateLimitMaxPackets = Int32(truncatingIfNeeded: config.rateLimitMaxPackets)
 				entity.dropUnknownEnabled = dropUnknown
-				entity.unknownPacketThreshold = Int32(config.unknownPacketThreshold)
+				entity.unknownPacketThreshold = Int32(truncatingIfNeeded: config.unknownPacketThreshold)
 				if sessionPasskey != nil {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -399,8 +399,11 @@ extension MeshPackets {
 						}
 					} else {
 						
-						let newUser = UserEntity()
-						modelContext.insert(newUser)
+						// findOrCreateNode already attached a find-or-create user for this num; reuse it
+						// (or find-or-create) instead of a bare insert. UserEntity.num is @Attribute(.unique)
+						// and the fetch only sees SAVED rows, so a duplicate insert inside the debounce
+						// window would trap on save when a second NODEINFO packet lands.
+						let newUser = newNode.user ?? findOrCreateUser(num: Int64(truncatingIfNeeded: packet.from), context: modelContext)
 						newUser.userId = newNode.num.toHex()
 						newUser.num = Int64(packet.from)
 						newUser.longName = newUserMessage.longName
@@ -542,8 +545,10 @@ extension MeshPackets {
 				} else if let userMessage = try? User(serializedBytes: packet.decoded.payload), !userMessage.id.isEmpty {
 					// Mesh broadcast sends a User protobuf (not wrapped in NodeInfo)
 					if fetchedNode[0].user == nil {
-						let newUser = UserEntity()
-						modelContext.insert(newUser)
+						// findOrCreateUser (not a bare insert): a user row for this unique num may already
+						// exist (orphaned or pending) even though this saved node's user is nil, so a bare
+						// insert would trap on save.
+						let newUser = findOrCreateUser(num: Int64(truncatingIfNeeded: packet.from), context: modelContext)
 						fetchedNode[0].user = newUser
 					}
 					fetchedNode[0].user?.userId = packet.from.toHex()
@@ -670,7 +675,11 @@ extension MeshPackets {
 						if positionMessage.groundTrack <= 360 {
 							position.heading = Int32(positionMessage.groundTrack)
 						}
-						position.precisionBits = Int32(truncatingIfNeeded: positionMessage.precisionBits)
+						// Clamp to the valid maximum (32 = full precision) instead of truncatingIfNeeded: an
+						// oversized UInt32 would wrap to a negative/garbage Int32 that the reduced-precision
+						// prune below (precisionBits != 32 && != 0) would treat as reduced accuracy and erase
+						// this node's stored position history. min(_, 32) is always <= 32 so it can't trap.
+						position.precisionBits = Int32(min(positionMessage.precisionBits, 32))
 						if positionMessage.timestamp != 0 {
 							position.time = Date(timeIntervalSince1970: TimeInterval(Int64(positionMessage.timestamp)))
 						} else {

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -294,7 +294,7 @@ extension MeshPackets {
 				node.viaMqtt = packet.viaMqtt
 				
 				if packet.hopStart != 0 && packet.hopLimit <= packet.hopStart {
-					node.hopsAway = Int32(packet.hopStart - packet.hopLimit)
+					node.hopsAway = Int32(truncatingIfNeeded: packet.hopStart - packet.hopLimit)
 					Logger.data.debug("💾 [updateAnyPacketFrom] Updating node \(packet.from.toHex(), privacy: .public) hopsAway=\(node.hopsAway)")
 				}
 				
@@ -381,7 +381,7 @@ extension MeshPackets {
 					newNode.hasXeddsaSigned = nodeInfoMessage.hasXeddsaSigned_p
 				}
 				if packet.hopStart != 0 && packet.hopLimit <= packet.hopStart {
-					newNode.hopsAway = Int32(packet.hopStart - packet.hopLimit)
+					newNode.hopsAway = Int32(truncatingIfNeeded: packet.hopStart - packet.hopLimit)
 				}
 				
 				if let newUserMessage = try? User(serializedBytes: packet.decoded.payload) {
@@ -563,11 +563,11 @@ extension MeshPackets {
 					// Security (finding H1): first-wins on the public key. See `applyInboundPublicKey`.
 					fetchedNode[0].user?.applyInboundPublicKey(userMessage.publicKey, nodeNum: Int64(packet.from))
 					if packet.hopStart != 0 && packet.hopLimit <= packet.hopStart {
-						fetchedNode[0].hopsAway = Int32(packet.hopStart - packet.hopLimit)
+						fetchedNode[0].hopsAway = Int32(truncatingIfNeeded: packet.hopStart - packet.hopLimit)
 					}
 
 				} else if packet.hopStart != 0 && packet.hopLimit <= packet.hopStart {
-					fetchedNode[0].hopsAway = Int32(packet.hopStart - packet.hopLimit)
+					fetchedNode[0].hopsAway = Int32(truncatingIfNeeded: packet.hopStart - packet.hopLimit)
 				}
 				if fetchedNode[0].user == nil {
 					do {

--- a/Meshtastic/Views/Settings/Routes.swift
+++ b/Meshtastic/Views/Settings/Routes.swift
@@ -87,8 +87,16 @@ struct Routes: View {
 										let longitude = longIndex >= 0 ? data[longIndex].trimmingCharacters(in: .whitespaces) : "0"
 										let loc = LocationEntity()
 										context.insert(loc)
-										loc.latitudeI = Int32((Double(latitude) ?? 0) * 1e7)
-										loc.longitudeI = Int32((Double(longitude) ?? 0) * 1e7)
+										// Clamp to valid coordinate ranges (and reject non-finite) before scaling:
+										// a malformed CSV cell (huge value, 1e400 -> inf, or nan) would otherwise
+										// make Int32(Double) trap and crash the import. Clamped × 1e7 stays well
+										// within Int32, so the conversion below can no longer overflow.
+										let latValue = Double(latitude) ?? 0
+										let lonValue = Double(longitude) ?? 0
+										let safeLat = latValue.isFinite ? min(max(latValue, -90), 90) : 0
+										let safeLon = lonValue.isFinite ? min(max(lonValue, -180), 180) : 0
+										loc.latitudeI = Int32(safeLat * 1e7)
+										loc.longitudeI = Int32(safeLon * 1e7)
 										newLocations.append(loc)
 									}
 								}

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -952,11 +952,12 @@ struct PositionPacketIngestHardeningTests {
 		await mesh.upsertPositionPacket(packet: packet)
 		await mesh.flushDebouncedSaves()
 
-		// Truncated, not crashed: 0xFFFFFFFF as Int32(truncatingIfNeeded:) == -1. Query by the
-		// sentinel so the assertion doesn't depend on node-relationship linkage internals.
+		// Truncated, not crashed: 0xFFFFFFFF as Int32(truncatingIfNeeded:) == -1. upsertPositionPacket
+		// links the position to the (find-or-created) node, so scope the query to THIS packet's node
+		// instead of the bare sentinel — a pre-existing row could otherwise satisfy it.
 		let context = ModelContext(sharedModelContainer)
 		let truncated = try context.fetch(FetchDescriptor<PositionEntity>(
-			predicate: #Predicate { $0.satsInView == -1 }
+			predicate: #Predicate { $0.nodePosition?.num == persistedNodeNum && $0.satsInView == -1 }
 		))
 		#expect(!truncated.isEmpty, "position was persisted with the truncated value, proving no crash")
 	}

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -910,6 +910,58 @@ struct TelemetryPacketIngestTests {
 
 // MARK: - PAX counter ingestion
 
+// MARK: - Position ingestion — malformed-packet hardening (DEF CON)
+
+@Suite("Position packet ingestion hardening", .serialized)
+@MainActor
+struct PositionPacketIngestHardeningTests {
+	private func makePositionPacket(from nodeNum: UInt32, mutate: (inout Position) -> Void) throws -> MeshPacket {
+		var position = Position()
+		// Real coordinates so the packet passes hasValidCoordinates and reaches the conversions.
+		position.latitudeI = Int32(47.6062 * 1e7)
+		position.longitudeI = Int32(-122.3321 * 1e7)
+		mutate(&position)
+
+		var dataMessage = DataMessage()
+		dataMessage.payload = try position.serializedData()
+		dataMessage.portnum = .positionApp
+
+		var packet = MeshPacket()
+		packet.from = nodeNum
+		packet.decoded = dataMessage
+		return packet
+	}
+
+	/// A single unauthenticated POSITION_APP packet whose UInt32 fields exceed Int32.max must
+	/// no longer SIGTRAP the app (the old `Int32(UInt32)` conversions trapped). The values must
+	/// land truncated rather than crash the process.
+	@Test func oversizedUInt32Fields_doNotCrashAndTruncate() async throws {
+		let nodeNum: UInt32 = 0x20DE_FC10
+		let persistedNodeNum = Int64(nodeNum)
+		let packet = try makePositionPacket(from: nodeNum) { p in
+			p.satsInView = 0xFFFF_FFFF   // > Int32.max — trapped before the fix
+			p.seqNumber = 0xFFFF_FFFF
+			p.groundSpeed = 0x8000_0000
+			p.groundTrack = 0xFFFF_FFFF  // also exercises the pre-conversion range check
+			p.precisionBits = 0xFFFF_FFFF
+		}
+
+		let mesh = MeshPackets(modelContainer: sharedModelContainer)
+		// Reaching this line at all (no fatalError / SIGTRAP) is the core assertion — the old
+		// code trapped here on the first oversized Int32(UInt32) conversion.
+		await mesh.upsertPositionPacket(packet: packet)
+		await mesh.flushDebouncedSaves()
+
+		// Truncated, not crashed: 0xFFFFFFFF as Int32(truncatingIfNeeded:) == -1. Query by the
+		// sentinel so the assertion doesn't depend on node-relationship linkage internals.
+		let context = ModelContext(sharedModelContainer)
+		let truncated = try context.fetch(FetchDescriptor<PositionEntity>(
+			predicate: #Predicate { $0.satsInView == -1 }
+		))
+		#expect(!truncated.isEmpty, "position was persisted with the truncated value, proving no crash")
+	}
+}
+
 @Suite("PAX counter ingestion", .serialized)
 @MainActor
 struct PaxCounterPacketIngestTests {


### PR DESCRIPTION
## Remote crash / crash-loop — the important ones (unauthenticated, any node in RF range)

- **Position packet single-packet crash (Critical).** `upsertPositionPacket` converted the `UInt32` fields (`seqNumber`, `satsInView`, `groundSpeed`, `groundTrack`, `precisionBits`) with the trapping `Int32(_:)`. One crafted `POSITION_APP` packet with a field > `Int32.max` — valid lat/lon to pass the coordinate check — deterministically `SIGTRAP`ped the app, and crash-looped on reconnect if it landed in the radio's node DB. Now `Int32(truncatingIfNeeded:)` (matching the rest of the file), with `groundTrack` range-checked on the `UInt32` before conversion.
- **Same trap class swept everywhere reachable** — the admin `getConfig`/`getModuleConfigResponse` upserts, `channel`, `hopsAway`, `batteryLevel`, `mapReportSettings.*`, etc. (~90 conversions). Enum `.rawValue` and already-safe conversions untouched.
- **SwiftData unique-collision crash (High).** `NodeInfoEntity.num`/`UserEntity.num` are `@Attribute(.unique)`; SwiftData dedups uniques only against the *saved* store, so two crafted packets from a new node inside the debounced-save window double-inserted and tripped a fatal assertion. `upsertNodeInfoPacket`, `createUser`, and `textMessageAppPacket` now go through the pending-insert-aware `findOrCreateNode`/`findOrCreateUser` (hardened `createUser` to be find-or-create, protecting all its callers).

## MITM / credential exposure (High)

- **MQTT TLS was trust-all** — `allowUntrustCACertificate = true` and the `didReceive` trust callback returned `completionHandler(true)` on *both* branches. Now rejects invalid/self-signed certs (`completionHandler(isValid)`, `allowUntrust = false`), closing the on-path MITM that captured broker credentials and injected spoofed downlinks. Also warns when credentials would be sent over a non-TLS connection.

## Silent mutation via App Intents (Medium)

- `SaveChannelSettingsIntent` / `AddContactIntent` now `requestConfirmation` before mutating radio state — mirroring the in-app QR/URL confirmation sheets and the destructive intents — so an untrusted Shortcut can't silently replace your channel list/PSK or inject a contact in the background.

## File-parsing / transport / info-disclosure

- Route-CSV import clamps lat/lon and rejects non-finite before scaling (no `Int32(Double)` trap).
- `MBTilesArchive` clamps attacker metadata zoom before `UInt8(...)`; `PMTilesExtractor` gets the overflow-safe offset arithmetic already applied to the reader in #2192.
- TCP reader skips zero-length frames instead of an undocumented `receive(0,0)`.
- Connect **Step 5a** gets a 120s timeout so a radio that withholds the DB-complete nonce can't wedge the connect flow forever.
- TAK logs redact full-precision coordinates (`privacy: .private`).

## Tests

- New `PositionPacketIngestHardeningTests`: an oversized-field position packet now truncates and persists instead of crashing.
- `PaxCounter` / `Telemetry` / `DeviceMetadata` / `ChannelURL` / `ShareContactURL` / `Entity` suites (26 tests) still pass — the ingestion-path changes didn't regress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts before adding contacts and before saving channel/LoRa settings.
* **Bug Fixes**
  * Improved connection reliability with a bounded database-sync wait and safer TCP frame reading.
  * Reduced persistence issues by preventing duplicate entries and hardening extreme/malformed packet and config value handling.
  * Hardened map tile/route ingestion (zoom bounds, overflow-safe extraction, sanitized CSV coordinates).
  * Enforced MQTT TLS trust validation.
* **Privacy**
  * Redacted latitude/longitude details in diagnostic logs.
* **Tests**
  * Added coverage for POSITION packet ingestion hardening with oversized values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->