### PR TITLE
feat(backup): store node backups in the Files-visible Meshtastic folder

### DIFF
--- a/Meshtastic/Persistence/NodeBackupManager.swift
+++ b/Meshtastic/Persistence/NodeBackupManager.swift
@@ -74,8 +74,22 @@ final class NodeBackupManager: NodeBackupManaging {
 		let newURL = documents.appendingPathComponent("NodeBackups", isDirectory: true)
 		let legacyURL = appSupport.appendingPathComponent("NodeBackups", isDirectory: true)
 
-		let newExists = fm.fileExists(atPath: newURL.path)
-		let legacyExists = fm.fileExists(atPath: legacyURL.path)
+		// Documents is user-writable through the Files app, so "something exists at the path"
+		// is not "our folder exists": a stray *file* named NodeBackups would make a bare
+		// fileExists check return true, the initializer's directory creation silently fail,
+		// and every subsequent backup write fail. Distinguish directories from files and
+		// never overwrite anything the user put there.
+		var newIsDir: ObjCBool = false
+		let newExists = fm.fileExists(atPath: newURL.path, isDirectory: &newIsDir)
+		var legacyIsDir: ObjCBool = false
+		let legacyExists = fm.fileExists(atPath: legacyURL.path, isDirectory: &legacyIsDir) && legacyIsDir.boolValue
+
+		if newExists && !newIsDir.boolValue {
+			// A user-created file is squatting on the folder name. Leave it untouched and keep
+			// backups working in the app-controlled legacy location until the user removes it.
+			Logger.data.error("💾 [Backup] A file named NodeBackups is blocking the Files-visible backup folder in Documents; keeping backups in Application Support until it is removed")
+			return legacyURL
+		}
 
 		if legacyExists && !newExists {
 			do {

--- a/Meshtastic/Persistence/NodeBackupManager.swift
+++ b/Meshtastic/Persistence/NodeBackupManager.swift
@@ -41,8 +41,7 @@ final class NodeBackupManager: NodeBackupManaging {
 	// MARK: - Initialization
 
 	private init() {
-		let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-		backupBaseURL = appSupport.appendingPathComponent("NodeBackups", isDirectory: true)
+		backupBaseURL = Self.resolveBackupBaseURL()
 
 		// Ensure backup directory exists
 		try? FileManager.default.createDirectory(at: backupBaseURL, withIntermediateDirectories: true)
@@ -52,6 +51,46 @@ final class NodeBackupManager: NodeBackupManaging {
 
 		// Validate index consistency on launch (T029)
 		validateIndexConsistency()
+	}
+
+	/// Backups live in Documents — the user-visible "Meshtastic" folder in the Files app —
+	/// alongside OfflineMaps, downloaded firmware, and imported GeoJSON, so users can copy a
+	/// backup off the phone (or drop one in) without any in-app export flow. Earlier releases
+	/// kept them in Application Support; the first launch after updating moves that folder here
+	/// wholesale (the backup index stores paths relative to the folder, so the move preserves
+	/// every entry). If the move fails (e.g. a partial earlier attempt left both folders), the
+	/// legacy location keeps working so existing backups are never orphaned.
+	private nonisolated static func resolveBackupBaseURL() -> URL {
+		let fm = FileManager.default
+		return resolveBackupBaseURL(
+			documents: fm.urls(for: .documentDirectory, in: .userDomainMask).first!,
+			appSupport: fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+		)
+	}
+
+	/// Testable core of the location resolution/migration — see `resolveBackupBaseURL()`.
+	nonisolated static func resolveBackupBaseURL(documents: URL, appSupport: URL) -> URL {
+		let fm = FileManager.default
+		let newURL = documents.appendingPathComponent("NodeBackups", isDirectory: true)
+		let legacyURL = appSupport.appendingPathComponent("NodeBackups", isDirectory: true)
+
+		let newExists = fm.fileExists(atPath: newURL.path)
+		let legacyExists = fm.fileExists(atPath: legacyURL.path)
+
+		if legacyExists && !newExists {
+			do {
+				try fm.moveItem(at: legacyURL, to: newURL)
+				Logger.data.info("💾 [Backup] Migrated node backups from Application Support to the Files-visible Documents folder")
+			} catch {
+				Logger.data.error("💾 [Backup] Failed to migrate node backups to Documents, continuing with the legacy location: \(error.localizedDescription, privacy: .public)")
+				return legacyURL
+			}
+		} else if legacyExists && newExists {
+			// Both exist (an interrupted earlier migration). Prefer the new location, but keep
+			// the legacy folder on disk untouched for manual recovery rather than merging blindly.
+			Logger.data.warning("💾 [Backup] Both legacy and Documents backup folders exist; using Documents. Legacy folder left in place at Application Support/NodeBackups")
+		}
+		return newURL
 	}
 
 	/// Initializer for testing with a custom base URL.

--- a/MeshtasticTests/NodeBackupManagerTests.swift
+++ b/MeshtasticTests/NodeBackupManagerTests.swift
@@ -415,4 +415,60 @@ struct NodeBackupManagerTests {
 		let manager = NodeBackupManager(baseURL: backupDir)
 		#expect(manager.totalBackupSize == 3000)
 	}
+
+	// MARK: - Backup location resolution / migration (Documents visibility)
+
+	@Test("Fresh install resolves to the Documents NodeBackups folder")
+	func resolveLocationFreshInstall() throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let documents = tempDir.appendingPathComponent("Documents", isDirectory: true)
+		let appSupport = tempDir.appendingPathComponent("AppSupport", isDirectory: true)
+
+		let resolved = NodeBackupManager.resolveBackupBaseURL(documents: documents, appSupport: appSupport)
+
+		#expect(resolved == documents.appendingPathComponent("NodeBackups", isDirectory: true))
+	}
+
+	@Test("Legacy Application Support backups migrate wholesale into Documents")
+	func resolveLocationMigratesLegacy() throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let documents = tempDir.appendingPathComponent("Documents", isDirectory: true)
+		let appSupport = tempDir.appendingPathComponent("AppSupport", isDirectory: true)
+		try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+		// Seed a legacy backup folder with a node backup + index, as an old install would have.
+		let legacy = appSupport.appendingPathComponent("NodeBackups", isDirectory: true)
+		let nodeDir = legacy.appendingPathComponent("1234", isDirectory: true)
+		try FileManager.default.createDirectory(at: nodeDir, withIntermediateDirectories: true)
+		try Data("legacy-backup".utf8).write(to: nodeDir.appendingPathComponent("Meshtastic.store"))
+
+		let resolved = NodeBackupManager.resolveBackupBaseURL(documents: documents, appSupport: appSupport)
+
+		let expected = documents.appendingPathComponent("NodeBackups", isDirectory: true)
+		#expect(resolved == expected)
+		// The whole folder moved: content readable at the new location, legacy gone.
+		let moved = expected.appendingPathComponent("1234/Meshtastic.store")
+		#expect(FileManager.default.fileExists(atPath: moved.path))
+		#expect(!FileManager.default.fileExists(atPath: legacy.path))
+	}
+
+	@Test("Both locations existing prefers Documents and leaves the legacy folder untouched")
+	func resolveLocationPrefersNewWhenBothExist() throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let documents = tempDir.appendingPathComponent("Documents", isDirectory: true)
+		let appSupport = tempDir.appendingPathComponent("AppSupport", isDirectory: true)
+		let newDir = documents.appendingPathComponent("NodeBackups", isDirectory: true)
+		let legacy = appSupport.appendingPathComponent("NodeBackups", isDirectory: true)
+		try FileManager.default.createDirectory(at: newDir, withIntermediateDirectories: true)
+		try FileManager.default.createDirectory(at: legacy, withIntermediateDirectories: true)
+		try Data("keep-me".utf8).write(to: legacy.appendingPathComponent("orphan.store"))
+
+		let resolved = NodeBackupManager.resolveBackupBaseURL(documents: documents, appSupport: appSupport)
+
+		#expect(resolved == newDir)
+		// Legacy content is preserved for manual recovery, never merged or deleted.
+		#expect(FileManager.default.fileExists(atPath: legacy.appendingPathComponent("orphan.store").path))
+	}
 }

--- a/MeshtasticTests/NodeBackupManagerTests.swift
+++ b/MeshtasticTests/NodeBackupManagerTests.swift
@@ -471,4 +471,42 @@ struct NodeBackupManagerTests {
 		// Legacy content is preserved for manual recovery, never merged or deleted.
 		#expect(FileManager.default.fileExists(atPath: legacy.appendingPathComponent("orphan.store").path))
 	}
+
+	@Test("A user file named NodeBackups in Documents falls back to the legacy location untouched")
+	func resolveLocationFileCollisionFallsBackToLegacy() throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let documents = tempDir.appendingPathComponent("Documents", isDirectory: true)
+		let appSupport = tempDir.appendingPathComponent("AppSupport", isDirectory: true)
+		try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+		// Documents is user-writable: someone saved a FILE with the folder's name.
+		let squatter = documents.appendingPathComponent("NodeBackups")
+		try Data("not a folder".utf8).write(to: squatter)
+
+		let resolved = NodeBackupManager.resolveBackupBaseURL(documents: documents, appSupport: appSupport)
+
+		#expect(resolved == appSupport.appendingPathComponent("NodeBackups", isDirectory: true))
+		// The user's file is never touched, moved, or overwritten.
+		#expect(try Data(contentsOf: squatter) == Data("not a folder".utf8))
+	}
+
+	@Test("A file collision with existing legacy backups keeps the legacy folder active and unmodified")
+	func resolveLocationFileCollisionPreservesLegacyBackups() throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let documents = tempDir.appendingPathComponent("Documents", isDirectory: true)
+		let appSupport = tempDir.appendingPathComponent("AppSupport", isDirectory: true)
+		try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+		try Data("squatter".utf8).write(to: documents.appendingPathComponent("NodeBackups"))
+		let legacy = appSupport.appendingPathComponent("NodeBackups", isDirectory: true)
+		let nodeDir = legacy.appendingPathComponent("5678", isDirectory: true)
+		try FileManager.default.createDirectory(at: nodeDir, withIntermediateDirectories: true)
+		try Data("precious-backup".utf8).write(to: nodeDir.appendingPathComponent("Meshtastic.store"))
+
+		let resolved = NodeBackupManager.resolveBackupBaseURL(documents: documents, appSupport: appSupport)
+
+		#expect(resolved == legacy)
+		// No migration was attempted into the blocked location; the backup is intact where it was.
+		#expect(FileManager.default.fileExists(atPath: nodeDir.appendingPathComponent("Meshtastic.store").path))
+	}
 }


### PR DESCRIPTION
## What changed?

Node database backups move from `Application Support/NodeBackups` (hidden) to **`Documents/NodeBackups`** — the Meshtastic folder users can browse in the Files app, alongside `OfflineMaps`, downloaded firmware, and imported GeoJSON. A backup can now be copied off the phone (or dropped onto it) with no in-app export flow.

## How?

- **Wholesale migration on first launch**: the legacy folder moves in one `moveItem`; the backup index stores folder-relative paths, so every entry survives.
- **Never orphans backups**: if the move fails, the legacy location keeps working; if both folders exist (interrupted migration), Documents wins and the legacy folder is left untouched for manual recovery — never merged or deleted.
- The **live database stays in Application Support** — only backups move.
- `resolveBackupBaseURL` gained an injectable-URL seam (`nonisolated` — pure FileManager work on a `@MainActor` class) so the migration logic is unit-testable.

## How is this tested?

- 3 new tests: fresh install resolves to Documents; legacy folder migrates wholesale (content readable at the new path, legacy gone); both-exist prefers Documents and preserves the legacy folder.
- Full `NodeBackupManagerTests` suite: 13/13 passing. Debug build for the iOS simulator succeeds.

## Deliberate consideration

Backups contain the full node database **including key material**. Making them Files-visible also exposes them to iTunes file sharing and device backups of Documents. This matches the `.cfg` device-profile export philosophy (user-controlled data, user responsible for copies) — flagged here so the choice is explicit in review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backups are now stored in the Documents folder when possible.
  * Existing backups are automatically moved from the legacy location on first launch.
  * If migration cannot be completed, the app continues using the existing backup location.
  * When backups exist in both locations, the Documents folder is preferred.
  * Existing files in the Documents folder are preserved during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->