### PR TITLE
guard(docs): fail the docs build when a page references a missing screenshot

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -40,6 +40,29 @@ if ! command -v cmark-gfm &>/dev/null; then
     exit 1
 fi
 
+# ── Referenced-image guard ────────────────────────────────────────────────────
+# Every screenshot a docs page references must exist in docs/assets/screenshots.
+# Test snapshot references have doubled as docs sources before, and a deletion that
+# looks "test-only" can silently break doc pages — fail the build instead.
+# Fenced code blocks are stripped first so documentation *examples* (e.g. the
+# foo_light/foo_dark <picture> pattern in developer/testing.md) don't count as
+# real references.
+missing_images=()
+while IFS= read -r ref; do
+    [[ -f "$REPO_ROOT/docs/assets/screenshots/$ref" ]] || missing_images+=("$ref")
+done < <(
+    find "$REPO_ROOT/docs" -name '*.md' -print0 | xargs -0 awk '
+        /^[[:space:]]*```/ { in_fence = !in_fence; next }
+        !in_fence { print }
+    ' | grep -oh 'screenshots/[^")* ]*\.png' | sed 's|screenshots/||' | sort -u
+)
+if (( ${#missing_images[@]} > 0 )); then
+    echo "error: docs pages reference screenshots that do not exist in docs/assets/screenshots:" >&2
+    printf '  - %s\n' "${missing_images[@]}" >&2
+    echo "Restore the image(s) or update the referencing page — never delete images the docs use." >&2
+    exit 1
+fi
+
 # ── Setup output directories ──────────────────────────────────────────────────
 mkdir -p "$OUTPUT_DIR/user" "$OUTPUT_DIR/developer" "$OUTPUT_DIR/assets"
 mkdir -p "$OUTPUT_DIR/markdown/user" "$OUTPUT_DIR/markdown/developer"


### PR DESCRIPTION
## What changed?

`build-docs.sh` now validates that **every screenshot referenced by a docs page exists in `docs/assets/screenshots/`**, and fails the build (naming the missing files) when one doesn't. Fenced code blocks are stripped before scanning, so documentation *examples* — like the `foo_light`/`foo_dark` `<picture>` pattern in `developer/testing.md` — don't count as real references.

## Why did it change?

Test snapshot references have doubled as docs image sources, so a deletion that looks "test-only" can silently break documentation pages. A recent snapshot-cleanup review nearly approved exactly that scenario. Rule going forward: never delete images the docs use — and now the build enforces it mechanically everywhere `build-docs.sh` runs (locally and in the docs deploy workflow).

## How is this tested?

- Clean run passes (current docs have zero dangling references outside code fences).
- A synthetic dangling reference makes the build exit nonzero with the filename in the error.
- A synthetic reference inside a code fence is correctly exempt.
- The regenerated bundle is byte-identical (validation only; no output change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation builds now detect missing PNG screenshots referenced in Markdown.
  * Builds provide a clear error listing missing images and stop until references are corrected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->