### PR TITLE
fix(appintent): accurate confirmation dialog for Save Channel Settings intent

### DIFF
--- a/Meshtastic/AppIntents/SaveChannelSettingsIntent.swift
+++ b/Meshtastic/AppIntents/SaveChannelSettingsIntent.swift
@@ -37,10 +37,14 @@ struct SaveChannelSettingsIntent: AppIntent {
 		// the radio's channel list, PSKs, and LoRa config in the background.
 		// requestConfirmation throws if the user declines; let that cancellation propagate
 		// unchanged rather than mislabeling it as a save failure.
-		let mode = channelLink.addChannels ? "add to" : "REPLACE"
-		try await requestConfirmation(
-			result: .result(dialog: "This will \(mode) the channels and LoRa settings on your connected Meshtastic radio. Continue?")
-		)
+		// The add path only sends channels; the replace path also rewrites LoRa config and
+		// reboots the radio. Describe each case accurately so the prompt matches the mutation.
+		// Annotate the type so the ternary's branches coerce to IntentDialog (a bare ternary
+		// of String literals would otherwise infer String, which IntentDialog can't accept).
+		let dialog: IntentDialog = channelLink.addChannels
+			? "This will add channels to your connected Meshtastic radio. Your LoRa settings will not change. Continue?"
+			: "This will REPLACE the channels and LoRa settings on your connected Meshtastic radio. Continue?"
+		try await requestConfirmation(result: .result(dialog: dialog))
 		do {
 			try await AccessoryManager.shared.saveChannelSet(
 				channelSet: channelLink.channelSet,


### PR DESCRIPTION
## What

Follow-up to the merged #2203. Splits the Save Channel Settings App Intent confirmation dialog so the prompt states exactly what will happen:

- **Add** path: "This will add channels to your connected Meshtastic radio. Your LoRa settings will not change."
- **Replace** path: "This will REPLACE the channels and LoRa settings on your connected Meshtastic radio."

## Why

The previous dialog built one sentence from an `add to`/`REPLACE` mode string, so the add path incorrectly told the user it would change "the channels and LoRa settings". The add path only sends channels and leaves LoRa config untouched; only the replace path rewrites LoRa config and reboots the radio. For a security-confirmation prompt, the wording should match the mutation.

Addresses the one remaining unresolved CodeRabbit review comment on #2203. The two other unresolved CodeRabbit threads on that PR (AddContactIntent cancellation handling, and routing user creation through dedup) were verified already-addressed in the merged code — `createUser` now deduplicates internally against the saved store and pending inserts, and `requestConfirmation` sits outside the do/catch so a user cancel propagates cleanly.

## Test

Debug build for iOS Simulator: **BUILD SUCCEEDED**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Experience**
  - Updated channel settings confirmation messages to clearly distinguish between adding channels and replacing channels.
  - The add option now clarifies that LoRa settings remain unchanged.
  - The replace option now explicitly states that both channels and LoRa settings will be replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->