### PR TITLE
ci: preserve snapshot build diagnostics

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -54,8 +54,20 @@ jobs:
             -workspace Meshtastic.xcworkspace \
             -scheme Meshtastic \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+            -resultBundlePath build-snapshots.xcresult \
             "${snapshot_tests[@]}" \
-            2>&1 | tail -20
+            2>&1 | tee build-snapshots.log
+
+      - name: Upload failed build diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-snapshots-diagnostics
+          path: |
+            build-snapshots.log
+            build-snapshots.xcresult
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Verify snapshot tests leave references unchanged
         run: |


### PR DESCRIPTION
## What changed?

- Keep the complete `xcodebuild` output instead of retaining only its final 20 lines.
- Write an `.xcresult` bundle for the snapshot test invocation.
- Upload the log and result bundle for seven days when the build fails.

## Why?

`Deploy Docs / build-snapshots` is failing on `main`, #2261, and #2262 with a Swift type-check timeout in `SecurityConfig.swift`. The current `tail -20` pipeline drops the source location and detailed compiler diagnostic needed to isolate the expression.

This PR only collects diagnostics. It does not change app code or attempt a fix. The snapshot check is expected to remain red while producing the diagnostic artifact.

## Validation

- `git diff --check`
- YAML syntax parsed with the system Ruby YAML parser
- `set -o pipefail` still propagates the `xcodebuild` failure through `tee`
