### PR TITLE
Make snapshot tests safe on Mac Catalyst

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		78B74168A96E756F203F9D13 /* AppIcon_Chirpy.icon in Resources */ = {isa = PBXBuildFile; fileRef = DD8FE67D6F2C7F041F8E3C8C /* AppIcon_Chirpy.icon */; };
 		987BD8AFF176A9670F175E5C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 26351F51CD01C94D8D82486A /* Localizable.xcstrings */; };
 		9B61C796B61232F1226AAA28 /* DatadogLogs in Frameworks */ = {isa = PBXBuildFile; productRef = 7F3F27310C566077475C7105 /* DatadogLogs */; };
-		A518007AF83AA6E15BE848FD /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 7F0CA2B608168551C6F95FEB /* SnapshotTesting */; };
 		B80DB8962DBDE2284BC9664A /* urls.json in Resources */ = {isa = PBXBuildFile; fileRef = B079D165838E646EE754DC6E /* urls.json */; };
 		B97B830773C8597258C1A96F /* MeshtasticProtobufs in Frameworks */ = {isa = PBXBuildFile; productRef = 838679D32875D367B9FC8FBF /* MeshtasticProtobufs */; };
 		BB73AFBEB76A7B00550C8F2F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A7443D3C9E82A023A4388EFC /* InfoPlist.strings */; };
@@ -522,14 +521,6 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		0CDEAEFB74FD23D58C244A58 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A518007AF83AA6E15BE848FD /* SnapshotTesting in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		507ACF225D7B4D1C1D2D9340 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -665,7 +656,6 @@
 			buildPhases = (
 				1873C2316C2E9226EA6AE7C8 /* Sources */,
 				10D31ADC03EA77B8648E37AA /* Resources */,
-				0CDEAEFB74FD23D58C244A58 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -677,7 +667,6 @@
 			);
 			name = MeshtasticTests;
 			packageProductDependencies = (
-				7F0CA2B608168551C6F95FEB /* SnapshotTesting */,
 			);
 			productName = MeshtasticTests;
 			productReference = 53E4E3191A93EDE5C8C08E1C /* MeshtasticTests.xctest */;
@@ -848,7 +837,6 @@
 				B9243D356FA56FD1728AC3D3 /* XCRemoteSwiftPackageReference "mvt-tools" */,
 				4EFE4EEC5E27B5E40276A67C /* XCRemoteSwiftPackageReference "swift-markdown" */,
 				981964D4D54F32AEF37E646A /* XCRemoteSwiftPackageReference "swift-protobuf" */,
-				179A6527140B3A37DDA2482A /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 				71B6C19C2660F20C79DC8366 /* XCLocalSwiftPackageReference "MeshtasticProtobufs" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -1504,14 +1492,6 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		179A6527140B3A37DDA2482A /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.17.0;
-			};
-		};
 		4E46BE4D3A1C5CF53B7D7592 /* XCRemoteSwiftPackageReference "SwiftDraw" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/swhitty/SwiftDraw";
@@ -1608,11 +1588,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D4D6B3C078FD6A403FA6BA8D /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
 			productName = DatadogCore;
-		};
-		7F0CA2B608168551C6F95FEB /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 179A6527140B3A37DDA2482A /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
 		};
 		7F3F27310C566077475C7105 /* DatadogLogs */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Meshtastic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Meshtastic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "11f0c5490d1168ef30f18d8d128eff6002676d0f891554c3d9659ef05419bdc5",
+  "originHash" : "c82849dea0e71e77d04682254b421273e10405a99e663ab519af2a54313d87f5",
   "pins" : [
     {
       "identity" : "cocoamqtt",
@@ -110,15 +110,6 @@
       }
     },
     {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
-        "version" : "1.5.0"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -146,24 +137,6 @@
       }
     },
     {
-      "identity" : "swift-snapshot-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
-      "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
-      "state" : {
-        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
-        "version" : "603.0.1"
-      }
-    },
-    {
       "identity" : "swiftdraw",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swhitty/SwiftDraw",
@@ -179,15 +152,6 @@
       "state" : {
         "revision" : "25658b6b16b20500f8561c7acbf86349e77e5db8",
         "version" : "0.5.1"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
       }
     },
     {

--- a/Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6b19c938af055d12682daa9edb062c89f4e3ccee0185c44f5333b43283bc3384",
+  "originHash" : "c82849dea0e71e77d04682254b421273e10405a99e663ab519af2a54313d87f5",
   "pins" : [
     {
       "identity" : "cocoamqtt",
@@ -119,15 +119,6 @@
       }
     },
     {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
-        "version" : "1.5.0"
-      }
-    },
-    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -155,24 +146,6 @@
       }
     },
     {
-      "identity" : "swift-snapshot-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
-      "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
-      "state" : {
-        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
-        "version" : "603.0.1"
-      }
-    },
-    {
       "identity" : "swiftdraw",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swhitty/SwiftDraw",
@@ -188,15 +161,6 @@
       "state" : {
         "revision" : "25658b6b16b20500f8561c7acbf86349e77e5db8",
         "version" : "0.5.1"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
       }
     },
     {

--- a/MeshtasticTests/SnapshotReferenceStore.swift
+++ b/MeshtasticTests/SnapshotReferenceStore.swift
@@ -1,0 +1,123 @@
+import Foundation
+import UIKit
+
+struct SnapshotPixelDimensions: Equatable {
+	let width: Int
+	let height: Int
+}
+
+enum SnapshotReferenceMode: Equatable {
+	case verify
+	case record
+
+	static func current(environment: [String: String] = ProcessInfo.processInfo.environment) -> SnapshotReferenceMode {
+		let variableNames = [
+			"MESHTASTIC_RECORD_SNAPSHOTS",
+			"TEST_RUNNER_MESHTASTIC_RECORD_SNAPSHOTS"
+		]
+		return variableNames.contains(where: { environment[$0] == "1" }) ? .record : .verify
+	}
+}
+
+enum SnapshotReferencePlatform {
+	case iOS
+	case macCatalyst
+
+	static var current: SnapshotReferencePlatform {
+		#if targetEnvironment(macCatalyst)
+		.macCatalyst
+		#else
+		.iOS
+		#endif
+	}
+}
+
+struct SnapshotReferencePath {
+	static func referenceURL(
+		testFileURL: URL,
+		snapshotName: String,
+		forDocs: Bool,
+		platform: SnapshotReferencePlatform
+	) -> URL {
+		let baseDirectory: URL
+		if forDocs {
+			baseDirectory = testFileURL
+				.deletingLastPathComponent()
+				.deletingLastPathComponent()
+				.appendingPathComponent("docs")
+				.appendingPathComponent("assets")
+				.appendingPathComponent("screenshots")
+		} else {
+			baseDirectory = testFileURL
+				.deletingLastPathComponent()
+				.appendingPathComponent("__Snapshots__")
+				.appendingPathComponent(testFileURL.deletingPathExtension().lastPathComponent)
+		}
+
+		let platformDirectory: URL
+		switch platform {
+		case .iOS:
+			platformDirectory = baseDirectory
+		case .macCatalyst:
+			platformDirectory = baseDirectory.appendingPathComponent("macCatalyst")
+		}
+		return platformDirectory.appendingPathComponent("\(snapshotName).png")
+	}
+}
+
+enum SnapshotReferenceError: Error, Equatable, CustomStringConvertible {
+	case missingReference(URL)
+	case unreadableReference(URL)
+	case dimensionMismatch(reference: SnapshotPixelDimensions, actual: SnapshotPixelDimensions)
+
+	var description: String {
+		switch self {
+		case let .missingReference(url):
+			"Missing snapshot reference at \(url.path). Run with TEST_RUNNER_MESHTASTIC_RECORD_SNAPSHOTS=1 to record it explicitly."
+		case let .unreadableReference(url):
+			"Unable to read snapshot reference at \(url.path)."
+		case let .dimensionMismatch(reference, actual):
+			"Snapshot dimensions changed from \(reference.width)×\(reference.height) to \(actual.width)×\(actual.height). Run with TEST_RUNNER_MESHTASTIC_RECORD_SNAPSHOTS=1 to replace the reference explicitly."
+		}
+	}
+}
+
+struct SnapshotReferenceStore {
+	private let fileManager = FileManager.default
+
+	func check(
+		pngData: Data,
+		pixelDimensions: SnapshotPixelDimensions,
+		referenceURL: URL,
+		mode: SnapshotReferenceMode
+	) throws {
+		if case .record = mode {
+			try fileManager.createDirectory(
+				at: referenceURL.deletingLastPathComponent(),
+				withIntermediateDirectories: true
+			)
+			try pngData.write(to: referenceURL, options: .atomic)
+			return
+		}
+
+		guard fileManager.fileExists(atPath: referenceURL.path) else {
+			throw SnapshotReferenceError.missingReference(referenceURL)
+		}
+		guard let referenceData = try? Data(contentsOf: referenceURL),
+			  let referenceImage = UIImage(data: referenceData),
+			  let referenceCGImage = referenceImage.cgImage else {
+			throw SnapshotReferenceError.unreadableReference(referenceURL)
+		}
+
+		let referenceDimensions = SnapshotPixelDimensions(
+			width: referenceCGImage.width,
+			height: referenceCGImage.height
+		)
+		guard referenceDimensions == pixelDimensions else {
+			throw SnapshotReferenceError.dimensionMismatch(
+				reference: referenceDimensions,
+				actual: pixelDimensions
+			)
+		}
+	}
+}

--- a/MeshtasticTests/SnapshotReferenceStoreTests.swift
+++ b/MeshtasticTests/SnapshotReferenceStoreTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+import UIKit
+
+@Suite("Snapshot reference storage")
+struct SnapshotReferenceStoreTests {
+
+	@Test("Verification does not create a missing reference")
+	func verificationDoesNotCreateMissingReference() throws {
+		let directory = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		let referenceURL = directory.appendingPathComponent("missing.png")
+		defer { try? FileManager.default.removeItem(at: directory) }
+
+		do {
+			try SnapshotReferenceStore().check(
+				pngData: Data("snapshot".utf8),
+				pixelDimensions: SnapshotPixelDimensions(width: 1, height: 1),
+				referenceURL: referenceURL,
+				mode: .verify
+			)
+			Issue.record("Verification unexpectedly accepted a missing reference")
+		} catch let error as SnapshotReferenceError {
+			#expect(error == .missingReference(referenceURL))
+		}
+
+		#expect(!FileManager.default.fileExists(atPath: referenceURL.path))
+		#expect(!FileManager.default.fileExists(atPath: directory.path))
+	}
+
+	@Test("Recording mode requires an explicit environment value")
+	func recordingModeRequiresExplicitEnvironmentValue() {
+		#expect(SnapshotReferenceMode.current(environment: [:]) == .verify)
+		#expect(SnapshotReferenceMode.current(environment: ["MESHTASTIC_RECORD_SNAPSHOTS": "0"]) == .verify)
+		#expect(SnapshotReferenceMode.current(environment: ["MESHTASTIC_RECORD_SNAPSHOTS": "1"]) == .record)
+		#expect(SnapshotReferenceMode.current(environment: ["TEST_RUNNER_MESHTASTIC_RECORD_SNAPSHOTS": "1"]) == .record)
+	}
+
+	@Test("iOS references keep their existing paths")
+	func iOSReferencesKeepExistingPaths() {
+		let testFileURL = URL(fileURLWithPath: "/repo/MeshtasticTests/SwiftUIViewSnapshotTests.swift")
+
+		let testReference = SnapshotReferencePath.referenceURL(
+			testFileURL: testFileURL,
+			snapshotName: "card",
+			forDocs: false,
+			platform: .iOS
+		)
+		#expect(testReference.path == "/repo/MeshtasticTests/__Snapshots__/SwiftUIViewSnapshotTests/card.png")
+
+		let docsReference = SnapshotReferencePath.referenceURL(
+			testFileURL: testFileURL,
+			snapshotName: "card",
+			forDocs: true,
+			platform: .iOS
+		)
+		#expect(docsReference.path == "/repo/docs/assets/screenshots/card.png")
+	}
+
+	@Test("Mac Catalyst references use separate directories")
+	func macCatalystReferencesUseSeparateDirectories() {
+		let testFileURL = URL(fileURLWithPath: "/repo/MeshtasticTests/SwiftUIViewSnapshotTests.swift")
+
+		let testReference = SnapshotReferencePath.referenceURL(
+			testFileURL: testFileURL,
+			snapshotName: "card",
+			forDocs: false,
+			platform: .macCatalyst
+		)
+		#expect(testReference.path == "/repo/MeshtasticTests/__Snapshots__/SwiftUIViewSnapshotTests/macCatalyst/card.png")
+
+		let docsReference = SnapshotReferencePath.referenceURL(
+			testFileURL: testFileURL,
+			snapshotName: "card",
+			forDocs: true,
+			platform: .macCatalyst
+		)
+		#expect(docsReference.path == "/repo/docs/assets/screenshots/macCatalyst/card.png")
+	}
+
+	@Test("Recording creates and replaces a reference")
+	func recordingCreatesAndReplacesReference() throws {
+		let directory = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		let referenceURL = directory.appendingPathComponent("recorded.png")
+		defer { try? FileManager.default.removeItem(at: directory) }
+
+		let firstData = try pngData(width: 1, height: 1)
+		try SnapshotReferenceStore().check(
+			pngData: firstData,
+			pixelDimensions: SnapshotPixelDimensions(width: 1, height: 1),
+			referenceURL: referenceURL,
+			mode: .record
+		)
+		#expect(try Data(contentsOf: referenceURL) == firstData)
+
+		let replacementData = try pngData(width: 2, height: 1)
+		try SnapshotReferenceStore().check(
+			pngData: replacementData,
+			pixelDimensions: SnapshotPixelDimensions(width: 2, height: 1),
+			referenceURL: referenceURL,
+			mode: .record
+		)
+		#expect(try Data(contentsOf: referenceURL) == replacementData)
+	}
+
+	@Test("Verification does not replace a reference with different dimensions")
+	func verificationDoesNotReplaceDimensionMismatch() throws {
+		let directory = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		let referenceURL = directory.appendingPathComponent("existing.png")
+		defer { try? FileManager.default.removeItem(at: directory) }
+
+		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+		let referenceData = try pngData(width: 1, height: 1)
+		try referenceData.write(to: referenceURL)
+		let newData = try pngData(width: 2, height: 1)
+
+		do {
+			try SnapshotReferenceStore().check(
+				pngData: newData,
+				pixelDimensions: SnapshotPixelDimensions(width: 2, height: 1),
+				referenceURL: referenceURL,
+				mode: .verify
+			)
+			Issue.record("Verification unexpectedly accepted different dimensions")
+		} catch let error as SnapshotReferenceError {
+			#expect(error == .dimensionMismatch(
+				reference: SnapshotPixelDimensions(width: 1, height: 1),
+				actual: SnapshotPixelDimensions(width: 2, height: 1)
+			))
+		}
+
+		#expect(try Data(contentsOf: referenceURL) == referenceData)
+	}
+
+	private func pngData(width: Int, height: Int) throws -> Data {
+		let format = UIGraphicsImageRendererFormat()
+		format.scale = 1
+		let image = UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format).image { context in
+			UIColor.systemBlue.setFill()
+			context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+		}
+		return try #require(image.pngData())
+	}
+}

--- a/MeshtasticTests/SwiftUIViewSnapshotTests.swift
+++ b/MeshtasticTests/SwiftUIViewSnapshotTests.swift
@@ -77,12 +77,13 @@ private func renderImage<V: View>(_ view: V, width: CGFloat, height: CGFloat? = 
 	}
 }
 
-/// Saves a snapshot image to disk. On first run, records the reference.
-/// On subsequent runs, compares against the reference and fails if different.
+/// Checks a rendered image against its reference dimensions without modifying
+/// the reference. Set `MESHTASTIC_RECORD_SNAPSHOTS=1` in the test process to
+/// create or replace references explicitly. Mac Catalyst references use their
+/// own subdirectory so they cannot replace the checked-in iOS references.
 /// When height is nil the view determines its own height via sizeThatFits.
-/// When `forDocs` is true, the PNG is saved to `docs/assets/screenshots/` so
-/// it is shared directly with the documentation site. When false, it is saved
-/// to `__Snapshots__/` next to the test file (test-only, not bundled in the app).
+/// When `forDocs` is true, the PNG is stored under `docs/assets/screenshots/`.
+/// Otherwise it is stored in `__Snapshots__/` next to the test file.
 @MainActor
 private func assertViewSnapshot<V: View>(
 	of view: V,
@@ -101,59 +102,26 @@ private func assertViewSnapshot<V: View>(
 		return
 	}
 
-	let fileUrl = URL(fileURLWithPath: filePath, isDirectory: false)
-	let snapshotDir: URL
-	if forDocs {
-		// Write to docs/assets/screenshots/ — shared with the documentation site.
-		let repoRoot = fileUrl
-			.deletingLastPathComponent()  // MeshtasticTests/
-			.deletingLastPathComponent()  // repo root
-		snapshotDir = repoRoot
-			.appendingPathComponent("docs")
-			.appendingPathComponent("assets")
-			.appendingPathComponent("screenshots")
-	} else {
-		// Write to __Snapshots__/ next to the test file (test-only).
-		snapshotDir = fileUrl.deletingLastPathComponent()
-			.appendingPathComponent("__Snapshots__")
-			.appendingPathComponent(fileUrl.deletingPathExtension().lastPathComponent)
-	}
-	let snapshotFile = snapshotDir.appendingPathComponent("\(name).png")
-
-	let fm = FileManager.default
-	do {
-		try fm.createDirectory(at: snapshotDir, withIntermediateDirectories: true)
-	} catch {
-		Issue.record("Failed to create snapshot directory: \(error)", sourceLocation: sourceLocation)
+	guard let cgImage = image.cgImage else {
+		Issue.record("Failed to read rendered image dimensions", sourceLocation: sourceLocation)
 		return
 	}
+	let snapshotFile = SnapshotReferencePath.referenceURL(
+		testFileURL: URL(fileURLWithPath: filePath, isDirectory: false),
+		snapshotName: name,
+		forDocs: forDocs,
+		platform: .current
+	)
 
-	if fm.fileExists(atPath: snapshotFile.path) {
-		// Compare against reference
-		guard let referenceData = try? Data(contentsOf: snapshotFile),
-			  let referenceImage = UIImage(data: referenceData),
-			  let refCG = referenceImage.cgImage,
-			  let newCG = image.cgImage else {
-			Issue.record("Failed to read reference snapshot: \(snapshotFile.lastPathComponent)", sourceLocation: sourceLocation)
-			return
-		}
-		// Compare pixel dimensions (not point sizes, which depend on scale factor)
-		guard refCG.width == newCG.width, refCG.height == newCG.height else {
-			// Dimensions changed — re-record
-			try? pngData.write(to: snapshotFile)
-			Issue.record(
-				"Snapshot dimensions changed from \(refCG.width)×\(refCG.height) to \(newCG.width)×\(newCG.height). Re-recorded.",
-				sourceLocation: sourceLocation
-			)
-			return
-		}
-	} else {
-		// First run - record reference silently (test passes; verify visually)
-		do {
-			try pngData.write(to: snapshotFile)
-		} catch {
-			Issue.record("Failed to write snapshot: \(error)", sourceLocation: sourceLocation)
-		}
+	do {
+		try SnapshotReferenceStore().check(
+			pngData: pngData,
+			pixelDimensions: SnapshotPixelDimensions(width: cgImage.width, height: cgImage.height),
+			referenceURL: snapshotFile,
+			mode: .current()
+		)
+	} catch {
+		Issue.record("\(error)", sourceLocation: sourceLocation)
 	}
 }
 

--- a/project.yml
+++ b/project.yml
@@ -28,9 +28,6 @@ packages:
   CocoaMQTT:
     url: https://github.com/emqx/CocoaMQTT
     majorVersion: 2.0.0
-  swift-snapshot-testing:
-    url: https://github.com/pointfreeco/swift-snapshot-testing
-    majorVersion: 1.17.0
   mvt-tools:
     url: https://github.com/Outdooractive/mvt-tools.git
     majorVersion: 1.2.1
@@ -536,8 +533,6 @@ targets:
         type: syncedFolder
     dependencies:
       - target: Meshtastic
-      - package: swift-snapshot-testing
-        product: SnapshotTesting
     settings:
       configs:
         Debug:


### PR DESCRIPTION
## What changed?

- Remove the unused `SnapshotTesting` product and package dependency that prevented the Catalyst test target from compiling.
- Make snapshot verification read-only by default.
- Require `MESHTASTIC_RECORD_SNAPSHOTS=1` to create or replace references.
- Store Mac Catalyst references under separate `macCatalyst` directories.
- Add focused tests for verification, recording, paths, dimensions, and byte preservation.

This is PR 3 of the stack and depends on #2233. Its base is the preceding stack branch, so this PR contains only the snapshot-test changes.

## Why did it change?

The project does not import `SnapshotTesting`, but the dependency failed to compile for the Catalyst test destination. After removing it, the existing helper exposed a second problem: verification could create or replace PNG references. A normal test run should report a missing or changed reference without modifying the source tree.

## How is this tested?

- Six `SnapshotReferenceStoreTests` pass with Xcode 27 on iOS 27 and Mac Catalyst.
- The same suite passes with Xcode 26.6 on iOS 26.5.
- Focused Xcode 27 iOS and Catalyst runs left all 309 tracked PNG hashes unchanged.
- Explicit recording was separately verified to create isolated Catalyst references.
- `xcodegen generate` reproduces the checked-in project without a diff.

## Screenshots/Videos (when applicable)

Not applicable. This changes test infrastructure and does not alter application rendering.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed; `skip-docs-check` is applied.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved SwiftUI snapshot testing across iOS and Mac Catalyst.
  * Added reliable validation for snapshot dimensions, reference files, recording, and comparison behavior.
  * Added coverage for missing references, platform-specific paths, recording modes, and protection against invalid replacements.
* **Refactor**
  * Replaced the external snapshot-testing dependency with the project’s own snapshot reference handling.
  * Updated snapshot documentation with recording instructions, validation details, and reference locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->