### PR TITLE
Fix BLE disconnect lifecycle teardown

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -534,9 +534,21 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		// Flush any debounced position/telemetry saves before disconnecting
 		await MeshPackets.shared.flushDebouncedSaves()
 
-		// Close out the connection
-		if let activeConnection = activeConnection {
-			try await activeConnection.connection.disconnect(withError: nil, shouldReconnect: false)
+		// Close out the transport, then finish manager teardown before returning. Connection
+		// events are asynchronous, so awaiting the transport alone can leave activeConnection set.
+		var disconnectError: Error?
+		if let activeConnection {
+			do {
+				try await activeConnection.connection.disconnect(withError: nil, shouldReconnect: false)
+			} catch {
+				disconnectError = error
+			}
+		}
+		try await closeConnection()
+		updateState(.discovering)
+
+		if let disconnectError {
+			throw disconnectError
 		}
 	}
 
@@ -697,8 +709,12 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			}
 			
 		case .disconnected:
+			guard !shouldIgnoreTransientEvent else {
+				Logger.transport.info("[Accessory] Ignoring disconnect event during teardown.")
+				return
+			}
 			Task {
-				// This is user-initatied, so don't reconnect
+				// This is user-initiated, so don't reconnect
 				shouldAutomaticallyConnectToPreferredPeripheralAfterError = false
 				try? await self.closeConnection()
 				updateState(.discovering)

--- a/MeshtasticTests/AccessoryManagerDisconnectTests.swift
+++ b/MeshtasticTests/AccessoryManagerDisconnectTests.swift
@@ -1,0 +1,63 @@
+//
+//  AccessoryManagerDisconnectTests.swift
+//  MeshtasticTests
+//
+
+import Foundation
+import Testing
+
+@testable import Meshtastic
+import MeshtasticProtobufs
+
+private actor DisconnectTestConnection: Connection {
+	let type: TransportType = .ble
+	var isConnected = true
+	private(set) var disconnectCallCount = 0
+
+	func send(_ data: ToRadio) async throws {}
+
+	func connect() async throws -> AsyncStream<ConnectionEvent> {
+		AsyncStream { _ in }
+	}
+
+	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {
+		disconnectCallCount += 1
+		isConnected = false
+	}
+
+	func drainPendingPackets() async throws {}
+	func startDrainPendingPackets() throws {}
+	func appDidEnterBackground() {}
+	func appDidBecomeActive() {}
+}
+
+@MainActor
+@Suite("AccessoryManager disconnect lifecycle", .serialized)
+struct AccessoryManagerDisconnectTests {
+	@Test func waitsForManagerTeardown() async throws {
+		let connection = DisconnectTestConnection()
+		let manager = AccessoryManager(transports: [])
+		let device = Device(
+			id: UUID(),
+			name: "Test Radio",
+			transportType: .ble,
+			identifier: "test-radio",
+			connectionState: .connected
+		)
+		manager.activeConnection = (device: device, connection: connection)
+		manager.activeDeviceNum = 123
+		manager.allowDisconnect = true
+		manager.isSwitchingDevices = true
+		manager.updateState(.subscribed)
+
+		try await manager.disconnect()
+
+		let disconnectCallCount = await connection.disconnectCallCount
+		#expect(manager.activeConnection == nil)
+		#expect(manager.activeDeviceNum == nil)
+		#expect(manager.allowDisconnect == false)
+		#expect(manager.isConnected == false)
+		#expect(manager.state == .discovering)
+		#expect(disconnectCallCount == 1)
+	}
+}

--- a/MeshtasticTests/AccessoryManagerDisconnectTests.swift
+++ b/MeshtasticTests/AccessoryManagerDisconnectTests.swift
@@ -3,26 +3,50 @@
 //  MeshtasticTests
 //
 
+// MARK: AccessoryManagerDisconnectTests
+
 import Foundation
 import Testing
 
 @testable import Meshtastic
 import MeshtasticProtobufs
 
+// MARK: - Test Doubles
+
+private enum DisconnectTestError: Error {
+	case transportFailure
+}
+
 private actor DisconnectTestConnection: Connection {
+	typealias DisconnectCallback = @MainActor @Sendable () async -> Void
+
 	let type: TransportType = .ble
 	var isConnected = true
 	private(set) var disconnectCallCount = 0
+	private let disconnectError: DisconnectTestError?
+	private var onDisconnect: DisconnectCallback?
+
+	init(disconnectError: DisconnectTestError? = nil) {
+		self.disconnectError = disconnectError
+	}
+
+	func setOnDisconnect(_ callback: @escaping DisconnectCallback) {
+		onDisconnect = callback
+	}
 
 	func send(_ data: ToRadio) async throws {}
 
 	func connect() async throws -> AsyncStream<ConnectionEvent> {
-		AsyncStream { _ in }
+		AsyncStream { $0.finish() }
 	}
 
 	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {
 		disconnectCallCount += 1
 		isConnected = false
+		await onDisconnect?()
+		if let disconnectError {
+			throw disconnectError
+		}
 	}
 
 	func drainPendingPackets() async throws {}
@@ -31,11 +55,12 @@ private actor DisconnectTestConnection: Connection {
 	func appDidBecomeActive() {}
 }
 
+// MARK: - Disconnect Lifecycle Tests
+
 @MainActor
 @Suite("AccessoryManager disconnect lifecycle", .serialized)
 struct AccessoryManagerDisconnectTests {
-	@Test func waitsForManagerTeardown() async throws {
-		let connection = DisconnectTestConnection()
+	private func makeManager(connection: DisconnectTestConnection) -> AccessoryManager {
 		let manager = AccessoryManager(transports: [])
 		let device = Device(
 			id: UUID(),
@@ -47,17 +72,52 @@ struct AccessoryManagerDisconnectTests {
 		manager.activeConnection = (device: device, connection: connection)
 		manager.activeDeviceNum = 123
 		manager.allowDisconnect = true
+		// Keep closeConnection() from arming discovery for this transport-free fixture.
 		manager.isSwitchingDevices = true
 		manager.updateState(.subscribed)
+		return manager
+	}
 
-		try await manager.disconnect()
-
-		let disconnectCallCount = await connection.disconnectCallCount
+	private func expectTornDown(_ manager: AccessoryManager, connection: DisconnectTestConnection) async {
 		#expect(manager.activeConnection == nil)
 		#expect(manager.activeDeviceNum == nil)
 		#expect(manager.allowDisconnect == false)
 		#expect(manager.isConnected == false)
 		#expect(manager.state == .discovering)
-		#expect(disconnectCallCount == 1)
+		#expect(await connection.disconnectCallCount == 1)
+	}
+
+	@Test func waitsForManagerTeardown() async throws {
+		let connection = DisconnectTestConnection()
+		let manager = makeManager(connection: connection)
+
+		try await manager.disconnect()
+
+		await expectTornDown(manager, connection: connection)
+	}
+
+	@Test func tearsDownBeforePropagatingTransportError() async {
+		let connection = DisconnectTestConnection(disconnectError: .transportFailure)
+		let manager = makeManager(connection: connection)
+
+		await #expect(throws: DisconnectTestError.transportFailure) {
+			try await manager.disconnect()
+		}
+
+		await expectTornDown(manager, connection: connection)
+	}
+
+	@Test func ignoresMirroredDisconnectEventDuringTeardown() async throws {
+		let connection = DisconnectTestConnection()
+		let manager = makeManager(connection: connection)
+		await connection.setOnDisconnect {
+			await manager.didReceive(.disconnected(shouldReconnect: false))
+		}
+
+		try await manager.disconnect()
+
+		await expectTornDown(manager, connection: connection)
+		#expect(manager.packetsReceived == 1)
+		#expect(manager.shouldAutomaticallyConnectToPreferredPeripheralAfterError)
 	}
 }


### PR DESCRIPTION
## What changed?

`AccessoryManager.disconnect()` now waits for manager teardown after disconnecting the transport. Transport errors are rethrown after cleanup, and the matching `.disconnected` event is ignored while teardown is already active.

Added a focused regression test for the disconnect contract.

## Why did it change?

Transport disconnect events are asynchronous. Awaiting the transport alone could return while `activeConnection` still referenced the old radio, so an immediate radio switch could fail with `Already connected to a device` before teardown caught up.

## How is this tested?

- `AccessoryManagerDisconnectTests`: 1 test passed on an iPhone 16 Pro Max simulator running iOS 26.5.
- Adjacent BLE lifecycle coverage: 16 tests passed across 4 suites.
- During development, removing the explicit manager teardown made the focused test fail all five manager-state assertions; restoring the fix passed.

## Screenshots/Videos (when applicable)

Not applicable.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation change is needed; this PR uses the `skip-docs-check` label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disconnection handling to ensure connections are fully cleaned up, even when transport errors occur.
  * Preserved and reported transport errors after cleanup completes.
  * Prevented duplicate cleanup during disconnect events.
  * Restored the accessory manager to discovering state after disconnection.

* **Tests**
  * Added coverage for successful and error-based teardown, state restoration, single-invocation disconnect behavior, packet handling, and automatic reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->