### PR TITLE
fix(tak): gate V2 on confirmed firmware

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -1107,10 +1107,24 @@ extension AccessoryManager {
 	/// ATAK_PLUGIN port (72) with the original `TAKPacket` schema, which only
 	/// supports PLI and GeoChat (no shapes, markers, routes, etc.).
 	///
-	/// Returns `true` when the firmware version is unknown (radio not yet
-	/// handshook) since v2 is now the predominant firmware in the field.
 	var supportsTAKv2: Bool {
-		checkIsVersionSupported(forVersion: "2.8.0")
+		Self.isTAKv2Supported(firmwareVersion: connectedVersion)
+	}
+
+	static func isTAKv2Supported(firmwareVersion: String?) -> Bool {
+		guard let firmwareVersion else {
+			return false
+		}
+
+		let components = firmwareVersion.split(separator: ".", omittingEmptySubsequences: false)
+		guard components.count >= 3,
+			  let major = Int(components[0]),
+			  let minor = Int(components[1]),
+			  let patch = Int(components[2]) else {
+			return false
+		}
+
+		return major > 2 || (major == 2 && (minor > 8 || (minor == 8 && patch >= 0)))
 	}
 
 	/// The Status Message module (`ModuleConfig.StatusMessageConfig` + the

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -1117,7 +1117,11 @@ extension AccessoryManager {
 		}
 
 		let components = firmwareVersion.split(separator: ".", omittingEmptySubsequences: false)
+		let decimalDigits = CharacterSet(charactersIn: "0123456789")
 		guard (3...4).contains(components.count),
+			  components.prefix(3).allSatisfy({
+				  !$0.isEmpty && $0.unicodeScalars.allSatisfy { decimalDigits.contains($0) }
+			  }),
 			  let major = Int(components[0]),
 			  let minor = Int(components[1]),
 			  let patch = Int(components[2]) else {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -1117,11 +1117,18 @@ extension AccessoryManager {
 		}
 
 		let components = firmwareVersion.split(separator: ".", omittingEmptySubsequences: false)
-		guard components.count >= 3,
+		guard (3...4).contains(components.count),
 			  let major = Int(components[0]),
 			  let minor = Int(components[1]),
 			  let patch = Int(components[2]) else {
 			return false
+		}
+		if components.count == 4 {
+			let hexDigits = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+			guard !components[3].isEmpty,
+				  components[3].unicodeScalars.allSatisfy(hexDigits.contains) else {
+				return false
+			}
 		}
 
 		return major > 2 || (major == 2 && (minor > 8 || (minor == 8 && patch >= 0)))

--- a/Meshtastic/Resources/docs/developer/tak-protocol.html
+++ b/Meshtastic/Resources/docs/developer/tak-protocol.html
@@ -127,10 +127,10 @@
 <li><code>AccessoryManager+TAK.handleATAKPluginV2Packet(_:)</code> posts a <code>Notification</code> titled <strong>Route Received</strong> with the route callsign as subtitle and body <strong>Saved to Files → Meshtastic → TAK Routes. Open in iTAK to import.</strong></li>
 </ol>
 <h2>Capabilities</h2>
-<p><code>AccessoryManager.supportsTAKv2</code> is the canonical gate:</p>
-<pre><code class="language-swift">var supportsTAKv2: Bool { checkIsVersionSupported(forVersion: &quot;2.8.0&quot;) }
+<p><code>AccessoryManager.supportsTAKv2</code> is the canonical gate. It enables V2 only when the active radio reports a supported, well-formed version; an unavailable, malformed, or older version uses V1.</p>
+<pre><code class="language-swift">var supportsTAKv2: Bool { Self.isTAKv2Supported(firmwareVersion: connectedVersion) }
 </code></pre>
-<p>Use this property (rather than parsing the firmware version inline) anywhere a V1/V2 decision is needed. Future TAK SDK features that require a higher firmware version should add a sibling property with a clear cut-off so the bridge stays declarative.</p>
+<p>The capability parser accepts numeric <code>major.minor.patch</code> versions and an optional hexadecimal build suffix, such as <code>2.8.0.3a0c08b</code>. Use this property (rather than parsing the firmware version inline) anywhere a V1/V2 decision is needed. Future TAK SDK features that require a higher firmware version should add a sibling property with a clear cut-off so the bridge stays declarative.</p>
 <h2>Related Files</h2>
 <ul>
 <li><code>Meshtastic/Helpers/TAK/TAKMeshtasticBridge.swift</code> — V1/V2 fork in <code>sendToMesh</code>.</li>

--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -1071,12 +1071,13 @@
             "takpacket",
             "send",
             "sdk",
+            "radio",
             "payload",
             "path",
             "into",
             "firmware",
             "channel",
-            "radio",
+            "version",
             "pli",
             "meshtastictak",
             "let",
@@ -1086,10 +1087,9 @@
             "zstd",
             "via",
             "supportstakv2",
-            "routes",
-            "protobuf"
+            "routes"
         ],
-        "charCount": 7653
+        "charCount": 7921
     },
     {
         "id": "testing",

--- a/Meshtastic/Resources/docs/markdown/developer/tak-protocol.md
+++ b/Meshtastic/Resources/docs/markdown/developer/tak-protocol.md
@@ -104,13 +104,13 @@ The pipeline:
 
 ## Capabilities
 
-`AccessoryManager.supportsTAKv2` is the canonical gate:
+`AccessoryManager.supportsTAKv2` is the canonical gate. It enables V2 only when the active radio reports a supported, well-formed version; an unavailable, malformed, or older version uses V1.
 
 ```swift
-var supportsTAKv2: Bool { checkIsVersionSupported(forVersion: "2.8.0") }
+var supportsTAKv2: Bool { Self.isTAKv2Supported(firmwareVersion: connectedVersion) }
 ```
 
-Use this property (rather than parsing the firmware version inline) anywhere a V1/V2 decision is needed. Future TAK SDK features that require a higher firmware version should add a sibling property with a clear cut-off so the bridge stays declarative.
+The capability parser accepts numeric `major.minor.patch` versions and an optional hexadecimal build suffix, such as `2.8.0.3a0c08b`. Use this property (rather than parsing the firmware version inline) anywhere a V1/V2 decision is needed. Future TAK SDK features that require a higher firmware version should add a sibling property with a clear cut-off so the bridge stays declarative.
 
 ## Related Files
 

--- a/MeshtasticTests/TAKCapabilityTests.swift
+++ b/MeshtasticTests/TAKCapabilityTests.swift
@@ -13,6 +13,8 @@ struct TAKCapabilityTests {
 	@Test func malformedFirmwareUsesLegacyTAKProtocol() {
 		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "unknown") == false)
 		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0-alpha") == false)
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0.") == false)
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0.x") == false)
 	}
 
 	@Test func legacyFirmwareUsesLegacyTAKProtocol() {

--- a/MeshtasticTests/TAKCapabilityTests.swift
+++ b/MeshtasticTests/TAKCapabilityTests.swift
@@ -1,0 +1,25 @@
+import Testing
+
+@testable import Meshtastic
+
+@MainActor
+@Suite("TAK firmware capability")
+struct TAKCapabilityTests {
+
+	@Test func unknownFirmwareUsesLegacyTAKProtocol() {
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: nil) == false)
+	}
+
+	@Test func malformedFirmwareUsesLegacyTAKProtocol() {
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "unknown") == false)
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0-alpha") == false)
+	}
+
+	@Test func legacyFirmwareUsesLegacyTAKProtocol() {
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.7.9") == false)
+	}
+
+	@Test func supportedFirmwareUsesTAKV2Protocol() {
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0.3a0c08b") == true)
+	}
+}

--- a/MeshtasticTests/TAKCapabilityTests.swift
+++ b/MeshtasticTests/TAKCapabilityTests.swift
@@ -12,6 +12,9 @@ struct TAKCapabilityTests {
 
 	@Test func malformedFirmwareUsesLegacyTAKProtocol() {
 		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "unknown") == false)
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "-2.8.0") == false)
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.-8.0") == false)
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.9.-1.abcdef0") == false)
 		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0-alpha") == false)
 		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0.") == false)
 		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0.x") == false)
@@ -22,6 +25,7 @@ struct TAKCapabilityTests {
 	}
 
 	@Test func supportedFirmwareUsesTAKV2Protocol() {
+		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0") == true)
 		#expect(AccessoryManager.isTAKv2Supported(firmwareVersion: "2.8.0.3a0c08b") == true)
 	}
 }

--- a/docs/developer/tak-protocol.md
+++ b/docs/developer/tak-protocol.md
@@ -104,13 +104,13 @@ The pipeline:
 
 ## Capabilities
 
-`AccessoryManager.supportsTAKv2` is the canonical gate:
+`AccessoryManager.supportsTAKv2` is the canonical gate. It enables V2 only when the active radio reports a supported, well-formed version; an unavailable, malformed, or older version uses V1.
 
 ```swift
-var supportsTAKv2: Bool { checkIsVersionSupported(forVersion: "2.8.0") }
+var supportsTAKv2: Bool { Self.isTAKv2Supported(firmwareVersion: connectedVersion) }
 ```
 
-Use this property (rather than parsing the firmware version inline) anywhere a V1/V2 decision is needed. Future TAK SDK features that require a higher firmware version should add a sibling property with a clear cut-off so the bridge stays declarative.
+The capability parser accepts numeric `major.minor.patch` versions and an optional hexadecimal build suffix, such as `2.8.0.3a0c08b`. Use this property (rather than parsing the firmware version inline) anywhere a V1/V2 decision is needed. Future TAK SDK features that require a higher firmware version should add a sibling property with a clear cut-off so the bridge stays declarative.
 
 ## Related Files
 


### PR DESCRIPTION
## Summary

- send legacy TAK packets until the active radio confirms firmware 2.8.0 or newer
- reject missing or malformed version metadata instead of sending an incompatible V2 packet
- cover unknown, malformed, legacy, and supported firmware versions

## Testing

- `MeshtasticTests/TAKCapabilityTests` was selected in the iOS simulator test runner
- test compilation is currently blocked before execution by an unchanged upstream compiler error in `Meshtastic/Views/Settings/Config/SecurityConfig.swift:54`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TAK protocol compatibility detection.
  * Devices with missing, malformed, or unknown firmware versions now correctly fall back to TAK v1.
  * TAK v2 is recognized only for well-formed firmware version 2.8.0 or newer, including supported hexadecimal build suffixes.

* **Tests**
  * Added coverage for unknown, malformed, legacy, and supported firmware versions.

* **Documentation**
  * Updated TAK protocol guidance to explain firmware requirements and version handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->