### PR TITLE
Make pre-build scripts sandbox-safe

### DIFF
--- a/.github/workflows/sync_device_svgs.yml
+++ b/.github/workflows/sync_device_svgs.yml
@@ -27,11 +27,10 @@ jobs:
         python-version: '3.11'
 
     - name: Sync device images and hardware catalog
-      # Reuse the exact script the Xcode "Download Node SVG Images" build phase runs,
-      # writing to the bundled resource location the app actually loads at runtime
-      # (the Bundle "images" subdirectory + DeviceHardware.json — see MeshtasticAPI).
+      # Write to the bundled resource location the app loads at runtime
+      # (the Bundle "images" subdirectory + DeviceHardware.json; see MeshtasticAPI).
       # --force ignores the cached API hash so the committed snapshot always matches
-      # the upstream device hardware API instead of drifting until someone clean-builds.
+      # the upstream device hardware API.
       run: |
         python3 scripts/download_images.py \
           --output-dir "Meshtastic/Resources/images" \

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -732,7 +732,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 63A955A9CB6FB8A135DC7D7B /* Build configuration list for PBXNativeTarget "Meshtastic" */;
 			buildPhases = (
-				046C462A3DE4D6A7A8A92162 /* Download Node SVG Images */,
 				412B37A25FF4D323EACB012B /* Run Script */,
 				D73F2A1F89670B5FAD74DC99 /* Sources */,
 				D531C94E5F672895C0FCE3B4 /* Resources */,
@@ -915,25 +914,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		046C462A3DE4D6A7A8A92162 /* Download Node SVG Images */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Download Node SVG Images";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "MARKER=\"${TARGET_TEMP_DIR}/first-build.marker\"\n\nif [ ! -f \"$MARKER\" ]; then\n # Treating as CLEAN build (or first build in this DerivedData)\n # Force update all the note board images\n \"$SRCROOT/scripts/download_images.py\" --output-dir \"$SRCROOT/Meshtastic/Resources/images\" --output-json \"$SRCROOT/Meshtastic/Resources/DeviceHardware.json\" --force\n touch \"$MARKER\"\nelse\n # Incremental build\n # update only if there was a change in the devices json\n \"$SRCROOT/scripts/download_images.py\" --output-dir \"$SRCROOT/Meshtastic/Resources/images\" --output-json \"$SRCROOT/Meshtastic/Resources/DeviceHardware.json\"\nfi\n";
-		};
 		412B37A25FF4D323EACB012B /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -943,6 +923,13 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/.swiftlint.yml",
+				"$(SRCROOT)/Meshtastic",
+				"$(SRCROOT)/Meshtastic Watch App",
+				"$(SRCROOT)/MeshtasticTests",
+				"$(SRCROOT)/MeshtasticUITests",
+				"$(SRCROOT)/Shared",
+				"$(SRCROOT)/Widgets",
 			);
 			name = "Run Script";
 			outputFileListPaths = (
@@ -951,7 +938,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint lint --cache-path \"$DERIVED_FILE_DIR/swiftlint-cache\"\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/project.yml
+++ b/project.yml
@@ -344,21 +344,6 @@ targets:
         product: MVTTools
     preBuildScripts:
       - script: |
-          MARKER="${TARGET_TEMP_DIR}/first-build.marker"
-          
-          if [ ! -f "$MARKER" ]; then
-           # Treating as CLEAN build (or first build in this DerivedData)
-           # Force update all the note board images
-           "$SRCROOT/scripts/download_images.py" --output-dir "$SRCROOT/Meshtastic/Resources/images" --output-json "$SRCROOT/Meshtastic/Resources/DeviceHardware.json" --force
-           touch "$MARKER"
-          else
-           # Incremental build
-           # update only if there was a change in the devices json
-           "$SRCROOT/scripts/download_images.py" --output-dir "$SRCROOT/Meshtastic/Resources/images" --output-json "$SRCROOT/Meshtastic/Resources/DeviceHardware.json"
-          fi
-        name: "Download Node SVG Images"
-        basedOnDependencyAnalysis: false
-      - script: |
           if [[ "$(uname -m)" == arm64 ]]
           then
               export PATH="/opt/homebrew/bin:$PATH"
@@ -366,11 +351,19 @@ targets:
           
           if command -v swiftlint >/dev/null 2>&1
           then
-              swiftlint
+              swiftlint lint --cache-path "$DERIVED_FILE_DIR/swiftlint-cache"
           else
               echo "warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions."
           fi
         name: "Run Script"
+        inputFiles:
+          - "$(SRCROOT)/.swiftlint.yml"
+          - "$(SRCROOT)/Meshtastic"
+          - "$(SRCROOT)/Meshtastic Watch App"
+          - "$(SRCROOT)/MeshtasticTests"
+          - "$(SRCROOT)/MeshtasticUITests"
+          - "$(SRCROOT)/Shared"
+          - "$(SRCROOT)/Widgets"
         basedOnDependencyAnalysis: false
     settings:
       configs:


### PR DESCRIPTION
## What changed?

- Remove the `Download Node SVG Images` pre-build phase.
- Keep device-image and hardware-catalog refreshes in the nightly/manual workflow added by #2114.
- Declare the SwiftLint configuration and linted source directories as Xcode script inputs.
- Store SwiftLint's cache under `DERIVED_FILE_DIR` instead of its default location.
- Regenerate the Xcode project from `project.yml`.

This is PR 2 of the stack and depends on #2232. Its base is the preceding stack branch, so this PR contains only the build-script changes.

## Why did it change?

Xcode's user-script sandbox prevented the Release SwiftLint phase from reading its configuration and writing the default cache. It also denied execution of `download_images.py`. That image phase duplicated #2114's scheduled refresh, made ordinary builds depend on network access, and mutated tracked resources during clean builds.

The scheduled workflow now remains the sole owner of resource refreshes. Normal app builds consume the checked-in snapshot without accessing the network or changing the source tree.

## How is this tested?

- Unsigned Release Mac Catalyst archives completed with Xcode 27 beta `27A5228h` and Xcode 26.6 `17F113`.
- Both archive runs executed SwiftLint and created its cache under DerivedData.
- Neither archive invoked `download_images.py` or reported a script-sandbox denial.
- Aggregate hashes for the tracked hardware catalog and device images remained unchanged during both archives.
- `.github/workflows/sync_device_svgs.yml` parses as valid YAML.
- `xcodegen generate` reproduces the checked-in project without a diff.

## Screenshots/Videos (when applicable)

Not applicable. This changes build and resource-refresh behavior only.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed; `skip-docs-check` is applied.
- [x] I have tested the change to ensure that it works as intended.
