### PR TITLE
Prevent stale SwiftData fetches after store replacement

### DIFF
--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -91,6 +91,13 @@ class PersistenceController {
 	/// long-lived context keeps the pre-clear objects registered; on reconnect SQLite reuses the
 	/// freed rowids, so a fetch/relationship access returns a dead instance and SwiftData traps
 	/// with "This model instance was destroyed by calling ModelContext.reset".
+	///
+	/// Invariant: any caller that can run while the UI is in the FOREGROUND must also bump
+	/// `AppState.databaseResetID` after this returns. The swap advances `containerGeneration`,
+	/// which makes guarded view tasks (e.g. the Nodes refresh loop) stop fetching; only the
+	/// `.id(databaseResetID)` remount re-binds them to the new container. A foreground caller
+	/// that forgets the bump gets a silently frozen list, not a crash. Background-only callers
+	/// (the first-unlock store reopen) are exempt because their views mount after the swap.
 	func recreateContainer() {
 		let schema = Schema(versionedSchema: MeshtasticSchema.current)
 		let config = ModelConfiguration(

--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -30,6 +30,9 @@ class PersistenceController {
 	}()
 
 	private(set) var container: ModelContainer
+	/// Advances synchronously with each container replacement. Long-lived view tasks capture the
+	/// generation they were mounted against and stop before touching a stale `ModelContext`.
+	private(set) var containerGeneration = 0
 
 	/// Remembered so the store can be reopened in a fresh container — see `recreateContainer()`.
 	private let storeName: String
@@ -106,6 +109,7 @@ class PersistenceController {
 				fresh = try ModelContainer(for: schema, migrationPlan: MeshtasticMigrationPlan.self, configurations: config)
 			}
 			fresh.mainContext.autosaveEnabled = false
+			containerGeneration &+= 1
 			container = fresh
 			Logger.data.info("💾 SwiftData container recreated after data clear")
 		} catch {

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -234,6 +234,9 @@ private struct FilteredNodeList: View {
 	/// cadence (see `.task`) instead of in `body`, so the full-node-set scan in `displayNodes`
 	/// doesn't run on every SwiftData write — which pegged the CPU on reconnect with a large DB.
 	@State private var displayedNodes: [NodeListEntry] = []
+	/// Kept in view state so a controller swap invalidates this task until SwiftUI remounts the
+	/// list against the new root `.modelContainer` and `databaseResetID`.
+	@State private var boundContainerGeneration = PersistenceController.shared.containerGeneration
 
 	var connectedNode: NodeInfoEntity?
 	@Binding var isPresentingDeleteNodeAlert: Bool
@@ -404,6 +407,8 @@ private struct FilteredNodeList: View {
 	}
 
 	private func refreshDisplayedNodes() {
+		// Accessing any property on a ModelContext whose container was replaced can trap in SwiftData.
+		guard boundContainerGeneration == PersistenceController.shared.containerGeneration else { return }
 		let allNodes = (try? context.fetch(makeNodeFetchDescriptor())) ?? []
 		replaceDisplayedNodesIfNeeded(with: displayNodes(from: allNodes, activeNodeNum: accessoryManager.activeDeviceNum))
 		router.updateNodeIndex(from: allNodes)

--- a/MeshtasticTests/PersistenceContainerGenerationTests.swift
+++ b/MeshtasticTests/PersistenceContainerGenerationTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Persistence container generation")
+@MainActor
+struct PersistenceContainerGenerationTests {
+
+	@Test("Recreating the container advances its generation")
+	func recreatingContainerAdvancesGeneration() {
+		let controller = PersistenceController(
+			inMemory: true,
+			storeName: "PersistenceContainerGenerationTests-\(UUID().uuidString)"
+		)
+		let originalContainer = controller.container
+		let originalGeneration = controller.containerGeneration
+
+		controller.recreateContainer()
+
+		#expect(controller.containerGeneration == originalGeneration + 1)
+		#expect(controller.container !== originalContainer)
+	}
+}


### PR DESCRIPTION
## What changed?

- Advance a persistence-container generation whenever `PersistenceController` replaces its `ModelContainer`.
- Have the Nodes refresh task retain its mounted generation and stop before fetching through an obsolete `ModelContext`.
- Add a focused test that verifies container replacement also advances the generation.

## Why did it change?

The foreign-database recovery path can replace the app's SwiftData container while the Nodes view still has a refresh task bound to the previous environment context. Its next fetch can trap inside SwiftData. The generation check invalidates that task before it touches the stale context.

## How is this tested?

- `PersistenceContainerGenerationTests` passes with Xcode 27 on iOS 27 and Mac Catalyst.
- The same focused test passes with Xcode 26.6 on iOS 26.5.
- An isolated Catalyst store-switch reproduction survived five short runs and one 60-second run after the fix. SQLite inspection confirmed that the old store was replaced and replay ingestion completed.
- Removing the generation increment made the focused test fail; restoring it returned the test to green.

## Screenshots/Videos (when applicable)

Not applicable. This fixes persistence lifecycle handling without changing the UI.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed; `skip-docs-check` is applied.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node list stability when the app replaces its local data container.
  * Prevented stale refresh operations from accessing outdated data.
  * Ensured node information refreshes safely after a new local data container is created.
  * Improved tracking of data container replacements.

* **Tests**
  * Added coverage verifying replacement tracking and confirming that each replacement uses a fresh container instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->