### PR TITLE
feat(waypoints): local-only waypoints + delete waypoints you can't edit

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1639,6 +1639,9 @@ actor MeshPackets {
 				let fetchWaypointDescriptor = FetchDescriptor<WaypointEntity>(predicate: #Predicate { $0.id == waypointId })
 
 				let fetchedWaypoint = try modelContext.fetch(fetchWaypointDescriptor)
+				// A local-only waypoint must never be overwritten by a mesh packet that happens to
+				// share its id — ignore the incoming waypoint entirely for that id.
+				if fetchedWaypoint.first?.isLocal == true { return }
 				// Fetch the node info to get the short name
 				var nodeShortName: String = "?"
 				let packetFrom = Int64(packet.from)

--- a/Meshtastic/Model/WaypointEntity.swift
+++ b/Meshtastic/Model/WaypointEntity.swift
@@ -19,6 +19,9 @@ final class WaypointEntity {
 	var lastUpdatedBy: Int64 = 0
 	var latitudeI: Int32 = 0
 	var locked: Bool = false
+	/// A local-only waypoint the user created on this device: it is never broadcast
+	/// over the mesh, and the mesh ingest never overwrites it (see MeshPackets.waypointPacket).
+	var isLocal: Bool = false
 	var longDescription: String?
 	var longitudeI: Int32 = 0
 	var name: String?

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -142,10 +142,17 @@ struct WaypointForm: View {
 							.datePickerStyle(.compact)
 							.font(.callout)
 					}
-					Toggle(isOn: $local) {
-						Label("Local Only", systemImage: "iphone")
+					// "Local Only" is offered only for a new waypoint or one that is already local.
+					// An existing shared waypoint is already mesh-known; demoting it to local would
+					// shadow its mesh id — MeshPackets.waypointPacket() drops incoming updates for any
+					// id whose local copy is isLocal — so future shared edits/expirations would be
+					// silently missed. To stop sharing a mesh waypoint, use "Delete for everyone".
+					if waypoint.id == 0 || waypoint.isLocal {
+						Toggle(isOn: $local) {
+							Label("Local Only", systemImage: "iphone")
+						}
+						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 					}
-					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
 					if local {
 						Text("Saved only on this device — not shared over the mesh. It can't be edited by other nodes, and you can always delete it.")
 							.font(.caption)
@@ -608,8 +615,8 @@ struct WaypointForm: View {
 	/// Expire the waypoint mesh-wide, then remove it locally. Only offered for shared
 	/// waypoints you can edit (connected, not local, not locked to another node).
 	private func deleteForEveryone() {
-		guard let deviceNum = accessoryManager.activeDeviceNum else {
-			Logger.mesh.error("Unable to delete waypoint: No Device num")
+		guard accessoryManager.activeDeviceNum != nil else {
+			Logger.mesh.error("Unable to delete waypoint: not connected to a device")
 			return
 		}
 		var newWaypoint = Waypoint()
@@ -619,9 +626,8 @@ struct WaypointForm: View {
 		newWaypoint.latitudeI = waypoint.latitudeI
 		newWaypoint.longitudeI = waypoint.longitudeI
 		newWaypoint.icon = icon.unicodeScalars.first?.value ?? 128205
-		if locked {
-			newWaypoint.lockedTo = lockedTo == 0 ? UInt32(deviceNum) : UInt32(lockedTo)
-		}
+		// Expire it mesh-wide. The receiver's expiration branch keys purely on `expire`
+		// (see MeshPackets.waypointPacket), so lockedTo is intentionally not set here.
 		newWaypoint.expire = UInt32(1)
 		applyGeofence(to: &newWaypoint)
 		Task {
@@ -629,7 +635,7 @@ struct WaypointForm: View {
 				try await accessoryManager.sendWaypoint(waypoint: newWaypoint)
 				await MainActor.run {
 					context.delete(waypoint)
-					do { try context.save() } catch { }
+					do { try context.save() } catch { Logger.mesh.error("Failed to delete waypoint after mesh expire: \(error)") }
 					dismiss()
 				}
 			} catch {

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -30,6 +30,8 @@ struct WaypointForm: View {
 	@State private var expire: Date = Date.now.addingTimeInterval(60 * 480) // 1 minute * 480 = 8 Hours
 	@State private var locked: Bool = false
 	@State private var lockedTo: Int64 = 0
+	/// Local-only waypoint: saved on this device, never broadcast over the mesh.
+	@State private var local: Bool = false
 	@State private var geofenceRadius: Double = 0 // meters; 0 = no circular geofence
 	@State private var notifyOnEnter: Bool = false
 	@State private var notifyOnExit: Bool = false
@@ -140,10 +142,20 @@ struct WaypointForm: View {
 							.datePickerStyle(.compact)
 							.font(.callout)
 					}
-					Toggle(isOn: $locked) {
-						Label("Locked", systemImage: "lock")
+					Toggle(isOn: $local) {
+						Label("Local Only", systemImage: "iphone")
 					}
 					.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+					if local {
+						Text("Saved only on this device — not shared over the mesh. It can't be edited by other nodes, and you can always delete it.")
+							.font(.caption)
+							.foregroundStyle(.secondary)
+					} else {
+						Toggle(isOn: $locked) {
+							Label("Locked", systemImage: "lock")
+						}
+						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+					}
 				}
 				Section(header: Text("Geofence")) {
 					Picker(selection: $geofenceRadius) {
@@ -194,6 +206,11 @@ struct WaypointForm: View {
 			.scrollDismissesKeyboard(.immediately)
 			HStack {
 				Button {
+					if local {
+						// Local-only: persist on this device, never touch the mesh (works offline).
+						commitLocal()
+						return
+					}
 					guard let deviceNum = accessoryManager.activeDeviceNum else {
 						Logger.mesh.warning("Send waypoint failed: No deviceNum")
 						return
@@ -201,6 +218,10 @@ struct WaypointForm: View {
 					if accessoryManager.isConnected {
 						/// Send a new or exiting waypoint
 						var newWaypoint = Waypoint()
+						// Sending publishes it to the mesh, so it is no longer local-only. Clear the
+						// flag — even if it started as a local waypoint — so it "promotes" to a shared
+						// waypoint and the mesh ingest is allowed to update it again.
+						waypoint.isLocal = false
 						if waypoint.id  ==  0 {
 							newWaypoint.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
 							waypoint.createdBy = Int64(deviceNum)
@@ -245,12 +266,12 @@ struct WaypointForm: View {
 						Logger.mesh.warning("Send waypoint failed, node not connected")
 					}
 				} label: {
-					Label("Send", systemImage: "arrow.up")
+					Label(local ? "Save" : "Send", systemImage: local ? "square.and.arrow.down" : "arrow.up")
 				}
 				.buttonStyle(.bordered)
 				.buttonBorderShape(.capsule)
 				.controlSize(.regular)
-				.disabled(!accessoryManager.isConnected)
+				.disabled(!local && !accessoryManager.isConnected)
 				.padding(.bottom)
 				
 				Button(role: .cancel) {
@@ -263,62 +284,17 @@ struct WaypointForm: View {
 				.controlSize(.regular)
 				.padding(.bottom)
 				
-				if waypoint.id > 0 && accessoryManager.isConnected {
-					
+				if waypoint.id != 0 || local {
 					Menu {
-						Button("For me", action: {
-							context.delete(waypoint)
-							do {
-								try context.save()
-							} catch {
+						Button(role: .destructive, action: deleteForMe) {
+							Label("Remove from this device", systemImage: "trash")
+						}
+						if accessoryManager.isConnected && !local && !waypoint.locked {
+							Button(role: .destructive, action: deleteForEveryone) {
+								Label("Delete for everyone", systemImage: "trash.slash")
 							}
-							dismiss() })
-						Button("For everyone", action: {
-							guard let deviceNum = accessoryManager.activeDeviceNum else {
-								Logger.mesh.error("Unable to set waypoint: No Device num")
-								return
-							}
-							var newWaypoint = Waypoint()
-							newWaypoint.id = UInt32(waypoint.id)
-							newWaypoint.name = name.count > 0 ? name : "Dropped Pin"
-							newWaypoint.description_p = description
-							newWaypoint.latitudeI = waypoint.latitudeI
-							newWaypoint.longitudeI = waypoint.longitudeI
-							// Unicode scalar value for the icon emoji string
-							let unicodeScalers = icon.unicodeScalars
-							// First element as an UInt32
-							let unicode = unicodeScalers[unicodeScalers.startIndex].value
-							newWaypoint.icon = unicode
-							if locked {
-								if lockedTo == 0 {
-									newWaypoint.lockedTo = UInt32(deviceNum)
-								} else {
-									newWaypoint.lockedTo = UInt32(lockedTo)
-								}
-							}
-							newWaypoint.expire = UInt32(1)
-							applyGeofence(to: &newWaypoint)
-							Task {
-								do {
-									try await accessoryManager.sendWaypoint(waypoint: newWaypoint)
-									Task { @MainActor in
-										context.delete(waypoint)
-										do {
-											try context.save()
-										} catch {
-										}
-										dismiss()
-									}
-								} catch {
-									Logger.mesh.warning("Send waypoint failed")
-									Task {@MainActor in
-										waypointFailedAlert = true
-									}
-								}
-							}
-						})
-					}
-					label: {
+						}
+					} label: {
 						Label("Delete", systemImage: "trash")
 							.foregroundColor(.red)
 					}
@@ -461,6 +437,23 @@ struct WaypointForm: View {
 						.accessibilityLabel(String(localized: "Edit waypoint", comment: "VoiceOver label for the edit waypoint button"))
 					}
 				}
+				if waypoint.id != 0 || waypoint.isLocal {
+					ToolbarItem(placement: .topBarTrailing) {
+						Menu {
+							Button(role: .destructive, action: deleteForMe) {
+								Label("Remove from this device", systemImage: "trash")
+							}
+							if accessoryManager.isConnected && !waypoint.isLocal && !waypoint.locked {
+								Button(role: .destructive, action: deleteForEveryone) {
+									Label("Delete for everyone", systemImage: "trash.slash")
+								}
+							}
+						} label: {
+							Image(systemName: "trash")
+						}
+						.accessibilityLabel(String(localized: "Delete waypoint", comment: "VoiceOver label for the delete waypoint menu"))
+					}
+				}
 			}
 		}
 		} // Group
@@ -518,6 +511,7 @@ struct WaypointForm: View {
 				if waypoint.locked {
 					locked = true
 				}
+				local = waypoint.isLocal
 				geofenceRadius = Double(waypoint.geofenceRadius)
 				notifyOnEnter = waypoint.notifyOnEnter
 				notifyOnExit = waypoint.notifyOnExit
@@ -534,6 +528,7 @@ struct WaypointForm: View {
 				name = ""
 				description = ""
 				locked = false
+				local = false
 				geofenceRadius = 0
 				notifyOnEnter = false
 				notifyOnExit = false
@@ -569,6 +564,81 @@ struct WaypointForm: View {
 		#endif
 	}
 	
+	private func commitLocal() {
+		if waypoint.id == 0 {
+			waypoint.id = Int64(UInt32.random(in: UInt32(UInt8.max)..<UInt32.max))
+			waypoint.created = Date()
+			waypoint.createdBy = Int64(accessoryManager.activeDeviceNum ?? 0)
+		} else {
+			waypoint.lastUpdated = Date()
+			waypoint.lastUpdatedBy = Int64(accessoryManager.activeDeviceNum ?? 0)
+		}
+		waypoint.isLocal = true
+		waypoint.locked = false
+		waypoint.name = name.count > 0 ? name : "Dropped Pin"
+		waypoint.longDescription = description
+		waypoint.icon = Int64(icon.unicodeScalars.first?.value ?? 128205)
+		waypoint.expire = expires ? expire : nil
+		waypoint.geofenceRadius = Int(max(0, geofenceRadius).rounded())
+		let hasGeofence = geofenceRadius > 0 || geofenceBounds != nil
+		waypoint.notifyOnEnter = hasGeofence && notifyOnEnter
+		waypoint.notifyOnExit = hasGeofence && notifyOnExit
+		waypoint.notifyFavoritesOnly = (waypoint.notifyOnEnter || waypoint.notifyOnExit) && notifyFavoritesOnly
+		if let b = geofenceBounds {
+			waypoint.hasBoundingBox = true
+			waypoint.boundingBoxLongitudeWestI = Int32((b.minLon * 1e7).rounded())
+			waypoint.boundingBoxLatitudeSouthI = Int32((b.minLat * 1e7).rounded())
+			waypoint.boundingBoxLongitudeEastI = Int32((b.maxLon * 1e7).rounded())
+			waypoint.boundingBoxLatitudeNorthI = Int32((b.maxLat * 1e7).rounded())
+		} else {
+			waypoint.hasBoundingBox = false
+		}
+		do { try context.save() } catch { Logger.mesh.error("Failed to save local waypoint: \(error)") }
+		dismiss()
+	}
+
+	/// Remove the waypoint from THIS device only — always available, even for waypoints
+	/// locked by (and so not editable from) another node.
+	private func deleteForMe() {
+		context.delete(waypoint)
+		do { try context.save() } catch { Logger.mesh.error("Failed to delete waypoint: \(error)") }
+		dismiss()
+	}
+
+	/// Expire the waypoint mesh-wide, then remove it locally. Only offered for shared
+	/// waypoints you can edit (connected, not local, not locked to another node).
+	private func deleteForEveryone() {
+		guard let deviceNum = accessoryManager.activeDeviceNum else {
+			Logger.mesh.error("Unable to delete waypoint: No Device num")
+			return
+		}
+		var newWaypoint = Waypoint()
+		newWaypoint.id = UInt32(waypoint.id)
+		newWaypoint.name = name.count > 0 ? name : "Dropped Pin"
+		newWaypoint.description_p = description
+		newWaypoint.latitudeI = waypoint.latitudeI
+		newWaypoint.longitudeI = waypoint.longitudeI
+		newWaypoint.icon = icon.unicodeScalars.first?.value ?? 128205
+		if locked {
+			newWaypoint.lockedTo = lockedTo == 0 ? UInt32(deviceNum) : UInt32(lockedTo)
+		}
+		newWaypoint.expire = UInt32(1)
+		applyGeofence(to: &newWaypoint)
+		Task {
+			do {
+				try await accessoryManager.sendWaypoint(waypoint: newWaypoint)
+				await MainActor.run {
+					context.delete(waypoint)
+					do { try context.save() } catch { }
+					dismiss()
+				}
+			} catch {
+				Logger.mesh.warning("Send waypoint failed")
+				await MainActor.run { waypointFailedAlert = true }
+			}
+		}
+	}
+
 	private func applyGeofence(to waypointProto: inout Waypoint) {
 		waypointProto.geofenceRadius = UInt32(max(0, geofenceRadius).rounded())
 		// The notification toggles are hidden in the UI when no geofence exists, but their


### PR DESCRIPTION
## What

Two waypoint improvements.

### 1. Local-only waypoints (not shared over the mesh)
- New `WaypointEntity.isLocal` flag and a **Local Only** toggle in `WaypointForm`.
- When on, the primary button becomes **Save**: the waypoint is persisted locally and **never broadcast** — so it works **offline** (no connected radio required), and the mesh-only *Locked* option is hidden.
- The mesh ingest (`MeshPackets.waypointPacket`) **skips** any incoming waypoint whose id collides with a local one, so a local waypoint can never be overwritten by the mesh.
- Turning **Local Only** back off and pressing **Send** promotes it to a shared waypoint (using its existing id) and clears `isLocal` so mesh updates resume.

### 2. Delete waypoints you can't edit
- Delete previously lived only inside edit mode, and the edit button is hidden for **locked** waypoints — so a waypoint you couldn't edit was also impossible to remove.
- Extracted `deleteForMe` / `deleteForEveryone` helpers and added a **delete menu to the read-only view's toolbar**:
  - **Remove from this device** — always available, even for waypoints locked by another node.
  - **Delete for everyone** (mesh expire) — only when you can actually share it (connected, not local, not locked).

## Notes
- `isLocal` is an additive field with a default → lightweight SwiftData migration; existing waypoints are unaffected.

## Test
- Debug builds for iOS Simulator and device: **BUILD SUCCEEDED**. Exercised on an iPhone 17 Pro: created a local waypoint offline, promoted it to the mesh, and removed a locked waypoint via the new read-only delete menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating and editing “Local Only” waypoints that remain on the current device and are not shared over the mesh.
  * Added separate options to remove a waypoint locally or delete it across the mesh.
  * Shared waypoints can be promoted from local-only status when sent to the mesh.

* **Bug Fixes**
  * Local-only waypoints are no longer overwritten by incoming mesh updates with matching IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->