### PR TITLE
fix: split SecurityConfig type checking

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -54,20 +54,8 @@ jobs:
             -workspace Meshtastic.xcworkspace \
             -scheme Meshtastic \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
-            -resultBundlePath build-snapshots.xcresult \
             "${snapshot_tests[@]}" \
-            2>&1 | tee build-snapshots.log
-
-      - name: Upload failed build diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-snapshots-diagnostics
-          path: |
-            build-snapshots.log
-            build-snapshots.xcresult
-          if-no-files-found: warn
-          retention-days: 7
+            2>&1 | tail -20
 
       - name: Verify snapshot tests leave references unchanged
         run: |

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -54,8 +54,20 @@ jobs:
             -workspace Meshtastic.xcworkspace \
             -scheme Meshtastic \
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+            -resultBundlePath build-snapshots.xcresult \
             "${snapshot_tests[@]}" \
-            2>&1 | tail -20
+            2>&1 | tee build-snapshots.log
+
+      - name: Upload failed build diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-snapshots-diagnostics
+          path: |
+            build-snapshots.log
+            build-snapshots.xcresult
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Verify snapshot tests leave references unchanged
         run: |

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -51,7 +51,7 @@ struct SecurityConfig: View {
 		return calculatedPublicKey == decodedPublicKey
 	}
 
-	// Keep the Form behind an opaque type boundary so Xcode 26.3 can type-check this view.
+	// Keep large view pieces behind opaque type boundaries so Xcode 26.3 can type-check this screen.
 	private var securityForm: some View {
 		Form {
 			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues)
@@ -249,7 +249,7 @@ struct SecurityConfig: View {
 		}
 	}
 
-	var body: some View {
+	private var formWithSaveControls: some View {
 		securityForm
 		.disabled(!accessoryManager.isConnected || node?.securityConfig == nil)
 		.safeAreaInset(edge: .bottom, alignment: .center) {
@@ -320,6 +320,10 @@ struct SecurityConfig: View {
 				}
 			}
 		}
+	}
+
+	var body: some View {
+		formWithSaveControls
 		.scrollDismissesKeyboard(.immediately)
 		.navigationTitle("Security Config")
 		.toolbar {
@@ -396,7 +400,9 @@ struct SecurityConfig: View {
 			)
 		}
 	}
+}
 
+extension SecurityConfig {
 	func setSecurityValues() {
 		self.publicKey = node?.securityConfig?.publicKey?.base64EncodedString() ?? ""
 		self.privateKey = node?.securityConfig?.privateKey?.base64EncodedString() ?? ""

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -322,7 +322,7 @@ struct SecurityConfig: View {
 		}
 	}
 
-	var body: some View {
+	private var formWithNavigation: some View {
 		formWithSaveControls
 		.scrollDismissesKeyboard(.immediately)
 		.navigationTitle("Security Config")
@@ -331,78 +331,96 @@ struct SecurityConfig: View {
 		ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
 	}
 }
-		.onChange(of: node) { _, _ in
-			setSecurityValues()
-		}
-		.onChange(of: isManaged) { _, newIsManaged in
-			if newIsManaged != node?.securityConfig?.isManaged { hasChanges = true }
-		}
-		.onChange(of: serialEnabled) { _, newSerialEnabled in
-			if newSerialEnabled != node?.securityConfig?.serialEnabled { hasChanges = true }
-		}
-		.onChange(of: debugLogApiEnabled) { _, newDebugLogApiEnabled in
-			if newDebugLogApiEnabled != node?.securityConfig?.debugLogApiEnabled { hasChanges = true }
-		}
+	}
+
+	var body: some View {
+		formWithNavigation
+		.onChange(of: node) { _, _ in setSecurityValues() }
+		.onChange(of: isManaged) { _, value in isManagedDidChange(to: value) }
+		.onChange(of: serialEnabled) { _, value in serialEnabledDidChange(to: value) }
+		.onChange(of: debugLogApiEnabled) { _, value in debugLogApiEnabledDidChange(to: value) }
 		.onChange(of: packetAuthenticitySelection.selected) { _, policy in packetAuthenticityDidChange(to: policy) }
-		.onChange(of: privateKey) { _, key in
-			let tempKey = Data(base64Encoded: privateKey) ?? Data()
-			if tempKey.count == 32 {
-				hasValidPrivateKey = true
-				if let privateKeyBytes = Data(base64Encoded: privateKey), privateKeyBytes.count == 32 {
-					// Valid private key -- generate the public key
-					publicKey = generatePublicKeyDisplay(from: privateKeyBytes)?.base64EncodedString() ?? ""
-				}
-			} else {
-				hasValidPrivateKey = false
-			}
-			if key != node?.securityConfig?.privateKey?.base64EncodedString() ?? "" && hasValidPrivateKey { hasChanges = true }
-		}
-		.onChange(of: adminKey) { _, key in
-			let tempKey = Data(base64Encoded: key) ?? Data()
-			if key.isEmpty {
-				hasValidAdminKey = true
-			} else if tempKey.count == 32 {
-				hasValidAdminKey = true
-			} else {
-				hasValidAdminKey = false
-			}
-			if key != node?.securityConfig?.adminKey?.base64EncodedString() ?? "" && hasValidAdminKey { hasChanges = true }
-		}
-		.onChange(of: adminKey2) { _, key in
-			let tempKey = Data(base64Encoded: key) ?? Data()
-			if key.isEmpty {
-				hasValidAdminKey2 = true
-			} else if tempKey.count == 32 {
-				hasValidAdminKey2 = true
-			} else {
-				hasValidAdminKey2 = false
-			}
-			if key != node?.securityConfig?.adminKey2?.base64EncodedString() ?? "" && hasValidAdminKey2 { hasChanges = true }
-		}
-		.onChange(of: adminKey3) { _, key in
-			let tempKey = Data(base64Encoded: key) ?? Data()
-			if key.isEmpty {
-				hasValidAdminKey3 = true
-			} else if tempKey.count == 32 {
-				hasValidAdminKey3 = true
-			} else {
-				hasValidAdminKey3 = false
-			}
-			if key != node?.securityConfig?.adminKey3?.base64EncodedString() ?? "" && hasValidAdminKey3 { hasChanges = true }
-		}
-		.onFirstAppear {
-			requestRemoteConfig(
-				node: node,
-				context: context,
-				accessoryManager: accessoryManager,
-				configIsNil: { $0.securityConfig == nil },
-				request: accessoryManager.requestSecurityConfig
-			)
-		}
+		.onChange(of: privateKey) { _, key in privateKeyDidChange(to: key) }
+		.onChange(of: adminKey) { _, key in adminKeyDidChange(to: key) }
+		.onChange(of: adminKey2) { _, key in adminKey2DidChange(to: key) }
+		.onChange(of: adminKey3) { _, key in adminKey3DidChange(to: key) }
+		.onFirstAppear { requestSecurityConfigOnFirstAppear() }
 	}
 }
 
 extension SecurityConfig {
+	private func isManagedDidChange(to value: Bool) {
+		if value != node?.securityConfig?.isManaged { hasChanges = true }
+	}
+
+	private func serialEnabledDidChange(to value: Bool) {
+		if value != node?.securityConfig?.serialEnabled { hasChanges = true }
+	}
+
+	private func debugLogApiEnabledDidChange(to value: Bool) {
+		if value != node?.securityConfig?.debugLogApiEnabled { hasChanges = true }
+	}
+
+	private func privateKeyDidChange(to key: String) {
+		let tempKey = Data(base64Encoded: privateKey) ?? Data()
+		if tempKey.count == 32 {
+			hasValidPrivateKey = true
+			if let privateKeyBytes = Data(base64Encoded: privateKey), privateKeyBytes.count == 32 {
+				// Valid private key -- generate the public key
+				publicKey = generatePublicKeyDisplay(from: privateKeyBytes)?.base64EncodedString() ?? ""
+			}
+		} else {
+			hasValidPrivateKey = false
+		}
+		if key != node?.securityConfig?.privateKey?.base64EncodedString() ?? "" && hasValidPrivateKey { hasChanges = true }
+	}
+
+	private func adminKeyDidChange(to key: String) {
+		let tempKey = Data(base64Encoded: key) ?? Data()
+		if key.isEmpty {
+			hasValidAdminKey = true
+		} else if tempKey.count == 32 {
+			hasValidAdminKey = true
+		} else {
+			hasValidAdminKey = false
+		}
+		if key != node?.securityConfig?.adminKey?.base64EncodedString() ?? "" && hasValidAdminKey { hasChanges = true }
+	}
+
+	private func adminKey2DidChange(to key: String) {
+		let tempKey = Data(base64Encoded: key) ?? Data()
+		if key.isEmpty {
+			hasValidAdminKey2 = true
+		} else if tempKey.count == 32 {
+			hasValidAdminKey2 = true
+		} else {
+			hasValidAdminKey2 = false
+		}
+		if key != node?.securityConfig?.adminKey2?.base64EncodedString() ?? "" && hasValidAdminKey2 { hasChanges = true }
+	}
+
+	private func adminKey3DidChange(to key: String) {
+		let tempKey = Data(base64Encoded: key) ?? Data()
+		if key.isEmpty {
+			hasValidAdminKey3 = true
+		} else if tempKey.count == 32 {
+			hasValidAdminKey3 = true
+		} else {
+			hasValidAdminKey3 = false
+		}
+		if key != node?.securityConfig?.adminKey3?.base64EncodedString() ?? "" && hasValidAdminKey3 { hasChanges = true }
+	}
+
+	private func requestSecurityConfigOnFirstAppear() {
+		requestRemoteConfig(
+			node: node,
+			context: context,
+			accessoryManager: accessoryManager,
+			configIsNil: { $0.securityConfig == nil },
+			request: accessoryManager.requestSecurityConfig
+		)
+	}
+
 	func setSecurityValues() {
 		self.publicKey = node?.securityConfig?.publicKey?.base64EncodedString() ?? ""
 		self.privateKey = node?.securityConfig?.privateKey?.base64EncodedString() ?? ""

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -51,7 +51,8 @@ struct SecurityConfig: View {
 		return calculatedPublicKey == decodedPublicKey
 	}
 
-	var body: some View {
+	// Keep the Form behind an opaque type boundary so Xcode 26.3 can type-check this view.
+	private var securityForm: some View {
 		Form {
 			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues)
 			Text("Security Config Settings require a firmware version 2.5+")
@@ -246,6 +247,10 @@ struct SecurityConfig: View {
 				}
 			}
 		}
+	}
+
+	var body: some View {
+		securityForm
 		.disabled(!accessoryManager.isConnected || node?.securityConfig == nil)
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {


### PR DESCRIPTION
## What changed?

Split `SecurityConfig` into smaller private `some View` properties and moved the inline change-handler bodies into private methods. The existing modifier order, state, bindings, save behavior, and view hierarchy are unchanged.

The existing helper methods now live in a same-file extension so the primary view stays below the SwiftLint `type_body_length` limit.

## Why did it change?

Xcode 26.3 could not type-check the original `SecurityConfig.body` expression within its time limit. The diagnostic run in #2263 identified the whole body at `SecurityConfig.swift:54:22`.

Each private view property gives the compiler an opaque boundary. The named change handlers also keep closure inference out of the SwiftUI modifier expression.

## How is this tested?

- `Deploy Docs / build-snapshots` passed under Xcode 26.3: [run 31766703893](https://github.com/meshtastic/Meshtastic-Apple/actions/runs/31766703893/job/94663996549).
- Xcode 27 simulator build passed with `-warn-long-expression-type-checking=50`; `SecurityConfig.swift` produced no expression timing warning above 50 ms.
- SwiftLint passed with zero violations.
- SourceKit reports no diagnostics in the changed file.
- A fresh review compared every moved handler and modifier against `main`; no behavioral differences were found.

## Screenshots/Videos (when applicable)

Not applicable. The rendered view is unchanged.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation changes are needed; the `skip-docs-check` label is applied.
- [x] I have tested the change to ensure that it works as intended.
