### PR TITLE
Build documentation search URLs safely

### DIFF
--- a/Meshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/AIDocAssistantView.swift
@@ -41,6 +41,22 @@ private struct ChirpyWebSnippet: Hashable {
 	let content: String
 }
 
+enum AIDocSearchURLBuilder {
+	static func url(for query: String) -> URL? {
+		let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard !trimmedQuery.isEmpty else { return nil }
+
+		var components = URLComponents()
+		components.scheme = "https"
+		components.host = "meshtastic.org"
+		components.path = "/search/"
+		components.queryItems = [URLQueryItem(name: "q", value: trimmedQuery)]
+		// URLQueryItem leaves "+" unescaped, but search backends commonly decode it as a space.
+		components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
+		return components.url
+	}
+}
+
 // MARK: - AIDocAssistantView (iOS 26+ only)
 
 @available(iOS 26, *)
@@ -552,13 +568,8 @@ struct AIDocAssistantView: View {
 	}
 
 	private func fetchWebFallbackSnippets(for query: String) async -> [ChirpyWebSnippet] {
-		guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-			let searchURL = URL(string: "https://meshtastic.org/search/?q=\(encodedQuery)")
-		else {
-			return []
-		}
-
-		guard let host = searchURL.host?.lowercased(), host.hasSuffix("meshtastic.org") else { return [] }
+		guard let searchURL = AIDocSearchURLBuilder.url(for: query) else { return [] }
+		guard searchURL.host?.lowercased() == "meshtastic.org" else { return [] }
 
 		let intentURLs = directIntentURLs(for: query)
 		let shouldSkipSearchSnippet = !intentURLs.isEmpty

--- a/MeshtasticTests/AIDocAssistantURLTests.swift
+++ b/MeshtasticTests/AIDocAssistantURLTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("AI documentation search URLs")
+struct AIDocAssistantURLTests {
+
+	@Test(arguments: [
+		("100% coverage", "https://meshtastic.org/search/?q=100%25%20coverage"),
+		("mesh & mqtt", "https://meshtastic.org/search/?q=mesh%20%26%20mqtt"),
+		("C++", "https://meshtastic.org/search/?q=C%2B%2B"),
+		("topic#one", "https://meshtastic.org/search/?q=topic%23one")
+	])
+	func webSearchURL_encodesQueryValue(query: String, expectedURL: String) throws {
+		let url = try #require(AIDocSearchURLBuilder.url(for: query))
+		#expect(url.absoluteString == expectedURL)
+
+		let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+		let queryValue = components.queryItems?.first(where: { $0.name == "q" })?.value
+		#expect(queryValue == query)
+	}
+
+	@Test func webSearchURL_trimsQuery() throws {
+		let url = try #require(AIDocSearchURLBuilder.url(for: "  mesh radio  \n"))
+		let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+		#expect(components.queryItems?.first?.value == "mesh radio")
+	}
+
+	@Test func webSearchURL_rejectsEmptyQuery() {
+		#expect(AIDocSearchURLBuilder.url(for: " \n\t ") == nil)
+	}
+}


### PR DESCRIPTION
## What changed?

- Build documentation-search URLs with `URLComponents` and `URLQueryItem`.
- Reject empty searches.
- Keep the destination fixed to HTTPS on `meshtastic.org`.
- Preserve literal `%`, `&`, `+`, and `#` characters as query data.
- Add focused URL-construction tests.

This is PR 5 of the stack and depends on #2235. Its base is the preceding stack branch, so this PR contains only the documentation-search fix.

## Why did it change?

Character-set percent encoding allowed query characters to alter the URL structure or change meaning when decoded by the search backend. Constructing the URL from components keeps user input inside the `q` query item.

## How is this tested?

- `AIDocAssistantURLTests` passes with Xcode 27 on iOS 27 and Mac Catalyst.
- The same suite passes with Xcode 26.6 on iOS 26.5.
- The tests cover percent signs, ampersands, C++, fragments, whitespace trimming, and empty input.

## Screenshots/Videos (when applicable)

Not applicable. This changes URL construction without changing the view.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed; `skip-docs-check` is applied.
- [x] I have tested the change to ensure that it works as intended.
