### PR TITLE
fix(messages): prevent preview links from intercepting navigation

### DIFF
--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -292,24 +292,24 @@
             "orange",
             "markdown",
             "delimiters",
+            "conversation",
+            "tap",
             "retry",
             "exclamationmark",
-            "tap",
             "recipient",
             "node",
             "meshtastic",
-            "conversation",
             "after",
             "selection",
+            "links",
             "bold",
             "radio",
             "public",
-            "links",
             "field",
             "button",
             "symbol"
         ],
-        "charCount": 11883
+        "charCount": 12005
     },
     {
         "id": "mqtt",

--- a/Meshtastic/Resources/docs/markdown/user/messages.md
+++ b/Meshtastic/Resources/docs/markdown/user/messages.md
@@ -182,7 +182,7 @@ On iOS 18 and later, formatting buttons appear in the compact toolbar below the 
 
 When the compose field contains markdown syntax, a preview bubble appears above the compose field showing how the message will look when sent. The preview updates in real time as you type. When no markdown is present, the preview is hidden.
 
-Markdown formatting is also rendered in the channel and user message list previews, so you can see formatted text at a glance.
+Markdown formatting is also rendered in the channel and user message list previews, so you can see formatted text at a glance. Links in these conversation-list previews are not interactive; open the conversation to tap a link in its message bubble.
 
 | Example | Description |
 |---------|-------------|

--- a/Meshtastic/Resources/docs/user/messages.html
+++ b/Meshtastic/Resources/docs/user/messages.html
@@ -317,7 +317,7 @@ Send channel broadcasts and direct messages. Long press any message for actions 
 </ol>
 <h3>Live Preview</h3>
 <p>When the compose field contains markdown syntax, a preview bubble appears above the compose field showing how the message will look when sent. The preview updates in real time as you type. When no markdown is present, the preview is hidden.</p>
-<p>Markdown formatting is also rendered in the channel and user message list previews, so you can see formatted text at a glance.</p>
+<p>Markdown formatting is also rendered in the channel and user message list previews, so you can see formatted text at a glance. Links in these conversation-list previews are not interactive; open the conversation to tap a link in its message bubble.</p>
 <table>
 <thead>
 <tr>

--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -113,7 +113,7 @@ struct ChannelList: View {
 
 				if hasMessages {
 					HStack(alignment: .top) {
-						Text(LocalizedStringKey(mostRecent?.messagePayload ?? " "))
+						MessagePreviewText(mostRecent?.messagePayload ?? " ")
 							.font(.footnote)
 							.foregroundColor(.onSurfaceVariant)
 					}

--- a/Meshtastic/Views/Messages/MessagePreviewText.swift
+++ b/Meshtastic/Views/Messages/MessagePreviewText.swift
@@ -1,4 +1,9 @@
-// MARK: MessagePreviewText
+//
+//  MessagePreviewText.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/12/26.
+//
 
 import SwiftUI
 

--- a/Meshtastic/Views/Messages/MessagePreviewText.swift
+++ b/Meshtastic/Views/Messages/MessagePreviewText.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct MessagePreviewText: View {
+
+	private let text: AttributedString
+
+	init(_ source: String) {
+		text = Self.attributedString(for: source)
+	}
+
+	var body: some View {
+		Text(text)
+	}
+
+	static func attributedString(for source: String) -> AttributedString {
+		guard var result = try? AttributedString(
+			markdown: source,
+			options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+		) else {
+			return AttributedString(source)
+		}
+
+		let linkRanges = result.runs.compactMap { run in
+			run.link == nil ? nil : run.range
+		}
+		for range in linkRanges {
+			result[range].link = nil
+		}
+		return result
+	}
+}

--- a/Meshtastic/Views/Messages/MessagePreviewText.swift
+++ b/Meshtastic/Views/Messages/MessagePreviewText.swift
@@ -1,3 +1,5 @@
+// MARK: MessagePreviewText
+
 import SwiftUI
 
 struct MessagePreviewText: View {

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -315,7 +315,7 @@ private struct DirectMessageUserRow: View {
 
 				if let summary {
 					HStack(alignment: .top) {
-						Text(LocalizedStringKey(summary.payload))
+						MessagePreviewText(summary.payload)
 							.font(.footnote)
 							.foregroundColor(.onSurfaceVariant)
 					}

--- a/MeshtasticTests/MessagePreviewTextTests.swift
+++ b/MeshtasticTests/MessagePreviewTextTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Message preview text")
+struct MessagePreviewTextTests {
+
+	@Test("Bare URLs are not interactive in conversation previews")
+	func bareURLIsNotInteractive() {
+		let source = "See https://meshtastic.org/docs for details"
+		let preview = MessagePreviewText.attributedString(for: source)
+
+		#expect(String(preview.characters) == source)
+		#expect(preview.runs.allSatisfy { $0.link == nil })
+	}
+
+	@Test("Markdown links keep their label without remaining interactive")
+	func markdownLinkIsNotInteractive() {
+		let preview = MessagePreviewText.attributedString(
+			for: "Read the [Meshtastic docs](https://meshtastic.org/docs)"
+		)
+
+		#expect(String(preview.characters) == "Read the Meshtastic docs")
+		#expect(preview.runs.allSatisfy { $0.link == nil })
+	}
+}

--- a/docs/user/messages.md
+++ b/docs/user/messages.md
@@ -182,7 +182,7 @@ On iOS 18 and later, formatting buttons appear in the compact toolbar below the 
 
 When the compose field contains markdown syntax, a preview bubble appears above the compose field showing how the message will look when sent. The preview updates in real time as you type. When no markdown is present, the preview is hidden.
 
-Markdown formatting is also rendered in the channel and user message list previews, so you can see formatted text at a glance.
+Markdown formatting is also rendered in the channel and user message list previews, so you can see formatted text at a glance. Links in these conversation-list previews are not interactive; open the conversation to tap a link in its message bubble.
 
 | Example | Description |
 |---------|-------------|


### PR DESCRIPTION
## Summary
- render channel and direct-message list previews as noninteractive attributed text
- preserve inline Markdown presentation while removing URL actions and link semantics from previews
- add regression tests for bare URLs and Markdown links

## Why
Conversation rows are already `NavigationLink`s. Parsing the latest message as an interactive Markdown link created a nested action, so tapping a URL preview opened the web view instead of the conversation.

This keeps links interactive inside an opened conversation while reserving all taps in conversation-list previews for row navigation.

Closes #2217

## Validation
- `MeshtasticTests/MessagePreviewTextTests`: 2 passed
- `MeshtasticTests/NavigationStateTests`: 6 passed
- strict SwiftLint on all four changed Swift files: 0 violations
- simulator regression: seeded a channel whose latest message was `https://meshtastic.org/docs`; tapping the URL preview opened the channel and did not open a web view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved channel and direct-message previews with Markdown-aware formatting.
  * Preserved readable link labels while keeping preview links non-interactive.
* **Bug Fixes**
  * Prevented URLs and links in conversation previews from being tappable.
* **Tests**
  * Added coverage for plain URLs and Markdown links in previews.
* **Documentation**
  * Clarified that links in preview cards must be opened from the conversation’s message bubble.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->