### PR TITLE
feat(map): cluster waypoints with nodes and add them to the coincident-item picker

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -83096,6 +83096,9 @@
         }
       }
     },
+    "Select an Item (%@)" : {
+      "comment" : "Title of the map picker shown when a tapped cluster or coincident stack contains more than one item (nodes and/or waypoints). %@ is the item count."
+    },
     "Select a Trace Route" : {
       "localizations" : {
         "da" : {

--- a/Meshtastic/Persistence/PerformanceSeedData.swift
+++ b/Meshtastic/Persistence/PerformanceSeedData.swift
@@ -959,7 +959,7 @@ extension PerformanceSeedData {
 /// With the map fan-out removed, nodes that sit within a few meters of each other stay stacked. When
 /// clustering is on they collapse into one count badge (tap -> picker); with `--cluster-demo-no-clustering`
 /// they render as overlapping pins (a plain pin tap must still open the picker, per the clustering-off
-/// path in `MeshMapMK.presentNodeSelection`).
+/// path in `MeshMapMK.presentItemSelection`).
 ///
 /// Scenarios (pick with a launch arg, or `MESHTASTIC_CLUSTER_DEMO_SCENARIO=<name>`; no rebuild needed
 /// to switch once compiled):

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/MeshMapContent.swift
@@ -32,12 +32,13 @@ struct MeshMapSelectedNode: Identifiable, Equatable {
 	let id: Int64
 }
 
-/// A tapped coincident stack of nodes (same location, can't be split by zoom), presented in the
-/// map's disambiguation picker. Carries its own nodes so the sheet reads them via `.sheet(item:)`
+/// A tapped coincident stack of map items (same location, can't be split by zoom), presented in the
+/// map's disambiguation picker. Carries its own items so the sheet reads them via `.sheet(item:)`
 /// rather than a separately-updated `@State` array (which can present before the array is observed).
-struct ColocatedNodeStack: Identifiable {
+/// Items are nodes and/or waypoints so the picker can offer both.
+struct ColocatedMapStack: Identifiable {
 	let id = UUID()
-	let nodes: [MeshMapPositionSnapshot]
+	let items: [MeshMapItem]
 }
 
 /// Lightweight snapshot of a position's node data, extracted outside the render pass so MapKit
@@ -54,6 +55,91 @@ struct MeshMapPositionSnapshot: Identifiable {
 	let isOnline: Bool
 	let viaMqtt: Bool
 	let calculatedDelay: Double
+}
+
+/// Lightweight snapshot of a waypoint, extracted outside the render pass (mirrors
+/// `MeshMapPositionSnapshot`) so waypoints can cluster with nodes and appear in the coincident-item
+/// picker without holding SwiftData entities in map state. The backing `WaypointEntity` is resolved
+/// from `id` only when a marker is actually tapped.
+struct MeshMapWaypointSnapshot: Identifiable {
+	/// Stable identity (the waypoint's `persistentModelID` hash) — also the key the map uses to
+	/// resolve the backing `WaypointEntity` when the marker is tapped.
+	let id: Int64
+	let coordinate: CLLocationCoordinate2D
+	let name: String
+	/// The waypoint's emoji glyph (decoded from `WaypointEntity.icon`), drawn in the orange map circle
+	/// and shown beside the name in the disambiguation picker.
+	let icon: String
+}
+
+/// One clustering item on the mesh map: either a node position or a waypoint. Unifying them behind a
+/// single `ClusterMapView` item type is what lets a waypoint and nearby nodes collapse into one
+/// numbered cluster pin (and waypoints cluster with each other), and what lets the coincident-item
+/// picker list waypoints alongside nodes.
+enum MeshMapItem: Identifiable {
+	case node(MeshMapPositionSnapshot)
+	case waypoint(MeshMapWaypointSnapshot)
+
+	/// Namespaced identity so a node and a waypoint that happen to share a raw id never collide in the
+	/// map's per-id annotation table or the picker `List`.
+	enum ID: Hashable {
+		case node(Int64)
+		case waypoint(Int64)
+	}
+
+	var id: ID {
+		switch self {
+		case let .node(snapshot): return .node(snapshot.id)
+		case let .waypoint(waypoint): return .waypoint(waypoint.id)
+		}
+	}
+
+	var coordinate: CLLocationCoordinate2D {
+		switch self {
+		case let .node(snapshot): return snapshot.coordinate
+		case let .waypoint(waypoint): return waypoint.coordinate
+		}
+	}
+
+	/// Display name used to sort the disambiguation picker.
+	var displayName: String {
+		switch self {
+		case let .node(snapshot): return snapshot.longName
+		case let .waypoint(waypoint): return waypoint.name
+		}
+	}
+}
+
+extension MeshMapItem {
+	/// The items in `items` that sit within `spreadMeters` (ground distance) of `origin`, including
+	/// `origin` itself.
+	///
+	/// Drives the coincident-item disambiguation on a plain marker tap when clustering is off: MapKit
+	/// forms no `MKClusterAnnotation`, so a tap lands only on the topmost of a set of overlapping
+	/// markers. Grouping the tapped item with its coincident neighbors here lets the map offer the
+	/// same picker instead of leaving the occluded markers untappable. A free/static function so this
+	/// policy is unit-testable without a live SwiftUI view.
+	static func colocated(
+		with origin: MeshMapItem,
+		in items: [MeshMapItem],
+		withinMeters spreadMeters: Double
+	) -> [MeshMapItem] {
+		let originLocation = CLLocation(latitude: origin.coordinate.latitude, longitude: origin.coordinate.longitude)
+		return items.filter {
+			CLLocation(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude)
+				.distance(from: originLocation) < spreadMeters
+		}
+	}
+
+	/// The picker-ready ordering of a coincident group: de-duplicated by identity (the picker `List`'s
+	/// row identity is `MeshMapItem.ID`, so duplicates would collide into duplicate List IDs) then
+	/// sorted by display name. Keeps the first item seen for each id.
+	static func dedupedSortedForPicker(_ items: [MeshMapItem]) -> [MeshMapItem] {
+		var seenIDs = Set<ID>()
+		return items
+			.filter { seenIDs.insert($0.id).inserted }
+			.sorted { $0.displayName < $1.displayName }
+	}
 }
 
 extension MeshMapPositionSnapshot {

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -306,7 +306,11 @@ struct MeshMapMK: View {
 	/// Cheap change-detector for the route set (drives rebuildRouteContent via onChange).
 	/// Change-detector for the waypoint set (rebuild markers on add/remove/move/icon change).
 	private var waypointsKey: String {
-		allWaypoints.map { "\($0.id)|\($0.icon)|\($0.latitudeI)|\($0.longitudeI)|\($0.geofenceRadius)|\($0.hasBoundingBox ? 1 : 0)|\($0.boundingBoxLatitudeNorthI)|\($0.boundingBoxLatitudeSouthI)|\($0.boundingBoxLongitudeEastI)|\($0.boundingBoxLongitudeWestI)" }.joined(separator: ",")
+		// Includes `name` and `expire`: both are now rendered directly from the snapshot (the map
+		// pin and the coincident-item picker), so a rename or an expiry must change this key to
+		// trigger rebuildWaypointItems() — otherwise a stale name / an expired-but-still-tappable
+		// waypoint would linger until some unrelated field changed.
+		allWaypoints.map { "\($0.id)|\($0.name ?? "")|\($0.icon)|\($0.latitudeI)|\($0.longitudeI)|\($0.geofenceRadius)|\($0.hasBoundingBox ? 1 : 0)|\($0.boundingBoxLatitudeNorthI)|\($0.boundingBoxLatitudeSouthI)|\($0.boundingBoxLongitudeEastI)|\($0.boundingBoxLongitudeWestI)|\($0.expire?.timeIntervalSinceReferenceDate ?? 0)" }.joined(separator: ",")
 	}
 	private var routesKey: String {
 		routes.map { "\($0.color)|\($0.locations.count)" }.joined(separator: ",")

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -92,7 +92,13 @@ struct MeshMapMK: View {
 	@StateObject private var flyover = TraceRouteFlyover()
 	@AppStorage("enableMapWaypoints") private var showWaypoints = true
 	@AppStorage("mapOverlaysEnabled") private var mapOverlaysEnabled = false
-	@State private var waypointDecorations: [ClusterMapDecoration] = []
+	/// Waypoints as clustering items (so they merge into node clusters) rather than standalone
+	/// decorations. Rebuilt on add/remove/move/icon change; drawn as an orange emoji circle when a
+	/// waypoint isn't clustered.
+	@State private var waypointSnapshots: [MeshMapWaypointSnapshot] = []
+	/// Snapshot id -> the backing waypoint, so a tapped/picked waypoint opens its form without the
+	/// snapshot having to carry a SwiftData entity.
+	@State private var waypointEntitiesByID: [Int64: WaypointEntity] = [:]
 	/// User-uploaded GeoJSON overlays: lines/polygons -> overlays, points -> decorations.
 	@State private var geoJSONOverlays: [ClusterMapOverlay] = []
 	@State private var geoJSONDecorations: [ClusterMapDecoration] = []
@@ -108,9 +114,9 @@ struct MeshMapMK: View {
 	@State private var editingFilters = false
 	@State var selectedNode: MeshMapSelectedNode?
 	/// A tapped un-splittable coincident stack, shown in a disambiguation picker (nil = hidden).
-	@State private var colocatedStack: ColocatedNodeStack?
-	/// A node chosen in the picker, opened only after that sheet dismisses (so the two don't collide).
-	@State private var pendingColocatedSelection: Int64?
+	@State private var colocatedStack: ColocatedMapStack?
+	/// An item chosen in the picker, opened only after that sheet dismisses (so the two don't collide).
+	@State private var pendingColocatedSelection: MeshMapItem?
 	@State private var visiblePositionSnapshots: [MeshMapPositionSnapshot] = []
 	@State var editingWaypoint: WaypointEntity?
 	@State var selectedWaypoint: WaypointEntity?
@@ -311,15 +317,15 @@ struct MeshMapMK: View {
 	/// The map itself, extracted from `body` so the big generic expression type-checks on its own.
 	@ViewBuilder private var meshClusterMapView: some View {
 		ClusterMapView(
-				items: visiblePositionSnapshots,
+				items: combinedMapItems,
 				coordinate: { $0.coordinate },
 				region: $visibleRegion,
 				cameraCommand: cameraCommand,
 				clustering: enableMapClustering,
-				onSelect: { snapshot in presentNodeSelection(for: snapshot) },
-				onColocatedStack: { snapshots in
-					// Coincident stack that zoom-to-fit can't separate -> let the user pick a node by name.
-					presentColocatedStack(snapshots)
+				onSelect: { item in presentItemSelection(for: item) },
+				onColocatedStack: { items in
+					// Coincident stack that zoom-to-fit can't separate -> let the user pick an item by name.
+					presentColocatedStack(items)
 				},
 				configuration: clusterConfiguration,
 				overlays: combinedMapOverlays(),
@@ -328,10 +334,28 @@ struct MeshMapMK: View {
 				onMapLongPress: { coordinate in beginNewWaypoint(at: coordinate) },
 				onMapCreated: { flyover.mapView = $0 },
 				suppressRegionUpdates: flyover.isFlying
-			) { snapshot in
-				MeshMapMKNodePin(nodeNum: snapshot.nodeNum, shortName: snapshot.shortName, isOnline: snapshot.isOnline, calculatedDelay: snapshot.calculatedDelay, dense: isDense)
-					.equatable()
+			) { item in
+				switch item {
+				case let .node(snapshot):
+					MeshMapMKNodePin(nodeNum: snapshot.nodeNum, shortName: snapshot.shortName, isOnline: snapshot.isOnline, calculatedDelay: snapshot.calculatedDelay, dense: isDense)
+						.equatable()
+				case let .waypoint(waypoint):
+					// Distinct waypoint glyph when not clustered (matches the map legend's orange circle).
+					CircleText(text: waypoint.icon, color: .orange, circleSize: 36)
+				}
 			}
+	}
+
+	/// Node position snapshots + waypoint snapshots merged into one clustering item list, so a waypoint
+	/// and nearby nodes collapse into one numbered cluster pin (and waypoints cluster with each other).
+	/// Empty off-screen so MapKit drops its annotation trees.
+	private var combinedMapItems: [MeshMapItem] {
+		guard isMapVisible else { return [] }
+		var result = visiblePositionSnapshots.map { MeshMapItem.node($0) }
+		if showWaypoints {
+			result += waypointSnapshots.map { MeshMapItem.waypoint($0) }
+		}
+		return result
 	}
 
 	/// Banner shown while a trace route is drawn on the map, with controls to fly through and clear it.
@@ -424,35 +448,24 @@ struct MeshMapMK: View {
 					}
 				}
 				.sheet(item: $colocatedStack, onDismiss: {
-					// Open the chosen node's detail only after the picker has fully dismissed, so the two
+					// Open the chosen item only after the picker has fully dismissed, so the two
 					// sheets don't fight over presentation.
-					if let nodeNum = pendingColocatedSelection {
+					if let selection = pendingColocatedSelection {
 						pendingColocatedSelection = nil
-						selectNode(nodeNum)
+						open(selection)
 					}
 				}) { stack in
 					NavigationStack {
-						List(stack.nodes) { snapshot in
+						List(stack.items) { item in
 							Button {
-								pendingColocatedSelection = snapshot.nodeNum
+								pendingColocatedSelection = item
 								colocatedStack = nil
 							} label: {
-								// Reuse the standard node-list cell so the disambiguation picker matches
-								// the Nodes tab. Fall back to the snapshot's name if the live node was
-								// pruned between the tap and the sheet appearing.
-								if let node = getNodeInfo(id: snapshot.nodeNum, context: context) {
-									NodeListItem(
-										node: node,
-										isDirectlyConnected: snapshot.nodeNum == accessoryManager.activeDeviceNum,
-										connectedNode: accessoryManager.activeConnection?.device.num ?? -1
-									)
-								} else {
-									Text(snapshot.longName)
-								}
+								colocatedRow(for: item)
 							}
 							.buttonStyle(.plain)
 						}
-						.navigationTitle(String.localizedStringWithFormat("Select a Node (%@)".localized, String(stack.nodes.count)))
+						.navigationTitle(String.localizedStringWithFormat("Select an Item (%@)".localized, String(stack.items.count)))
 						#if !targetEnvironment(macCatalyst)
 						.navigationBarTitleDisplayMode(.inline)
 						#endif
@@ -463,7 +476,7 @@ struct MeshMapMK: View {
 								} label: {
 									Image(systemName: "xmark")
 								}
-								.accessibilityLabel(String(localized: "Cancel", comment: "VoiceOver: dismiss the node disambiguation picker"))
+								.accessibilityLabel(String(localized: "Cancel", comment: "VoiceOver: dismiss the map item disambiguation picker"))
 							}
 						}
 					}
@@ -661,7 +674,7 @@ struct MeshMapMK: View {
 			}
 			let activeFiles = GeoJSONOverlayManager.shared.getUploadedFilesWithState().filter { $0.isActive }
 			enabledOverlayConfigs = Set(activeFiles.map { $0.id })
-			rebuildWaypointDecorations()
+			rebuildWaypointItems()
 			rebuildGeoJSONOverlays()
 			rebuildRouteContent()
 			applyTraceRouteSelection()
@@ -860,36 +873,70 @@ struct MeshMapMK: View {
 		return key
 	}
 
-	/// Route a tapped pin to node detail, or — when other visible nodes sit on (nearly) the same
-	/// point — to the disambiguation picker. MapKit only forms `MKClusterAnnotation`s (which drive
-	/// `onColocatedStack`) when clustering is enabled, so with clustering OFF a pin tap can land on a
-	/// fully-occluded stack; without this the covered nodes would be permanently untappable. Detecting
-	/// coincident siblings here keeps every stacked node reachable regardless of the clustering setting.
-	private func presentNodeSelection(for snapshot: MeshMapPositionSnapshot) {
-		// De-dupe by nodeNum before deciding: two coincident snapshots that share a num (e.g. positions
-		// whose node is nil, both 0) are one selectable node, not a two-row picker.
-		let coincident = MeshMapPositionSnapshot.dedupedByNodeNumSortedByName(
-			MeshMapPositionSnapshot.colocated(
-				with: snapshot,
-				in: visiblePositionSnapshots,
+	/// Route a tapped marker to its detail, or — when other visible markers (nodes and/or waypoints)
+	/// sit on (nearly) the same point — to the disambiguation picker. MapKit only forms
+	/// `MKClusterAnnotation`s (which drive `onColocatedStack`) when clustering is enabled, so with
+	/// clustering OFF a tap can land on a fully-occluded stack; without this the covered markers would
+	/// be permanently untappable. Detecting coincident siblings here keeps every stacked marker
+	/// reachable regardless of the clustering setting.
+	private func presentItemSelection(for item: MeshMapItem) {
+		// De-dupe by identity before deciding: two coincident node snapshots that share a num (e.g.
+		// positions whose node is nil, both 0) are one selectable item, not a two-row picker.
+		let coincident = MeshMapItem.dedupedSortedForPicker(
+			MeshMapItem.colocated(
+				with: item,
+				in: combinedMapItems,
 				withinMeters: MapColocation.spreadMeters
 			)
 		)
 		if coincident.count > 1 {
 			presentColocatedStack(coincident)
 		} else {
-			selectNode(snapshot.nodeNum)
+			open(item)
 		}
 	}
 
-	/// Present the colocated disambiguation picker for a set of coincident nodes. De-dupes by
-	/// `nodeNum` first: the picker's `List` is keyed on `snapshot.id` (== `nodeNum`), so two snapshots
-	/// sharing a num (e.g. positions whose node is nil, both 0) would collide into duplicate List IDs
-	/// and mis-render.
-	private func presentColocatedStack(_ snapshots: [MeshMapPositionSnapshot]) {
+	/// Present the colocated disambiguation picker for a set of coincident items. De-dupes by identity
+	/// first: the picker's `List` is keyed on `MeshMapItem.ID`, so duplicates would collide into
+	/// duplicate List IDs and mis-render.
+	private func presentColocatedStack(_ items: [MeshMapItem]) {
 		selectedWaypoint = nil
 		editingWaypoint = nil
-		colocatedStack = ColocatedNodeStack(nodes: MeshMapPositionSnapshot.dedupedByNodeNumSortedByName(snapshots))
+		colocatedStack = ColocatedMapStack(items: MeshMapItem.dedupedSortedForPicker(items))
+	}
+
+	/// The disambiguation-picker row for one map item: the standard node cell for nodes (matching the
+	/// Nodes tab) or a waypoint's emoji + name for waypoints (matching the map pin / legend).
+	@ViewBuilder
+	private func colocatedRow(for item: MeshMapItem) -> some View {
+		switch item {
+		case let .node(snapshot):
+			// Reuse the standard node-list cell so the picker matches the Nodes tab. Fall back to the
+			// snapshot's name if the live node was pruned between the tap and the sheet appearing.
+			if let node = getNodeInfo(id: snapshot.nodeNum, context: context) {
+				NodeListItem(
+					node: node,
+					isDirectlyConnected: snapshot.nodeNum == accessoryManager.activeDeviceNum,
+					connectedNode: accessoryManager.activeConnection?.device.num ?? -1
+				)
+			} else {
+				Text(snapshot.longName)
+			}
+		case let .waypoint(waypoint):
+			Label {
+				Text(waypoint.name)
+			} icon: {
+				CircleText(text: waypoint.icon, color: .orange, circleSize: 28)
+			}
+		}
+	}
+
+	/// Open a tapped/picked map item: node detail for nodes, the waypoint form for waypoints.
+	private func open(_ item: MeshMapItem) {
+		switch item {
+		case let .node(snapshot): selectNode(snapshot.nodeNum)
+		case let .waypoint(waypoint): openWaypoint(id: waypoint.id)
+		}
 	}
 
 	/// Open a single node's detail sheet, clearing any in-flight waypoint selection first.
@@ -897,6 +944,15 @@ struct MeshMapMK: View {
 		selectedWaypoint = nil
 		editingWaypoint = nil
 		selectedNode = MeshMapSelectedNode(id: nodeNum)
+	}
+
+	/// Open a waypoint's form — the same path a direct waypoint-marker tap takes — resolving the
+	/// backing entity from the snapshot id. No-op if the waypoint was pruned since the snapshot built.
+	private func openWaypoint(id: Int64) {
+		guard let waypoint = waypointEntitiesByID[id] else { return }
+		selectedNode = nil
+		editingWaypoint = nil
+		selectedWaypoint = waypoint
 	}
 
 		private func refreshVisiblePositionSnapshots(from positions: [PositionEntity]) {
@@ -1060,7 +1116,7 @@ struct MeshMapMK: View {
 									reloadOfflineSource()
 									rebuildOfflineVectorOverlays()
 									rebuildRouteContent()
-									rebuildWaypointDecorations()
+									rebuildWaypointItems()
 									rebuildGeoJSONOverlays()
 									rebuildOverlays()
 								}
@@ -1082,7 +1138,6 @@ struct MeshMapMK: View {
 									guard isMapVisible else { return [] }
 									var result = routeDecorations
 									result += tracerouteDecorations
-									result += waypointDecorations
 									result += geoJSONDecorations
 									return result
 								}
@@ -1130,27 +1185,37 @@ struct MeshMapMK: View {
 									geoJSONDecorations = decorations
 								}
 
-/// Build tappable waypoint markers (icon bubble) from saved waypoints; tap -> open the form.
-				private func rebuildWaypointDecorations() {
+/// Build waypoint clustering items (orange emoji circle) from saved waypoints, plus the id -> entity
+			/// lookup used to open a waypoint's form when its marker (or picker row) is tapped. As items —
+			/// not standalone decorations — waypoints merge into node clusters and appear in the picker.
+				private func rebuildWaypointItems() {
 					let key = "\(showWaypoints)|\(waypointsKey)"
 					guard key != lastWaypointKey else { return }
 					lastWaypointKey = key
 					guard showWaypoints else {
-						if !waypointDecorations.isEmpty { waypointDecorations = [] }
+						if !waypointSnapshots.isEmpty { waypointSnapshots = [] }
+						if !waypointEntitiesByID.isEmpty { waypointEntitiesByID = [:] }
 						if !geofenceOverlays.isEmpty { geofenceOverlays = [] }
 						return
 					}
 					let visibleWaypoints = allWaypoints.filter { $0.expire == nil || $0.expire! >= Date.now }
 					geofenceOverlays = buildGeofenceOverlays(from: visibleWaypoints)
-					waypointDecorations = visibleWaypoints.map { waypoint in
+					var snapshots: [MeshMapWaypointSnapshot] = []
+					var entitiesByID: [Int64: WaypointEntity] = [:]
+					snapshots.reserveCapacity(visibleWaypoints.count)
+					for waypoint in visibleWaypoints {
+						let id = Int64(truncatingIfNeeded: waypoint.persistentModelID.hashValue)
 						let icon = String(UnicodeScalar(Int(waypoint.icon)) ?? "📍")
-						return ClusterMapDecoration(
-							id: "waypoint-\(waypoint.persistentModelID.hashValue)",
+						snapshots.append(MeshMapWaypointSnapshot(
+							id: id,
 							coordinate: waypoint.mapCoordinate,
-							content: AnyView(CircleText(text: icon, color: .orange, circleSize: 36)),
-							onTap: { selectedNode = nil; editingWaypoint = nil; selectedWaypoint = waypoint }
-						)
+							name: waypoint.name ?? "Dropped Pin",
+							icon: icon
+						))
+						entitiesByID[id] = waypoint
 					}
+					waypointSnapshots = snapshots
+					waypointEntitiesByID = entitiesByID
 				}
 
 				/// Build geofence overlays (radius circle + bounding-box rectangle) for any waypoint

--- a/MeshtasticTests/MapColocatedItemsTests.swift
+++ b/MeshtasticTests/MapColocatedItemsTests.swift
@@ -1,0 +1,154 @@
+// MapColocatedItemsTests.swift
+// MeshtasticTests
+//
+// Coverage for the mesh map's UNIFIED coincident-item grouping over `MeshMapItem`
+// (`MeshMapItem.colocated(with:in:withinMeters:)` + `MeshMapItem.dedupedSortedForPicker(_:)`).
+//
+// Since waypoints now cluster with nodes (both are `MeshMapItem`s sharing one clustering identifier),
+// the "Select an Item" picker can contain nodes AND waypoints. These tests pin the mixed-scene
+// grouping, the node/waypoint id-namespace separation (a node and a waypoint that share a raw id must
+// NOT collide into one picker row), and the picker ordering.
+
+import Testing
+import Foundation
+import CoreLocation
+@testable import Meshtastic
+
+@Suite("Map colocated-item (node + waypoint) grouping")
+struct MapColocatedItemsTests {
+
+	private static let baseLat = 47.6001
+	private static let baseLon = -122.3301
+	/// The production threshold, referenced (not re-hardcoded) so the tests track the single source of
+	/// truth and offsets stay valid if it changes.
+	private static let spread = MapColocation.spreadMeters
+
+	private func nodeItem(_ nodeNum: Int64, lat: Double = baseLat, lon: Double = baseLon, name: String? = nil) -> MeshMapItem {
+		.node(MeshMapPositionSnapshot(
+			id: nodeNum,
+			coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+			latitudeI: Int32(lat * 1e7),
+			longitudeI: Int32(lon * 1e7),
+			precisionBits: 32,
+			nodeNum: nodeNum,
+			longName: name ?? "Node \(nodeNum)",
+			shortName: "\(nodeNum)",
+			isOnline: true,
+			viaMqtt: false,
+			calculatedDelay: 0
+		))
+	}
+
+	private func waypointItem(_ id: Int64, lat: Double = baseLat, lon: Double = baseLon, name: String? = nil, icon: String = "📍") -> MeshMapItem {
+		.waypoint(MeshMapWaypointSnapshot(
+			id: id,
+			coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+			name: name ?? "Waypoint \(id)",
+			icon: icon
+		))
+	}
+
+	/// A coordinate offset `meters` due north of the base point (1° latitude ≈ 111_320 m).
+	private func north(_ meters: Double) -> (lat: Double, lon: Double) {
+		(Self.baseLat + meters / 111_320.0, Self.baseLon)
+	}
+
+	// MARK: - Mixed membership
+
+	@Test("A waypoint coincident with a node groups with it")
+	func waypointGroupsWithNode() {
+		let node = nodeItem(1)
+		let waypoint = waypointItem(1) // same point, raw id collides with the node num on purpose
+		let result = MeshMapItem.colocated(with: node, in: [node, waypoint], withinMeters: Self.spread)
+		#expect(Set(result.map(\.id)) == [.node(1), .waypoint(1)])
+	}
+
+	@Test("A waypoint beyond the threshold is excluded")
+	func distantWaypointExcluded() {
+		let node = nodeItem(1)
+		let far = north(Self.spread * 1.2)
+		let waypoint = waypointItem(9, lat: far.lat, lon: far.lon)
+		let result = MeshMapItem.colocated(with: node, in: [node, waypoint], withinMeters: Self.spread)
+		#expect(result.map(\.id) == [.node(1)])
+	}
+
+	@Test("Tapping a waypoint pulls in its coincident nodes (occluded-marker reachability)")
+	func waypointTapGroupsNodes() {
+		let waypoint = waypointItem(5)
+		let nodeA = nodeItem(1)
+		let nodeB = nodeItem(2)
+		let result = MeshMapItem.colocated(with: waypoint, in: [waypoint, nodeA, nodeB], withinMeters: Self.spread)
+		#expect(Set(result.map(\.id)) == [.waypoint(5), .node(1), .node(2)])
+	}
+
+	@Test("Grouping is scoped to the tapped marker's neighborhood, not the whole scene")
+	func neighborhoodScoped() {
+		let stackA: [MeshMapItem] = [nodeItem(1), waypointItem(1)]
+		let farPoint = north(50)
+		let stackB: [MeshMapItem] = [
+			nodeItem(2, lat: farPoint.lat, lon: farPoint.lon),
+			waypointItem(2, lat: farPoint.lat, lon: farPoint.lon)
+		]
+		let scene = stackA + stackB
+		let resultA = MeshMapItem.colocated(with: stackA[0], in: scene, withinMeters: Self.spread)
+		#expect(Set(resultA.map(\.id)) == [.node(1), .waypoint(1)])
+	}
+
+	// MARK: - Picker de-duplication (id namespace)
+
+	@Test("A node and a waypoint sharing a raw id are two distinct picker rows")
+	func nodeAndWaypointDoNotCollide() {
+		// Node num 7 and waypoint id 7 — different ID cases, so both must survive de-dup.
+		let items = [nodeItem(7), waypointItem(7)]
+		let result = MeshMapItem.dedupedSortedForPicker(items)
+		#expect(result.count == 2)
+		#expect(Set(result.map(\.id)) == [.node(7), .waypoint(7)])
+	}
+
+	@Test("Duplicate node nums collapse but a coincident waypoint stays")
+	func duplicateNodesCollapseWaypointStays() {
+		// Two nil-node positions both num 0, plus a real waypoint at the same point.
+		let items = [nodeItem(0), nodeItem(0), waypointItem(3)]
+		let result = MeshMapItem.dedupedSortedForPicker(items)
+		#expect(Set(result.map(\.id)) == [.node(0), .waypoint(3)]) // one node row, one waypoint row
+	}
+
+	@Test("Duplicate waypoint ids collapse to one row")
+	func duplicateWaypointsCollapse() {
+		let items = [waypointItem(4), waypointItem(4)]
+		let result = MeshMapItem.dedupedSortedForPicker(items)
+		#expect(result.map(\.id) == [.waypoint(4)])
+	}
+
+	// MARK: - Ordering
+
+	@Test("Picker input is sorted by display name across nodes and waypoints")
+	func sortsMixedByName() {
+		let zebra = nodeItem(1, name: "Zebra")
+		let apple = waypointItem(2, name: "Apple")
+		let mango = nodeItem(3, name: "Mango")
+		let result = MeshMapItem.dedupedSortedForPicker([zebra, apple, mango])
+		#expect(result.map(\.displayName) == ["Apple", "Mango", "Zebra"])
+	}
+
+	// MARK: - Decision semantics (count > 1 -> picker)
+
+	@Test("A lone node with only distant waypoints selects directly (no picker)")
+	func loneNodeDirectSelect() {
+		let node = nodeItem(1)
+		let far = north(30)
+		let waypoint = waypointItem(2, lat: far.lat, lon: far.lon)
+		let result = MeshMapItem.colocated(with: node, in: [node, waypoint], withinMeters: Self.spread)
+		#expect(result.count == 1) // count == 1 -> open directly, not the picker
+	}
+
+	@Test("A node stacked with a waypoint drives the picker")
+	func stackedDrivesPicker() {
+		let node = nodeItem(1)
+		let waypoint = waypointItem(2)
+		let result = MeshMapItem.dedupedSortedForPicker(
+			MeshMapItem.colocated(with: node, in: [node, waypoint], withinMeters: Self.spread)
+		)
+		#expect(result.count > 1) // count > 1 -> present the "Select an Item" picker
+	}
+}


### PR DESCRIPTION
## What & why

Waypoints previously rendered as standalone, **non-clustering** map decorations. A waypoint sitting among nodes never merged into a cluster, and it could never appear in the "Select a Node" disambiguation picker that opens when a cluster / coincident stack is tapped. This unifies nodes and waypoints so they cluster and disambiguate together.

## How

Introduce a single `MeshMapItem` (`.node` / `.waypoint`) clustering item so nodes and waypoints share one clustering identifier in `ClusterMapView`. Waypoints move from the map's `decorations` list to its `items` list; geofence circles/boxes stay as overlays.

- **Clustering** — a waypoint + nearby nodes now collapse into one numbered cluster pin, multiple waypoints cluster together, and the cluster count badge includes waypoints. A waypoint keeps its distinct orange emoji glyph when not clustered.
- **Disambiguation picker** — a tapped cluster (or a coincident stack when clustering is off) that contains waypoints now lists them alongside nodes. Node rows keep the standard `NodeListItem` cell; waypoint rows show the waypoint's emoji in an orange circle + its name (matching the map pin / legend). Selecting a waypoint **reuses the existing waypoint-tap path** — it opens that waypoint's `WaypointForm` — while selecting a node keeps node detail.
- Both the cluster-tap path and the clustering-off coincident-stack path route through one unified `MeshMapItem.colocated` / `dedupedSortedForPicker` policy, so behavior is identical regardless of the clustering setting. The node/waypoint id namespaces are kept separate so a node and a waypoint that share a raw id never collide into one picker row.
- The picker title generalizes from **"Select a Node (n)"** to **"Select an Item (n)"** (new `Localizable.xcstrings` key).
- The existing X close-button pattern on the sheet is preserved.

## Tests

Adds `MapColocatedItemsTests` covering mixed node+waypoint grouping, occluded-marker reachability, the id-namespace separation, picker de-duplication, and ordering. The existing node-only `MapColocatedNodesTests` remain green.

- Build: `xcodebuild build … -scheme Meshtastic -destination 'generic/platform=iOS Simulator'` — **succeeds**.
- Tests: `MapColocatedItemsTests` + `MapColocatedNodesTests` — **27/27 pass**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waypoints now participate in map clustering alongside nodes.
  * Coincident selections (nodes + waypoints) open a unified picker listing all nearby items.
  * Picker entries are deduplicated, uniquely identified across item types, and sorted by display name.
  * Added localized “Select an Item” title text for multi-item selection.
* **Bug Fixes**
  * Improved disambiguation when multiple nodes and waypoints overlap or are in close proximity.
* **Tests**
  * Added coverage for coincident clustering, picker grouping, de-duplication, and sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->