### PR TITLE
fix(messages): stop long bubbles truncating above a tapback pill

### DIFF
--- a/Meshtastic/Views/Messages/MessageText.swift
+++ b/Meshtastic/Views/Messages/MessageText.swift
@@ -109,6 +109,10 @@ struct MessageText: View {
 				Text(LocalizedStringKey(payload))
 			}
 		}
+			// Never yield vertical space to row siblings: without this, a flexible sibling in the
+			// message row (the tapback pill's ScrollView) could win the height auction and the
+			// bubble text tail-truncated with "…" on long wrapping messages.
+			.fixedSize(horizontal: false, vertical: true)
 			.tint(Color("Colors/MeshtasticLink"))
 			.padding(.vertical, 10)
 			.padding(.horizontal, 8)

--- a/Meshtastic/Views/Messages/TapbackResponses.swift
+++ b/Meshtastic/Views/Messages/TapbackResponses.swift
@@ -39,6 +39,18 @@ struct TapbackResponses: View {
 		return min(contentWidth, Self.maxWidth)
 	}
 
+	/// Exact content height, arithmetic like `pillWidth`: the grid rows are `.fixed(38)` with 4pt
+	/// spacing plus the grid padding. Fixing the `ScrollView`'s height matters beyond cosmetics —
+	/// a `ScrollView`'s ideal height isn't content-driven, so left flexible it competes with the
+	/// message bubble's `Text` for the row's vertical space, and the loser is the bubble: a long
+	/// wrapping message above a reaction pill tail-truncates with "…" (seen in the field on ~6-line
+	/// messages). Sized exactly, the pill stops bidding for height it doesn't need.
+	private var pillHeight: CGFloat {
+		CGFloat(rowCount) * 38
+			+ CGFloat(max(0, rowCount - 1)) * 4
+			+ 2 * Self.gridPadding
+	}
+
 	@ViewBuilder
 	var body: some View {
 		if !tapbacks.isEmpty {
@@ -64,7 +76,7 @@ struct TapbackResponses: View {
 					}
 					.padding(Self.gridPadding)
 				}
-				.frame(width: pillWidth, alignment: .trailing)
+				.frame(width: pillWidth, height: pillHeight, alignment: .trailing)
 				.overlay(
 					RoundedRectangle(cornerRadius: 18)
 						.stroke(Color.gray, lineWidth: 1)


### PR DESCRIPTION
## What changed?

A message with tapback reactions could tail-truncate its bubble with "…" at around five or six wrapped lines — while the very same text rendered in full inside a reply quote. Reported from the field (observed at DEF CON on long single-paragraph broadcasts) and reproduced in the simulator with a real-world 186-byte paragraph plus two tapbacks.

## Why did it change?

`TapbackResponses` wraps its reaction grid in a horizontal `ScrollView` with a fixed **width** but a flexible **height**. A `ScrollView`'s ideal size along and across its scroll axis isn't content-driven (the file's own comments already document fighting exactly this on the width axis), so as a sibling of the bubble in the message row's VStack it competed with the bubble's `Text` for vertical space — and the `Text` lost and truncated. The pill only exists when a message has reactions, which is why messages without tapbacks never clipped and why this was hard to reproduce synthetically.

Two changes:
- **`TapbackResponses`**: size the `ScrollView` to its exact content height (`pillHeight` — the same closed-form arithmetic `pillWidth` already uses) so the pill stops bidding for vertical space it doesn't need.
- **`MessageText`**: `.fixedSize(horizontal: false, vertical: true)` on the bubble text so it can never be vertically compressed by any row sibling, present or future.

## How is this tested?

- Reproduced the field report in the simulator (same paragraph + two tapbacks): **before** — bubble clips at 5 lines with "…"; **after** — full text renders, reaction pill visually unchanged (both 1-row and 2-row pill heights are covered by the arithmetic).
- Regression sweep with the same rig: 12-line multi-line messages, URLs, bracket tags, emphasis/backticks/emoji, angle brackets, and accessibility-XL Dynamic Type all still render in full.
- Debug build for the iOS simulator succeeds; the only message-related snapshot reference (`messagePreview_hidden`) covers `MessagePreview` (compose preview), which this change does not touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message text layout so wrapped messages display at their full height without being cut off.
  * Fixed reaction controls so their scroll area has the correct height and displays consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->