### PR TITLE
fix(persistence): never destroy a data-protection-locked store on pre-unlock launches

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -1231,7 +1231,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1266,7 +1266,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1301,7 +1301,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1335,7 +1335,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1382,7 +1382,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -1432,7 +1432,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,

--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -8,6 +8,7 @@
 import SwiftData
 import OSLog
 import Foundation
+import UIKit
 
 @MainActor
 class PersistenceController {
@@ -36,6 +37,48 @@ class PersistenceController {
 
 	var context: ModelContext {
 		container.mainContext
+	}
+
+	/// True while `container` is a provisional, empty in-memory stand-in because the on-disk
+	/// store was unreadable under data protection (the process launched in the background before
+	/// the user's first unlock — Bluetooth state restoration does this after a phone reboot).
+	/// The real store is untouched on disk and is reopened by `observeFirstUnlockToReopenStore()`.
+	private(set) var isProvisionalPendingFirstUnlock = false
+
+	/// Distinguishes "the store file is locked by data protection" from "the store file is corrupt".
+	/// Before the first unlock, `open(2)` on a file protected with the default
+	/// CompleteUntilFirstUserAuthentication class fails outright; a corrupt-but-unlocked file opens
+	/// fine at the POSIX layer (its damage surfaces inside SQLite instead). Any exists-but-unopenable
+	/// state is treated as locked: the cost of a false positive is one provisional in-memory session,
+	/// while destructive "recovery" of a merely-locked store permanently deletes the user's data (#2243).
+	nonisolated static func storeExistsButIsUnreadable(at url: URL) -> Bool {
+		guard FileManager.default.fileExists(atPath: url.path) else { return false }
+		let fd = open(url.path, O_RDONLY)
+		if fd >= 0 {
+			close(fd)
+			return false
+		}
+		return true
+	}
+
+	/// Reopens the on-disk store once protected data becomes available (first unlock). The app is
+	/// still backgrounded at that moment — the user unlocks the phone before they can foreground
+	/// us — so nothing in the UI holds entities from the provisional container, and the scene
+	/// re-reads `container` on its next body evaluation (the same eventual-consistency the
+	/// data-clear flow's `recreateContainer()` relies on).
+	private func observeFirstUnlockToReopenStore() {
+		NotificationCenter.default.addObserver(
+			forName: UIApplication.protectedDataDidBecomeAvailableNotification,
+			object: nil,
+			queue: .main
+		) { [weak self] _ in
+			MainActor.assumeIsolated {
+				guard let self, self.isProvisionalPendingFirstUnlock else { return }
+				Logger.data.info("💾 Protected data is now available — reopening the on-disk store in place of the provisional container")
+				self.isProvisionalPendingFirstUnlock = false
+				self.recreateContainer()
+			}
+		}
 	}
 
 	/// Reopen the (already-migrated) store in a brand-new `ModelContainer`, replacing `container`.
@@ -151,8 +194,35 @@ class PersistenceController {
 			container.mainContext.autosaveEnabled = false
 			Logger.data.info("💾 SwiftData store initialized successfully")
 		} catch {
-			// The store could not be opened (e.g. a Core Data file that
-			// prepareForMigration() did not rename, or a corrupt store from a
+			// The store could not be opened. Before treating that as corruption, rule out
+			// data protection: launched in the background before the user's first unlock
+			// (Bluetooth state restoration does this after a phone reboot), the store file
+			// exists but is unreadable, and destroying it here is how a reboot cost users
+			// their message history (#2243). A locked store is not a broken store — leave
+			// it alone, run this session on a provisional in-memory container, and reopen
+			// the real store once protected data becomes available.
+			if !inMemory && Self.storeExistsButIsUnreadable(at: config.url) {
+				Logger.data.critical("💾 SwiftData store exists but is unreadable — data protection lock (pre-first-unlock launch), not corruption. Leaving the store untouched and using a provisional in-memory container: \(error.localizedDescription, privacy: .public)")
+				let memoryConfig = ModelConfiguration(
+					storeName,
+					schema: schema,
+					isStoredInMemoryOnly: true,
+					allowsSave: true
+				)
+				do {
+					container = try ModelContainer(for: schema, configurations: memoryConfig)
+					container.mainContext.autosaveEnabled = false
+				} catch let memoryError {
+					fatalError("💾 SwiftData in-memory fallback failed: \(memoryError.localizedDescription)")
+				}
+				isProvisionalPendingFirstUnlock = true
+				observeFirstUnlockToReopenStore()
+				// Skip the legacy Core Data migration too — its files are equally unreadable
+				// right now, and the next post-unlock open runs the normal path.
+				return
+			}
+			// A readable-but-unopenable store really is corrupt (e.g. a Core Data file
+			// that prepareForMigration() did not rename, or a damaged store from a
 			// previous build).  Log the error, rename the broken file so it is
 			// preserved for diagnosis, and retry with a fresh empty store.
 			// A fatalError here would leave users permanently unable to open

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -3,6 +3,7 @@
  */
 
 import SwiftUI
+import UIKit
 
 struct ContentView: View {
 	@ObservedObject var appState: AppState
@@ -54,7 +55,13 @@ struct ContentView: View {
 				LockdownSheet()
 			}
 			.onAppear {
-				if UserDefaults.firstLaunch {
+				// Trust the first-launch flag only when this process can actually read it. Launched
+				// in the background before the phone's first unlock (Bluetooth state restoration
+				// after a reboot), UserDefaults is still encrypted and `firstLaunch` returns its
+				// default `true` — which re-ran the whole setup wizard on an installed app (#2243).
+				// A pre-unlock launch can never be a genuine first launch: a fresh install has no
+				// restoration session to be relaunched for.
+				if UserDefaults.firstLaunch && UIApplication.shared.isProtectedDataAvailable {
 					isShowingDeviceOnboardingFlow = true
 				}
 				// Present the gate if the device is already in a blocking state when

--- a/MeshtasticTests/ProtectedDataStoreGuardTests.swift
+++ b/MeshtasticTests/ProtectedDataStoreGuardTests.swift
@@ -1,0 +1,58 @@
+//
+//  ProtectedDataStoreGuardTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/11/26.
+//
+//  Locks down the probe that keeps a data-protection-locked store from being destroyed by the
+//  corruption-recovery path (#2243). When the app is relaunched in the background before the
+//  phone's first unlock (Bluetooth state restoration after a reboot), the store file exists but
+//  cannot be opened; treating that as corruption renamed the user's database aside and started
+//  an empty one. The probe must say "unreadable" for an exists-but-unopenable file, and
+//  "readable" for anything the corruption path should still handle.
+//
+//  The simulator cannot reproduce the real pre-unlock data-protection state, so the
+//  exists-but-unopenable condition is stood in for with POSIX permissions — the probe is a
+//  plain open(2) check, so the two are equivalent at the layer under test.
+//
+
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Protected-data store guard")
+struct ProtectedDataStoreGuardTests {
+
+	private func tempFile(named name: String) -> URL {
+		FileManager.default.temporaryDirectory
+			.appendingPathComponent("pdguard-\(UUID().uuidString)-\(name)")
+	}
+
+	@Test("A missing store is not 'unreadable' — nothing to protect, recovery may proceed")
+	func missingFileIsReadable() {
+		let url = tempFile(named: "missing.store")
+		#expect(PersistenceController.storeExistsButIsUnreadable(at: url) == false)
+	}
+
+	@Test("A readable (even corrupt) store is not 'unreadable' — corruption recovery may proceed")
+	func readableGarbageIsReadable() throws {
+		let url = tempFile(named: "garbage.store")
+		// Not a valid SQLite file — the corruption case the recovery path exists for.
+		try Data("definitely not sqlite".utf8).write(to: url)
+		defer { try? FileManager.default.removeItem(at: url) }
+		#expect(PersistenceController.storeExistsButIsUnreadable(at: url) == false)
+	}
+
+	@Test("An exists-but-unopenable store reads as locked — recovery must not touch it")
+	func unopenableFileIsUnreadable() throws {
+		let url = tempFile(named: "locked.store")
+		try Data("locked".utf8).write(to: url)
+		defer {
+			try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+			try? FileManager.default.removeItem(at: url)
+		}
+		try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: url.path)
+		#expect(PersistenceController.storeExistsButIsUnreadable(at: url) == true)
+	}
+}

--- a/project.yml
+++ b/project.yml
@@ -403,7 +403,7 @@ targets:
             - "$(inherited)"
             - "@executable_path/Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           OTHER_LDFLAGS:
             - "-weak_framework"
             - "SwiftUI"
@@ -446,7 +446,7 @@ targets:
             - "$(inherited)"
             - "@executable_path/Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           OTHER_LDFLAGS:
             - "-weak_framework"
             - "SwiftUI"
@@ -492,7 +492,7 @@ targets:
             - "@executable_path/Frameworks"
             - "@executable_path/../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.Widgets"
           PRODUCT_NAME: "$(TARGET_NAME)"
           PROVISIONING_PROFILE_SPECIFIER: ""
@@ -521,7 +521,7 @@ targets:
             - "@executable_path/Frameworks"
             - "@executable_path/../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.Widgets"
           PRODUCT_NAME: "$(TARGET_NAME)"
           PROVISIONING_PROFILE_SPECIFIER: ""
@@ -615,7 +615,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.watchkitapp"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "watchos"
@@ -643,7 +643,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.watchkitapp"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "watchos"


### PR DESCRIPTION
Fixes #2243.

## What changed?

After an iPhone reboot, Bluetooth state restoration can relaunch the app **in the background before the user's first unlock**. In that window the app's files are still encrypted under data protection: the SwiftData store exists but cannot be opened, and UserDefaults reads return built-in defaults. Two destructive behaviors followed:

- The store-open failure fell into the **corruption-recovery path**, which renames the database aside and starts an empty one — i.e. a mere reboot could permanently discard message history ("message history disappearing").
- `UserDefaults.firstLaunch` read as its default `true`, so the app **re-ran the entire first-time setup wizard** on an installed app ("application resets on iPhone reboot").

Both reported in #2243 (passcode set — precondition confirmed; intermittent — it's a race on whether the background relaunch lands inside the pre-unlock window, which is why the reporter couldn't reproduce it on demand).

## How?

- **`PersistenceController`**: when the store fails to open, a new `open(2)` probe distinguishes *locked* from *corrupt*. A data-protection-locked file fails at the POSIX layer outright; a corrupt-but-unlocked file opens fine and breaks inside SQLite instead. Locked ⇒ hands off: the on-disk store is left untouched, the session runs on a provisional in-memory container, and a `protectedDataDidBecomeAvailable` observer reopens the real store through the existing `recreateContainer()` machinery the moment the user unlocks (the app is still backgrounded at that point, so nothing in the UI holds provisional entities). Only a *readable*-but-unopenable store — genuine corruption — still takes the rename-aside recovery.
- **`ContentView`**: the setup wizard is gated on `isProtectedDataAvailable`. A pre-unlock launch can never be a genuine first launch — a fresh install has no restoration session to be relaunched for.

## How is this tested?

- New `ProtectedDataStoreGuardTests` (3 tests, passing) pin the probe's contract: missing store → recoverable; readable garbage (real corruption) → recoverable; exists-but-unopenable → off-limits. The simulator can't enter the real pre-unlock state, so POSIX permissions stand in — equivalent at the `open(2)` layer under test.
- Full Debug build for the iOS simulator succeeds.
- The true end-to-end (reboot a passcode-locked phone with a radio advertising nearby) is inherently a field race; the guard makes the destructive paths unreachable in that state regardless of timing.

## Notes

- The old behavior preserved shunted stores as `Meshtastic.store-broken-<timestamp>`; automatically re-adopting those for previously-affected users is a possible follow-up, left out here because choosing between the shunted store and the current one needs careful heuristics.
- The reporter also described a Live Activity / disconnect-on-quit behavior change; that's a separate report (it may share the state-restoration mechanism but not this fix's code path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup when protected device data is temporarily unavailable before the first unlock.
  * Preserved existing local data and automatically restored access once protected data becomes available.
  * Prevented first-launch device onboarding from appearing prematurely during background restoration.
  * Improved recovery handling for unreadable or corrupted local data stores.

* **Updates**
  * Updated the app, widget extension, and watch app to version 2.7.19.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->