### PR TITLE
feat(waypoints): local notify opt-in for received geofences (design#114)

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		BD1780B27CE8A3FF56E1C632 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = "zh-Hant"; path = "zh-Hant.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
 		BDE4E12D1CA4D31DF54808B6 /* MeshtasticDataModelV 28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 28.xcdatamodel"; sourceTree = "<group>"; };
 		BF2A0F6C2F79E131B73DE4D4 /* MeshtasticDataModelV 41.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 41.xcdatamodel"; sourceTree = "<group>"; };
-		BF325A6359A74DDECD015FA1 /* MeshtasticProtobufs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MeshtasticProtobufs; path = MeshtasticProtobufs; sourceTree = SOURCE_ROOT; };
+		BF325A6359A74DDECD015FA1 /* MeshtasticProtobufs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MeshtasticProtobufs; sourceTree = SOURCE_ROOT; };
 		BFF8C95A2DA86E1690F165CE /* MeshtasticDataModelV15.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV15.xcdatamodel; sourceTree = "<group>"; };
 		C0810161F73BC57A90E60D0C /* event_firmware.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = event_firmware.json; sourceTree = "<group>"; };
 		C6BCC32505771F08628D70D7 /* DeviceHardware.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = DeviceHardware.json; sourceTree = "<group>"; };
@@ -200,7 +200,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		60FB5122E93A45D014918572 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		60FB5122E93A45D014918572 /* Exceptions for "images" folder in "Meshtastic" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				crowpanel_2_8.svg,
@@ -208,6 +208,8 @@
 				crowpanel_5_0.svg,
 				crowpanel_7_0.svg,
 				diy.svg,
+				heltec_mesh_pocket.svg,
+				heltec_v4.svg,
 				"heltec-ht62-esp32c3-sx1262.svg",
 				"heltec-mesh-node-t114-case.svg",
 				"heltec-mesh-node-t114.svg",
@@ -220,8 +222,6 @@
 				"heltec-wireless-paper.svg",
 				"heltec-wireless-tracker.svg",
 				"heltec-wsl-v3.svg",
-				heltec_mesh_pocket.svg,
-				heltec_v4.svg,
 				image_manifest.json,
 				"lilygo-tlora-pager.svg",
 				m5_c6l.svg,
@@ -230,20 +230,20 @@
 				"nano-g2-ultra.svg",
 				pico.svg,
 				promicro.svg,
-				"rak-wismesh-tap-v2.svg",
-				"rak-wismeshtap.svg",
-				rak11200.svg,
-				rak11310.svg,
-				rak2560.svg,
-				rak4631.svg,
-				rak4631_case.svg,
 				rak_3312.svg,
 				rak_wismesh_tag.svg,
+				"rak-wismesh-tap-v2.svg",
+				"rak-wismeshtap.svg",
+				rak2560.svg,
+				rak4631_case.svg,
+				rak4631.svg,
+				rak11200.svg,
+				rak11310.svg,
 				rpipicow.svg,
-				"seeed-sensecap-indicator.svg",
-				"seeed-xiao-s3.svg",
 				seeed_solar.svg,
 				seeed_xiao_nrf52_kit.svg,
+				"seeed-sensecap-indicator.svg",
+				"seeed-xiao-s3.svg",
 				"station-g2.svg",
 				"t-deck.svg",
 				"t-echo.svg",
@@ -259,25 +259,23 @@
 				"tlora-v2-1-1_6.svg",
 				"tlora-v2-1-1_8.svg",
 				"tracker-t1000-e.svg",
-				"wio-tracker-wm1110.svg",
 				wio_tracker_l1_case.svg,
 				wio_tracker_l1_eink.svg,
+				"wio-tracker-wm1110.svg",
 			);
 			target = FEF4168AE260CFE34C972EBB /* Meshtastic */;
 		};
-		8924DE954AC79FD140612404 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		8924DE954AC79FD140612404 /* Exceptions for "Widgets" folder in "WidgetsExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
-				WidgetsExtension.entitlements,
 			);
 			target = A2F1595BC848E48B138C58E1 /* WidgetsExtension */;
 		};
-		DB19C69A7D6E83F95BB67635 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		DB19C69A7D6E83F95BB67635 /* Exceptions for "Meshtastic Watch App" folder in "Meshtastic Watch App" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
-				"Meshtastic Watch App.entitlements",
 			);
 			target = C4BC64E061C609D15F5DFAF5 /* Meshtastic Watch App */;
 		};
@@ -287,225 +285,119 @@
 		0846840A4300FE311DCFDA44 /* images */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				60FB5122E93A45D014918572 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+				60FB5122E93A45D014918572 /* Exceptions for "images" folder in "Meshtastic" target */,
 			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = images;
 			path = images;
 			sourceTree = "<group>";
 		};
 		0B1C4E352D6981242B97EF9C /* Widgets */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				8924DE954AC79FD140612404 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
+				8924DE954AC79FD140612404 /* Exceptions for "Widgets" folder in "WidgetsExtension" target */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
 		};
 		0B574D8559FE5799ADB5A517 /* Services */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Services;
 			path = Services;
 			sourceTree = "<group>";
 		};
 		11D3172B1FEF230630B7A990 /* Extensions */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Extensions;
 			path = Extensions;
 			sourceTree = "<group>";
 		};
 		1B104A61866EBBAB39A96CD6 /* API */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = API;
 			path = API;
 			sourceTree = "<group>";
 		};
 		22FDA4B8722F2CC1F4B5A929 /* Helpers */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Helpers;
 			path = Helpers;
 			sourceTree = "<group>";
 		};
 		25C42CF0517289648017F9AA /* Intents */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Intents;
 			path = Intents;
 			sourceTree = "<group>";
 		};
 		306AEE0BD7EDAF65F6E3B376 /* Measurement */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Measurement;
 			path = Measurement;
 			sourceTree = "<group>";
 		};
 		456E28D41A9B7B1788FEE0CD /* Shared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
 			path = Shared;
 			sourceTree = "<group>";
 		};
 		46D9EC9A9870D40B64CBD339 /* Accessory */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Accessory;
 			path = Accessory;
 			sourceTree = "<group>";
 		};
 		4E52FFD5347832FDB8575177 /* Persistence */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Persistence;
 			path = Persistence;
 			sourceTree = "<group>";
 		};
 		811D897CDBB8285F81701314 /* Enums */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Enums;
 			path = Enums;
 			sourceTree = "<group>";
 		};
 		867FD80926C4A4286D635BAD /* MeshtasticTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
 			path = MeshtasticTests;
 			sourceTree = "<group>";
 		};
 		91DE2B8079DF4453A2B7A512 /* AppIntents */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = AppIntents;
 			path = AppIntents;
 			sourceTree = "<group>";
 		};
 		9F6D2EC582CAA968D897F796 /* Router */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Router;
 			path = Router;
 			sourceTree = "<group>";
 		};
 		B47C68738DD365F2A873DF1E /* CarPlay */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = CarPlay;
 			path = CarPlay;
 			sourceTree = "<group>";
 		};
 		C21C46F8F2BCFF68F31B12C0 /* Export */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Export;
 			path = Export;
 			sourceTree = "<group>";
 		};
 		C95A60ECD93D37F4971EC685 /* Tips */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Tips;
 			path = Tips;
 			sourceTree = "<group>";
 		};
 		D983771846F46D151DDE372B /* Views */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Views;
 			path = Views;
 			sourceTree = "<group>";
 		};
 		F0E2A06151AF30290D808624 /* Meshtastic Watch App */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				DB19C69A7D6E83F95BB67635 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
+				DB19C69A7D6E83F95BB67635 /* Exceptions for "Meshtastic Watch App" folder in "Meshtastic Watch App" target */,
 			);
 			path = "Meshtastic Watch App";
 			sourceTree = "<group>";
 		};
 		F7C2596BDB5FBBD06602EAAF /* Model */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Model;
 			path = Model;
 			sourceTree = "<group>";
 		};
 		FFE592D22DEA437B6844BD5F /* Provisioning */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Provisioning;
 			path = Provisioning;
 			sourceTree = "<group>";
 		};
@@ -685,8 +577,8 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				456E28D41A9B7B1788FEE0CD /* Shared */,
 				0B1C4E352D6981242B97EF9C /* Widgets */,
+				456E28D41A9B7B1788FEE0CD /* Shared */,
 			);
 			name = WidgetsExtension;
 			packageProductDependencies = (
@@ -736,25 +628,25 @@
 				9F8D08FE8C3920E29BC0C051 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				1B104A61866EBBAB39A96CD6 /* API */,
-				46D9EC9A9870D40B64CBD339 /* Accessory */,
-				91DE2B8079DF4453A2B7A512 /* AppIntents */,
-				B47C68738DD365F2A873DF1E /* CarPlay */,
-				811D897CDBB8285F81701314 /* Enums */,
-				C21C46F8F2BCFF68F31B12C0 /* Export */,
+				0846840A4300FE311DCFDA44 /* images */,
+				0B574D8559FE5799ADB5A517 /* Services */,
 				11D3172B1FEF230630B7A990 /* Extensions */,
+				1B104A61866EBBAB39A96CD6 /* API */,
 				22FDA4B8722F2CC1F4B5A929 /* Helpers */,
 				25C42CF0517289648017F9AA /* Intents */,
 				306AEE0BD7EDAF65F6E3B376 /* Measurement */,
-				F7C2596BDB5FBBD06602EAAF /* Model */,
-				4E52FFD5347832FDB8575177 /* Persistence */,
-				FFE592D22DEA437B6844BD5F /* Provisioning */,
-				9F6D2EC582CAA968D897F796 /* Router */,
-				0B574D8559FE5799ADB5A517 /* Services */,
 				456E28D41A9B7B1788FEE0CD /* Shared */,
+				46D9EC9A9870D40B64CBD339 /* Accessory */,
+				4E52FFD5347832FDB8575177 /* Persistence */,
+				811D897CDBB8285F81701314 /* Enums */,
+				91DE2B8079DF4453A2B7A512 /* AppIntents */,
+				9F6D2EC582CAA968D897F796 /* Router */,
+				B47C68738DD365F2A873DF1E /* CarPlay */,
+				C21C46F8F2BCFF68F31B12C0 /* Export */,
 				C95A60ECD93D37F4971EC685 /* Tips */,
 				D983771846F46D151DDE372B /* Views */,
-				0846840A4300FE311DCFDA44 /* images */,
+				F7C2596BDB5FBBD06602EAAF /* Model */,
+				FFE592D22DEA437B6844BD5F /* Provisioning */,
 			);
 			name = Meshtastic;
 			packageProductDependencies = (
@@ -1231,7 +1123,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1266,7 +1158,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1301,7 +1193,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1335,7 +1227,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1382,7 +1274,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -1432,7 +1324,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.18;
+				MARKETING_VERSION = 2.7.19;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		BD1780B27CE8A3FF56E1C632 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = "zh-Hant"; path = "zh-Hant.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
 		BDE4E12D1CA4D31DF54808B6 /* MeshtasticDataModelV 28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 28.xcdatamodel"; sourceTree = "<group>"; };
 		BF2A0F6C2F79E131B73DE4D4 /* MeshtasticDataModelV 41.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 41.xcdatamodel"; sourceTree = "<group>"; };
-		BF325A6359A74DDECD015FA1 /* MeshtasticProtobufs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MeshtasticProtobufs; sourceTree = SOURCE_ROOT; };
+		BF325A6359A74DDECD015FA1 /* MeshtasticProtobufs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MeshtasticProtobufs; path = MeshtasticProtobufs; sourceTree = SOURCE_ROOT; };
 		BFF8C95A2DA86E1690F165CE /* MeshtasticDataModelV15.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV15.xcdatamodel; sourceTree = "<group>"; };
 		C0810161F73BC57A90E60D0C /* event_firmware.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = event_firmware.json; sourceTree = "<group>"; };
 		C6BCC32505771F08628D70D7 /* DeviceHardware.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = DeviceHardware.json; sourceTree = "<group>"; };
@@ -200,7 +200,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		60FB5122E93A45D014918572 /* Exceptions for "images" folder in "Meshtastic" target */ = {
+		60FB5122E93A45D014918572 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				crowpanel_2_8.svg,
@@ -208,8 +208,6 @@
 				crowpanel_5_0.svg,
 				crowpanel_7_0.svg,
 				diy.svg,
-				heltec_mesh_pocket.svg,
-				heltec_v4.svg,
 				"heltec-ht62-esp32c3-sx1262.svg",
 				"heltec-mesh-node-t114-case.svg",
 				"heltec-mesh-node-t114.svg",
@@ -222,6 +220,8 @@
 				"heltec-wireless-paper.svg",
 				"heltec-wireless-tracker.svg",
 				"heltec-wsl-v3.svg",
+				heltec_mesh_pocket.svg,
+				heltec_v4.svg,
 				image_manifest.json,
 				"lilygo-tlora-pager.svg",
 				m5_c6l.svg,
@@ -230,20 +230,20 @@
 				"nano-g2-ultra.svg",
 				pico.svg,
 				promicro.svg,
-				rak_3312.svg,
-				rak_wismesh_tag.svg,
 				"rak-wismesh-tap-v2.svg",
 				"rak-wismeshtap.svg",
-				rak2560.svg,
-				rak4631_case.svg,
-				rak4631.svg,
 				rak11200.svg,
 				rak11310.svg,
+				rak2560.svg,
+				rak4631.svg,
+				rak4631_case.svg,
+				rak_3312.svg,
+				rak_wismesh_tag.svg,
 				rpipicow.svg,
-				seeed_solar.svg,
-				seeed_xiao_nrf52_kit.svg,
 				"seeed-sensecap-indicator.svg",
 				"seeed-xiao-s3.svg",
+				seeed_solar.svg,
+				seeed_xiao_nrf52_kit.svg,
 				"station-g2.svg",
 				"t-deck.svg",
 				"t-echo.svg",
@@ -259,23 +259,25 @@
 				"tlora-v2-1-1_6.svg",
 				"tlora-v2-1-1_8.svg",
 				"tracker-t1000-e.svg",
+				"wio-tracker-wm1110.svg",
 				wio_tracker_l1_case.svg,
 				wio_tracker_l1_eink.svg,
-				"wio-tracker-wm1110.svg",
 			);
 			target = FEF4168AE260CFE34C972EBB /* Meshtastic */;
 		};
-		8924DE954AC79FD140612404 /* Exceptions for "Widgets" folder in "WidgetsExtension" target */ = {
+		8924DE954AC79FD140612404 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				WidgetsExtension.entitlements,
 			);
 			target = A2F1595BC848E48B138C58E1 /* WidgetsExtension */;
 		};
-		DB19C69A7D6E83F95BB67635 /* Exceptions for "Meshtastic Watch App" folder in "Meshtastic Watch App" target */ = {
+		DB19C69A7D6E83F95BB67635 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				"Meshtastic Watch App.entitlements",
 			);
 			target = C4BC64E061C609D15F5DFAF5 /* Meshtastic Watch App */;
 		};
@@ -285,119 +287,225 @@
 		0846840A4300FE311DCFDA44 /* images */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				60FB5122E93A45D014918572 /* Exceptions for "images" folder in "Meshtastic" target */,
+				60FB5122E93A45D014918572 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
 			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = images;
 			path = images;
 			sourceTree = "<group>";
 		};
 		0B1C4E352D6981242B97EF9C /* Widgets */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				8924DE954AC79FD140612404 /* Exceptions for "Widgets" folder in "WidgetsExtension" target */,
+				8924DE954AC79FD140612404 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
 			);
 			path = Widgets;
 			sourceTree = "<group>";
 		};
 		0B574D8559FE5799ADB5A517 /* Services */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Services;
 			path = Services;
 			sourceTree = "<group>";
 		};
 		11D3172B1FEF230630B7A990 /* Extensions */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Extensions;
 			path = Extensions;
 			sourceTree = "<group>";
 		};
 		1B104A61866EBBAB39A96CD6 /* API */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = API;
 			path = API;
 			sourceTree = "<group>";
 		};
 		22FDA4B8722F2CC1F4B5A929 /* Helpers */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Helpers;
 			path = Helpers;
 			sourceTree = "<group>";
 		};
 		25C42CF0517289648017F9AA /* Intents */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Intents;
 			path = Intents;
 			sourceTree = "<group>";
 		};
 		306AEE0BD7EDAF65F6E3B376 /* Measurement */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Measurement;
 			path = Measurement;
 			sourceTree = "<group>";
 		};
 		456E28D41A9B7B1788FEE0CD /* Shared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
 			path = Shared;
 			sourceTree = "<group>";
 		};
 		46D9EC9A9870D40B64CBD339 /* Accessory */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Accessory;
 			path = Accessory;
 			sourceTree = "<group>";
 		};
 		4E52FFD5347832FDB8575177 /* Persistence */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Persistence;
 			path = Persistence;
 			sourceTree = "<group>";
 		};
 		811D897CDBB8285F81701314 /* Enums */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Enums;
 			path = Enums;
 			sourceTree = "<group>";
 		};
 		867FD80926C4A4286D635BAD /* MeshtasticTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
 			path = MeshtasticTests;
 			sourceTree = "<group>";
 		};
 		91DE2B8079DF4453A2B7A512 /* AppIntents */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = AppIntents;
 			path = AppIntents;
 			sourceTree = "<group>";
 		};
 		9F6D2EC582CAA968D897F796 /* Router */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Router;
 			path = Router;
 			sourceTree = "<group>";
 		};
 		B47C68738DD365F2A873DF1E /* CarPlay */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = CarPlay;
 			path = CarPlay;
 			sourceTree = "<group>";
 		};
 		C21C46F8F2BCFF68F31B12C0 /* Export */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Export;
 			path = Export;
 			sourceTree = "<group>";
 		};
 		C95A60ECD93D37F4971EC685 /* Tips */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Tips;
 			path = Tips;
 			sourceTree = "<group>";
 		};
 		D983771846F46D151DDE372B /* Views */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Views;
 			path = Views;
 			sourceTree = "<group>";
 		};
 		F0E2A06151AF30290D808624 /* Meshtastic Watch App */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				DB19C69A7D6E83F95BB67635 /* Exceptions for "Meshtastic Watch App" folder in "Meshtastic Watch App" target */,
+				DB19C69A7D6E83F95BB67635 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
 			);
 			path = "Meshtastic Watch App";
 			sourceTree = "<group>";
 		};
 		F7C2596BDB5FBBD06602EAAF /* Model */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Model;
 			path = Model;
 			sourceTree = "<group>";
 		};
 		FFE592D22DEA437B6844BD5F /* Provisioning */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			name = Provisioning;
 			path = Provisioning;
 			sourceTree = "<group>";
 		};
@@ -577,8 +685,8 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				0B1C4E352D6981242B97EF9C /* Widgets */,
 				456E28D41A9B7B1788FEE0CD /* Shared */,
+				0B1C4E352D6981242B97EF9C /* Widgets */,
 			);
 			name = WidgetsExtension;
 			packageProductDependencies = (
@@ -628,25 +736,25 @@
 				9F8D08FE8C3920E29BC0C051 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				0846840A4300FE311DCFDA44 /* images */,
-				0B574D8559FE5799ADB5A517 /* Services */,
-				11D3172B1FEF230630B7A990 /* Extensions */,
 				1B104A61866EBBAB39A96CD6 /* API */,
+				46D9EC9A9870D40B64CBD339 /* Accessory */,
+				91DE2B8079DF4453A2B7A512 /* AppIntents */,
+				B47C68738DD365F2A873DF1E /* CarPlay */,
+				811D897CDBB8285F81701314 /* Enums */,
+				C21C46F8F2BCFF68F31B12C0 /* Export */,
+				11D3172B1FEF230630B7A990 /* Extensions */,
 				22FDA4B8722F2CC1F4B5A929 /* Helpers */,
 				25C42CF0517289648017F9AA /* Intents */,
 				306AEE0BD7EDAF65F6E3B376 /* Measurement */,
-				456E28D41A9B7B1788FEE0CD /* Shared */,
-				46D9EC9A9870D40B64CBD339 /* Accessory */,
+				F7C2596BDB5FBBD06602EAAF /* Model */,
 				4E52FFD5347832FDB8575177 /* Persistence */,
-				811D897CDBB8285F81701314 /* Enums */,
-				91DE2B8079DF4453A2B7A512 /* AppIntents */,
+				FFE592D22DEA437B6844BD5F /* Provisioning */,
 				9F6D2EC582CAA968D897F796 /* Router */,
-				B47C68738DD365F2A873DF1E /* CarPlay */,
-				C21C46F8F2BCFF68F31B12C0 /* Export */,
+				0B574D8559FE5799ADB5A517 /* Services */,
+				456E28D41A9B7B1788FEE0CD /* Shared */,
 				C95A60ECD93D37F4971EC685 /* Tips */,
 				D983771846F46D151DDE372B /* Views */,
-				F7C2596BDB5FBBD06602EAAF /* Model */,
-				FFE592D22DEA437B6844BD5F /* Provisioning */,
+				0846840A4300FE311DCFDA44 /* images */,
 			);
 			name = Meshtastic;
 			packageProductDependencies = (

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -878,6 +878,13 @@ extension AccessoryManager {
 			} else {
 				wayPointEntity.locked = false
 			}
+			// Persist the author's geofence here: the mesh ingest applies geometry only and
+			// never touches the notify flags (design#114 — those are receiver-local), so the
+			// sending device is the one place its own preferences are recorded.
+			wayPointEntity.applyGeofenceGeometry(from: waypoint)
+			wayPointEntity.notifyOnEnter = waypoint.notifyOnEnter
+			wayPointEntity.notifyOnExit = waypoint.notifyOnExit
+			wayPointEntity.notifyFavoritesOnly = waypoint.notifyFavoritesOnly
 			if wayPointEntity.created == nil {
 				wayPointEntity.created = Date()
 			} else {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -880,11 +880,20 @@ extension AccessoryManager {
 			}
 			// Persist the author's geofence here: the mesh ingest applies geometry only and
 			// never touches the notify flags (design#114 — those are receiver-local), so the
-			// sending device is the one place its own preferences are recorded.
+			// sending device is the one place its own preferences are recorded. When
+			// re-sending someone else's waypoint the outgoing flags are forced false
+			// (see WaypointEntity.outgoingNotifyFlags), so only mirror them back into the
+			// entity for the author — otherwise this device's local opt-in would be wiped.
 			wayPointEntity.applyGeofenceGeometry(from: waypoint)
-			wayPointEntity.notifyOnEnter = waypoint.notifyOnEnter
-			wayPointEntity.notifyOnExit = waypoint.notifyOnExit
-			wayPointEntity.notifyFavoritesOnly = waypoint.notifyFavoritesOnly
+			if WaypointEntity.isAuthoredLocally(
+				waypointId: wayPointEntity.id,
+				createdBy: wayPointEntity.createdBy,
+				activeDeviceNum: Int64(deviceNum)
+			) {
+				wayPointEntity.notifyOnEnter = waypoint.notifyOnEnter
+				wayPointEntity.notifyOnExit = waypoint.notifyOnExit
+				wayPointEntity.notifyFavoritesOnly = waypoint.notifyFavoritesOnly
+			}
 			if wayPointEntity.created == nil {
 				wayPointEntity.created = Date()
 			} else {

--- a/Meshtastic/Extensions/SwiftData/WaypointEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/WaypointEntityExtension.swift
@@ -100,12 +100,16 @@ struct WaypointCoordinate: Identifiable {
 
 extension WaypointEntity {
 
-	/// Copies the geofence fields from a received `Waypoint` protobuf into this entity.
-	func applyGeofence(from waypoint: Waypoint) {
+	/// Copies the geofence *geometry* (circular radius + bounding box) from a `Waypoint`
+	/// protobuf into this entity — and nothing else.
+	///
+	/// The notify flags (`notifyOnEnter` / `notifyOnExit` / `notifyFavoritesOnly`) are
+	/// deliberately NOT taken from the wire: under the design#114 notification-scope model
+	/// each receiver decides locally whether a geofence notifies it. A received waypoint
+	/// therefore never notifies until this user opts in (creator-only default), and a mesh
+	/// update can never overwrite a local opt-in.
+	func applyGeofenceGeometry(from waypoint: Waypoint) {
 		geofenceRadius = Int(waypoint.geofenceRadius)
-		notifyOnEnter = waypoint.notifyOnEnter
-		notifyOnExit = waypoint.notifyOnExit
-		notifyFavoritesOnly = waypoint.notifyFavoritesOnly
 		hasBoundingBox = waypoint.hasBoundingBox
 		if waypoint.hasBoundingBox {
 			boundingBoxLatitudeNorthI = waypoint.boundingBox.latitudeNorthI
@@ -123,6 +127,26 @@ extension WaypointEntity {
 	/// True when the waypoint defines any geofence (circular radius and/or bounding box).
 	var hasGeofence: Bool {
 		geofenceRadius > 0 || hasBoundingBox
+	}
+
+	/// Whether the geofence notification preferences may be edited in place, without any
+	/// mesh send (design#114 notification-scope model).
+	///
+	/// True for a *received* waypoint that carries a geofence: one this device did not
+	/// author (including waypoints locked to another node) and that is not a local-only
+	/// waypoint. The notify flags are receiver-local and never travel back to the mesh,
+	/// so flipping them must not require re-broadcasting someone else's waypoint.
+	/// When no device is connected (`activeDeviceNum == nil`) authorship cannot be
+	/// checked, but the preference is still purely local — editing stays allowed.
+	static func canEditNotifyPreferencesLocally(
+		isLocalWaypoint: Bool,
+		createdBy: Int64,
+		activeDeviceNum: Int64?,
+		hasGeofence: Bool
+	) -> Bool {
+		guard hasGeofence, !isLocalWaypoint else { return false }
+		guard let activeDeviceNum else { return true }
+		return createdBy != activeDeviceNum
 	}
 
 	/// The bounding-box corners as a closed rectangle (SW, SE, NE, NW) suitable for an

--- a/Meshtastic/Extensions/SwiftData/WaypointEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/WaypointEntityExtension.swift
@@ -149,6 +149,51 @@ extension WaypointEntity {
 		return createdBy != activeDeviceNum
 	}
 
+	/// Whether the connected device is this waypoint's author: a brand-new waypoint
+	/// (`waypointId == 0`, about to be created here) or one created by the connected node.
+	/// Without a connected device authorship cannot be established, so an existing
+	/// waypoint is treated as someone else's.
+	static func isAuthoredLocally(
+		waypointId: Int64,
+		createdBy: Int64,
+		activeDeviceNum: Int64?
+	) -> Bool {
+		if waypointId == 0 { return true }
+		guard let activeDeviceNum else { return false }
+		return createdBy == activeDeviceNum
+	}
+
+	/// The notify flag values to serialize onto an outgoing `Waypoint` proto.
+	struct OutgoingNotifyFlags {
+		let notifyOnEnter: Bool
+		let notifyOnExit: Bool
+		let notifyFavoritesOnly: Bool
+	}
+
+	/// Computes the notify flag values to serialize onto an outgoing `Waypoint` proto.
+	///
+	/// The wire notify fields carry the *author's own* preference only (design#114 —
+	/// each receiver decides locally, and this app ignores the fields on receipt). When
+	/// this device is not the waypoint's author (`isAuthor`, see `isAuthoredLocally`),
+	/// all three serialize as false so that re-sending someone else's waypoint can never
+	/// leak this receiver's local opt-in. Also normalizes: no geofence means no notify
+	/// flags, and favorites-only is only meaningful when actually notifying.
+	static func outgoingNotifyFlags(
+		isAuthor: Bool,
+		hasGeofence: Bool,
+		notifyOnEnter: Bool,
+		notifyOnExit: Bool,
+		notifyFavoritesOnly: Bool
+	) -> OutgoingNotifyFlags {
+		let onEnter = isAuthor && hasGeofence && notifyOnEnter
+		let onExit = isAuthor && hasGeofence && notifyOnExit
+		return OutgoingNotifyFlags(
+			notifyOnEnter: onEnter,
+			notifyOnExit: onExit,
+			notifyFavoritesOnly: (onEnter || onExit) && notifyFavoritesOnly
+		)
+	}
+
 	/// The bounding-box corners as a closed rectangle (SW, SE, NE, NW) suitable for an
 	/// `MKPolygon`, or `nil` when no bounding box is set.
 	var boundingBoxCoordinates: [CLLocationCoordinate2D]? {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1666,7 +1666,9 @@ actor MeshPackets {
 					waypoint.icon = Int64(waypointMessage.icon)
 					waypoint.locked = waypointMessage.lockedTo != 0
 					waypoint.createdBy = Int64(packet.from)
-					waypoint.applyGeofence(from: waypointMessage)
+					// Geometry only: the notify flags are receiver-local (design#114), so a
+					// received waypoint never notifies unless this user opts in via WaypointForm.
+					waypoint.applyGeofenceGeometry(from: waypointMessage)
 					if waypointMessage.expire >= 1 {
 						waypoint.expire = Date(timeIntervalSince1970: TimeInterval(Int64(waypointMessage.expire)))
 					} else {
@@ -1711,7 +1713,9 @@ actor MeshPackets {
 							existingWaypoint.icon = Int64(waypointMessage.icon)
 							existingWaypoint.locked = waypointMessage.lockedTo != 0
 							existingWaypoint.lastUpdatedBy = Int64(packet.from)
-							existingWaypoint.applyGeofence(from: waypointMessage)
+							// Geometry only — a mesh update must never overwrite this user's
+							// local notification opt-in/opt-out (design#114).
+							existingWaypoint.applyGeofenceGeometry(from: waypointMessage)
 							if waypointMessage.expire >= 1 {
 								existingWaypoint.expire = Date(timeIntervalSince1970: TimeInterval(Int64(waypointMessage.expire)))
 							} else {

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -398,6 +398,35 @@ struct WaypointForm: View {
 					Text("Location")
 				}
 
+				// Local notification opt-in for a received geofence (design#114): editable in
+				// place — even for locked waypoints — and persisted only on this device. The
+				// mesh Send path is never involved; the flags never travel over the wire.
+				if canEditNotifyPreferencesLocally {
+					Section {
+						Toggle(isOn: $notifyOnEnter) {
+							Label("Notify on Enter", systemImage: "bell")
+						}
+						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+						.onChange(of: notifyOnEnter) { commitNotifyPreferences() }
+						Toggle(isOn: $notifyOnExit) {
+							Label("Notify on Exit", systemImage: "bell.slash")
+						}
+						.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+						.onChange(of: notifyOnExit) { commitNotifyPreferences() }
+						if notifyOnEnter || notifyOnExit {
+							Toggle(isOn: $notifyFavoritesOnly) {
+								Label("Favorites Only", systemImage: "star")
+							}
+							.toggleStyle(SwitchToggleStyle(tint: .accentColor))
+							.onChange(of: notifyFavoritesOnly) { commitNotifyPreferences() }
+						}
+					} header: {
+						Text("Geofence Notifications")
+					} footer: {
+						Text("Saved only on this device — nothing is sent over the mesh.")
+					}
+				}
+
 				Section {
 					Label {
 						Text(waypoint.created?.formatted(date: .numeric, time: .shortened) ?? "?")
@@ -571,6 +600,32 @@ struct WaypointForm: View {
 		#endif
 	}
 	
+	/// Whether the geofence notification toggles are offered as an in-place, local-only
+	/// setting in the read-only view: a received waypoint (not authored by the connected
+	/// node — including ones locked to another node — and not local-only) with a geofence.
+	private var canEditNotifyPreferencesLocally: Bool {
+		WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: waypoint.isLocal,
+			createdBy: waypoint.createdBy,
+			activeDeviceNum: accessoryManager.activeDeviceNum,
+			hasGeofence: waypoint.hasGeofence
+		)
+	}
+
+	/// Persist the geofence notification opt-in for a received waypoint. Local-only by
+	/// design (design#114): writes exactly the three receiver-local preference flags and
+	/// saves the context — nothing is ever sent to the mesh from this path.
+	private func commitNotifyPreferences() {
+		// Favorites-only is meaningless (and its toggle hidden) unless notifying.
+		if !notifyOnEnter && !notifyOnExit {
+			notifyFavoritesOnly = false
+		}
+		waypoint.notifyOnEnter = notifyOnEnter
+		waypoint.notifyOnExit = notifyOnExit
+		waypoint.notifyFavoritesOnly = notifyFavoritesOnly
+		do { try context.save() } catch { Logger.mesh.error("Failed to save notification preferences: \(error)") }
+	}
+
 	private func commitLocal() {
 		if waypoint.id == 0 {
 			waypoint.id = Int64(UInt32.random(in: UInt32(UInt8.max)..<UInt32.max))

--- a/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/WaypointForm.swift
@@ -702,15 +702,25 @@ struct WaypointForm: View {
 
 	private func applyGeofence(to waypointProto: inout Waypoint) {
 		waypointProto.geofenceRadius = UInt32(max(0, geofenceRadius).rounded())
-		// The notification toggles are hidden in the UI when no geofence exists, but their
-		// @State values persist. Normalize before serializing so turning a geofence off can't
-		// leak stale `true` flags onto the mesh; favorites-only only applies when notifying.
-		let hasGeofence = geofenceRadius > 0 || geofenceBounds != nil
-		let serializedNotifyOnEnter = hasGeofence && notifyOnEnter
-		let serializedNotifyOnExit = hasGeofence && notifyOnExit
-		waypointProto.notifyOnEnter = serializedNotifyOnEnter
-		waypointProto.notifyOnExit = serializedNotifyOnExit
-		waypointProto.notifyFavoritesOnly = (serializedNotifyOnEnter || serializedNotifyOnExit) && notifyFavoritesOnly
+		// The wire notify fields carry the author's own preference only (design#114):
+		// re-sending someone else's waypoint serializes them as false so this receiver's
+		// local opt-in never leaks onto the mesh. Also normalizes stale @State — the
+		// toggles are hidden when no geofence exists but their values persist, and
+		// favorites-only only applies when notifying.
+		let flags = WaypointEntity.outgoingNotifyFlags(
+			isAuthor: WaypointEntity.isAuthoredLocally(
+				waypointId: waypoint.id,
+				createdBy: waypoint.createdBy,
+				activeDeviceNum: accessoryManager.activeDeviceNum
+			),
+			hasGeofence: geofenceRadius > 0 || geofenceBounds != nil,
+			notifyOnEnter: notifyOnEnter,
+			notifyOnExit: notifyOnExit,
+			notifyFavoritesOnly: notifyFavoritesOnly
+		)
+		waypointProto.notifyOnEnter = flags.notifyOnEnter
+		waypointProto.notifyOnExit = flags.notifyOnExit
+		waypointProto.notifyFavoritesOnly = flags.notifyFavoritesOnly
 		if let b = geofenceBounds {
 			var box = BoundingBox()
 			box.longitudeWestI = Int32((b.minLon * 1e7).rounded())

--- a/MeshtasticTests/GeofenceTests.swift
+++ b/MeshtasticTests/GeofenceTests.swift
@@ -344,3 +344,91 @@ struct WaypointNotifyPolicyTests {
 		) == true)
 	}
 }
+
+// MARK: - Outgoing wire notify flags (design#114)
+
+@Suite("Outgoing notify flag serialization")
+struct WaypointOutgoingNotifyFlagsTests {
+
+	/// Mirrors WaypointForm.applyGeofence(to:): authorship resolved via
+	/// isAuthoredLocally, then fed into outgoingNotifyFlags.
+	private func serialize(
+		waypointId: Int64, createdBy: Int64, activeDeviceNum: Int64? = 222,
+		hasGeofence: Bool = true, notifyOnEnter: Bool = false, notifyOnExit: Bool = false,
+		notifyFavoritesOnly: Bool = false
+	) -> WaypointEntity.OutgoingNotifyFlags {
+		WaypointEntity.outgoingNotifyFlags(
+			isAuthor: WaypointEntity.isAuthoredLocally(
+				waypointId: waypointId, createdBy: createdBy, activeDeviceNum: activeDeviceNum
+			),
+			hasGeofence: hasGeofence,
+			notifyOnEnter: notifyOnEnter,
+			notifyOnExit: notifyOnExit,
+			notifyFavoritesOnly: notifyFavoritesOnly
+		)
+	}
+
+	@Test("Re-sending someone else's waypoint never leaks this receiver's local opt-in")
+	func resendOfReceivedWaypointSerializesFalse() {
+		// A received waypoint (created by node 111, we are node 222) the user locally
+		// opted in to, then edited and re-sent from the edit form.
+		let flags = serialize(
+			waypointId: 42, createdBy: 111, activeDeviceNum: 222,
+			hasGeofence: true, notifyOnEnter: true, notifyOnExit: true, notifyFavoritesOnly: true
+		)
+		#expect(flags.notifyOnEnter == false)
+		#expect(flags.notifyOnExit == false)
+		#expect(flags.notifyFavoritesOnly == false)
+	}
+
+	@Test("The author's own preferences serialize as set")
+	func authoredWaypointSerializesAsSet() {
+		let flags = serialize(
+			waypointId: 42, createdBy: 222, activeDeviceNum: 222,
+			hasGeofence: true, notifyOnEnter: true, notifyOnExit: false, notifyFavoritesOnly: true
+		)
+		#expect(flags.notifyOnEnter == true)
+		#expect(flags.notifyOnExit == false)
+		#expect(flags.notifyFavoritesOnly == true)
+	}
+
+	@Test("A brand-new waypoint (id == 0) counts as authored here")
+	func newWaypointSerializesAsSet() {
+		let flags = serialize(
+			waypointId: 0, createdBy: 0, activeDeviceNum: 222,
+			hasGeofence: true, notifyOnEnter: false, notifyOnExit: true, notifyFavoritesOnly: false
+		)
+		#expect(flags.notifyOnEnter == false)
+		#expect(flags.notifyOnExit == true)
+		#expect(flags.notifyFavoritesOnly == false)
+	}
+
+	@Test("Removing the geofence clears stale flags even for the author")
+	func noGeofenceNormalizesFlagsOff() {
+		let flags = serialize(
+			waypointId: 42, createdBy: 222, activeDeviceNum: 222,
+			hasGeofence: false, notifyOnEnter: true, notifyOnExit: true, notifyFavoritesOnly: true
+		)
+		#expect(flags.notifyOnEnter == false)
+		#expect(flags.notifyOnExit == false)
+		#expect(flags.notifyFavoritesOnly == false)
+	}
+
+	@Test("Favorites-only requires actually notifying")
+	func favoritesOnlyRequiresNotifying() {
+		let flags = serialize(
+			waypointId: 42, createdBy: 222, activeDeviceNum: 222,
+			hasGeofence: true, notifyOnEnter: false, notifyOnExit: false, notifyFavoritesOnly: true
+		)
+		#expect(flags.notifyFavoritesOnly == false)
+	}
+
+	@Test("isAuthoredLocally: new is authored; existing needs a matching connected node")
+	func authorshipPolicy() {
+		#expect(WaypointEntity.isAuthoredLocally(waypointId: 0, createdBy: 0, activeDeviceNum: nil) == true)
+		#expect(WaypointEntity.isAuthoredLocally(waypointId: 42, createdBy: 222, activeDeviceNum: 222) == true)
+		#expect(WaypointEntity.isAuthoredLocally(waypointId: 42, createdBy: 111, activeDeviceNum: 222) == false)
+		// Disconnected: authorship of an existing waypoint cannot be established.
+		#expect(WaypointEntity.isAuthoredLocally(waypointId: 42, createdBy: 222, activeDeviceNum: nil) == false)
+	}
+}

--- a/MeshtasticTests/GeofenceTests.swift
+++ b/MeshtasticTests/GeofenceTests.swift
@@ -4,8 +4,9 @@
 //
 //  Tests for the waypoint-geofence alert engine (MeshPackets+Geofence):
 //  the crossing-state store (baseline / transition / geometry-key rotation /
-//  thread-safety), the WaypointEntity.contains(location:) geometry, and
-//  applyGeofence(from:) proto→entity mapping.
+//  thread-safety), the WaypointEntity.contains(location:) geometry, the
+//  applyGeofenceGeometry(from:) proto→entity mapping, and the local
+//  notify opt-in policy (design#114).
 //
 
 import Testing
@@ -199,27 +200,52 @@ struct WaypointGeofenceGeometryTests {
 	}
 }
 
-// MARK: - WaypointEntity.applyGeofence(from:)
+// MARK: - WaypointEntity.applyGeofenceGeometry(from:)
 
-@Suite("Waypoint applyGeofence(from:)")
+@Suite("Waypoint applyGeofenceGeometry(from:)")
 struct WaypointApplyGeofenceTests {
 
-	@Test("Copies circular geofence + notification flags from the proto")
-	func copiesCircleAndFlags() {
+	@Test("Copies the circular geofence but never the wire notify flags (creator-only default)")
+	func copiesCircleButNotFlags() {
 		let wp = WaypointEntity()
 		var proto = Waypoint()
 		proto.geofenceRadius = 250
 		proto.notifyOnEnter = true
-		proto.notifyOnExit = false
+		proto.notifyOnExit = true
 		proto.notifyFavoritesOnly = true
 
-		wp.applyGeofence(from: proto)
+		wp.applyGeofenceGeometry(from: proto)
 
 		#expect(wp.geofenceRadius == 250)
+		// design#114: notification scope is receiver-local — a received waypoint must not
+		// notify just because the sender's flags rode along on the wire.
+		#expect(wp.notifyOnEnter == false)
+		#expect(wp.notifyOnExit == false)
+		#expect(wp.notifyFavoritesOnly == false)
+		#expect(wp.hasBoundingBox == false)
+	}
+
+	@Test("A mesh update preserves this receiver's local notification opt-in")
+	func updatePreservesLocalOptIn() {
+		let wp = WaypointEntity()
+		wp.geofenceRadius = 100
+		// The user opted in locally on this device.
+		wp.notifyOnEnter = true
+		wp.notifyFavoritesOnly = true
+
+		// The author re-broadcasts the waypoint with different geometry and flags off.
+		var proto = Waypoint()
+		proto.geofenceRadius = 500
+		proto.notifyOnEnter = false
+		proto.notifyOnExit = false
+		proto.notifyFavoritesOnly = false
+
+		wp.applyGeofenceGeometry(from: proto)
+
+		#expect(wp.geofenceRadius == 500)
 		#expect(wp.notifyOnEnter == true)
 		#expect(wp.notifyOnExit == false)
 		#expect(wp.notifyFavoritesOnly == true)
-		#expect(wp.hasBoundingBox == false)
 	}
 
 	@Test("Copies the bounding box when the proto has one")
@@ -233,7 +259,7 @@ struct WaypointApplyGeofenceTests {
 		proto.boundingBox.longitudeWestI = -1220010000
 		#expect(proto.hasBoundingBox == true)
 
-		wp.applyGeofence(from: proto)
+		wp.applyGeofenceGeometry(from: proto)
 
 		#expect(wp.hasBoundingBox == true)
 		#expect(wp.boundingBoxLatitudeNorthI == 370010000)
@@ -254,12 +280,67 @@ struct WaypointApplyGeofenceTests {
 
 		var proto = Waypoint()
 		proto.geofenceRadius = 100   // circle only, no bounding box
-		wp.applyGeofence(from: proto)
+		wp.applyGeofenceGeometry(from: proto)
 
 		#expect(wp.hasBoundingBox == false)
 		#expect(wp.boundingBoxLatitudeNorthI == 0)
 		#expect(wp.boundingBoxLatitudeSouthI == 0)
 		#expect(wp.boundingBoxLongitudeEastI == 0)
 		#expect(wp.boundingBoxLongitudeWestI == 0)
+	}
+}
+
+// MARK: - Local notify opt-in policy (design#114)
+
+@Suite("Waypoint local notify opt-in policy")
+struct WaypointNotifyPolicyTests {
+
+	@Test("A received waypoint with a geofence is locally editable")
+	func receivedWaypointIsEditable() {
+		#expect(WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: false, createdBy: 111, activeDeviceNum: 222, hasGeofence: true
+		) == true)
+	}
+
+	@Test("A waypoint authored by the connected node keeps the send-based edit flow")
+	func authoredWaypointIsNotLocallyEditable() {
+		#expect(WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: false, createdBy: 222, activeDeviceNum: 222, hasGeofence: true
+		) == false)
+	}
+
+	@Test("No connected device: still editable — the preference is purely local")
+	func nilDeviceNumStillEditable() {
+		#expect(WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: false, createdBy: 111, activeDeviceNum: nil, hasGeofence: true
+		) == true)
+	}
+
+	@Test("A local-only waypoint uses the regular edit form, not the in-place toggles")
+	func localWaypointIsExcluded() {
+		#expect(WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: true, createdBy: 111, activeDeviceNum: 222, hasGeofence: true
+		) == false)
+		// Even without a connected device.
+		#expect(WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: true, createdBy: 111, activeDeviceNum: nil, hasGeofence: true
+		) == false)
+	}
+
+	@Test("Without a geofence there is nothing to notify about")
+	func noGeofenceIsExcluded() {
+		#expect(WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: false, createdBy: 111, activeDeviceNum: 222, hasGeofence: false
+		) == false)
+		#expect(WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: false, createdBy: 111, activeDeviceNum: nil, hasGeofence: false
+		) == false)
+	}
+
+	@Test("Unknown author (createdBy == 0) counts as received, not authored")
+	func unknownAuthorCountsAsReceived() {
+		#expect(WaypointEntity.canEditNotifyPreferencesLocally(
+			isLocalWaypoint: false, createdBy: 0, activeDeviceNum: 222, hasGeofence: true
+		) == true)
 	}
 }

--- a/project.yml
+++ b/project.yml
@@ -403,7 +403,7 @@ targets:
             - "$(inherited)"
             - "@executable_path/Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           OTHER_LDFLAGS:
             - "-weak_framework"
             - "SwiftUI"
@@ -446,7 +446,7 @@ targets:
             - "$(inherited)"
             - "@executable_path/Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           OTHER_LDFLAGS:
             - "-weak_framework"
             - "SwiftUI"
@@ -492,7 +492,7 @@ targets:
             - "@executable_path/Frameworks"
             - "@executable_path/../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.Widgets"
           PRODUCT_NAME: "$(TARGET_NAME)"
           PROVISIONING_PROFILE_SPECIFIER: ""
@@ -521,7 +521,7 @@ targets:
             - "@executable_path/Frameworks"
             - "@executable_path/../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.Widgets"
           PRODUCT_NAME: "$(TARGET_NAME)"
           PROVISIONING_PROFILE_SPECIFIER: ""
@@ -615,7 +615,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.watchkitapp"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "watchos"
@@ -643,7 +643,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.18"
+          MARKETING_VERSION: "2.7.19"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.watchkitapp"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "watchos"


### PR DESCRIPTION
## What

Adds a local, per-geofence notification opt-in for received waypoints, completing iOS's side of the meshtastic/design#114 notification-scope model (matching what Android shipped in meshtastic/Meshtastic-Android#6117: creator-only default, per-geofence opt-in on the receiver).

- **WaypointForm**: a received waypoint (not authored by the connected node — including waypoints locked to another node — and not local-only) that carries a geofence now shows a **Geofence Notifications** section in the read-only detail view: Notify on Enter, Notify on Exit, and Favorites Only toggles. They commit immediately through a dedicated local save path (`commitNotifyPreferences`) that writes only the three preference flags and saves the context. The mesh Send path is never involved.
- **Ingest** (`MeshPackets.waypointPacket`): `applyGeofence(from:)` became `applyGeofenceGeometry(from:)` — geofence geometry (radius + bounding box) still syncs from the mesh, but the sender's notify flags are no longer imported. Newly received waypoints therefore never notify until the user opts in, and a later mesh update can no longer overwrite a local opt-in/opt-out.
- **sendWaypoint** now persists the author's own geofence geometry and notify preferences to the local entity at send time, so the creator's device keeps its preferences without relying on the ingest echo.
- The geofence monitor (`MeshPackets+Geofence`) is unchanged — it already keys off the local `notifyOnEnter`/`notifyOnExit` flags, so it picks up locally opted-in received waypoints automatically.
- Includes the 2.7.19 version bump (project.yml + regenerated project) as a separate commit.

## Why

There was no clean opt-in path for a waypoint you didn't author: flipping the notify toggles on an unlocked received waypoint required the edit form, whose commit path re-broadcasts someone else's waypoint to the mesh, and a locked waypoint couldn't opt in at all. Worse, ingest imported the sender's notify flags, so the sender — not the receiver — controlled whether a received geofence notified, and any local preference was clobbered on the next mesh update. Notification scope is receiver-local by design: creator-only default, local opt-in, and the flags never take effect from the wire.

## How tested

- `xcodebuild` Debug build for the iOS simulator: **BUILD SUCCEEDED**.
- Swift Testing suites in `GeofenceTests.swift`: 25 tests in 4 suites, all passing — including reworked `applyGeofenceGeometry(from:)` coverage (wire notify flags ignored on receipt; a mesh geometry update preserves the receiver's local opt-in) and a new `WaypointNotifyPolicyTests` suite for the opt-in editability policy (received vs authored, locked, local-only, no-geofence, and disconnected cases).
- SwiftLint clean on touched files (no new violations).

Fixes #2248
Refs meshtastic/design#114, meshtastic/Meshtastic-Android#6117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local geofence notification controls for eligible received waypoints, including enter, exit, and favorites-only alerts.
  * Notification preferences are saved immediately and automatically cleared when both alert types are disabled.

* **Bug Fixes**
  * Mesh updates now preserve receiver-local notification preferences instead of overwriting them.
  * Sent waypoints retain their geofence settings while sharing notification preferences only when appropriate.

* **Release**
  * Updated the app, Widgets extension, and Watch app to version 2.7.19.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->