### PR TITLE
fix(messages): time out orphaned "Sending…" messages so they become retryable

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -1231,7 +1231,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.17;
+				MARKETING_VERSION = 2.7.18;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1266,7 +1266,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.17;
+				MARKETING_VERSION = 2.7.18;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1301,7 +1301,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.17;
+				MARKETING_VERSION = 2.7.18;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1335,7 +1335,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.17;
+				MARKETING_VERSION = 2.7.18;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1382,7 +1382,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.17;
+				MARKETING_VERSION = 2.7.18;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -1432,7 +1432,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.17;
+				MARKETING_VERSION = 2.7.18;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,

--- a/Meshtastic/Extensions/SwiftData/MessageDeliveryStatus.swift
+++ b/Meshtastic/Extensions/SwiftData/MessageDeliveryStatus.swift
@@ -31,6 +31,18 @@ struct MessageDeliveryStatus {
 		canRetry: true
 	)
 
+	/// Shown for an outgoing message that has gone unacknowledged past `MessageEntity.sendAckTimeout`
+	/// — the radio's ack/nak never reached the app, so the message is stuck. Retryable, rather than an
+	/// indefinite "Sending…". Reuses the max-retransmit detail wording: to the user the outcome is the
+	/// same — the mesh never confirmed it.
+	static let notDelivered = MessageDeliveryStatus(
+		text: "Not delivered".localized,
+		detail: "No node confirmed this message. Try again when you have better signal or more mesh coverage.".localized,
+		systemImage: "exclamationmark.circle.fill",
+		color: Color(uiColor: .systemOrange),
+		canRetry: true
+	)
+
 	static let deliveredToRecipient = MessageDeliveryStatus(
 		text: "Delivered to recipient".localized,
 		detail: "The recipient confirmed this message.".localized,

--- a/Meshtastic/Extensions/SwiftData/MessageDeliveryStatus.swift
+++ b/Meshtastic/Extensions/SwiftData/MessageDeliveryStatus.swift
@@ -33,11 +33,12 @@ struct MessageDeliveryStatus {
 
 	/// Shown for an outgoing message that has gone unacknowledged past `MessageEntity.sendAckTimeout`
 	/// — the radio's ack/nak never reached the app, so the message is stuck. Retryable, rather than an
-	/// indefinite "Sending…". Reuses the max-retransmit detail wording: to the user the outcome is the
-	/// same — the mesh never confirmed it.
+	/// indefinite "Sending…". Reuses `RoutingError.maxRetransmit.description` (the same detail `.failed`
+	/// shows) so the copy and its localization can't drift: to the user the outcome is the same — the
+	/// mesh never confirmed it.
 	static let notDelivered = MessageDeliveryStatus(
 		text: "Not delivered".localized,
-		detail: "No node confirmed this message. Try again when you have better signal or more mesh coverage.".localized,
+		detail: RoutingError.maxRetransmit.description,
 		systemImage: "exclamationmark.circle.fill",
 		color: Color(uiColor: .systemOrange),
 		canRetry: true

--- a/Meshtastic/Extensions/SwiftData/MessageEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/MessageEntityExtension.swift
@@ -41,6 +41,13 @@ extension MessageEntity {
 		return re?.canRetry ?? false
 	}
 
+	/// Grace period after which an unacknowledged outgoing message is treated as failed
+	/// (retryable) rather than an endless "Sending…". The radio ack/naks a `wantAck` message
+	/// within its retransmit window (well under a minute); well past that with no response, the
+	/// ack/nak never reached the app — typically we were disconnected when it arrived — and the
+	/// message is orphaned. Kept generous so a slow, multi-hop mesh doesn't trip a false timeout.
+	static let sendAckTimeout: TimeInterval = 5 * 60
+
 	func deliveryStatus(isDirectMessage: Bool) -> MessageDeliveryStatus {
 		if receivedACK {
 			if isDirectMessage {
@@ -49,7 +56,18 @@ extension MessageEntity {
 			return .deliveredToMesh
 		}
 
-		guard ackError != 0 else { return .sending }
+		guard ackError != 0 else {
+			// No ACK and no routing error yet. The radio ack/naks a wantAck message within its
+			// retransmit window; once the grace period passes with no response, the ack/nak never
+			// reached us (usually we were disconnected when it arrived) and the message is orphaned
+			// — surface it as retryable rather than an endless "Sending…". Purely derived from the
+			// send time, so the row flips the next time it renders (e.g. on opening the conversation).
+			if messageTimestamp > 0,
+			   Date().timeIntervalSince1970 - Double(messageTimestamp) > Self.sendAckTimeout {
+				return .notDelivered
+			}
+			return .sending
+		}
 
 		if let routingError = RoutingError(rawValue: Int(ackError)) {
 			return .failed(routingError)

--- a/MeshtasticTests/MessageAckStatusRefreshTests.swift
+++ b/MeshtasticTests/MessageAckStatusRefreshTests.swift
@@ -283,12 +283,27 @@ struct MessageAckStatusRefreshTests {
 	// MARK: - Message delivery status wording
 
 	@Test func deliveryStatus_sendingUsesCanonicalText() throws {
-		let msg = try insertChannelMessage(channelIndex: 7_707, messageId: 970_700_001)
+		// A just-sent, still-unacknowledged message is "Sending…" — the send timeout hasn't elapsed.
+		let msg = try insertChannelMessage(channelIndex: 7_707, messageId: 970_700_001,
+										   timestamp: Int32(Date().timeIntervalSince1970))
 
 		let status = msg.deliveryStatus(isDirectMessage: false)
 
 		#expect(status.text == "Sending...")
 		#expect(status.canRetry == false)
+	}
+
+	@Test func deliveryStatus_orphanedSendTimesOutToNotDelivered() throws {
+		// A message left unacknowledged (no ACK, no routing error) well past the send timeout is
+		// surfaced as failed/retryable rather than an indefinite "Sending…" — the ack/nak never
+		// reached the app and the message is orphaned.
+		let stale = Int32(Date().timeIntervalSince1970 - MessageEntity.sendAckTimeout - 60)
+		let msg = try insertChannelMessage(channelIndex: 7_709, messageId: 970_900_001, timestamp: stale)
+
+		let status = msg.deliveryStatus(isDirectMessage: false)
+
+		#expect(status.text == "Not delivered")
+		#expect(status.canRetry == true)
 	}
 
 	@Test func deliveryStatus_channelImplicitAckIsDeliveredToMesh() throws {

--- a/project.yml
+++ b/project.yml
@@ -403,7 +403,7 @@ targets:
             - "$(inherited)"
             - "@executable_path/Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.17"
+          MARKETING_VERSION: "2.7.18"
           OTHER_LDFLAGS:
             - "-weak_framework"
             - "SwiftUI"
@@ -446,7 +446,7 @@ targets:
             - "$(inherited)"
             - "@executable_path/Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.17"
+          MARKETING_VERSION: "2.7.18"
           OTHER_LDFLAGS:
             - "-weak_framework"
             - "SwiftUI"
@@ -492,7 +492,7 @@ targets:
             - "@executable_path/Frameworks"
             - "@executable_path/../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.17"
+          MARKETING_VERSION: "2.7.18"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.Widgets"
           PRODUCT_NAME: "$(TARGET_NAME)"
           PROVISIONING_PROFILE_SPECIFIER: ""
@@ -521,7 +521,7 @@ targets:
             - "@executable_path/Frameworks"
             - "@executable_path/../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.17"
+          MARKETING_VERSION: "2.7.18"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.Widgets"
           PRODUCT_NAME: "$(TARGET_NAME)"
           PROVISIONING_PROFILE_SPECIFIER: ""
@@ -615,7 +615,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.17"
+          MARKETING_VERSION: "2.7.18"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.watchkitapp"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "watchos"
@@ -643,7 +643,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.17"
+          MARKETING_VERSION: "2.7.18"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.watchkitapp"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "watchos"


### PR DESCRIPTION
## Summary
An outgoing message that never receives an ACK **or** a NAK stayed in **"Sending…"** indefinitely — no timeout, no retry affordance (`.sending` has `canRetry: false`). This happens when the radio's ack/nak never reaches the app (typically the app was disconnected when it arrived), orphaning the message. In the wild a message sat like this for the better part of a day with no way to act on it.

## Change
`MessageEntity.deliveryStatus(isDirectMessage:)` now treats an unacknowledged outgoing message (no `receivedACK`, no `ackError`) as a retryable **"Not delivered"** once it's older than a grace period (`MessageEntity.sendAckTimeout`, 5 min) — well past the radio's retransmit window. It reuses the existing max-retransmit detail wording ("No node confirmed this message…"), so an orphaned message gets the same retry flow as a max-retransmit failure.

The status is derived **purely from the send time** — no new DB fields, no background sweep, and no change to the ACK change-token / refresh machinery. An orphaned message flips to retryable the next time its row renders (e.g. on opening the conversation).

## Tests
- Updated `deliveryStatus_sendingUsesCanonicalText` to use a fresh timestamp (a just-sent message is still "Sending…").
- Added `deliveryStatus_orphanedSendTimesOutToNotDelivered` — a message older than the timeout resolves to a retryable "Not delivered".
- `MessageAckStatusRefreshTests` passes (17/17); Debug build for the iOS simulator succeeds.

## Context
Surfaced while investigating a report that the retry button "acts on multiple messages." That turned out to be a **re-render artifact** — the retry only ever touches the one tapped message (verified against a copy of the reporter's database: distinct message ids, non-PKI, the two "undelivered" messages sent ~19 h apart). The genuine defect the investigation exposed is this one: a message with no ack/nak has no timeout and no retry path. Reproduced in the simulator with the reporter's store loaded.

### Possible follow-up (not in this PR)
The status only re-derives on render, so a message crossing the timeout while the user is staring at an otherwise-idle conversation won't flip until the next reload. A proactive sweep (or folding a "timed-out" tally into the existing change token) would make it flip live; left out here to keep the change minimal and low-risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Not delivered” status for outgoing messages unacknowledged after five minutes.
  * The status includes clear visual feedback and allows users to retry sending.

* **Bug Fixes**
  * Improved delivery status accuracy during and after the acknowledgment grace period.

* **Release**
  * Updated the app, watch app, and widget to version 2.7.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->