### PR TITLE
Give CSV exports valid filenames

### DIFF
--- a/Meshtastic/Export/CsvDocument.swift
+++ b/Meshtastic/Export/CsvDocument.swift
@@ -12,6 +12,13 @@ struct CsvDocument: FileDocument {
 
 	static let readableContentTypes =  [UTType.commaSeparatedText]
 
+	static func exportFilename(_ baseName: String) -> String {
+		let sanitizedName = baseName
+			.replacingOccurrences(of: "/", with: "-")
+			.replacingOccurrences(of: ":", with: "-")
+		return sanitizedName.lowercased().hasSuffix(".csv") ? sanitizedName : "\(sanitizedName).csv"
+	}
+
 	@State var csvData: String
 
 	init(emptyCsv: String = "" ) {

--- a/Meshtastic/Views/Nodes/AirQualityMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/AirQualityMetricsLog.swift
@@ -171,7 +171,7 @@ struct AirQualityMetricsLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: String("\(node.user?.longName ?? "Node") Air Quality Metrics Log \(Date.now.exportTimestamp)"),
+			defaultFilename: CsvDocument.exportFilename("\(node.user?.longName ?? "Node") Air Quality Metrics Log \(Date.now.exportTimestamp)"),
 			onCompletion: { result in
 				switch result {
 				case .success:

--- a/Meshtastic/Views/Nodes/DetectionSensorLog.swift
+++ b/Meshtastic/Views/Nodes/DetectionSensorLog.swift
@@ -132,7 +132,7 @@ struct DetectionSensorLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: String("\(node.user?.longName ?? "Node") \("Detection Sensor Log".localized) \(Date.now.exportTimestamp)"),
+			defaultFilename: CsvDocument.exportFilename("\(node.user?.longName ?? "Node") \("Detection Sensor Log".localized) \(Date.now.exportTimestamp)"),
 			onCompletion: { result in
 				switch result {
 				case .success:

--- a/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
@@ -254,7 +254,7 @@ struct DeviceMetricsLog: View {
 				isPresented: $isExporting,
 				document: CsvDocument(emptyCsv: exportString),
 				contentType: .commaSeparatedText,
-				defaultFilename: String("\(node.user?.longName ?? "Node") \("Device Metrics Log".localized) \(Date.now.exportTimestamp)"),
+				defaultFilename: CsvDocument.exportFilename("\(node.user?.longName ?? "Node") \("Device Metrics Log".localized) \(Date.now.exportTimestamp)"),
 				onCompletion: { result in
 					switch result {
 					case .success:

--- a/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
@@ -166,7 +166,7 @@ struct EnvironmentMetricsLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: String("\(node.user?.longName ?? "Node") Environment Metrics Log \(Date.now.exportTimestamp)"),
+			defaultFilename: CsvDocument.exportFilename("\(node.user?.longName ?? "Node") Environment Metrics Log \(Date.now.exportTimestamp)"),
 			onCompletion: { result in
 				switch result {
 				case .success:

--- a/Meshtastic/Views/Nodes/LocalStatsLog.swift
+++ b/Meshtastic/Views/Nodes/LocalStatsLog.swift
@@ -110,7 +110,7 @@ struct LocalStatsLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: String("\(node.user?.longName ?? "Node") \("Local Stats Log".localized) \(Date.now.exportTimestamp)"),
+			defaultFilename: CsvDocument.exportFilename("\(node.user?.longName ?? "Node") \("Local Stats Log".localized) \(Date.now.exportTimestamp)"),
 			onCompletion: { result in
 				switch result {
 				case .success:

--- a/Meshtastic/Views/Nodes/PaxCounterLog.swift
+++ b/Meshtastic/Views/Nodes/PaxCounterLog.swift
@@ -223,7 +223,7 @@ struct PaxCounterLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: String("\(node.user?.longName ?? "Node") \("paxcounter.log".localized) \(Date.now.exportTimestamp)"),
+			defaultFilename: CsvDocument.exportFilename("\(node.user?.longName ?? "Node") \("paxcounter.log".localized) \(Date.now.exportTimestamp)"),
 			onCompletion: { result in
 				switch result {
 				case .success:

--- a/Meshtastic/Views/Nodes/PositionLog.swift
+++ b/Meshtastic/Views/Nodes/PositionLog.swift
@@ -163,7 +163,7 @@ struct PositionLog: View {
 					isPresented: $isExporting,
 					document: CsvDocument(emptyCsv: exportString),
 					contentType: .commaSeparatedText,
-					defaultFilename: String("\(node.user?.longName ?? "Node") Position Log \(Date.now.exportTimestamp)"),
+					defaultFilename: CsvDocument.exportFilename("\(node.user?.longName ?? "Node") Position Log \(Date.now.exportTimestamp)"),
 					onCompletion: { result in
 						switch result {
 						case .success:

--- a/Meshtastic/Views/Nodes/PowerMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/PowerMetricsLog.swift
@@ -338,7 +338,7 @@ struct PowerMetricsLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: String("\(node.user?.longName ?? "Node") \("Power Metrics Log".localized) \(Date.now.exportTimestamp)"),
+			defaultFilename: CsvDocument.exportFilename("\(node.user?.longName ?? "Node") \("Power Metrics Log".localized) \(Date.now.exportTimestamp)"),
 			onCompletion: { result in
 				switch result {
 				case .success:

--- a/Meshtastic/Views/Settings/AppLog.swift
+++ b/Meshtastic/Views/Settings/AppLog.swift
@@ -110,7 +110,7 @@ struct AppLog: View {
 			isPresented: $isExporting,
 			document: CsvDocument(emptyCsv: exportString),
 			contentType: .commaSeparatedText,
-			defaultFilename: String("Meshtastic Application Logs \(Date.now.exportTimestamp)"),
+			defaultFilename: CsvDocument.exportFilename("Meshtastic Application Logs \(Date.now.exportTimestamp)"),
 			onCompletion: { result in
 				switch result {
 				case .success:

--- a/Meshtastic/Views/Settings/Routes.swift
+++ b/Meshtastic/Views/Settings/Routes.swift
@@ -302,7 +302,7 @@ struct Routes: View {
 					isPresented: $isExporting,
 					document: CsvDocument(emptyCsv: exportString),
 					contentType: .commaSeparatedText,
-					defaultFilename: String("\(selectedRoute?.name ?? "Route") Log"),
+					defaultFilename: CsvDocument.exportFilename("\(selectedRoute?.name ?? "Route") Log"),
 					onCompletion: { result in
 						switch result {
 						case .success:

--- a/MeshtasticTests/RoutingAndMiscTests.swift
+++ b/MeshtasticTests/RoutingAndMiscTests.swift
@@ -210,6 +210,19 @@ struct CsvDocumentTests {
 	@Test func readableContentTypes_csv() {
 		#expect(CsvDocument.readableContentTypes.count == 1)
 	}
+
+	@Test func exportFilename_appendsCsvExtension() {
+		#expect(CsvDocument.exportFilename("Meshtastic Logs") == "Meshtastic Logs.csv")
+	}
+
+	@Test(arguments: ["Meshtastic Logs.csv", "Meshtastic Logs.CSV"])
+	func exportFilename_preservesExistingCsvExtension(filename: String) {
+		#expect(CsvDocument.exportFilename(filename) == filename)
+	}
+
+	@Test func exportFilename_replacesFilesystemSeparators() {
+		#expect(CsvDocument.exportFilename("Base/Roof: West") == "Base-Roof- West.csv")
+	}
 }
 
 // MARK: - LogDocument


### PR DESCRIPTION
## What changed?

- Add one `CsvDocument.exportFilename` helper for CSV exports.
- Append `.csv` when the caller does not supply it, preserving existing `.csv` suffixes case-insensitively.
- Replace `/` and `:` so user-derived names remain valid filenames.
- Use the helper for application logs and every metrics-log export.
- Add focused filename tests.

This is PR 4 of the stack and depends on #2234. Its base is the preceding stack branch, so this PR contains only the CSV filename fix.

## Why did it change?

Several export routes supplied extensionless filenames, and node names could introduce path separators. This produced inconsistent or invalid filenames in the document exporter, including on Mac Catalyst.

## How is this tested?

- `CsvDocumentTests` passes with Xcode 27 on iOS 27 and Mac Catalyst.
- The same suite passes with Xcode 26.6 on iOS 26.5.
- The tests cover extension insertion, case-insensitive suffix preservation, and separator replacement.

## Screenshots/Videos (when applicable)

Not applicable. The change affects the filename proposed by the system document exporter.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed; `skip-docs-check` is applied.
- [x] I have tested the change to ensure that it works as intended.
