### PR TITLE
Fix crashes and wrong reconnects when switching nodes

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -50,12 +50,19 @@ jobs:
             exit 1
           fi
 
-          xcodebuild test \
+          # tee the full log so a failure can surface the actual error lines — a bare
+          # `tail -20` swallowed the file/line of compile failures (e.g. the
+          # "unable to type-check this expression in reasonable time" incidents).
+          if ! xcodebuild test \
             -workspace Meshtastic.xcworkspace \
             -scheme Meshtastic \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
             "${snapshot_tests[@]}" \
-            2>&1 | tail -20
+            2>&1 | tee /tmp/xcodebuild-snapshots.log | tail -20; then
+            echo "── error lines from full log ──" >&2
+            grep -E "error:|: Fatal error|failed \(" /tmp/xcodebuild-snapshots.log | head -40 >&2
+            exit 1
+          fi
 
       - name: Verify snapshot tests leave references unchanged
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,11 @@ For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
 `specs/014-mesh-beacons/plan.md` (feature: Mesh Beacons).
 <!-- SPECKIT END -->
+
+## Writing style
+
+Keep explanations, PR descriptions, and commit messages short and plain.
+Say what broke and what changed in ordinary words. No invented jargon,
+no dramatized debugging stories, no bold-lead bullet lists that read like
+marketing. Match how existing PRs in this repo are written (Summary /
+What changed / Testing). If there's nothing worth saying, say nothing.

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -232,7 +232,7 @@
 			);
 			target = 2E65E76AD018C0989DFAD699 /* Meshtastic Vision */;
 		};
-		585D5DD1A1B0250218AA526A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		5099928EA6DABEDD38011FE4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				MeshtasticTVApp.swift,
@@ -378,6 +378,15 @@
 			path = Import;
 			sourceTree = "<group>";
 		};
+		1AD194D2867F9E467B1D56F2 /* Meshtastic TV/Models */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Meshtastic TV/Models";
+			sourceTree = "<group>";
+		};
 		1B104A61866EBBAB39A96CD6 /* API */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			explicitFileTypes = {
@@ -418,19 +427,6 @@
 			path = Measurement;
 			sourceTree = "<group>";
 		};
-		3202898A807FE04D4DC066D4 /* App */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				585D5DD1A1B0250218AA526A /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = App;
-			path = App;
-			sourceTree = "<group>";
-		};
 		456E28D41A9B7B1788FEE0CD /* Shared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			explicitFileTypes = {
@@ -450,6 +446,18 @@
 			path = Accessory;
 			sourceTree = "<group>";
 		};
+		4A37BC260E1DAC54FCA15DE5 /* Meshtastic TV/App */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				5099928EA6DABEDD38011FE4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Meshtastic TV/App";
+			sourceTree = "<group>";
+		};
 		4E52FFD5347832FDB8575177 /* Persistence */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			explicitFileTypes = {
@@ -458,26 +466,6 @@
 			);
 			name = Persistence;
 			path = Persistence;
-			sourceTree = "<group>";
-		};
-		6FBFD4D647263AFDB189E4B8 /* Views */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Views;
-			path = Views;
-			sourceTree = "<group>";
-		};
-		75D19723569FE55F26C70E36 /* Map */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Map;
-			path = Map;
 			sourceTree = "<group>";
 		};
 		7CECEBBD0650101FDB559A1A /* Meshtastic Vision */ = {
@@ -531,6 +519,15 @@
 			path = Router;
 			sourceTree = "<group>";
 		};
+		AF4C3426BC34C4503507AACC /* Meshtastic TV/Map */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Meshtastic TV/Map";
+			sourceTree = "<group>";
+		};
 		B47C68738DD365F2A873DF1E /* CarPlay */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			explicitFileTypes = {
@@ -541,14 +538,13 @@
 			path = CarPlay;
 			sourceTree = "<group>";
 		};
-		BEC568E86239A706FBF36EE2 /* Models */ = {
+		B865A679A81C7DC145C6B558 /* Meshtastic TV/Views */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			explicitFileTypes = {
 			};
 			explicitFolders = (
 			);
-			name = Models;
-			path = Models;
+			path = "Meshtastic TV/Views";
 			sourceTree = "<group>";
 		};
 		C21C46F8F2BCFF68F31B12C0 /* Export */ = {
@@ -559,6 +555,15 @@
 			);
 			name = Export;
 			path = Export;
+			sourceTree = "<group>";
+		};
+		C82ADB363DF3474D328BFDF3 /* Meshtastic TV/Client */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Meshtastic TV/Client";
 			sourceTree = "<group>";
 		};
 		C95A60ECD93D37F4971EC685 /* Tips */ = {
@@ -579,16 +584,6 @@
 			);
 			name = Views;
 			path = Views;
-			sourceTree = "<group>";
-		};
-		E1CAF819F3BF329C9C924DF2 /* Client */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			name = Client;
-			path = Client;
 			sourceTree = "<group>";
 		};
 		EA229AC7C87CBBD64EC61AA1 /* Meshtastic TV */ = {
@@ -701,6 +696,18 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+		3654D9303DC1F4ACDA626942 /* Shared TV Client */ = {
+			isa = PBXGroup;
+			children = (
+				4A37BC260E1DAC54FCA15DE5 /* Meshtastic TV/App */,
+				C82ADB363DF3474D328BFDF3 /* Meshtastic TV/Client */,
+				AF4C3426BC34C4503507AACC /* Meshtastic TV/Map */,
+				1AD194D2867F9E467B1D56F2 /* Meshtastic TV/Models */,
+				B865A679A81C7DC145C6B558 /* Meshtastic TV/Views */,
+			);
+			name = "Shared TV Client";
+			sourceTree = "<group>";
+		};
 		48EA9DEE0C429F4A032EBC6F /* Transports */ = {
 			isa = PBXGroup;
 			children = (
@@ -720,18 +727,6 @@
 				E4053FDE501FD7E0A02CEA8D /* WidgetsExtension.appex */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		615D439CBFAC4AA6EE6F0E34 /* Meshtastic TV */ = {
-			isa = PBXGroup;
-			children = (
-				3202898A807FE04D4DC066D4 /* App */,
-				E1CAF819F3BF329C9C924DF2 /* Client */,
-				75D19723569FE55F26C70E36 /* Map */,
-				BEC568E86239A706FBF36EE2 /* Models */,
-				6FBFD4D647263AFDB189E4B8 /* Views */,
-			);
-			path = "Meshtastic TV";
 			sourceTree = "<group>";
 		};
 		68569A5CFCF946568B4E32C5 /* Meshtastic */ = {
@@ -802,13 +797,13 @@
 				26351F51CD01C94D8D82486A /* Localizable.xcstrings */,
 				68569A5CFCF946568B4E32C5 /* Meshtastic */,
 				EA229AC7C87CBBD64EC61AA1 /* Meshtastic TV */,
-				615D439CBFAC4AA6EE6F0E34 /* Meshtastic TV */,
 				7CECEBBD0650101FDB559A1A /* Meshtastic Vision */,
 				F0E2A06151AF30290D808624 /* Meshtastic Watch App */,
 				867FD80926C4A4286D635BAD /* MeshtasticTests */,
 				8F644F7974EA8B14E77ED53A /* Packages */,
 				F15A1577564640951AD3EA40 /* Settings.bundle */,
 				456E28D41A9B7B1788FEE0CD /* Shared */,
+				3654D9303DC1F4ACDA626942 /* Shared TV Client */,
 				0B1C4E352D6981242B97EF9C /* Widgets */,
 				5D4AFA4225AF7D85EE343B80 /* Products */,
 			);
@@ -874,12 +869,12 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				3202898A807FE04D4DC066D4 /* App */,
-				E1CAF819F3BF329C9C924DF2 /* Client */,
-				75D19723569FE55F26C70E36 /* Map */,
+				4A37BC260E1DAC54FCA15DE5 /* Meshtastic TV/App */,
+				C82ADB363DF3474D328BFDF3 /* Meshtastic TV/Client */,
+				AF4C3426BC34C4503507AACC /* Meshtastic TV/Map */,
 				7CECEBBD0650101FDB559A1A /* Meshtastic Vision */,
-				BEC568E86239A706FBF36EE2 /* Models */,
-				6FBFD4D647263AFDB189E4B8 /* Views */,
+				1AD194D2867F9E467B1D56F2 /* Meshtastic TV/Models */,
+				B865A679A81C7DC145C6B558 /* Meshtastic TV/Views */,
 			);
 			name = "Meshtastic Vision";
 			packageProductDependencies = (

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -801,8 +801,8 @@
 			children = (
 				26351F51CD01C94D8D82486A /* Localizable.xcstrings */,
 				68569A5CFCF946568B4E32C5 /* Meshtastic */,
-				615D439CBFAC4AA6EE6F0E34 /* Meshtastic TV */,
 				EA229AC7C87CBBD64EC61AA1 /* Meshtastic TV */,
+				615D439CBFAC4AA6EE6F0E34 /* Meshtastic TV */,
 				7CECEBBD0650101FDB559A1A /* Meshtastic Vision */,
 				F0E2A06151AF30290D808624 /* Meshtastic Watch App */,
 				867FD80926C4A4286D635BAD /* MeshtasticTests */,

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -137,6 +137,12 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		PersistenceController.shared.recreateContainer()
 		MeshPackets.recreateShared()
 		context = PersistenceController.shared.context
+		// Re-deliver the new container to the SwiftUI environment immediately: the scene body
+		// re-evaluates on this bump and .modelContainer(...) reads the recreated container, so
+		// @Query subscriptions re-bind in place instead of staying attached to the old store
+		// (whose notifications they would otherwise process — the switch-nodes SIGTRAP,
+		// Datadog 324bff02). Deliberately NOT databaseResetID: no identity change, no teardown.
+		appState?.containerStamp = UUID()
 	}
 
 	/// `repointToFreshContainer()` plus a UI refresh: bumps `databaseResetID` so @Query-backed

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -135,6 +135,14 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// ("destroyed by ModelContext.reset") when a reconnect reuses freed SQLite rowids.
 	func repointToFreshContainer() {
 		PersistenceController.shared.recreateContainer()
+		rebindToCurrentContainer()
+	}
+
+	/// The repoint minus the container recreation: rebuilds the MeshPackets actor and this
+	/// manager's cached context on whatever container PersistenceController currently holds.
+	/// Used when the caller already recreated the container (the store-destroy escalation) —
+	/// every recreation mints a potential stale observer bridge, so never recreate twice.
+	func rebindToCurrentContainer() {
 		MeshPackets.recreateShared()
 		context = PersistenceController.shared.context
 		// Re-deliver the new container to the SwiftUI environment immediately: the scene body

--- a/Meshtastic/AppState.swift
+++ b/Meshtastic/AppState.swift
@@ -33,6 +33,22 @@ class AppState: ObservableObject {
 	/// refetch, so they drop objects cached from the previous node's database. Applied
 	/// as `.id(appState.databaseResetID)` on the root content view.
 	@Published var databaseResetID = UUID()
+	/// True while a node switch is clearing/swapping the SwiftData container. ContentView
+	/// replaces the whole tab tree with a lightweight non-SwiftData placeholder for the
+	/// duration, so no @Query subscription exists while the store underneath it is cleared,
+	/// destroyed, or repointed. Without this, the _SwiftData_SwiftUI bridge can process a
+	/// store-change notification against the swapped-out context and trap (SIGTRAP,
+	/// Datadog issue 324bff02-6b22-11f1, first seen 2.7.13 — the "repeatable crash when
+	/// switching nodes"). The databaseResetID bump alone runs AFTER the swap, which is
+	/// too late for subscriptions that are live during it.
+	@Published var isDatabaseResetting = false
+	/// Bumped immediately after the SwiftData container is recreated (repointToFreshContainer)
+	/// so the scene body re-evaluates and `.modelContainer(...)` hands the NEW container to the
+	/// environment. @Query subscriptions then re-bind in place — no view teardown. This is the
+	/// counterpart to `databaseResetID`, which changes root identity and unmounts the whole
+	/// tree: identity churn mid-switch is what produced the UIKit/CoreAnimation dead-view
+	/// SIGTRAPs on device, so container delivery must never ride on it.
+	@Published var containerStamp = UUID()
 	/// A contact parsed from a meshtastic.org/v/# URL (QR code, link, or NFC tag)
 	/// awaiting user confirmation. Presented as a sheet from MeshtasticApp, the
 	/// same pattern the channel-link import uses.

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -231,17 +231,93 @@ struct MeshtasticAppleApp: App {
 				FirmwareUpdateGameDemoHost()
 			} else if appState.isDatabaseResetting {
 				// Unmount the WHOLE SwiftData-bound tree — including the `.modelContainer`
-				// modifier below — while a node switch clears/swaps the container. The modifier's
-				// SwiftData↔SwiftUI bridge observes save notifications process-wide and never
-				// rebinds to a swapped container (its attachment point here is structurally
-				// stable, so `.id(databaseResetID)` deeper down can't recreate it); the restore's
-				// background save then traps inside the stale bridge (the "silent exit" flavor of
-				// Datadog 324bff02 — no crash report, EXC_BREAKPOINT in _SwiftData_SwiftUI caught
-				// live in lldb at NodeBackupManager.restoreFromBackup's save). Recreating this
-				// branch on gate-drop rebuilds the bridge against the fresh container.
+				// modifier in mainAppContent — while a node switch clears the store. The
+				// modifier's SwiftData↔SwiftUI bridge observes save notifications process-wide
+				// and never rebinds (its attachment point is structurally stable, so
+				// `.id(databaseResetID)` deeper down can't recreate it); stale bridges from any
+				// container the app has moved off of trap on the next save callout (the "silent
+				// exit" flavor of Datadog 324bff02 — no crash report, EXC_BREAKPOINT in
+				// _SwiftData_SwiftUI, caught live in lldb). This gate plus the process-lifetime
+				// container (see backupCurrentAndRestoreDatabase) is the pair that ended it.
 				DatabaseResettingPlaceholder()
 			} else {
-				EventFirmwareTintScope {
+				mainAppContent
+			}
+			}
+			.onChange(of: lockdownCoordinator.state) { _, newState in
+				// US-3: when the coordinator resolves to .lockNowAcknowledged
+				// (either via inbound LOCKED status or a BLE disconnect race),
+				// tear down the connection so the next reconnect re-auths.
+				if case .lockNowAcknowledged = newState {
+					Task { try? await accessoryManager.closeConnection() }
+				}
+			}
+		}
+		.onChange(of: scenePhase) { (_, newScenePhase) in
+			// Also skipped in Chirpy OTA demo mode, where persistenceController is nil —
+			// backgrounding the demo must not touch (or force-unwrap) SwiftData.
+			guard Self.shouldInitializeAppServices, let persistenceController else { return }
+			accessoryManager.isInBackground = (newScenePhase == .background)
+			switch newScenePhase {
+			case .background:
+				Logger.services.info("🎬 [App] Scene is in the background")
+				accessoryManager.appDidEnterBackground()
+				do {
+					try persistenceController.container.mainContext.save()
+					Logger.services.info("💾 [App] Saved SwiftData context when the app went to the background.")
+
+				} catch {
+
+					Logger.services.error("💥 [App] Failed to save context when the app goes to the background.")
+				}
+			case .inactive:
+				Logger.services.info("🎬 [App] Scene is inactive")
+			case .active:
+				Logger.services.info("🎬 [App] Scene is active")
+				accessoryManager.appDidBecomeActive()
+				appState.refreshBadgeCount(context: persistenceController.container.mainContext)
+			@unknown default:
+				Logger.services.error("🍎 [App] Apple must have changed something")
+			}
+		}
+		.environmentObject(appState)
+		.environmentObject(accessoryManager)
+		.environmentObject(lockdownCoordinator)
+		.environmentObject(appState.router)
+		.environmentObject(MeshtasticAPI.shared)
+
+			WindowGroup("Mesh Map", id: "meshmap-window") {
+				// Gated on shouldInitializeAppServices (not just tests): in Chirpy OTA demo mode
+				// persistenceController is nil, so building this scene would force-unwrap-crash.
+				// Also gated on the database reset, for the same stale-bridge reason as the main
+				// window: this scene's .modelContainer must unmount during a container swap.
+				if Self.shouldInitializeAppServices, let persistenceController, !appState.isDatabaseResetting {
+					EventFirmwareTintScope {
+						MapWindow()
+							.id(appState.databaseResetID)
+					}
+					.modelContainer(persistenceController.container)
+					.environmentObject(appState)
+					.environmentObject(accessoryManager)
+					.environmentObject(lockdownCoordinator)
+					.environmentObject(appState.router)
+					.environmentObject(MeshtasticAPI.shared)
+				}
+			}
+		.handlesExternalEvents(matching: [])
+		.windowResizability(.contentMinSize)
+		#if os(visionOS)
+		.windowStyle(.plain)
+		#endif
+	}
+
+	/// The full SwiftData-bound app tree, extracted from the WindowGroup builder both to keep
+	/// the scene-level expression type-checkable in reasonable time (the four-branch builder
+	/// with this chain inlined blew Swift's type-check budget on CI) and so the database-reset
+	/// gate can unmount it — `.modelContainer` included — as one unit.
+	@ViewBuilder
+	private var mainAppContent: some View {
+		EventFirmwareTintScope {
 					ContentView(
 						appState: appState,
 						router: appState.router
@@ -323,72 +399,5 @@ struct MeshtasticAppleApp: App {
 				.environmentObject(accessoryManager)
 				.environmentObject(appState.router)
 				.environmentObject(MeshtasticAPI.shared)
-			}
-			}
-			.onChange(of: lockdownCoordinator.state) { _, newState in
-				// US-3: when the coordinator resolves to .lockNowAcknowledged
-				// (either via inbound LOCKED status or a BLE disconnect race),
-				// tear down the connection so the next reconnect re-auths.
-				if case .lockNowAcknowledged = newState {
-					Task { try? await accessoryManager.closeConnection() }
-				}
-			}
-		}
-		.onChange(of: scenePhase) { (_, newScenePhase) in
-			// Also skipped in Chirpy OTA demo mode, where persistenceController is nil —
-			// backgrounding the demo must not touch (or force-unwrap) SwiftData.
-			guard Self.shouldInitializeAppServices, let persistenceController else { return }
-			accessoryManager.isInBackground = (newScenePhase == .background)
-			switch newScenePhase {
-			case .background:
-				Logger.services.info("🎬 [App] Scene is in the background")
-				accessoryManager.appDidEnterBackground()
-				do {
-					try persistenceController.container.mainContext.save()
-					Logger.services.info("💾 [App] Saved SwiftData context when the app went to the background.")
-
-				} catch {
-
-					Logger.services.error("💥 [App] Failed to save context when the app goes to the background.")
-				}
-			case .inactive:
-				Logger.services.info("🎬 [App] Scene is inactive")
-			case .active:
-				Logger.services.info("🎬 [App] Scene is active")
-				accessoryManager.appDidBecomeActive()
-				appState.refreshBadgeCount(context: persistenceController.container.mainContext)
-			@unknown default:
-				Logger.services.error("🍎 [App] Apple must have changed something")
-			}
-		}
-		.environmentObject(appState)
-		.environmentObject(accessoryManager)
-		.environmentObject(lockdownCoordinator)
-		.environmentObject(appState.router)
-		.environmentObject(MeshtasticAPI.shared)
-
-			WindowGroup("Mesh Map", id: "meshmap-window") {
-				// Gated on shouldInitializeAppServices (not just tests): in Chirpy OTA demo mode
-				// persistenceController is nil, so building this scene would force-unwrap-crash.
-				// Also gated on the database reset, for the same stale-bridge reason as the main
-				// window: this scene's .modelContainer must unmount during a container swap.
-				if Self.shouldInitializeAppServices, let persistenceController, !appState.isDatabaseResetting {
-					EventFirmwareTintScope {
-						MapWindow()
-							.id(appState.databaseResetID)
-					}
-					.modelContainer(persistenceController.container)
-					.environmentObject(appState)
-					.environmentObject(accessoryManager)
-					.environmentObject(lockdownCoordinator)
-					.environmentObject(appState.router)
-					.environmentObject(MeshtasticAPI.shared)
-				}
-			}
-		.handlesExternalEvents(matching: [])
-		.windowResizability(.contentMinSize)
-		#if os(visionOS)
-		.windowStyle(.plain)
-		#endif
 	}
 }

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -37,6 +37,9 @@ struct MeshtasticAppleApp: App {
 	private static var shouldInitializeAppServices: Bool {
 		!isRunningTests && !isChirpyOTADemo
 	}
+	/// TipKit configuration must run once per process; the owning `.task` re-runs whenever the
+	/// database-reset gate remounts the main tree after a node switch.
+	@MainActor private static var hasConfiguredTips = false
 
 	init() {
 
@@ -226,6 +229,17 @@ struct MeshtasticAppleApp: App {
 				Color.clear
 			} else if Self.isChirpyOTADemo {
 				FirmwareUpdateGameDemoHost()
+			} else if appState.isDatabaseResetting {
+				// Unmount the WHOLE SwiftData-bound tree — including the `.modelContainer`
+				// modifier below — while a node switch clears/swaps the container. The modifier's
+				// SwiftData↔SwiftUI bridge observes save notifications process-wide and never
+				// rebinds to a swapped container (its attachment point here is structurally
+				// stable, so `.id(databaseResetID)` deeper down can't recreate it); the restore's
+				// background save then traps inside the stale bridge (the "silent exit" flavor of
+				// Datadog 324bff02 — no crash report, EXC_BREAKPOINT in _SwiftData_SwiftUI caught
+				// live in lldb at NodeBackupManager.restoreFromBackup's save). Recreating this
+				// branch on gate-drop rebuilds the bridge against the fresh container.
+				DatabaseResettingPlaceholder()
 			} else {
 				EventFirmwareTintScope {
 					ContentView(
@@ -288,8 +302,11 @@ struct MeshtasticAppleApp: App {
 				}
 				.task {
 					// Skip TipKit entirely during marketing screenshot capture so tip popovers never
-					// appear in the shots (unconfigured TipKit displays nothing).
-					if !CommandLine.arguments.contains("--marketing-capture") {
+					// appear in the shots (unconfigured TipKit displays nothing). The once-guard
+					// matters now that this branch remounts after every node switch (the database
+					// reset gate above) — Tips.configure must not re-run per switch.
+					if !Self.hasConfiguredTips, !CommandLine.arguments.contains("--marketing-capture") {
+						Self.hasConfiguredTips = true
 						try? Tips.configure(
 							[
 								// Reset which tips have been shown and what parameters have been tracked, useful during testing and for this sample project
@@ -353,7 +370,9 @@ struct MeshtasticAppleApp: App {
 			WindowGroup("Mesh Map", id: "meshmap-window") {
 				// Gated on shouldInitializeAppServices (not just tests): in Chirpy OTA demo mode
 				// persistenceController is nil, so building this scene would force-unwrap-crash.
-				if Self.shouldInitializeAppServices, let persistenceController {
+				// Also gated on the database reset, for the same stale-bridge reason as the main
+				// window: this scene's .modelContainer must unmount during a container swap.
+				if Self.shouldInitializeAppServices, let persistenceController, !appState.isDatabaseResetting {
 					EventFirmwareTintScope {
 						MapWindow()
 							.id(appState.databaseResetID)

--- a/Meshtastic/Model/EventFirmwarePresentation.swift
+++ b/Meshtastic/Model/EventFirmwarePresentation.swift
@@ -62,7 +62,28 @@ extension EnvironmentValues {
 
 /// Applies the event's contrast-safe tint above the root presentation modifiers so tabs,
 /// navigation actions, and app-level sheets all inherit the same highlight color.
+/// Gate around the tinting core: during a database reset the core (which holds a @Query on
+/// the event editions) is unmounted entirely, so no SwiftData subscription survives the
+/// container swap (see AppState.isDatabaseResetting; Datadog 324bff02-6b22-11f1). Content
+/// renders with the standard accent tint for the second or two the gate is up.
 struct EventFirmwareTintScope<Content: View>: View {
+	@EnvironmentObject private var appState: AppState
+	private let content: Content
+
+	init(@ViewBuilder content: () -> Content) {
+		self.content = content()
+	}
+
+	var body: some View {
+		if appState.isDatabaseResetting {
+			content
+		} else {
+			EventFirmwareTintScopeCore { content }
+		}
+	}
+}
+
+private struct EventFirmwareTintScopeCore<Content: View>: View {
 	@EnvironmentObject private var accessoryManager: AccessoryManager
 	@Environment(\.colorScheme) private var colorScheme
 	@AppStorage("useEventTheme") private var useEventTheme: Bool = true

--- a/Meshtastic/Persistence/NodeBackupManager.swift
+++ b/Meshtastic/Persistence/NodeBackupManager.swift
@@ -115,7 +115,6 @@ final class NodeBackupManager: NodeBackupManaging {
 		validateIndexConsistency()
 	}
 
-
 	// MARK: - Index Management
 
 	private static func loadIndex(from baseURL: URL) -> BackupIndex {
@@ -429,9 +428,9 @@ final class NodeBackupManager: NodeBackupManaging {
 					guard fileManager.fileExists(atPath: backupStoreURL.path) else { continue }
 
 					// Staged copy: a pending schema migration cannot run on a read-only store,
-					// and the backup itself must never be mutated. See stagedBackupContainer.
-					let (backupContainer, cleanup) = try Self.stagedBackupContainer(for: backupStoreURL, schema: schema)
-					defer { cleanup() }
+					// and the backup itself must never be mutated. See stagedBackupContainer
+					// (staging dirs are swept at launch, never removed while live).
+					let backupContainer = try Self.stagedBackupContainer(for: backupStoreURL, schema: schema)
 					let backupContext = ModelContext(backupContainer)
 					backupContext.autosaveEnabled = false
 
@@ -515,19 +514,24 @@ final class NodeBackupManager: NodeBackupManaging {
 		}
 
 		do {
-			try await Task.detached(priority: .userInitiated) {
+			// The import runs on the MainActor through the LIVE container's mainContext. Two
+			// invariants, both learned from live lldb catches of the switch-crash cluster:
+			// 1. `container` must be the same object the UI has always been bound to — a save
+			//    into a replaced container is processed by the previous container's immortal
+			//    observer bridge (they unregister on dealloc, never on unmount) and traps.
+			// 2. The backup opens through a staged temp copy — a pending schema migration
+			//    cannot run on a read-only store, and that failure used to abort the restore
+			//    and bounce the switch back to the previous device.
+			try await MainActor.run {
 				let schema = Schema(versionedSchema: MeshtasticSchema.current)
-				// Staged copy: a pending schema migration cannot run on a read-only store —
-				// that failure aborted the restore and bounced a node switch back to the
-				// previous device. The migration runs on the disposable copy; the real
-				// backup file is never touched. See stagedBackupContainer.
-				let (backupContainer, cleanup) = try Self.stagedBackupContainer(for: backupStoreURL, schema: schema)
-				defer { cleanup() }
+				let backupContainer = try Self.stagedBackupContainer(for: backupStoreURL, schema: schema)
 				let backupContext = ModelContext(backupContainer)
 				backupContext.autosaveEnabled = false
 
-				let liveContext = ModelContext(container)
+				let liveContext = container.mainContext
+				let hadAutosave = liveContext.autosaveEnabled
 				liveContext.autosaveEnabled = false
+				defer { liveContext.autosaveEnabled = hadAutosave }
 
 				// Import in dependency order
 				let nodesByNum = try Self.importNodes(from: backupContext, into: liveContext)
@@ -544,7 +548,7 @@ final class NodeBackupManager: NodeBackupManaging {
 
 				try liveContext.save()
 				Logger.backup.info("💾 Full restore complete for node \(nodeNum)")
-			}.value
+			}
 
 			return .success(entry)
 		} catch {
@@ -594,11 +598,17 @@ extension NodeBackupManager {
 	/// advance and bounced the switch back to the previous device. Copying the store (plus
 	/// WAL/SHM sidecars) into a temp directory and opening the copy writable lets the
 	/// migration run against the disposable copy while the real backup stays byte-identical.
-	/// The caller must invoke `cleanup()` when finished with the container.
+	///
+	/// The staged directory is deliberately NOT removed when the caller finishes: the
+	/// `ModelContainer` object outlives the call (SwiftData keeps internal observers alive
+	/// until dealloc), and unlinking a live container's store trips SQLite's vnode watch —
+	/// it invalidates the open fds ("vnode unlinked while in use") and the broken container
+	/// can then trap on a later notification callout. Temp staging dirs are swept at next
+	/// launch (`sweepStagedBackupDirectories`), and the OS purges tmp/ anyway.
 	nonisolated static func stagedBackupContainer(
 		for backupStoreURL: URL,
 		schema: Schema
-	) throws -> (container: ModelContainer, cleanup: () -> Void) {
+	) throws -> ModelContainer {
 		let fm = FileManager.default
 		let stageDir = fm.temporaryDirectory
 			.appendingPathComponent("staged-backup-\(UUID().uuidString)", isDirectory: true)
@@ -609,15 +619,25 @@ extension NodeBackupManager {
 			guard fm.fileExists(atPath: from.path) else { continue }
 			try fm.copyItem(at: from, to: URL(fileURLWithPath: stagedStoreURL.path + sidecar))
 		}
-		let cleanup: () -> Void = { try? fm.removeItem(at: stageDir) }
 		do {
 			// Writable so a pending lightweight migration can run — against the copy only.
 			let config = ModelConfiguration(url: stagedStoreURL, allowsSave: true)
-			let container = try ModelContainer(for: schema, configurations: config)
-			return (container, cleanup)
+			return try ModelContainer(for: schema, configurations: config)
 		} catch {
-			cleanup()
+			// Nothing holds the copy open when the container failed to construct.
+			try? fm.removeItem(at: stageDir)
 			throw error
+		}
+	}
+
+	/// Remove staging directories left by previous sessions (never removed live — see
+	/// `stagedBackupContainer`). Called once at launch, when nothing can hold them open.
+	nonisolated static func sweepStagedBackupDirectories() {
+		let fm = FileManager.default
+		let tmp = fm.temporaryDirectory
+		guard let names = try? fm.contentsOfDirectory(atPath: tmp.path) else { return }
+		for name in names where name.hasPrefix("staged-backup-") {
+			try? fm.removeItem(at: tmp.appendingPathComponent(name))
 		}
 	}
 }

--- a/Meshtastic/Persistence/NodeBackupManager.swift
+++ b/Meshtastic/Persistence/NodeBackupManager.swift
@@ -115,6 +115,7 @@ final class NodeBackupManager: NodeBackupManaging {
 		validateIndexConsistency()
 	}
 
+
 	// MARK: - Index Management
 
 	private static func loadIndex(from baseURL: URL) -> BackupIndex {
@@ -427,8 +428,10 @@ final class NodeBackupManager: NodeBackupManaging {
 					let backupStoreURL = nodeBackupDir.appendingPathComponent(Self.storeFileName)
 					guard fileManager.fileExists(atPath: backupStoreURL.path) else { continue }
 
-					let backupConfig = ModelConfiguration(url: backupStoreURL, allowsSave: false)
-					let backupContainer = try ModelContainer(for: schema, configurations: backupConfig)
+					// Staged copy: a pending schema migration cannot run on a read-only store,
+					// and the backup itself must never be mutated. See stagedBackupContainer.
+					let (backupContainer, cleanup) = try Self.stagedBackupContainer(for: backupStoreURL, schema: schema)
+					defer { cleanup() }
 					let backupContext = ModelContext(backupContainer)
 					backupContext.autosaveEnabled = false
 
@@ -514,8 +517,12 @@ final class NodeBackupManager: NodeBackupManaging {
 		do {
 			try await Task.detached(priority: .userInitiated) {
 				let schema = Schema(versionedSchema: MeshtasticSchema.current)
-				let backupConfig = ModelConfiguration(url: backupStoreURL, allowsSave: false)
-				let backupContainer = try ModelContainer(for: schema, configurations: backupConfig)
+				// Staged copy: a pending schema migration cannot run on a read-only store —
+				// that failure aborted the restore and bounced a node switch back to the
+				// previous device. The migration runs on the disposable copy; the real
+				// backup file is never touched. See stagedBackupContainer.
+				let (backupContainer, cleanup) = try Self.stagedBackupContainer(for: backupStoreURL, schema: schema)
+				defer { cleanup() }
 				let backupContext = ModelContext(backupContainer)
 				backupContext.autosaveEnabled = false
 
@@ -571,6 +578,46 @@ enum BackupError: Error, LocalizedError {
 			return "Backup file not found"
 		case .insufficientStorage:
 			return "Insufficient storage for backup"
+		}
+	}
+}
+
+// MARK: - Staged backup opening
+
+extension NodeBackupManager {
+
+	/// Opens a backup store for reading through a disposable staged copy.
+	///
+	/// Backups must never be mutated — but SwiftData cannot open a store read-only when a
+	/// schema migration is pending ("Cannot migrate store in-place: … attempt to write a
+	/// readonly database"), which is exactly what aborted node-switch restores after a schema
+	/// advance and bounced the switch back to the previous device. Copying the store (plus
+	/// WAL/SHM sidecars) into a temp directory and opening the copy writable lets the
+	/// migration run against the disposable copy while the real backup stays byte-identical.
+	/// The caller must invoke `cleanup()` when finished with the container.
+	nonisolated static func stagedBackupContainer(
+		for backupStoreURL: URL,
+		schema: Schema
+	) throws -> (container: ModelContainer, cleanup: () -> Void) {
+		let fm = FileManager.default
+		let stageDir = fm.temporaryDirectory
+			.appendingPathComponent("staged-backup-\(UUID().uuidString)", isDirectory: true)
+		try fm.createDirectory(at: stageDir, withIntermediateDirectories: true)
+		let stagedStoreURL = stageDir.appendingPathComponent(backupStoreURL.lastPathComponent)
+		for sidecar in ["", "-wal", "-shm"] {
+			let from = URL(fileURLWithPath: backupStoreURL.path + sidecar)
+			guard fm.fileExists(atPath: from.path) else { continue }
+			try fm.copyItem(at: from, to: URL(fileURLWithPath: stagedStoreURL.path + sidecar))
+		}
+		let cleanup: () -> Void = { try? fm.removeItem(at: stageDir) }
+		do {
+			// Writable so a pending lightweight migration can run — against the copy only.
+			let config = ModelConfiguration(url: stagedStoreURL, allowsSave: true)
+			let container = try ModelContainer(for: schema, configurations: config)
+			return (container, cleanup)
+		} catch {
+			cleanup()
+			throw error
 		}
 	}
 }

--- a/Meshtastic/Persistence/Persistence.swift
+++ b/Meshtastic/Persistence/Persistence.swift
@@ -138,9 +138,58 @@ class PersistenceController {
 		}
 		let schema = Schema(versionedSchema: MeshtasticSchema.current)
 		let config = ModelConfiguration(storeName, schema: schema, isStoredInMemoryOnly: false, allowsSave: true)
-		Self.removeStoreFiles(at: config.url)
+		// Park, don't unlink — a leaked previous container may still hold the store open
+		// (see restoreStoreFromBackup); unlinking it live invalidates its fds and the broken
+		// container traps on the next save notification in the process.
+		Self.parkStoreFiles(at: config.url)
 		recreateContainer()
 		Logger.data.warning("💾 Store files destroyed and container recreated (escalated database reset)")
+	}
+
+	/// File-swap restore: replace the on-disk store with a copy of a backup and reopen the
+	/// container on top of it. The switch path must not run SwiftData saves at all —
+	/// observer bridges from previous containers survive any amount of view unmounting
+	/// (registration lives until dealloc and the graph retains them), and a bulk restore
+	/// save's synchronous NotificationCenter callout traps inside the stale bridge
+	/// regardless of thread or of what is mounted (caught live in lldb at the restore's
+	/// `save()`; the no-crash-report flavor of Datadog 324bff02). Replacing the store file
+	/// and reopening posts nothing. POSIX unlink semantics keep stragglers safe, as with
+	/// the destroy path above; `recreateContainer()` runs the migration plan in place on
+	/// the writable copy, which also covers backups written by older schemas.
+	/// Rename the store files out of the way instead of deleting them — unlinking a store a
+	/// leaked container still has open trips SQLite's vnode watch, which invalidates the open
+	/// fds ("database integrity compromised by API violation: vnode unlinked while in use")
+	/// and breaks that container and everything observing through it. (SQLite alarms on a
+	/// rename too, but the destroy path is an already-broken escalation; parking at least
+	/// preserves the bytes.) Parked files are orphans from this or previous sessions;
+	/// `sweepParkedStoreFiles()` removes last session's on launch.
+	private static func parkStoreFiles(at storeURL: URL) {
+		let fm = FileManager.default
+		let tag = ".parked-\(UUID().uuidString.prefix(8))"
+		for suffix in ["", "-wal", "-shm"] {
+			let src = URL(fileURLWithPath: storeURL.path + suffix)
+			guard fm.fileExists(atPath: src.path) else { continue }
+			let dst = URL(fileURLWithPath: storeURL.path + tag + suffix)
+			do {
+				try fm.moveItem(at: src, to: dst)
+			} catch {
+				Logger.data.error("💾 Failed to park store file \(src.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
+				// Fall back to unlink rather than restoring on top of a stale file.
+				try? fm.removeItem(at: src)
+			}
+		}
+	}
+
+	/// Remove parked store files left by previous sessions' node switches. Called once at
+	/// launch, when nothing can still hold them open.
+	private static func sweepParkedStoreFiles(near storeURL: URL) {
+		let fm = FileManager.default
+		let dir = storeURL.deletingLastPathComponent()
+		let prefix = storeURL.lastPathComponent + ".parked-"
+		guard let names = try? fm.contentsOfDirectory(atPath: dir.path) else { return }
+		for name in names where name.hasPrefix(prefix) {
+			try? fm.removeItem(at: dir.appendingPathComponent(name))
+		}
 	}
 
 	private static func removeStoreFiles(at storeURL: URL) {
@@ -178,6 +227,15 @@ class PersistenceController {
 			Self.removeStoreFiles(at: config.url)
 		}
 #endif
+
+		// Clean up store files parked by previous sessions' node switches (renamed aside
+		// instead of unlinked — see parkStoreFiles) and staged backup copies (never removed
+		// while their container object lives — see stagedBackupContainer). Nothing can hold
+		// either open at launch.
+		if !inMemory {
+			Self.sweepParkedStoreFiles(near: config.url)
+			NodeBackupManager.sweepStagedBackupDirectories()
+		}
 
 		// ── Step 0: guard Core Data store from being clobbered ───────────────
 		// Both the App Store (Core Data) build and this (SwiftData) build use

--- a/Meshtastic/Persistence/SwitchStress.swift
+++ b/Meshtastic/Persistence/SwitchStress.swift
@@ -23,6 +23,12 @@ enum SwitchStress {
 		CommandLine.arguments.contains("-switch-stress")
 	}
 
+	/// The switch flow bumps `appState.databaseResetID`, which recreates ContentView and
+	/// re-runs its `.task` — without this guard the harness re-arms once per switch and the
+	/// superseded (cancelled) instances spin their judge loops to instant FAILs while still
+	/// issuing competing `switchToDevice` calls.
+	private static var started = false
+
 	private static var requestedCycles: Int {
 		guard let idx = CommandLine.arguments.firstIndex(of: "-switch-stress"),
 			  idx + 1 < CommandLine.arguments.count,
@@ -30,17 +36,29 @@ enum SwitchStress {
 		return n
 	}
 
+	static func runIfNeeded(accessoryManager: AccessoryManager, appState: AppState) async {
+		guard isActive, !started else { return }
+		started = true
+		// Unstructured task: the calling `.task` dies with the old ContentView identity on
+		// every databaseResetID bump, and a structured child would be cancelled with it.
+		Task {
+			await run(accessoryManager: accessoryManager, appState: appState)
+		}
+	}
+
 	/// Waits for discovery to surface at least two TCP devices, then alternates full
 	/// switch cycles between them, logging a machine-greppable verdict per cycle.
-	static func runIfNeeded(accessoryManager: AccessoryManager, appState: AppState) async {
-		guard isActive else { return }
+	private static func run(accessoryManager: AccessoryManager, appState: AppState) async {
 		let cycles = requestedCycles
 		Logger.services.warning("🧪 [SwitchStress] armed: \(cycles, privacy: .public) cycles")
 
-		// Let launch settle, then wait (up to 30s) for two distinct TCP devices.
+		// Let launch settle, then wait (up to 30s) for two distinct TCP devices. Kick
+		// discovery every pass (idempotent): an auto-reconnect to the preferred device at
+		// launch stops discovery and clears the list before this first scan can run.
 		try? await Task.sleep(for: .seconds(5))
 		var targets: [Device] = []
 		for _ in 0..<60 {
+			accessoryManager.startDiscovery()
 			targets = accessoryManager.devices.filter { $0.transportType == .tcp }
 			if targets.count >= 2 { break }
 			try? await Task.sleep(for: .milliseconds(500))
@@ -53,36 +71,50 @@ enum SwitchStress {
 
 		var passes = 0
 		var failures = 0
+		// Alternate by transport identifier (IP:port) — stable across discovery refreshes,
+		// unlike `num`, which stays nil for discovered-but-never-connected TCP devices.
+		var lastIdentifier: String?
 		for cycle in 1...cycles {
-			// Always switch to the device we are NOT currently connected to.
-			let currentNum = accessoryManager.activeDeviceNum
-			let candidates = accessoryManager.devices.filter { $0.transportType == .tcp }
-			guard let target = candidates.first(where: { $0.num != currentNum }) ?? candidates.first else {
-				Logger.services.error("🧪 [SwitchStress] cycle \(cycle, privacy: .public): no target visible, waiting")
-				try? await Task.sleep(for: .seconds(3))
+			// Connecting stops discovery (AccessoryManager+Connect) and clears the device
+			// list; the Connect tab normally restarts it on appear. Kick it ourselves and
+			// wait for the other radio to reappear instead of burning the cycle.
+			accessoryManager.startDiscovery()
+			var target: Device?
+			for _ in 0..<30 {
+				let connectedIdentifier = accessoryManager.activeConnection?.device.identifier
+				let candidates = accessoryManager.devices.filter { $0.transportType == .tcp }
+				target = candidates.first(where: { $0.identifier != connectedIdentifier && $0.identifier != lastIdentifier })
+					?? candidates.first(where: { $0.identifier != connectedIdentifier })
+				if target != nil { break }
+				try? await Task.sleep(for: .milliseconds(500))
+			}
+			guard let target else {
+				failures += 1
+				Logger.services.error("🧪 [SwitchStress] cycle \(cycle, privacy: .public): FAIL (no other TCP device reappeared in 15s)")
 				continue
 			}
-			Logger.services.warning("🧪 [SwitchStress] cycle \(cycle, privacy: .public)/\(cycles, privacy: .public): switching to \(target.name, privacy: .public) (num \(target.num.map(String.init) ?? "?", privacy: .public))")
+			lastIdentifier = target.identifier
+			Logger.services.warning("🧪 [SwitchStress] cycle \(cycle, privacy: .public)/\(cycles, privacy: .public): switching to \(target.name, privacy: .public) @ \(target.identifier, privacy: .public)")
 
 			await switchToDevice(target, accessoryManager: accessoryManager, appState: appState)
 
-			// Give the connect + node dump a window, then judge.
+			// Give the connect + node dump a window, then judge by connected identifier.
 			var landed = false
 			for _ in 0..<40 {
 				try? await Task.sleep(for: .milliseconds(500))
 				if accessoryManager.isConnected,
-				   let now = accessoryManager.activeDeviceNum,
-				   target.num == nil || now == target.num {
+				   accessoryManager.activeConnection?.device.identifier == target.identifier {
 					landed = true
 					break
 				}
 			}
 			if landed {
 				passes += 1
-				Logger.services.warning("🧪 [SwitchStress] cycle \(cycle, privacy: .public): PASS (connected to \(accessoryManager.activeDeviceNum.map(String.init) ?? "?", privacy: .public))")
+				Logger.services.warning("🧪 [SwitchStress] cycle \(cycle, privacy: .public): PASS (connected to \(target.identifier, privacy: .public))")
 			} else {
 				failures += 1
-				Logger.services.error("🧪 [SwitchStress] cycle \(cycle, privacy: .public): FAIL (isConnected=\(accessoryManager.isConnected, privacy: .public) active=\(accessoryManager.activeDeviceNum.map(String.init) ?? "nil", privacy: .public) wanted=\(target.num.map(String.init) ?? "?", privacy: .public))")
+				let current = accessoryManager.activeConnection?.device.identifier ?? "nil"
+				Logger.services.error("🧪 [SwitchStress] cycle \(cycle, privacy: .public): FAIL (isConnected=\(accessoryManager.isConnected, privacy: .public) connected=\(current, privacy: .public) wanted=\(target.identifier, privacy: .public))")
 			}
 			// Brief inter-cycle settle so the verdict isn't tangled with the next teardown.
 			try? await Task.sleep(for: .seconds(2))

--- a/Meshtastic/Persistence/SwitchStress.swift
+++ b/Meshtastic/Persistence/SwitchStress.swift
@@ -33,7 +33,8 @@ enum SwitchStress {
 		guard let idx = CommandLine.arguments.firstIndex(of: "-switch-stress"),
 			  idx + 1 < CommandLine.arguments.count,
 			  let n = Int(CommandLine.arguments[idx + 1]) else { return 6 }
-		return n
+		// The cycle loop iterates `1...cycles`, which traps on a non-positive bound.
+		return max(1, n)
 	}
 
 	static func runIfNeeded(accessoryManager: AccessoryManager, appState: AppState) async {

--- a/Meshtastic/Persistence/SwitchStress.swift
+++ b/Meshtastic/Persistence/SwitchStress.swift
@@ -1,0 +1,93 @@
+//
+//  SwitchStress.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/13/26.
+//
+//  DEBUG-only node-switch stress harness. Launch with `-switch-stress N` while two or more
+//  TCP radios (e.g. meshtastic-mcp replay instances) are discoverable, and it drives the real
+//  `switchToDevice` flow back and forth N times — the exact production path behind the
+//  "repeatable crash when switching nodes" reports (Datadog 324bff02 + the UICollectionView
+//  batch-update SIGABRT). Follows the MarketingCapture in-app-harness pattern: zero effect
+//  unless the launch argument is present, compiled out of Release entirely.
+//
+
+#if DEBUG
+import Foundation
+import OSLog
+import SwiftUI
+
+@MainActor
+enum SwitchStress {
+	static var isActive: Bool {
+		CommandLine.arguments.contains("-switch-stress")
+	}
+
+	private static var requestedCycles: Int {
+		guard let idx = CommandLine.arguments.firstIndex(of: "-switch-stress"),
+			  idx + 1 < CommandLine.arguments.count,
+			  let n = Int(CommandLine.arguments[idx + 1]) else { return 6 }
+		return n
+	}
+
+	/// Waits for discovery to surface at least two TCP devices, then alternates full
+	/// switch cycles between them, logging a machine-greppable verdict per cycle.
+	static func runIfNeeded(accessoryManager: AccessoryManager, appState: AppState) async {
+		guard isActive else { return }
+		let cycles = requestedCycles
+		Logger.services.warning("🧪 [SwitchStress] armed: \(cycles, privacy: .public) cycles")
+
+		// Let launch settle, then wait (up to 30s) for two distinct TCP devices.
+		try? await Task.sleep(for: .seconds(5))
+		var targets: [Device] = []
+		for _ in 0..<60 {
+			targets = accessoryManager.devices.filter { $0.transportType == .tcp }
+			if targets.count >= 2 { break }
+			try? await Task.sleep(for: .milliseconds(500))
+		}
+		guard targets.count >= 2 else {
+			Logger.services.error("🧪 [SwitchStress] ABORT: found \(targets.count, privacy: .public) TCP devices, need 2")
+			return
+		}
+		Logger.services.warning("🧪 [SwitchStress] targets: \(targets.prefix(2).map(\.name).joined(separator: " ⇄ "), privacy: .public)")
+
+		var passes = 0
+		var failures = 0
+		for cycle in 1...cycles {
+			// Always switch to the device we are NOT currently connected to.
+			let currentNum = accessoryManager.activeDeviceNum
+			let candidates = accessoryManager.devices.filter { $0.transportType == .tcp }
+			guard let target = candidates.first(where: { $0.num != currentNum }) ?? candidates.first else {
+				Logger.services.error("🧪 [SwitchStress] cycle \(cycle, privacy: .public): no target visible, waiting")
+				try? await Task.sleep(for: .seconds(3))
+				continue
+			}
+			Logger.services.warning("🧪 [SwitchStress] cycle \(cycle, privacy: .public)/\(cycles, privacy: .public): switching to \(target.name, privacy: .public) (num \(target.num.map(String.init) ?? "?", privacy: .public))")
+
+			await switchToDevice(target, accessoryManager: accessoryManager, appState: appState)
+
+			// Give the connect + node dump a window, then judge.
+			var landed = false
+			for _ in 0..<40 {
+				try? await Task.sleep(for: .milliseconds(500))
+				if accessoryManager.isConnected,
+				   let now = accessoryManager.activeDeviceNum,
+				   target.num == nil || now == target.num {
+					landed = true
+					break
+				}
+			}
+			if landed {
+				passes += 1
+				Logger.services.warning("🧪 [SwitchStress] cycle \(cycle, privacy: .public): PASS (connected to \(accessoryManager.activeDeviceNum.map(String.init) ?? "?", privacy: .public))")
+			} else {
+				failures += 1
+				Logger.services.error("🧪 [SwitchStress] cycle \(cycle, privacy: .public): FAIL (isConnected=\(accessoryManager.isConnected, privacy: .public) active=\(accessoryManager.activeDeviceNum.map(String.init) ?? "nil", privacy: .public) wanted=\(target.num.map(String.init) ?? "?", privacy: .public))")
+			}
+			// Brief inter-cycle settle so the verdict isn't tangled with the next teardown.
+			try? await Task.sleep(for: .seconds(2))
+		}
+		Logger.services.warning("🧪 [SwitchStress] DONE: \(passes, privacy: .public) pass / \(failures, privacy: .public) fail of \(cycles, privacy: .public)")
+	}
+}
+#endif

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -1087,7 +1087,10 @@ func backupCurrentAndRestoreDatabase(
 		// a half-cleared store is how one radio's nodes bleed into another's session.
 		Logger.backup.error("💾 clearDatabase failed — escalating to store destruction before the switch")
 		PersistenceController.shared.destroyStoreAndRecreateContainer()
-		accessoryManager.repointToFreshContainer()
+		// destroy… already recreated the container; rebind rather than repoint so the
+		// escalation recreates exactly once (every recreation mints a potential stale
+		// observer bridge).
+		accessoryManager.rebindToCurrentContainer()
 	}
 
 	// The restore imports the backup's object graph into the SAME live container. With no
@@ -1148,8 +1151,10 @@ func switchToDevice(
 	// preferred in place, so the error-path auto-reconnect bounced back to the previous
 	// radio instead of retrying the node the user asked for — and worse, that reconnect
 	// (a plain connect, no clear) dumped the previous radio's nodes on top of the target's
-	// freshly restored database.
+	// freshly restored database. The node num moves with it (0 = unknown for a never-seen
+	// radio) so nothing keyed on the num keeps pointing at the abandoned node.
 	UserDefaults.preferredPeripheralId = device.id.uuidString
+	UserDefaults.preferredPeripheralNum = Int(targetNodeNum ?? 0)
 
 	// Mark the switch in flight so the disconnect's teardown doesn't re-arm discovery and
 	// auto-connect can't launch a second connect + node dump while the store is mid-reset.

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -1038,7 +1038,31 @@ func backupCurrentAndRestoreDatabase(
 	appState.router.popToRoot(tab: .map)
 	appState.router.popToRoot(tab: .settings)
 	appState.router.selectedTab = selectedTab
+
+	// Unmount every @Query holder (the gate replaces the tree AND the query-owning wrappers —
+	// see ContentView.gatedContent / EventFirmwareTintScope) before touching the store. Stale
+	// subscriptions process store-change notifications from ANY SwiftData save in the process
+	// (TipKit's internal store saves on background queues) against the swapped-out container —
+	// the switch-nodes SIGTRAP, Datadog 324bff02-6b22-11f1.
+	//
+	// Sequencing is load-bearing, learned from on-device crash reports:
+	// 1. Settle FIRST with the tree intact, so the confirmation dialog's dismissal animation
+	//    finishes — flipping mid-dismissal produced dead-view SIGTRAPs in UIKit/CA commits.
+	// 2. Flip WITHOUT animation: animated List removal goes through UICollectionView batch
+	//    updates, which assert ("attempt to delete item…") when the data churns mid-flight;
+	//    non-animated replacement reloads instead.
+	// 3. Settle again so the unmount commits before the store work begins.
+	try? await Task.sleep(for: .milliseconds(350))
+	var gateTransaction = Transaction()
+	gateTransaction.disablesAnimations = true
+	withTransaction(gateTransaction) { appState.isDatabaseResetting = true }
+	defer {
+		var dropTransaction = Transaction()
+		dropTransaction.disablesAnimations = true
+		withTransaction(dropTransaction) { appState.isDatabaseResetting = false }
+	}
 	await Task.yield()
+	try? await Task.sleep(for: .milliseconds(300))
 
 	await MeshPackets.shared.flushDebouncedSaves()
 	let cleared = await MeshPackets.shared.clearDatabase(includeRoutes: false)

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -1065,30 +1065,34 @@ func backupCurrentAndRestoreDatabase(
 	try? await Task.sleep(for: .milliseconds(300))
 
 	await MeshPackets.shared.flushDebouncedSaves()
+
+	// The clear is unconditional and IN PLACE, on the one process-lifetime container — a
+	// switch must NEVER dump the new radio's nodes on top of the old radio's (nodes have no
+	// owner column; the store is global). Deliberately NO repointToFreshContainer here:
+	// replacing the container mints an immortal stale observer bridge — SwiftUI's
+	// _SwiftData_SwiftUI bridges unregister from NotificationCenter only on dealloc and stay
+	// retained after any amount of unmounting, so the next save's synchronous callout traps
+	// in SwiftData (caught live in lldb: restore saves, and post-swap dump saves, on any
+	// thread, gate up or down — every container-replacement variant died there). Keeping the
+	// container's identity means every observer processes every save against the store it
+	// actually belongs to. The mounted-view hazard that container recreation was introduced
+	// for (#1922's "destroyed by ModelContext.reset") is covered by the reset gate above —
+	// nothing is mounted during the clear — plus the databaseResetID remount below.
 	let cleared = await MeshPackets.shared.clearDatabase(includeRoutes: false)
-	if cleared {
-		// Repoint at a fresh container so the restore below (and the post-restore UI refresh)
-		// operate on a context with no stale registrations. The databaseResetID bump stays after
-		// the restore.
-		accessoryManager.repointToFreshContainer()
-		Logger.backup.info("💾 Database cleared and container recreated")
-	} else {
+	if !cleared {
 		// The per-model clear aborted part-way (e.g. a relationship constraint failed a batch
-		// delete). A half-cleared store MUST NOT receive the next radio's dump — that is exactly
-		// how nodes bleed between radios — so escalate: destroy the store files and reopen a
-		// guaranteed-empty container. The current radio's data was backed up above; routes are
-		// lost in this (already-broken) path, which beats merging two radios' databases.
+		// delete). A half-cleared store MUST NOT receive the next radio's dump, so escalate:
+		// destroy the store files and reopen a guaranteed-empty container. This rare path
+		// does replace the container (accepting the stale-bridge risk) because proceeding on
+		// a half-cleared store is how one radio's nodes bleed into another's session.
 		Logger.backup.error("💾 clearDatabase failed — escalating to store destruction before the switch")
 		PersistenceController.shared.destroyStoreAndRecreateContainer()
-		// Repoint re-creates once more on the fresh (now empty) store and rebuilds the
-		// MeshPackets actor + cached context; the double recreate is harmless.
 		accessoryManager.repointToFreshContainer()
 	}
 
-	// The clear above is unconditional — a switch must NEVER dump the new radio's nodes on top
-	// of the old radio's (nodes have no owner column; the store is global). The restore is the
-	// only optional part: with no resolvable target node (first connect to a never-seen radio)
-	// there is simply no backup to import, and the radio populates the now-empty store fresh.
+	// The restore imports the backup's object graph into the SAME live container. With no
+	// resolvable target node (first connect to a never-seen radio) there is no backup, and
+	// the radio populates the now-empty store fresh.
 	let restoreResult: NodeBackupResult
 	if let targetNodeNum {
 		restoreResult = await NodeBackupManager.shared.restoreFromBackup(

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -1142,6 +1142,15 @@ func switchToDevice(
 	}()
 	Logger.backup.info("💾 Node switch — current: \(currentNodeNum.map { String($0) } ?? "nil", privacy: .public), target: \(targetNodeNum.map { String($0) } ?? "unknown", privacy: .public)")
 
+	// The user's explicit choice IS the new preferred radio — record it at switch
+	// initiation, not only deep in the connect flow (Step 5 writes it again on success).
+	// When it moved only on a fully-successful connect, any failed switch left the OLD
+	// preferred in place, so the error-path auto-reconnect bounced back to the previous
+	// radio instead of retrying the node the user asked for — and worse, that reconnect
+	// (a plain connect, no clear) dumped the previous radio's nodes on top of the target's
+	// freshly restored database.
+	UserDefaults.preferredPeripheralId = device.id.uuidString
+
 	// Mark the switch in flight so the disconnect's teardown doesn't re-arm discovery and
 	// auto-connect can't launch a second connect + node dump while the store is mid-reset.
 	accessoryManager.isSwitchingDevices = true

--- a/Meshtastic/Views/Connect/EventFirmwareInfoView.swift
+++ b/Meshtastic/Views/Connect/EventFirmwareInfoView.swift
@@ -11,6 +11,9 @@ struct EventFirmwareInfoView: View {
 	let edition: FirmwareEditions
 	let info: EventFirmwareEntity
 	let deviceFirmwareVersion: String?
+	/// Invoked from the post-event section's update button (the sheet's presenter routes
+	/// to the firmware-update flow). Optional so preview/simple presentations stay valid.
+	var onUpdateFirmware: (() -> Void)?
 
 	@Environment(\.colorScheme) private var colorScheme
 	@Environment(\.dismiss) private var dismiss
@@ -52,6 +55,7 @@ struct EventFirmwareInfoView: View {
 					EventFirmwarePaletteRule(colors: info.paletteColors, height: 6)
 				}
 				List {
+					eventEndedSection
 					if let welcome = info.welcomeMessage, !welcome.isEmpty {
 						Section {
 							Text(welcome)
@@ -115,6 +119,34 @@ struct EventFirmwareInfoView: View {
 		.padding(.vertical, 18)
 		.frame(maxWidth: .infinity, alignment: .leading)
 		.background(accent)
+	}
+
+	/// Post-event call to action, first in the list. `hasEnded()` mirrors Android's
+	/// day-granular check (an edition without a valid end date never counts as ended).
+	@ViewBuilder
+	private var eventEndedSection: some View {
+		if info.hasEnded() {
+			Section {
+				Label {
+					Text("\(displayName) has ended. Update your node to the latest stable firmware.")
+						.font(bodyFont(16, .callout))
+				} icon: {
+					Image(systemName: "flag.checkered")
+						.foregroundColor(highlight)
+				}
+				if onUpdateFirmware != nil {
+					Button {
+						dismiss()
+						onUpdateFirmware?()
+					} label: {
+						Label("Update Firmware", systemImage: "arrow.up.circle.fill")
+							.font(bodyFont(17, .body).weight(.semibold))
+					}
+				}
+			} footer: {
+				Text("Updates use the app's verified firmware workflow.")
+			}
+		}
 	}
 
 	@ViewBuilder

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -139,6 +139,10 @@ struct ContentView: View {
 		@EnvironmentObject var accessoryManager: AccessoryManager
 		@Query private var eventFirmwareEditions: [EventFirmwareEntity]
 		@State private var isShowingEventFirmwareInfo: Bool = false
+		/// The post-event upgrade sheet auto-presents once per connect. ActiveContent is
+		/// remounted for every node switch (databaseResetID), so plain @State is exactly
+		/// "once per connected session".
+		@State private var hasAutoPresentedEventEnded: Bool = false
 		private let content: Content
 
 		init(appState: AppState, router: Router, @ViewBuilder content: () -> Content) {
@@ -167,13 +171,30 @@ struct ContentView: View {
 						EventFirmwareInfoView(
 							edition: eventPresentation.edition,
 							info: eventPresentation.info,
-							deviceFirmwareVersion: eventPresentation.deviceFirmwareVersion
+							deviceFirmwareVersion: eventPresentation.deviceFirmwareVersion,
+							onUpdateFirmware: {
+								// Route to the verified firmware-update flow (Settings →
+								// Firmware Updates); the sheet dismissed itself first.
+								router.selectedTab = .settings
+								router.settingsPath = [.firmwareUpdates]
+							}
 						)
 					}
 				}
 				.onChange(of: eventPresentation?.edition) { _, edition in
-					if edition == nil {
+					guard edition != nil else {
 						isShowingEventFirmwareInfo = false
+						return
+					}
+					// Once the event's end date has passed, surface the info sheet (with its
+					// post-event update call to action) automatically on connect — parity with
+					// Android's post-event upgrade prompt; hasEnded() is false without a valid
+					// end date, so live/undated editions never nag.
+					if let presentation = eventPresentation,
+					   presentation.info.hasEnded(),
+					   !hasAutoPresentedEventEnded {
+						hasAutoPresentedEventEnded = true
+						isShowingEventFirmwareInfo = true
 					}
 				}
 		}

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -122,16 +122,7 @@ struct ContentView: View {
 	@ViewBuilder
 	private var gatedContent: some View {
 		if appState.isDatabaseResetting {
-			VStack(spacing: 16) {
-				ProgressView()
-					.controlSize(.large)
-				Text("Switching Radios")
-					.font(.title3)
-				Text("Backing up and restoring the node database…")
-					.font(.callout)
-					.foregroundColor(.gray)
-			}
-			.frame(maxWidth: .infinity, maxHeight: .infinity)
+			DatabaseResettingPlaceholder()
 		} else {
 			ActiveContent(appState: appState, router: router) {
 				tabContent
@@ -259,5 +250,28 @@ struct ContentView: View {
 				.tag(NavigationState.Tab.connect)
 			}
 		}
+	}
+}
+
+// MARK: - Reset Placeholder
+
+/// SwiftData-free stand-in shown while a node switch clears/swaps the container. Shared by
+/// the WindowGroup-root gate in MeshtasticAppleApp (which unmounts the `.modelContainer`
+/// modifier itself — its SwiftData↔SwiftUI bridge observes save notifications process-wide
+/// and does NOT rebind when the container underneath it is swapped; a restore-time save then
+/// traps in the stale bridge, the "silent" half of Datadog 324bff02) and by ContentView's
+/// inner gate (defense in depth).
+struct DatabaseResettingPlaceholder: View {
+	var body: some View {
+		VStack(spacing: 16) {
+			ProgressView()
+				.controlSize(.large)
+			Text("Switching Radios")
+				.font(.title3)
+			Text("Backing up and restoring the node database…")
+				.font(.callout)
+				.foregroundColor(.gray)
+		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
 	}
 }

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -10,7 +10,6 @@ struct ContentView: View {
 	@ObservedObject var appState: AppState
 	@EnvironmentObject var accessoryManager: AccessoryManager
 	@EnvironmentObject var lockdown: LockdownCoordinator
-	@Query private var eventFirmwareEditions: [EventFirmwareEntity]
 	// Observe (not just hold) the router so a *programmatic* `selectedTab` change re-renders
 	// ContentView and the TabView re-reads its selection binding immediately. As plain @State this
 	// view never subscribed to the router's objectWillChange, so a programmatic tab switch only took
@@ -38,35 +37,13 @@ struct ContentView: View {
 	/// blocking state clears it.
 	@State private var isShowingLockdownGate: Bool = false
 
-	private var eventPresentation: EventFirmwarePresentation? {
-		EventFirmwarePresentation.resolve(
-			isConnected: accessoryManager.isConnected,
-			edition: accessoryManager.firmwareEdition,
-			metadata: eventFirmwareEditions,
-			deviceFirmwareVersion: accessoryManager.connectedVersion
-		)
-	}
-
 	init(appState: AppState, router: Router) {
 		self.appState = appState
 		self.router = router
 	}
 
 	var body: some View {
-		tabContent
-			.environment(\.eventFirmwarePresentation, eventPresentation)
-			.environment(\.openEventFirmwareInfo) {
-				isShowingEventFirmwareInfo = true
-			}
-			.sheet(isPresented: $isShowingEventFirmwareInfo) {
-				if let eventPresentation {
-					EventFirmwareInfoView(
-						edition: eventPresentation.edition,
-						info: eventPresentation.info,
-						deviceFirmwareVersion: eventPresentation.deviceFirmwareVersion
-					)
-				}
-			}
+		gatedContent
 			.sheet(
 				isPresented: $isShowingDeviceOnboardingFlow,
 				onDismiss: {
@@ -103,16 +80,13 @@ struct ContentView: View {
 			.onChange(of: UserDefaults.showDeviceOnboarding) {_, newValue in
 				isShowingDeviceOnboardingFlow = newValue
 			}
-			.onChange(of: eventPresentation?.edition) { _, edition in
-				if edition == nil {
-					isShowingEventFirmwareInfo = false
-				}
-			}
 			.task {
 #if DEBUG
 				MarketingCapture.simulateEventFirmwareIfNeeded(accessoryManager)
 				// No-op unless launched with --marketing-capture (see MarketingCapture / PerformanceSeedData).
 				await MarketingCapture.runIfNeeded(router: router, accessoryManager: accessoryManager)
+				// No-op unless launched with `-switch-stress N` (node-switch crash harness).
+				await SwitchStress.runIfNeeded(accessoryManager: accessoryManager, appState: appState)
 #endif
 			}
 	}
@@ -134,6 +108,85 @@ struct ContentView: View {
 	}
 
 	// MARK: - Tab Content
+
+	/// While a node switch is clearing/swapping the SwiftData container, the tab tree AND every
+	/// @Query holder above it (the event-editions query lived on ContentView itself) are replaced
+	/// by this SwiftData-free placeholder, so zero @Query subscriptions exist during the swap.
+	/// Stale subscriptions process store-change notifications posted by ANY SwiftData save in the
+	/// process (TipKit runs its own store, saving on background queues) against the swapped-out
+	/// container — the switch-nodes SIGTRAP, Datadog 324bff02-6b22-11f1. The flag is flipped
+	/// inside a no-animation transaction after presented dialogs settle (see the switch flow):
+	/// animated List removal goes through UICollectionView batch updates, which assert when the
+	/// data churns mid-flight (the SIGABRT half of the switch crashes); non-animated replacement
+	/// reloads instead.
+	@ViewBuilder
+	private var gatedContent: some View {
+		if appState.isDatabaseResetting {
+			VStack(spacing: 16) {
+				ProgressView()
+					.controlSize(.large)
+				Text("Switching Radios")
+					.font(.title3)
+				Text("Backing up and restoring the node database…")
+					.font(.callout)
+					.foregroundColor(.gray)
+			}
+			.frame(maxWidth: .infinity, maxHeight: .infinity)
+		} else {
+			ActiveContent(appState: appState, router: router) {
+				tabContent
+			}
+		}
+	}
+
+	/// Owns every SwiftData dependency of the main UI (the event-editions @Query and the
+	/// presentation environment built from it) so that unmounting it during a database reset
+	/// removes ALL query subscriptions, not just the ones inside the tabs.
+	private struct ActiveContent<Content: View>: View {
+		@ObservedObject var appState: AppState
+		@ObservedObject var router: Router
+		@EnvironmentObject var accessoryManager: AccessoryManager
+		@Query private var eventFirmwareEditions: [EventFirmwareEntity]
+		@State private var isShowingEventFirmwareInfo: Bool = false
+		private let content: Content
+
+		init(appState: AppState, router: Router, @ViewBuilder content: () -> Content) {
+			self.appState = appState
+			self.router = router
+			self.content = content()
+		}
+
+		private var eventPresentation: EventFirmwarePresentation? {
+			EventFirmwarePresentation.resolve(
+				isConnected: accessoryManager.isConnected,
+				edition: accessoryManager.firmwareEdition,
+				metadata: eventFirmwareEditions,
+				deviceFirmwareVersion: accessoryManager.connectedVersion
+			)
+		}
+
+		var body: some View {
+			content
+				.environment(\.eventFirmwarePresentation, eventPresentation)
+				.environment(\.openEventFirmwareInfo) {
+					isShowingEventFirmwareInfo = true
+				}
+				.sheet(isPresented: $isShowingEventFirmwareInfo) {
+					if let eventPresentation {
+						EventFirmwareInfoView(
+							edition: eventPresentation.edition,
+							info: eventPresentation.info,
+							deviceFirmwareVersion: eventPresentation.deviceFirmwareVersion
+						)
+					}
+				}
+				.onChange(of: eventPresentation?.edition) { _, edition in
+					if edition == nil {
+						isShowingEventFirmwareInfo = false
+					}
+				}
+		}
+	}
 
 	@ViewBuilder
 	private var tabContent: some View {

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -172,273 +172,11 @@ struct LoRaConfig: View {
 	}
 
 	var body: some View {
-		Form {
-			ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues)
-
-			Section(header: Text("Options")) {
-
-				VStack(alignment: .leading) {
-					Picker("Region", selection: $region ) {
-						// 2.8-only regions (ham/amateur bands, EU SRD/narrow) are
-						// hidden when the connected radio runs firmware older than
-						// 2.8, which has no band table for them.
-						ForEach(RegionCodes.selectable(supports2_8: supports2_8)) { r in
-							Text(r.description)
-						}
-					}
-					Text("The region where you will be using your radios.")
-						.foregroundColor(.gray)
-						.font(.callout)
-				}
-
-				if let info = regionPresetInfo, info.licensedOnly {
-					let licensed = node?.user?.isLicensed ?? false
-					HStack(alignment: .top, spacing: 8) {
-						Image(systemName: licensed ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
-							.foregroundColor(licensed ? .green : .orange)
-							// Decorative status glyph; the adjacent "Licensed band" title and
-							// description already convey licensed/unlicensed state to VoiceOver.
-							.accessibilityHidden(true)
-						VStack(alignment: .leading, spacing: 2) {
-							Text("Licensed band")
-								.font(.callout).bold()
-							Text(licensed
-								 ? "This region is restricted to licensed amateur radio operators. Your operator profile is marked as licensed.".localized
-								 : "This region is restricted to licensed amateur radio operators. Enable “Licensed Operator” and set your call sign in User Config before transmitting.".localized)
-								.foregroundColor(.gray)
-								.font(.caption)
-						}
-					}
-				}
-
-				Toggle(isOn: $usePreset) {
-					Label("Use Preset", systemImage: "list.bullet.rectangle")
-				}
-
-				if usePreset {
-					VStack(alignment: .leading) {
-						Picker("Presets", selection: $modemPreset ) {
-							// Constrained to the selected region's legal presets when
-							// the firmware advertises a region→preset map (2.8+), and
-							// to the firmware-gated set otherwise.
-							ForEach(availablePresets) { m in
-								Text(m.description)
-							}
-						}
-						.fixedSize()
-						Text("Available modem presets, default is Long Fast.")
-							.foregroundColor(.gray)
-							.font(.callout)
-					}
-				}
-			}
-			Section(header: Text("Advanced")) {
-
-				Toggle(isOn: $ignoreMqtt) {
-					Label("Ignore MQTT", systemImage: "server.rack")
-				}
-				Toggle(isOn: $okToMqtt) {
-					Label("Ok to MQTT", systemImage: "network")
-				}
-
-				Toggle(isOn: $txEnabled) {
-					Label("Transmit Enabled", systemImage: "waveform.path")
-				}
-
-				if !usePreset {
-					CustomBandwidthPicker(
-						selection: bandwidthSelection,
-						options: availableBandwidths,
-						region: RegionCodes(rawValue: region),
-						validationIssue: customBandwidthValidationIssue
-					)
-					HStack {
-						Picker("Spread Factor", selection: $spreadFactor) {
-							ForEach(7..<13) {
-								Text("\($0)")
-									.tag($0 == 12 ? 0 : $0)
-							}
-						}
-					}
-				}
-
-				VStack(alignment: .leading, spacing: 8) {
-					HStack {
-						Text("Coding Rate")
-						Spacer()
-						Text(CodingRates.description(for: normalizedCodingRate, modemPreset: selectedModemPreset))
-							.foregroundColor(.secondary)
-					}
-					if usePreset {
-						Toggle("Follow Preset Coding Rate", isOn: usePresetCodingRate)
-						if !canOverridePresetCodingRate {
-							Text("This preset already uses 4/\(defaultCodingRate), the highest redundancy available.")
-								.foregroundColor(.gray)
-								.font(.callout)
-						} else if normalizedCodingRate == 0 {
-							Text("Uses \(selectedModemPreset.description)'s 4/\(defaultCodingRate) coding rate. Turn this off only when nearby nodes use the same preset and you want extra error correction on noisy links.")
-								.foregroundColor(.gray)
-								.font(.callout)
-						} else {
-							Slider(
-								value: presetCodingRateSliderValue,
-								in: Double(defaultCodingRate + 1)...Double(CodingRates.validRange.upperBound),
-								step: 1
-							) {
-								Text("Coding Rate")
-							} minimumValueLabel: {
-								Text("4/\(defaultCodingRate + 1)")
-							} maximumValueLabel: {
-								Text("4/\(CodingRates.validRange.upperBound)")
-							}
-							Text("Uses 4/\(normalizedCodingRate) while keeping the \(selectedModemPreset.description) bandwidth and spread factor. Higher values add error correction, but each packet uses more airtime and has less throughput.")
-								.foregroundColor(.gray)
-								.font(.callout)
-						}
-					} else {
-						Slider(
-							value: customCodingRateSliderValue,
-							in: Double(CodingRates.validRange.lowerBound)...Double(CodingRates.validRange.upperBound),
-							step: 1
-						) {
-							Text("Coding Rate")
-						} minimumValueLabel: {
-							Text("4/\(CodingRates.validRange.lowerBound)")
-						} maximumValueLabel: {
-							Text("4/\(CodingRates.validRange.upperBound)")
-						}
-						Text("Coding rate controls error-correction redundancy. Higher values can help noisy links, but reduce throughput and increase airtime. Keep 4/5 unless your channel plan calls for a different value.")
-							.foregroundColor(.gray)
-							.font(.callout)
-					}
-				}
-
-				VStack(alignment: .leading) {
-					Picker("Number of hops", selection: $hopLimit) {
-						ForEach(0..<8) {
-							Text("\($0)")
-								.tag($0)
-						}
-					}
-					Text("Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. 0 hop broadcast messages will not get ACKs.")
-						.foregroundColor(.gray)
-						.font(.callout)
-				}
-
-				VStack(alignment: .leading) {
-					HStack {
-						Text("Frequency Slot")
-							.fixedSize()
-						TextField("Frequency Slot", value: $channelNum, formatter: formatter)
-							.keyboardType(.numberPad)
-							.focused($focusedField, equals: .channelNum)
-							.disabled(overrideFrequency > 0.0)
-					}
-					Text("Your node’s operating frequency is calculated based on the region, modem preset, and this field. When 0, the slot is automatically calculated based on the primary channel name.")
-						.foregroundColor(.gray)
-						.font(.callout)
-				}
-
-				Toggle(isOn: $rxBoostedGain) {
-					Label("RX Boosted Gain", systemImage: "waveform.badge.plus")
-				}
-
-				HStack {
-					Label("Frequency Override", systemImage: "waveform.path.ecg")
-					Spacer()
-					TextField("Frequency Override", value: $overrideFrequency, formatter: floatFormatter)
-						.keyboardType(.decimalPad)
-						.focused($focusedField, equals: .frequencyOverride)
-				}
-
-				HStack {
-					Image(systemName: "antenna.radiowaves.left.and.right")
-						.foregroundColor(.accentColor)
-						// Decorative icon; the Stepper carries the label for VoiceOver.
-						.accessibilityHidden(true)
-					Stepper(txPower == 0 ? "Max Transmit Power" : "\(txPower)dBm Transmit Power", value: $txPower, in: 0...30, step: 1)
-						.padding(5)
-				}
-			}
-		}
-		.scrollDismissesKeyboard(.immediately)
-		.disabled(!accessoryManager.isConnected || node?.loRaConfig == nil)
-		.safeAreaInset(edge: .bottom, alignment: .center) {
-			HStack(spacing: 0) {
-				SaveConfigButton(node: node, hasChanges: $hasChanges) {
-					guard customBandwidthValidationIssue == nil else { return }
-					performConfigSave(
-						node: node,
-						context: context,
-						accessoryManager: accessoryManager,
-						hasChanges: $hasChanges,
-						dismiss: goBack
-					) { fromUser, toUser in
-						var lc = Config.LoRaConfig()
-						lc.hopLimit = UInt32(hopLimit)
-						lc.region = RegionCodes(rawValue: region)!.protoEnumValue()
-						lc.modemPreset = ModemPresets(rawValue: modemPreset)!.protoEnumValue()
-						lc.usePreset = usePreset
-						lc.txEnabled = txEnabled
-						lc.txPower = Int32(txPower)
-						lc.channelNum = UInt32(channelNum)
-						lc.bandwidth = UInt32(bandwidth)
-						lc.codingRate = UInt32(normalizedCodingRate)
-						lc.spreadFactor = UInt32(spreadFactor)
-						lc.sx126XRxBoostedGain = rxBoostedGain
-						lc.overrideFrequency = overrideFrequency
-						lc.ignoreMqtt = ignoreMqtt
-						lc.configOkToMqtt = okToMqtt
-						if let deviceNum = accessoryManager.activeDeviceNum,
-						   let connectedNode = getNodeInfo(id: deviceNum, context: context),
-						   connectedNode.num == node?.user?.num ?? 0 {
-							UserDefaults.modemPreset = modemPreset
-						}
-						_ = try await accessoryManager.saveLoRaConfig(config: lc, fromUser: fromUser, toUser: toUser)
-					}
-				}
-				.disabled(customBandwidthValidationIssue != nil)
-			}
-		}
-		.navigationTitle("LoRa Config")
-		.toolbar {
-			ToolbarItem(placement: .topBarTrailing) {
-				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-			}
-		}
-		.onFirstAppear {
-			requestRemoteConfig(
-				node: node,
-				context: context,
-				accessoryManager: accessoryManager,
-				configIsNil: { $0.loRaConfig == nil },
-				request: accessoryManager.requestLoRaConfig
-			)
-		}
-		.onChange(of: region) { _, newRegion in
-			if newRegion != node?.loRaConfig?.regionCode ?? -1 { hasChanges = true }
-			applyRegionPresetDefault(forRegion: newRegion)
-		}
-		.onChange(of: accessoryManager.loRaRegionPresets) { _, _ in
-			applyRegionPresetDefault(forRegion: region)
-		}
-		.onChange(of: usePreset) { _, newPreset in
-			codingRate = CodingRates.normalized(codingRate, usePreset: newPreset, modemPreset: selectedModemPreset)
-			if newPreset != node?.loRaConfig?.usePreset { hasChanges = true }
-		}
-		.onChange(of: modemPreset) { _, newModemPreset in
-			codingRate = CodingRates.normalized(codingRate, usePreset: usePreset, modemPreset: ModemPresets(rawValue: newModemPreset) ?? .longFast)
-			if newModemPreset != node?.loRaConfig?.modemPreset ?? -1 { hasChanges = true }
-		}
-		.onChange(of: hopLimit) { _, newHopLimit in
-			if newHopLimit != node?.loRaConfig?.hopLimit ?? -1 { hasChanges = true }
-		}
-		.onChange(of: channelNum) { _, newChannelNum in
-			if newChannelNum != node?.loRaConfig?.channelNum ?? -1 { hasChanges = true }
-		}
-		.onChange(of: bandwidth) { _, newBandwidth in
-			if newBandwidth != node?.loRaConfig?.bandwidth ?? -1 { hasChanges = true }
-		}
+		// The fourteen .onChange closures each carry a mixed-optional comparison
+		// (`newX != node?.loRaConfig?.x ?? -1`); solved together with the inlined Form
+		// they formed a single ~10s type-check expression (build-snapshots' budget
+		// blowups). Rooting the chain at an opaque property splits the solve.
+		trackedForm
 		.onChange(of: codingRate) { _, newCodingRate in
 			let normalizedNewCodingRate = CodingRates.normalized(newCodingRate, usePreset: usePreset, modemPreset: selectedModemPreset)
 			if normalizedNewCodingRate != newCodingRate {
@@ -466,6 +204,304 @@ struct LoRaConfig: View {
 		}
 		.onChange(of: okToMqtt) { _, newOkToMqtt in
 			if newOkToMqtt != node?.loRaConfig?.okToMqtt { hasChanges = true }
+		}
+	}
+
+	/// First half of the change-tracking chain — all the .onChange calls chained in one
+	/// expression were still a multi-second type-check after the section/save splits;
+	/// halving the chain keeps each solve small.
+	private var trackedForm: some View {
+		loRaForm
+		.onChange(of: region) { _, newRegion in
+			if newRegion != node?.loRaConfig?.regionCode ?? -1 { hasChanges = true }
+			applyRegionPresetDefault(forRegion: newRegion)
+		}
+		.onChange(of: accessoryManager.loRaRegionPresets) { _, _ in
+			applyRegionPresetDefault(forRegion: region)
+		}
+		.onChange(of: usePreset) { _, newPreset in
+			codingRate = CodingRates.normalized(codingRate, usePreset: newPreset, modemPreset: selectedModemPreset)
+			if newPreset != node?.loRaConfig?.usePreset { hasChanges = true }
+		}
+		.onChange(of: modemPreset) { _, newModemPreset in
+			codingRate = CodingRates.normalized(codingRate, usePreset: usePreset, modemPreset: ModemPresets(rawValue: newModemPreset) ?? .longFast)
+			if newModemPreset != node?.loRaConfig?.modemPreset ?? -1 { hasChanges = true }
+		}
+		.onChange(of: hopLimit) { _, newHopLimit in
+			if newHopLimit != node?.loRaConfig?.hopLimit ?? -1 { hasChanges = true }
+		}
+		.onChange(of: channelNum) { _, newChannelNum in
+			if newChannelNum != node?.loRaConfig?.channelNum ?? -1 { hasChanges = true }
+		}
+		.onChange(of: bandwidth) { _, newBandwidth in
+			if newBandwidth != node?.loRaConfig?.bandwidth ?? -1 { hasChanges = true }
+		}
+	}
+
+	/// See `body` — the Form and its chrome, split out for type-check time.
+	private var loRaForm: some View {
+		Form {
+			ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues)
+
+			optionsSection
+
+			advancedSection
+		}
+		.scrollDismissesKeyboard(.immediately)
+		.disabled(!accessoryManager.isConnected || node?.loRaConfig == nil)
+		.safeAreaInset(edge: .bottom, alignment: .center) {
+			HStack(spacing: 0) {
+				SaveConfigButton(node: node, hasChanges: $hasChanges) {
+					saveLoRaConfig()
+				}
+				.disabled(customBandwidthValidationIssue != nil)
+			}
+		}
+		.navigationTitle("LoRa Config")
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+			}
+		}
+		.onFirstAppear {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.loRaConfig == nil },
+				request: accessoryManager.requestLoRaConfig
+			)
+		}
+	}
+
+	/// The save routine, extracted from the `SaveConfigButton` trailing closure — same
+	/// type-check-time treatment as SecurityConfig (body's chained expression measured ~10s
+	/// with -warn-long-expression-type-checking before extraction).
+	private func saveLoRaConfig() {
+		guard customBandwidthValidationIssue == nil else { return }
+		performConfigSave(
+			node: node,
+			context: context,
+			accessoryManager: accessoryManager,
+			hasChanges: $hasChanges,
+			dismiss: goBack
+		) { fromUser, toUser in
+			var lc = Config.LoRaConfig()
+			lc.hopLimit = UInt32(hopLimit)
+			lc.region = RegionCodes(rawValue: region)!.protoEnumValue()
+			lc.modemPreset = ModemPresets(rawValue: modemPreset)!.protoEnumValue()
+			lc.usePreset = usePreset
+			lc.txEnabled = txEnabled
+			lc.txPower = Int32(txPower)
+			lc.channelNum = UInt32(channelNum)
+			lc.bandwidth = UInt32(bandwidth)
+			lc.codingRate = UInt32(normalizedCodingRate)
+			lc.spreadFactor = UInt32(spreadFactor)
+			lc.sx126XRxBoostedGain = rxBoostedGain
+			lc.overrideFrequency = overrideFrequency
+			lc.ignoreMqtt = ignoreMqtt
+			lc.configOkToMqtt = okToMqtt
+			if let deviceNum = accessoryManager.activeDeviceNum,
+			   let connectedNode = getNodeInfo(id: deviceNum, context: context),
+			   connectedNode.num == node?.user?.num ?? 0 {
+				UserDefaults.modemPreset = modemPreset
+			}
+			_ = try await accessoryManager.saveLoRaConfig(config: lc, fromUser: fromUser, toUser: toUser)
+		}
+	}
+
+	/// Extracted from `body`: the inlined Form was a single ~10s type-check expression on
+	/// dev hardware (measured with -warn-long-expression-type-checking) and blew the budget
+	/// outright on CI's runners (build-snapshots: "unable to type-check in reasonable time").
+	private var optionsSection: some View {
+		Section(header: Text("Options")) {
+
+			VStack(alignment: .leading) {
+				Picker("Region", selection: $region ) {
+					// 2.8-only regions (ham/amateur bands, EU SRD/narrow) are
+					// hidden when the connected radio runs firmware older than
+					// 2.8, which has no band table for them.
+					ForEach(RegionCodes.selectable(supports2_8: supports2_8)) { r in
+						Text(r.description)
+					}
+				}
+				Text("The region where you will be using your radios.")
+					.foregroundColor(.gray)
+					.font(.callout)
+			}
+
+			if let info = regionPresetInfo, info.licensedOnly {
+				let licensed = node?.user?.isLicensed ?? false
+				HStack(alignment: .top, spacing: 8) {
+					Image(systemName: licensed ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+						.foregroundColor(licensed ? .green : .orange)
+						// Decorative status glyph; the adjacent "Licensed band" title and
+						// description already convey licensed/unlicensed state to VoiceOver.
+						.accessibilityHidden(true)
+					VStack(alignment: .leading, spacing: 2) {
+						Text("Licensed band")
+							.font(.callout).bold()
+						Text(licensed
+							 ? "This region is restricted to licensed amateur radio operators. Your operator profile is marked as licensed.".localized
+							 : "This region is restricted to licensed amateur radio operators. Enable “Licensed Operator” and set your call sign in User Config before transmitting.".localized)
+							.foregroundColor(.gray)
+							.font(.caption)
+					}
+				}
+			}
+
+			Toggle(isOn: $usePreset) {
+				Label("Use Preset", systemImage: "list.bullet.rectangle")
+			}
+
+			if usePreset {
+				VStack(alignment: .leading) {
+					Picker("Presets", selection: $modemPreset ) {
+						// Constrained to the selected region's legal presets when
+						// the firmware advertises a region→preset map (2.8+), and
+						// to the firmware-gated set otherwise.
+						ForEach(availablePresets) { m in
+							Text(m.description)
+						}
+					}
+					.fixedSize()
+					Text("Available modem presets, default is Long Fast.")
+						.foregroundColor(.gray)
+						.font(.callout)
+				}
+			}
+		}
+	}
+
+	/// See `optionsSection` — split out of `body` for type-check time.
+	private var advancedSection: some View {
+		Section(header: Text("Advanced")) {
+
+			Toggle(isOn: $ignoreMqtt) {
+				Label("Ignore MQTT", systemImage: "server.rack")
+			}
+			Toggle(isOn: $okToMqtt) {
+				Label("Ok to MQTT", systemImage: "network")
+			}
+
+			Toggle(isOn: $txEnabled) {
+				Label("Transmit Enabled", systemImage: "waveform.path")
+			}
+
+			if !usePreset {
+				CustomBandwidthPicker(
+					selection: bandwidthSelection,
+					options: availableBandwidths,
+					region: RegionCodes(rawValue: region),
+					validationIssue: customBandwidthValidationIssue
+				)
+				HStack {
+					Picker("Spread Factor", selection: $spreadFactor) {
+						ForEach(7..<13) {
+							Text("\($0)")
+								.tag($0 == 12 ? 0 : $0)
+						}
+					}
+				}
+			}
+
+			VStack(alignment: .leading, spacing: 8) {
+				HStack {
+					Text("Coding Rate")
+					Spacer()
+					Text(CodingRates.description(for: normalizedCodingRate, modemPreset: selectedModemPreset))
+						.foregroundColor(.secondary)
+				}
+				if usePreset {
+					Toggle("Follow Preset Coding Rate", isOn: usePresetCodingRate)
+					if !canOverridePresetCodingRate {
+						Text("This preset already uses 4/\(defaultCodingRate), the highest redundancy available.")
+							.foregroundColor(.gray)
+							.font(.callout)
+					} else if normalizedCodingRate == 0 {
+						Text("Uses \(selectedModemPreset.description)'s 4/\(defaultCodingRate) coding rate. Turn this off only when nearby nodes use the same preset and you want extra error correction on noisy links.")
+							.foregroundColor(.gray)
+							.font(.callout)
+					} else {
+						Slider(
+							value: presetCodingRateSliderValue,
+							in: Double(defaultCodingRate + 1)...Double(CodingRates.validRange.upperBound),
+							step: 1
+						) {
+							Text("Coding Rate")
+						} minimumValueLabel: {
+							Text("4/\(defaultCodingRate + 1)")
+						} maximumValueLabel: {
+							Text("4/\(CodingRates.validRange.upperBound)")
+						}
+						Text("Uses 4/\(normalizedCodingRate) while keeping the \(selectedModemPreset.description) bandwidth and spread factor. Higher values add error correction, but each packet uses more airtime and has less throughput.")
+							.foregroundColor(.gray)
+							.font(.callout)
+					}
+				} else {
+					Slider(
+						value: customCodingRateSliderValue,
+						in: Double(CodingRates.validRange.lowerBound)...Double(CodingRates.validRange.upperBound),
+						step: 1
+					) {
+						Text("Coding Rate")
+					} minimumValueLabel: {
+						Text("4/\(CodingRates.validRange.lowerBound)")
+					} maximumValueLabel: {
+						Text("4/\(CodingRates.validRange.upperBound)")
+					}
+					Text("Coding rate controls error-correction redundancy. Higher values can help noisy links, but reduce throughput and increase airtime. Keep 4/5 unless your channel plan calls for a different value.")
+						.foregroundColor(.gray)
+						.font(.callout)
+				}
+			}
+
+			VStack(alignment: .leading) {
+				Picker("Number of hops", selection: $hopLimit) {
+					ForEach(0..<8) {
+						Text("\($0)")
+							.tag($0)
+					}
+				}
+				Text("Sets the maximum number of hops, default is 3. Increasing hops also increases congestion and should be used carefully. 0 hop broadcast messages will not get ACKs.")
+					.foregroundColor(.gray)
+					.font(.callout)
+			}
+
+			VStack(alignment: .leading) {
+				HStack {
+					Text("Frequency Slot")
+						.fixedSize()
+					TextField("Frequency Slot", value: $channelNum, formatter: formatter)
+						.keyboardType(.numberPad)
+						.focused($focusedField, equals: .channelNum)
+						.disabled(overrideFrequency > 0.0)
+				}
+				Text("Your node’s operating frequency is calculated based on the region, modem preset, and this field. When 0, the slot is automatically calculated based on the primary channel name.")
+					.foregroundColor(.gray)
+					.font(.callout)
+			}
+
+			Toggle(isOn: $rxBoostedGain) {
+				Label("RX Boosted Gain", systemImage: "waveform.badge.plus")
+			}
+
+			HStack {
+				Label("Frequency Override", systemImage: "waveform.path.ecg")
+				Spacer()
+				TextField("Frequency Override", value: $overrideFrequency, formatter: floatFormatter)
+					.keyboardType(.decimalPad)
+					.focused($focusedField, equals: .frequencyOverride)
+			}
+
+			HStack {
+				Image(systemName: "antenna.radiowaves.left.and.right")
+					.foregroundColor(.accentColor)
+					// Decorative icon; the Stepper carries the label for VoiceOver.
+					.accessibilityHidden(true)
+				Stepper(txPower == 0 ? "Max Transmit Power" : "\(txPower)dBm Transmit Power", value: $txPower, in: 0...30, step: 1)
+					.padding(5)
+			}
 		}
 	}
 	/// When the user switches region, pre-select the appropriate preset: a

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -52,106 +52,9 @@ struct SecurityConfig: View {
 	}
 
 	var body: some View {
-		Form {
-			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues)
-			Text("Security Config Settings require a firmware version 2.5+")
-				.font(.title3)
-			packetAuthenticitySection
-			directMessageKeySection
-			adminKeysSection
-			LockdownSection(lockdown: lockdown, showLockNowAlert: $showLockNowAlert)
-			logsSection
-			administrationSection
-		}
-		.disabled(!accessoryManager.isConnected || node?.securityConfig == nil)
-		.safeAreaInset(edge: .bottom, alignment: .center) {
-			HStack(spacing: 0) {
-				SaveConfigButton(node: node, hasChanges: $hasChanges) {
-
-					if !hasValidPrivateKey || !hasValidAdminKey || !hasValidAdminKey2 || !hasValidAdminKey3 {
-						return
-					}
-
-					guard let deviceNum = accessoryManager.activeDeviceNum,
-						  let connectedNode = getNodeInfo(id: deviceNum, context: context),
-						  let fromUser = connectedNode.user,
-						  let toUser = node?.user else {
-						return
-					}
-
-					var config = Config.SecurityConfig()
-					config.privateKey = Data(base64Encoded: privateKey) ?? Data()
-					config.adminKey = [Data(base64Encoded: adminKey) ?? Data(), Data(base64Encoded: adminKey2) ?? Data(), Data(base64Encoded: adminKey3) ?? Data()]
-					config.isManaged = isManaged
-					config.serialEnabled = serialEnabled
-					config.debugLogApiEnabled = debugLogApiEnabled
-					// Always written back, even when the capability gate hid the control, so a policy
-					// the radio already holds round-trips untouched instead of being reset to Compatible.
-					config.packetSignaturePolicy = packetAuthenticitySelection.selected
-
-					let keyUpdated = node?.securityConfig?.privateKey?.base64EncodedString() ?? "" != privateKey
-					Task {
-						_ = try await accessoryManager.saveSecurityConfig(
-							config: config,
-							fromUser: fromUser,
-							toUser: toUser
-						)
-						Task { @MainActor in
-							// Should show a saved successfully alert once I know that to be true
-							// for now just disable the button after a successful save
-							if keyUpdated {
-								// This is the *local* node's own keypair being changed deliberately by the user in the
-								// Security config screen (gated behind `keyUpdated` + an explicit save), not an inbound
-								// mesh key — so the first-wins protection doesn't apply. `keyMatch`/`newPublicKey` track
-								// *remote* contacts' keys, so they are intentionally left untouched here.
-								node?.user?.publicKey = Data(base64Encoded: publicKey) ?? Data()
-								do {
-									try context.save()
-									Logger.data.info("💾 Saved UserEntity Public Key to Core Data for \(node?.num ?? 0, privacy: .public)")
-								} catch {
-									let nsError = error as NSError
-									Logger.data.error("Error Updating UserEntity: \(nsError, privacy: .public)")
-								}
-							}
-						}
-						hasChanges = false
-						if keyUpdated {
-							Task {
-								do {
-									try await accessoryManager.sendReboot(
-										fromUser: fromUser,
-										toUser: toUser
-									)
-								} catch {
-									Logger.mesh.warning("Reboot Failed")
-								}
-							}
-						}
-						goBack()
-					}
-				}
-			}
-		}
-		.scrollDismissesKeyboard(.immediately)
-		.navigationTitle("Security Config")
-		.toolbar {
-	ToolbarItem(placement: .topBarTrailing) {
-		ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-	}
-}
-		.onChange(of: node) { _, _ in
-			setSecurityValues()
-		}
-		.onChange(of: isManaged) { _, newIsManaged in
-			if newIsManaged != node?.securityConfig?.isManaged { hasChanges = true }
-		}
-		.onChange(of: serialEnabled) { _, newSerialEnabled in
-			if newSerialEnabled != node?.securityConfig?.serialEnabled { hasChanges = true }
-		}
-		.onChange(of: debugLogApiEnabled) { _, newDebugLogApiEnabled in
-			if newDebugLogApiEnabled != node?.securityConfig?.debugLogApiEnabled { hasChanges = true }
-		}
-		.onChange(of: packetAuthenticitySelection.selected) { _, policy in packetAuthenticityDidChange(to: policy) }
+		// Chain rooted at an opaque property for type-check time — same treatment as
+		// LoRaConfig; this file was the one build-snapshots' compiler actually timed out on.
+		trackedSecurityForm
 		.onChange(of: privateKey) { _, key in
 			let tempKey = Data(base64Encoded: privateKey) ?? Data()
 			if tempKey.count == 32 {
@@ -206,6 +109,123 @@ struct SecurityConfig: View {
 				configIsNil: { $0.securityConfig == nil },
 				request: accessoryManager.requestSecurityConfig
 			)
+		}
+	}
+
+	/// First half of the change-tracking chain — halved like LoRaConfig so no single
+	/// expression carries the whole overloaded .onChange stack.
+	private var trackedSecurityForm: some View {
+		securityForm
+		.onChange(of: node) { _, _ in
+			setSecurityValues()
+		}
+		.onChange(of: isManaged) { _, newIsManaged in
+			if newIsManaged != node?.securityConfig?.isManaged { hasChanges = true }
+		}
+		.onChange(of: serialEnabled) { _, newSerialEnabled in
+			if newSerialEnabled != node?.securityConfig?.serialEnabled { hasChanges = true }
+		}
+		.onChange(of: debugLogApiEnabled) { _, newDebugLogApiEnabled in
+			if newDebugLogApiEnabled != node?.securityConfig?.debugLogApiEnabled { hasChanges = true }
+		}
+		.onChange(of: packetAuthenticitySelection.selected) { _, policy in packetAuthenticityDidChange(to: policy) }
+	}
+
+	/// See `body` — the Form and its chrome, split out for type-check time.
+	private var securityForm: some View {
+		Form {
+			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues)
+			Text("Security Config Settings require a firmware version 2.5+")
+				.font(.title3)
+			packetAuthenticitySection
+			directMessageKeySection
+			adminKeysSection
+			LockdownSection(lockdown: lockdown, showLockNowAlert: $showLockNowAlert)
+			logsSection
+			administrationSection
+		}
+		.disabled(!accessoryManager.isConnected || node?.securityConfig == nil)
+		.safeAreaInset(edge: .bottom, alignment: .center) {
+			HStack(spacing: 0) {
+				SaveConfigButton(node: node, hasChanges: $hasChanges) {
+					saveSecurityConfig()
+				}
+			}
+		}
+		.scrollDismissesKeyboard(.immediately)
+		.navigationTitle("Security Config")
+		.toolbar {
+	ToolbarItem(placement: .topBarTrailing) {
+		ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+	}
+}
+	}
+
+	/// The save routine, extracted from the `SaveConfigButton` trailing closure: inference
+	/// for the inlined closure inside body's modifier chain was a type-check hot spot
+	/// (the build-snapshots "unable to type-check in reasonable time" failures on CI).
+	private func saveSecurityConfig() {
+
+		if !hasValidPrivateKey || !hasValidAdminKey || !hasValidAdminKey2 || !hasValidAdminKey3 {
+			return
+		}
+
+		guard let deviceNum = accessoryManager.activeDeviceNum,
+			  let connectedNode = getNodeInfo(id: deviceNum, context: context),
+			  let fromUser = connectedNode.user,
+			  let toUser = node?.user else {
+			return
+		}
+
+		var config = Config.SecurityConfig()
+		config.privateKey = Data(base64Encoded: privateKey) ?? Data()
+		config.adminKey = [Data(base64Encoded: adminKey) ?? Data(), Data(base64Encoded: adminKey2) ?? Data(), Data(base64Encoded: adminKey3) ?? Data()]
+		config.isManaged = isManaged
+		config.serialEnabled = serialEnabled
+		config.debugLogApiEnabled = debugLogApiEnabled
+		// Always written back, even when the capability gate hid the control, so a policy
+		// the radio already holds round-trips untouched instead of being reset to Compatible.
+		config.packetSignaturePolicy = packetAuthenticitySelection.selected
+
+		let keyUpdated = node?.securityConfig?.privateKey?.base64EncodedString() ?? "" != privateKey
+		Task {
+			_ = try await accessoryManager.saveSecurityConfig(
+				config: config,
+				fromUser: fromUser,
+				toUser: toUser
+			)
+			Task { @MainActor in
+				// Should show a saved successfully alert once I know that to be true
+				// for now just disable the button after a successful save
+				if keyUpdated {
+					// This is the *local* node's own keypair being changed deliberately by the user in the
+					// Security config screen (gated behind `keyUpdated` + an explicit save), not an inbound
+					// mesh key — so the first-wins protection doesn't apply. `keyMatch`/`newPublicKey` track
+					// *remote* contacts' keys, so they are intentionally left untouched here.
+					node?.user?.publicKey = Data(base64Encoded: publicKey) ?? Data()
+					do {
+						try context.save()
+						Logger.data.info("💾 Saved UserEntity Public Key to Core Data for \(node?.num ?? 0, privacy: .public)")
+					} catch {
+						let nsError = error as NSError
+						Logger.data.error("Error Updating UserEntity: \(nsError, privacy: .public)")
+					}
+				}
+			}
+			hasChanges = false
+			if keyUpdated {
+				Task {
+					do {
+						try await accessoryManager.sendReboot(
+							fromUser: fromUser,
+							toUser: toUser
+						)
+					} catch {
+						Logger.mesh.warning("Reboot Failed")
+					}
+				}
+			}
+			goBack()
 		}
 	}
 

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -57,194 +57,11 @@ struct SecurityConfig: View {
 			Text("Security Config Settings require a firmware version 2.5+")
 				.font(.title3)
 			packetAuthenticitySection
-			Section(header: Text("Direct Message Key")) {
-				VStack(alignment: .leading) {
-					HStack(alignment: .firstTextBaseline) {
-						Label("Public Key", systemImage: "key")
-						Spacer()
-						// Explicit copy action. On Mac Catalyst `.textSelection(.enabled)` on a
-						// Text inside a Form does not reliably offer a right-click "Copy", so the
-						// selection-only approach left macOS users unable to copy their key (#1943).
-						Button {
-							UIPasteboard.general.string = publicKey
-						} label: {
-							Image(systemName: "doc.on.doc")
-							Text("Copy")
-						}
-						.buttonStyle(.bordered)
-						.buttonBorderShape(.capsule)
-						.controlSize(.small)
-						.disabled(publicKey.isEmpty)
-					}
-					Text(publicKey)
-						.font(idiom == .phone ? .caption : .callout)
-						.allowsTightening(true)
-						.monospaced()
-						.keyboardType(.alphabet)
-						.foregroundStyle(.tertiary)
-						.disableAutocorrection(true)
-						// Retained as the iOS copy path (long-press to select); the Copy button
-						// above is the reliable path on Mac Catalyst, where this doesn't offer
-						// a right-click "Copy" inside a Form (#1943).
-						.textSelection(.enabled)
-						.background(
-							RoundedRectangle(cornerRadius: 10.0)
-								.stroke(isValidKeyPair ? Color.clear : Color.red, lineWidth: 2.0)
-						)
-					Text("Your public key is generated from your private key and sent to other nodes on the mesh so they can compute a shared secret key with you.")
-						.foregroundStyle(.secondary)
-						.font(idiom == .phone ? .caption : .callout)
-					Divider()
-					Label("Private Key", systemImage: "key.fill")
-					SecureInput("Private Key", text: $privateKey, isValid: $hasValidPrivateKey, isSecure: $privateKeyIsSecure)
-						.background(
-							RoundedRectangle(cornerRadius: 10.0)
-								.stroke(hasValidPrivateKey ? Color.clear : Color.red, lineWidth: 2.0)
-						)
-					Text("Used to create a shared key with a remote device.")
-						.foregroundStyle(.secondary)
-						.font(idiom == .phone ? .caption : .callout)
-					if let currentNode = node {
-						Divider()
-						Label("Key Backup", systemImage: "icloud")
-						HStack(alignment: .firstTextBaseline) {
-							let keychainKey = "PrivateKeyNode\(currentNode.num)"
-							Button {
-								let status = KeychainHelper.standard.save(key: keychainKey, value: privateKey)
-								if status == errSecSuccess {
-									backupStatus = KeyBackupStatus.saved
-								} else {
-									backupStatus = KeyBackupStatus.saveFailed
-									backupStatusError = status
-								}
-							}
-							label: {
-								Image(systemName: "icloud.and.arrow.up")
-								Text("Backup")
-							}
-							.buttonStyle(.bordered)
-							.buttonBorderShape(.capsule)
-							.controlSize(.small)
-							Spacer()
-							Button {
-								if let value = KeychainHelper.standard.read(key: keychainKey) {
-									self.privateKey = value
-									self.privateKeyIsSecure = false
-									backupStatus = KeyBackupStatus.restored
-								} else {
-									backupStatus = KeyBackupStatus.restoreFailed
-								}
-							}
-							label: {
-								Image(systemName: "key.icloud")
-								Text("Restore")
-							}
-							.buttonStyle(.bordered)
-							.buttonBorderShape(.capsule)
-							.controlSize(.small)
-							Spacer()
-							Button {
-								let status = KeychainHelper.standard.delete(key: keychainKey)
-								if status == errSecSuccess {
-									backupStatus = KeyBackupStatus.deleted
-								} else {
-									backupStatus = KeyBackupStatus.deleteFailed
-								}
-							}
-							label: {
-								Image(systemName: "trash")
-							}
-							.buttonStyle(.bordered)
-							.buttonBorderShape(.capsule)
-							.controlSize(.small)
-							.accessibilityLabel(String(localized: "Delete key backup", comment: "VoiceOver label for the delete key backup button"))
-						}
-						if let status = backupStatus {
-							let state = status.success
-							Text("\(status.description)")
-								.font(.caption)
-								.foregroundColor(state ? .green : .red)
-						}
-						Text("Backup your private key to your iCloud keychain.")
-							.foregroundStyle(.secondary)
-							.font(idiom == .phone ? .caption : .callout)
-					}
-					Divider()
-					HStack(alignment: .firstTextBaseline) {
-						Label("Regenerate Private Key", systemImage: "arrow.clockwise.circle")
-						Spacer()
-						Button {
-							if let keyBytes = generatePrivateKey(count: 32) {
-								privateKey = keyBytes.base64EncodedString()
-								self.privateKeyIsSecure = false
-							}
-						} label: {
-							Image(systemName: "lock.rotation")
-								.font(.title)
-						}
-						.buttonStyle(.bordered)
-						.buttonBorderShape(.capsule)
-						.controlSize(.small)
-						.accessibilityLabel(String(localized: "Regenerate private key", comment: "VoiceOver label for the regenerate private key button"))
-					}
-					Text("Generate a new private key to replace the one currently in use. The public key will automatically be regenerated from your private key.")
-						.foregroundStyle(.secondary)
-						.font(idiom == .phone ? .caption : .callout)
-				}
-			}
-			Section(header: Text("Admin Keys")) {
-				Label("Primary Admin Key", systemImage: "key.viewfinder")
-				SecureInput("Primary Admin Key", text: $adminKey, isValid: $hasValidAdminKey)
-					.background(
-						RoundedRectangle(cornerRadius: 10.0)
-							.stroke(hasValidAdminKey ? Color.clear : Color.red, lineWidth: 2.0)
-					)
-				Text("The primary public key authorized to send admin messages to this node.")
-					.foregroundStyle(.secondary)
-					.font(idiom == .phone ? .caption : .callout)
-				Label("Secondary Admin Key", systemImage: "key.viewfinder")
-				SecureInput("Secondary Admin Key", text: $adminKey2, isValid: $hasValidAdminKey2)
-					.background(
-						RoundedRectangle(cornerRadius: 10.0)
-							.stroke(hasValidAdminKey2 ? Color.clear : Color.red, lineWidth: 2.0)
-					)
-				Text("The secondary public key authorized to send admin messages to this node.")
-					.foregroundStyle(.secondary)
-					.font(idiom == .phone ? .caption : .callout)
-				Label("Tertiary Admin Key", systemImage: "key.viewfinder")
-				SecureInput("Tertiary Admin Key", text: $adminKey3, isValid: $hasValidAdminKey3)
-					.background(
-						RoundedRectangle(cornerRadius: 10.0)
-							.stroke(hasValidAdminKey3 ? Color.clear : Color.red, lineWidth: 2.0)
-					)
-				Text("The tertiary public key authorized to send admin messages to this node.")
-					.foregroundStyle(.secondary)
-					.font(idiom == .phone ? .caption : .callout)
-			}
+			directMessageKeySection
+			adminKeysSection
 			LockdownSection(lockdown: lockdown, showLockNowAlert: $showLockNowAlert)
-
-			Section(header: Text("Logs")) {
-				Toggle(isOn: $serialEnabled) {
-					Label("Serial Console", systemImage: "terminal")
-					Text("Serial Console over the Stream API.")
-				}
-				Toggle(isOn: $debugLogApiEnabled) {
-					Label("Debug Logs", systemImage: "ant.fill")
-					Text("Output live debug logging over serial, view and export position-redacted device logs over Bluetooth.")
-				}
-			}
-			Section(header: Text("Administration")) {
-				Toggle(isOn: $isManaged) {
-					Label("Managed Device", systemImage: "gearshape.arrow.triangle.2.circlepath")
-					Text("Device is managed by a mesh administrator, the user is unable to access any of the device settings.")
-				}
-				.disabled(adminKey.length == 0)
-				if adminKey.length == 0 {
-					Label("An admin key must be set before enabling managed mode.", systemImage: "exclamationmark.triangle.fill")
-						.font(.caption)
-						.foregroundStyle(.orange)
-				}
-			}
+			logsSection
+			administrationSection
 		}
 		.disabled(!accessoryManager.isConnected || node?.securityConfig == nil)
 		.safeAreaInset(edge: .bottom, alignment: .center) {
@@ -389,6 +206,208 @@ struct SecurityConfig: View {
 				configIsNil: { $0.securityConfig == nil },
 				request: accessoryManager.requestSecurityConfig
 			)
+		}
+	}
+
+	/// Extracted from `body`: the inlined Form expression blew Swift's type-check budget on the CI runners (build-snapshots: "unable to type-check this expression in reasonable time").
+	private var directMessageKeySection: some View {
+		Section(header: Text("Direct Message Key")) {
+			VStack(alignment: .leading) {
+				HStack(alignment: .firstTextBaseline) {
+					Label("Public Key", systemImage: "key")
+					Spacer()
+					// Explicit copy action. On Mac Catalyst `.textSelection(.enabled)` on a
+					// Text inside a Form does not reliably offer a right-click "Copy", so the
+					// selection-only approach left macOS users unable to copy their key (#1943).
+					Button {
+						UIPasteboard.general.string = publicKey
+					} label: {
+						Image(systemName: "doc.on.doc")
+						Text("Copy")
+					}
+					.buttonStyle(.bordered)
+					.buttonBorderShape(.capsule)
+					.controlSize(.small)
+					.disabled(publicKey.isEmpty)
+				}
+				Text(publicKey)
+					.font(idiom == .phone ? .caption : .callout)
+					.allowsTightening(true)
+					.monospaced()
+					.keyboardType(.alphabet)
+					.foregroundStyle(.tertiary)
+					.disableAutocorrection(true)
+					// Retained as the iOS copy path (long-press to select); the Copy button
+					// above is the reliable path on Mac Catalyst, where this doesn't offer
+					// a right-click "Copy" inside a Form (#1943).
+					.textSelection(.enabled)
+					.background(
+						RoundedRectangle(cornerRadius: 10.0)
+							.stroke(isValidKeyPair ? Color.clear : Color.red, lineWidth: 2.0)
+					)
+				Text("Your public key is generated from your private key and sent to other nodes on the mesh so they can compute a shared secret key with you.")
+					.foregroundStyle(.secondary)
+					.font(idiom == .phone ? .caption : .callout)
+				Divider()
+				Label("Private Key", systemImage: "key.fill")
+				SecureInput("Private Key", text: $privateKey, isValid: $hasValidPrivateKey, isSecure: $privateKeyIsSecure)
+					.background(
+						RoundedRectangle(cornerRadius: 10.0)
+							.stroke(hasValidPrivateKey ? Color.clear : Color.red, lineWidth: 2.0)
+					)
+				Text("Used to create a shared key with a remote device.")
+					.foregroundStyle(.secondary)
+					.font(idiom == .phone ? .caption : .callout)
+				if let currentNode = node {
+					Divider()
+					Label("Key Backup", systemImage: "icloud")
+					HStack(alignment: .firstTextBaseline) {
+						let keychainKey = "PrivateKeyNode\(currentNode.num)"
+						Button {
+							let status = KeychainHelper.standard.save(key: keychainKey, value: privateKey)
+							if status == errSecSuccess {
+								backupStatus = KeyBackupStatus.saved
+							} else {
+								backupStatus = KeyBackupStatus.saveFailed
+								backupStatusError = status
+							}
+						}
+						label: {
+							Image(systemName: "icloud.and.arrow.up")
+							Text("Backup")
+						}
+						.buttonStyle(.bordered)
+						.buttonBorderShape(.capsule)
+						.controlSize(.small)
+						Spacer()
+						Button {
+							if let value = KeychainHelper.standard.read(key: keychainKey) {
+								self.privateKey = value
+								self.privateKeyIsSecure = false
+								backupStatus = KeyBackupStatus.restored
+							} else {
+								backupStatus = KeyBackupStatus.restoreFailed
+							}
+						}
+						label: {
+							Image(systemName: "key.icloud")
+							Text("Restore")
+						}
+						.buttonStyle(.bordered)
+						.buttonBorderShape(.capsule)
+						.controlSize(.small)
+						Spacer()
+						Button {
+							let status = KeychainHelper.standard.delete(key: keychainKey)
+							if status == errSecSuccess {
+								backupStatus = KeyBackupStatus.deleted
+							} else {
+								backupStatus = KeyBackupStatus.deleteFailed
+							}
+						}
+						label: {
+							Image(systemName: "trash")
+						}
+						.buttonStyle(.bordered)
+						.buttonBorderShape(.capsule)
+						.controlSize(.small)
+						.accessibilityLabel(String(localized: "Delete key backup", comment: "VoiceOver label for the delete key backup button"))
+					}
+					if let status = backupStatus {
+						let state = status.success
+						Text("\(status.description)")
+							.font(.caption)
+							.foregroundColor(state ? .green : .red)
+					}
+					Text("Backup your private key to your iCloud keychain.")
+						.foregroundStyle(.secondary)
+						.font(idiom == .phone ? .caption : .callout)
+				}
+				Divider()
+				HStack(alignment: .firstTextBaseline) {
+					Label("Regenerate Private Key", systemImage: "arrow.clockwise.circle")
+					Spacer()
+					Button {
+						if let keyBytes = generatePrivateKey(count: 32) {
+							privateKey = keyBytes.base64EncodedString()
+							self.privateKeyIsSecure = false
+						}
+					} label: {
+						Image(systemName: "lock.rotation")
+							.font(.title)
+					}
+					.buttonStyle(.bordered)
+					.buttonBorderShape(.capsule)
+					.controlSize(.small)
+					.accessibilityLabel(String(localized: "Regenerate private key", comment: "VoiceOver label for the regenerate private key button"))
+				}
+				Text("Generate a new private key to replace the one currently in use. The public key will automatically be regenerated from your private key.")
+					.foregroundStyle(.secondary)
+					.font(idiom == .phone ? .caption : .callout)
+			}
+		}
+	}
+
+	/// See `directMessageKeySection` — split out of `body` for type-check time.
+	private var adminKeysSection: some View {
+		Section(header: Text("Admin Keys")) {
+			Label("Primary Admin Key", systemImage: "key.viewfinder")
+			SecureInput("Primary Admin Key", text: $adminKey, isValid: $hasValidAdminKey)
+				.background(
+					RoundedRectangle(cornerRadius: 10.0)
+						.stroke(hasValidAdminKey ? Color.clear : Color.red, lineWidth: 2.0)
+				)
+			Text("The primary public key authorized to send admin messages to this node.")
+				.foregroundStyle(.secondary)
+				.font(idiom == .phone ? .caption : .callout)
+			Label("Secondary Admin Key", systemImage: "key.viewfinder")
+			SecureInput("Secondary Admin Key", text: $adminKey2, isValid: $hasValidAdminKey2)
+				.background(
+					RoundedRectangle(cornerRadius: 10.0)
+						.stroke(hasValidAdminKey2 ? Color.clear : Color.red, lineWidth: 2.0)
+				)
+			Text("The secondary public key authorized to send admin messages to this node.")
+				.foregroundStyle(.secondary)
+				.font(idiom == .phone ? .caption : .callout)
+			Label("Tertiary Admin Key", systemImage: "key.viewfinder")
+			SecureInput("Tertiary Admin Key", text: $adminKey3, isValid: $hasValidAdminKey3)
+				.background(
+					RoundedRectangle(cornerRadius: 10.0)
+						.stroke(hasValidAdminKey3 ? Color.clear : Color.red, lineWidth: 2.0)
+				)
+			Text("The tertiary public key authorized to send admin messages to this node.")
+				.foregroundStyle(.secondary)
+				.font(idiom == .phone ? .caption : .callout)
+		}
+	}
+
+	/// See `directMessageKeySection` — split out of `body` for type-check time.
+	private var logsSection: some View {
+		Section(header: Text("Logs")) {
+			Toggle(isOn: $serialEnabled) {
+				Label("Serial Console", systemImage: "terminal")
+				Text("Serial Console over the Stream API.")
+			}
+			Toggle(isOn: $debugLogApiEnabled) {
+				Label("Debug Logs", systemImage: "ant.fill")
+				Text("Output live debug logging over serial, view and export position-redacted device logs over Bluetooth.")
+			}
+		}
+	}
+
+	/// See `directMessageKeySection` — split out of `body` for type-check time.
+	private var administrationSection: some View {
+		Section(header: Text("Administration")) {
+			Toggle(isOn: $isManaged) {
+				Label("Managed Device", systemImage: "gearshape.arrow.triangle.2.circlepath")
+				Text("Device is managed by a mesh administrator, the user is unable to access any of the device settings.")
+			}
+			.disabled(adminKey.length == 0)
+			if adminKey.length == 0 {
+				Label("An admin key must be set before enabling managed mode.", systemImage: "exclamationmark.triangle.fill")
+					.font(.caption)
+					.foregroundStyle(.orange)
+			}
 		}
 	}
 

--- a/project.yml
+++ b/project.yml
@@ -722,16 +722,21 @@ targets:
       # .xcassets inside a synced folder is compiled as a unit, and per-child
       # membership exceptions do not remove it from actool's inputs.
       - path: "Meshtastic TV/App"
+        group: "Shared TV Client"
         type: syncedFolder
         excludes:
           - "MeshtasticTVApp.swift"
       - path: "Meshtastic TV/Client"
+        group: "Shared TV Client"
         type: syncedFolder
       - path: "Meshtastic TV/Models"
+        group: "Shared TV Client"
         type: syncedFolder
       - path: "Meshtastic TV/Map"
+        group: "Shared TV Client"
         type: syncedFolder
       - path: "Meshtastic TV/Views"
+        group: "Shared TV Client"
         type: syncedFolder
       # Same portable primitives the TV target reuses (no UIKit/BLE/CoreLocation).
       - path: "Meshtastic/Accessory/Transports/TCP/TCPConnection.swift"


### PR DESCRIPTION
## Summary

Switching between nodes could crash the app (Datadog `324bff02`, since 2.7.13), and when the connect to the new node failed the app went back to the old one instead of retrying.

## What changed

The switch flow was tearing down and recreating the SwiftData container. SwiftUI keeps observers attached to the old container after that, and the next database save crashes — often without leaving a crash report. The container is now created once at launch and never replaced. A switch clears the data in place and imports the backup into the same container, behind a "Switching Radios" placeholder so no views are on screen while the data changes underneath them.

Other problems found and fixed along the way:

- Restores from a backup written by an older schema failed because migration can't run on a read-only file. Backups now open through a temp copy.
- Store files were being deleted while still open, which breaks the open SQLite connection. Old files are left in place and cleaned up at next launch.
- The preferred device only updated after a successful connect, so a failed switch fell back to the old node and dumped its data on top of the restored database. It now updates when you pick the device.
- Nodes still on event firmware after the event ends now get the event sheet with an Update Firmware button on connect (once per connection). The end-date check existed but nothing used it.

## Testing

32 automated switch cycles between two replay radios on the simulator using my real database and backups, no crashes (previously crashed within 1-2 cycles). The `-switch-stress N` debug harness is included for regression testing. Verified on my phone against real nodes.
