### PR TITLE
fix(security): derive Signed-node shield from the radio-verified transport bit

### DIFF
--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -378,7 +378,14 @@ extension MeshPackets {
 				}
 				if let nodeInfoMessage = try? NodeInfo(serializedBytes: packet.decoded.payload) {
 					newNode.favorite = nodeInfoMessage.isFavorite
-					newNode.hasXeddsaSigned = nodeInfoMessage.hasXeddsaSigned_p
+					// Derive the "Signed node" shield from the radio-verified transport signature
+					// (MeshPacket.xeddsa_signed, set by the local radio only after it cryptographically
+					// verifies this packet's XEdDSA signature) — NOT from the NodeInfo payload's
+					// has_xeddsa_signed bit, which is attacker-controlled over the mesh and would let a
+					// spoofed NODEINFO forge the verified shield. This still marks any node we hear
+					// signing (not just the connected one); the connected radio's NodeDB dump path
+					// (MeshPackets.nodeInfoPacket) keeps sourcing it from the radio's own database.
+					newNode.hasXeddsaSigned = packet.xeddsaSigned
 				}
 				if packet.hopStart != 0 && packet.hopLimit <= packet.hopStart {
 					newNode.hopsAway = Int32(truncatingIfNeeded: packet.hopStart - packet.hopLimit)
@@ -498,9 +505,11 @@ extension MeshPackets {
 				if let nodeInfoMessage = try? NodeInfo(serializedBytes: packet.decoded.payload) {
 
 					fetchedNode[0].favorite = nodeInfoMessage.isFavorite
-					// has_xeddsa_signed means the node has signed ≥1 verified broadcast and persists; latch it
-					// so a later NodeInfo that omits the bit doesn't downgrade a node we've seen sign.
-					fetchedNode[0].hasXeddsaSigned = fetchedNode[0].hasXeddsaSigned || nodeInfoMessage.hasXeddsaSigned_p
+					// Latch the "Signed node" shield from the radio-verified transport signature
+					// (MeshPacket.xeddsa_signed), NOT the attacker-controllable NodeInfo payload bit —
+					// otherwise a spoofed NODEINFO could forge the verified shield for any node. Latching
+					// means one verified signed broadcast persists even if a later packet omits the bit.
+					fetchedNode[0].hasXeddsaSigned = fetchedNode[0].hasXeddsaSigned || packet.xeddsaSigned
 					if nodeInfoMessage.hasDeviceMetrics {
 						let telemetry = TelemetryEntity()
 						modelContext.insert(telemetry)

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -963,6 +963,78 @@ struct PositionPacketIngestHardeningTests {
 	}
 }
 
+// MARK: - "Signed node" shield authenticity (forgeable-shield fix)
+
+@Suite("Signed-node shield authenticity", .serialized)
+@MainActor
+struct SignedShieldAuthenticityTests {
+	private func freshMesh() throws -> (MeshPackets, ModelContainer) {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		return (MeshPackets(modelContainer: container), container)
+	}
+
+	private func makeNodeInfoPacket(from num: UInt32, payloadClaimsSigned: Bool, transportVerified: Bool) throws -> MeshPacket {
+		var nodeInfo = NodeInfo()
+		nodeInfo.num = num
+		nodeInfo.hasXeddsaSigned_p = payloadClaimsSigned
+		var dataMessage = DataMessage()
+		dataMessage.payload = try nodeInfo.serializedData()
+		dataMessage.portnum = .nodeinfoApp
+		var packet = MeshPacket()
+		packet.from = num
+		packet.decoded = dataMessage
+		packet.xeddsaSigned = transportVerified
+		return packet
+	}
+
+	private func fetchNode(_ num: UInt32, in container: ModelContainer) throws -> NodeInfoEntity? {
+		let persisted = Int64(num)
+		return try ModelContext(container)
+			.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == persisted })).first
+	}
+
+	@Test func spoofedPayloadBit_doesNotForgeShield() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: UInt32 = 0x20DE_FC50
+		// Attacker claims signed IN THE PAYLOAD, but the radio did NOT verify a signature.
+		let packet = try makeNodeInfoPacket(from: num, payloadClaimsSigned: true, transportVerified: false)
+		await mesh.upsertNodeInfoPacket(packet: packet)
+		await mesh.flushDebouncedSaves()
+
+		let node = try fetchNode(num, in: container)
+		#expect(node != nil)
+		#expect(node?.hasXeddsaSigned == false)   // forge blocked — payload bit is not trusted
+	}
+
+	@Test func radioVerifiedBit_marksSigned() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: UInt32 = 0x20DE_FC51
+		// Payload omits the claim, but the radio VERIFIED the packet's signature — any node we hear
+		// signing (not just the connected one) should legitimately show the shield.
+		let packet = try makeNodeInfoPacket(from: num, payloadClaimsSigned: false, transportVerified: true)
+		await mesh.upsertNodeInfoPacket(packet: packet)
+		await mesh.flushDebouncedSaves()
+
+		#expect(try fetchNode(num, in: container)?.hasXeddsaSigned == true)
+	}
+
+	@Test func latch_survivesLaterUnverifiedPacket() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: UInt32 = 0x20DE_FC52
+		// First a radio-verified signed packet marks the node, then a spoofed/unverified one must
+		// neither downgrade it (latch) nor be able to forge it in the first place.
+		await mesh.upsertNodeInfoPacket(packet: try makeNodeInfoPacket(from: num, payloadClaimsSigned: false, transportVerified: true))
+		await mesh.flushDebouncedSaves()
+		await mesh.upsertNodeInfoPacket(packet: try makeNodeInfoPacket(from: num, payloadClaimsSigned: false, transportVerified: false))
+		await mesh.flushDebouncedSaves()
+
+		#expect(try fetchNode(num, in: container)?.hasXeddsaSigned == true)   // latched, not downgraded
+	}
+}
+
 @Suite("PAX counter ingestion", .serialized)
 @MainActor
 struct PaxCounterPacketIngestTests {


### PR DESCRIPTION
## What

The "Signed node" verified shield shown in Node Detail / the node list was derived from the **NodeInfo payload's `has_xeddsa_signed` field**. Over the mesh that field is attacker-controllable, so a node's green "verified by the radio" shield could be set from an untrusted broadcast rather than from an actual verified signature.

This changes `upsertNodeInfoPacket` to derive the shield from **`MeshPacket.xeddsa_signed`** — the transport-level signature bit the *local radio* sets only after it cryptographically verifies the packet's XEdDSA signature. That's the same trusted signal the message-level signed shield already uses (`newMessage.xeddsaSigned = packet.xeddsaSigned && isBroadcastMessage`).

## Why this shape (not just "trust only the connected node")

The shield should still light for **any** node we actually hear signing a verified broadcast — not only the directly-connected radio — so gating on `overTheMesh`/connected-node alone would be too restrictive. Deriving from the radio-verified transport bit keeps that: a genuinely-signed broadcast from a distant node still shows the shield, because our radio verified the signature and set the bit; a spoofed payload claim does not, because no signature was verified. The connected radio's NodeDB-dump path (`MeshPackets.nodeInfoPacket`) is unchanged — it keeps sourcing the bit from the radio's own verified database. As a bonus this also closes the same forge via a crafted contact QR/URL import, since a synthetic import packet carries no verified signature.

## Tests

`SignedShieldAuthenticityTests` (3, all green):
- a spoofed payload `has_xeddsa_signed = true` with no verified signature → node is **not** marked signed,
- a radio-verified packet (payload bit unset) → node **is** marked signed,
- the latch preserves a previously-verified signed state against a later unverified packet.

Scoped to the shield derivation only — no key/identity or admin behavior changes. This was the item deliberately held out of the crash/MITM hardening PR (#2203); it's independent and touches disjoint code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signed-node status accuracy by relying on verified transport signatures rather than untrusted packet claims.
  * Preserved verified signed status once established, preventing later spoofed or unverified packets from downgrading it.

* **Tests**
  * Added coverage for spoofed claims, verified signatures, and signed-status persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->