### PR TITLE
fix(search): match message search on displayed text, not a SQL-translated predicate

### DIFF
--- a/Meshtastic/Extensions/SwiftData/MessageSearch.swift
+++ b/Meshtastic/Extensions/SwiftData/MessageSearch.swift
@@ -38,6 +38,28 @@ actor MessageSearchActor {
 
 enum MessageSearch {
 
+	/// Substring test used for every content match, run in Swift on the fetched rows rather than
+	/// inside the SwiftData `#Predicate`. Two reasons this is deliberately NOT a predicate term:
+	///
+	/// 1. `localizedStandardContains` inside a `#Predicate` is translated to a SQL query, and that
+	///    translation does not reliably reproduce the in-memory `String` semantics across every
+	///    iOS version — a message whose text is plainly on screen could return no search hit
+	///    (reported in the field). Running the same `String` API the UI uses guarantees search
+	///    matches exactly what the user sees, on every OS version.
+	/// 2. It lets search cover the *displayed* text: when a message is showing its translation, the
+	///    bubble renders `messagePayloadTranslated`, so searching only the original `messagePayload`
+	///    would miss the very words on screen. Matching against original OR translation finds the
+	///    message whichever the user is viewing.
+	static func contentMatches(_ message: MessageEntity, query trimmed: String) -> Bool {
+		if let original = message.messagePayload, original.localizedStandardContains(trimmed) {
+			return true
+		}
+		if let translated = message.messagePayloadTranslated, translated.localizedStandardContains(trimmed) {
+			return true
+		}
+		return false
+	}
+
 	// MARK: Channel conversations
 
 	/// Matches within a channel conversation, oldest → newest.
@@ -49,19 +71,22 @@ enum MessageSearch {
 	static func channelMatches(in context: ModelContext, channelIndex: Int32, query: String) throws -> [MessageSearchMatch] {
 		let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
 		guard !trimmed.isEmpty else { return [] }
-		var descriptor = FetchDescriptor<MessageEntity>(
+		// Fetch the conversation with the SAME scope the message list displays (no payload term),
+		// then filter the text in memory. This mirrors ChannelMessageList's own predicate exactly,
+		// so any message the user can see is a search candidate — the content test is the only
+		// difference, and it runs via `contentMatches` (see its note for why not in the predicate).
+		let descriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> {
 				$0.channel == channelIndex && $0.toUser == nil && $0.isEmoji == false
-					&& ($0.messagePayload?.localizedStandardContains(trimmed) ?? false)
 			},
 			sortBy: [
 				SortDescriptor(\MessageEntity.messageTimestamp, order: .forward),
 				SortDescriptor(\MessageEntity.messageId, order: .forward)
 			]
 		)
-		// Only the id/timestamp are needed to build matches — avoid hydrating message text + relationships.
-		descriptor.propertiesToFetch = [\.messageId, \.messageTimestamp]
-		return try context.fetch(descriptor).map { MessageSearchMatch(messageId: $0.messageId, timestamp: $0.messageTimestamp) }
+		return try context.fetch(descriptor)
+			.filter { contentMatches($0, query: trimmed) }
+			.map { MessageSearchMatch(messageId: $0.messageId, timestamp: $0.messageTimestamp) }
 	}
 
 	/// Number of channel messages strictly newer than `match` in the timeline. Used to expand a
@@ -93,26 +118,23 @@ enum MessageSearch {
 		let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
 		guard !trimmed.isEmpty else { return [] }
 		let detectionSensorPortNum: Int32 = 10
+		// Same scope UserMessageList displays (no payload term), filtered in memory via `contentMatches`.
 		// `toUser != nil` is safe for the same reason as the channel search: a concrete scalar term
 		// (`fromUser?.num == userNum`) leads the predicate, mirroring fetchIncomingMessages' shipping shape.
-		var incoming = FetchDescriptor<MessageEntity>(
+		let incoming = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> {
 				$0.fromUser?.num == userNum && $0.toUser != nil
 					&& $0.isEmoji == false && $0.admin == false && $0.portNum != detectionSensorPortNum
-					&& ($0.messagePayload?.localizedStandardContains(trimmed) ?? false)
 			}
 		)
-		var outgoing = FetchDescriptor<MessageEntity>(
+		let outgoing = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> {
 				$0.toUser?.num == userNum
 					&& $0.isEmoji == false && $0.admin == false && $0.portNum != detectionSensorPortNum
-					&& ($0.messagePayload?.localizedStandardContains(trimmed) ?? false)
 			}
 		)
-		// Only the id/timestamp are needed to build matches — avoid hydrating message text + relationships.
-		incoming.propertiesToFetch = [\.messageId, \.messageTimestamp]
-		outgoing.propertiesToFetch = [\.messageId, \.messageTimestamp]
-		let matches = try context.fetch(incoming) + context.fetch(outgoing)
+		let matches = try (context.fetch(incoming) + context.fetch(outgoing))
+			.filter { contentMatches($0, query: trimmed) }
 		return matches
 			.sorted {
 				if $0.messageTimestamp == $1.messageTimestamp { return $0.messageId < $1.messageId }

--- a/MeshtasticTests/MessageSearchTests.swift
+++ b/MeshtasticTests/MessageSearchTests.swift
@@ -135,4 +135,38 @@ struct MessageSearchTests {
 		let target = try #require(matches.first)
 		#expect(try MessageSearch.directNewerCount(in: context, userNum: 9102, than: target) == 2)
 	}
+
+	// MARK: Displayed-text matching (translations)
+
+	@Test("Channel search matches the translated text a user is looking at")
+	func channelSearchMatchesTranslatedText() throws {
+		let context = makeContext()
+		let ch: Int32 = 71
+		// Original text has no "hola"; the translation the user sees does. Searching the visible
+		// (translated) word must find it — this is the field bug where the text is on screen but
+		// search returned nothing.
+		let m = addChannelMessage(context, id: 7101, channel: ch, ts: 100, text: "hello everyone")
+		m.messagePayloadTranslated = "hola a todos"
+		m.showTranslatedMessage = true
+		try context.save()
+
+		#expect(try MessageSearch.channelMatches(in: context, channelIndex: ch, query: "hola").map(\.messageId) == [7101])
+		// The original is still findable too (search covers both original and translation).
+		#expect(try MessageSearch.channelMatches(in: context, channelIndex: ch, query: "everyone").map(\.messageId) == [7101])
+	}
+
+	@Test("Direct search matches translated text regardless of the show-translation toggle")
+	func directSearchMatchesTranslatedText() throws {
+		let context = makeContext()
+		let me = makeUser(context, num: 9201)
+		let them = makeUser(context, num: 9202)
+		// Translation present but the per-message toggle is OFF — the user may still search the
+		// translated wording, and should find it.
+		let m = addDirectMessage(context, id: 8201, between: (them, me), ts: 100, text: "good morning")
+		m.messagePayloadTranslated = "buenos días"
+		m.showTranslatedMessage = false
+		try context.save()
+
+		#expect(try MessageSearch.directMatches(in: context, userNum: 9202, query: "días").map(\.messageId) == [8201])
+	}
 }


### PR DESCRIPTION
## What changed?

"Find in conversation" search could return **nothing while the searched words were plainly on screen** (observed in the field at scale). This makes search match exactly what the user sees.

## Root cause

The message-list **display** predicate and the **search** predicate use identical scoping (`fromUser`/`toUser`/`channel`/`isEmoji`/`admin`/`portNum`), so any visible message is already in search's scope. The only differentiator was the content term — and it diverged from the displayed text two ways:

1. **`localizedStandardContains` inside a SwiftData `#Predicate` is translated to SQL**, and that translation doesn't reliably reproduce the in-memory `String` semantics across every iOS version — an in-scope, visible message could return no hit. (Suspected primary cause of the field reports; reproduced structurally, not on a single simulator OS version — see Testing.)
2. **Translated messages**: the bubble renders `messagePayloadTranslated` when a message is showing its translation, but search only scanned the original `messagePayload` — so searching the words on screen missed them. (Confirmed in code.)

## How?

`channelMatches` / `directMatches` now fetch with the **same scope the message list displays** (no payload term in the predicate) and filter in Swift via a new `contentMatches(_:query:)`, which runs `localizedStandardContains` against the **original OR translated** payload — the exact `String` API the UI uses, on every OS version. This removes the SQL-translation class of failure entirely and covers the displayed (translated) text.

- Scans are bounded per conversation and by the global 50k message cap, and run on the existing **background search actor** (off the main thread), so the move from a SQL `CONTAINS` to an in-memory filter is not a UI cost.
- The newer-count windowing helpers are unchanged — they were always content-independent.

## How is this tested?

- New tests: channel and DM search finding **translation-only** text (toggle on and off), plus the original still matching. Full `MessageSearchTests` suite passes (8/8).
- The SQL-translation angle is iOS-version-dependent and did not reproduce on the available simulator OS; the fix eliminates it by construction (search now uses the same `String` API as the UI) rather than relying on reproducing every affected OS version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message search now matches both original and translated text.
  * Searches ignore differences in capitalization and diacritics.
  * Channel and direct-message searches provide more complete content matching.

* **Bug Fixes**
  * Fixed searches failing to find messages based on their translated text, regardless of translation display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->