### PR TITLE
Keep alternate icon options in a stable order

### DIFF
--- a/Meshtastic/Views/Settings/AppIconPicker.swift
+++ b/Meshtastic/Views/Settings/AppIconPicker.swift
@@ -1,25 +1,36 @@
 import SwiftUI
 
-struct AppIconPicker: View {
-	private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
-	@Environment(\.modelContext) private var context
-	@Binding var isPresenting: Bool
-	@State private var didError = false
-	@State private var errorDetails: String?
-	var iconNames: [String?: String] = [nil: "Default", "AppIcon_MPowered": "Meshtastic Powered", "AppIcon_Chirpy": "Chirpy", "AppIcon_Ham": "Ham"]
+struct AppIconOption: Identifiable, Equatable {
+	let id: String
+	let iconName: String?
+	let description: String
+}
 
-	// MARK: View
+struct AppIconPicker: View {
+	@Binding var isPresenting: Bool
+
+	static let iconOptions = [
+		AppIconOption(id: "default", iconName: nil, description: "Default"),
+		AppIconOption(id: "mpowered", iconName: "AppIcon_MPowered", description: "Meshtastic Powered"),
+		AppIconOption(id: "chirpy", iconName: "AppIcon_Chirpy", description: "Chirpy"),
+		AppIconOption(id: "ham", iconName: "AppIcon_Ham", description: "Ham")
+	]
+
 	var body: some View {
 		List {
 			Section(header: Text("Icons")) {
-				ForEach(Array(iconNames.enumerated()), id: \.offset) { _, icon in
-					AppIconButton(iconDescription: .constant(icon.value), iconName: .constant(icon.key), isPresenting: $isPresenting)
+				ForEach(Self.iconOptions) { icon in
+					AppIconButton(
+						iconDescription: .constant(icon.description),
+						iconName: .constant(icon.iconName),
+						isPresenting: $isPresenting
+					)
 				}
 			}
 		}
 	}
 }
 
-#Preview{
+#Preview {
 	AppIconPicker(isPresenting: .constant(true))
 }

--- a/MeshtasticTests/AppIconPickerTests.swift
+++ b/MeshtasticTests/AppIconPickerTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import Meshtastic
+
+@Suite("App icon picker")
+@MainActor
+struct AppIconPickerTests {
+	@Test("Options have a stable user-facing order")
+	func optionsHaveStableOrder() {
+		#expect(AppIconPicker.iconOptions.map(\.description) == [
+			"Default",
+			"Meshtastic Powered",
+			"Chirpy",
+			"Ham"
+		])
+		#expect(AppIconPicker.iconOptions.map(\.iconName) == [
+			nil,
+			"AppIcon_MPowered",
+			"AppIcon_Chirpy",
+			"AppIcon_Ham"
+		])
+	}
+
+	@Test("Options have unique stable identifiers and alternate icon names")
+	func optionsAreUnique() {
+		let identifiers = AppIconPicker.iconOptions.map(\.id)
+		let alternateNames = AppIconPicker.iconOptions.compactMap(\.iconName)
+
+		#expect(Set(identifiers).count == identifiers.count)
+		#expect(Set(alternateNames).count == alternateNames.count)
+	}
+}


### PR DESCRIPTION
## What changed?

- Replace alternate-icon dictionary enumeration with an ordered `AppIconOption` model.
- Keep the user-facing order fixed as Default, Meshtastic Powered, Chirpy, and Ham.
- Give every option a stable identifier while preserving `nil` as the Default icon request.
- Add focused order and uniqueness tests.

This is PR 6 of the stack and depends on #2236. Its base is the preceding stack branch, so this PR contains only the icon-picker ordering fix.

## Why did it change?

Dictionary iteration changed the row order whenever the picker sheet was reconstructed. Besides presenting an inconsistent interface, that made automated and accessibility-driven selection unreliable.

## How is this tested?

- `AppIconPickerTests` passes with Xcode 27 on iOS 27 and Mac Catalyst.
- The same suite passes with Xcode 26.6 on iOS 26.5.
- Swapping two options makes the exact-order test fail.
- The fixed order remained stable across three cold relaunches each on an iOS 27 iPhone and iPad simulator.
- Runtime checks switched every alternate and Default on iPhone and representative alternates on iPad and iOS 26.5.

## Screenshots/Videos (when applicable)

Not applicable. The same rows are shown in a deterministic order.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed; `skip-docs-check` is applied.
- [x] I have tested the change to ensure that it works as intended.
