### PR TITLE
fix(onboarding): skip Siri permission request on simulator

### DIFF
--- a/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
+++ b/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
@@ -590,7 +590,10 @@ struct DeviceOnboarding: View {
 			return
 		}
 
-		#if targetEnvironment(macCatalyst)
+		#if targetEnvironment(simulator)
+		// Siri authorization prompt is not available in the simulator
+		Logger.services.info("Skipping Siri permission request in simulator")
+		#elseif targetEnvironment(macCatalyst)
 		// Siri authorization prompt is not available on Mac Catalyst
 		Logger.services.info("Siri permissions not available on Mac Catalyst")
 		#else


### PR DESCRIPTION
## What changed?

Added a `targetEnvironment(simulator)` guard to `DeviceOnboarding.requestSiriPermissions()` so it skips `INPreferences.requestSiriAuthorization()` on the iOS simulator.

## Why did it change?

Unsigned simulator builds do not include the `com.apple.developer.siri` entitlement, so calling `INPreferences.requestSiriAuthorization()` throws an exception and aborts the app during the Siri onboarding screen. `MeshtasticAppDelegate` already skips Siri authorization on the simulator; `DeviceOnboarding` did the same for Mac Catalyst but not for the simulator.

## How is this tested?

- Built and ran the `Meshtastic` target on an iPhone 17 Pro iOS 26.2 simulator — onboarding now proceeds past the Siri screen.
- Ran `MeshtasticTests/DeviceOnboardingTests` suites; all 15 tests passed.

## Screenshots/Videos (when applicable)

N/A — crash fix.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas.
- [ ] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding behavior in simulator environments by skipping unavailable Siri permission prompts.
  * Preserved the existing Siri authorization flow on supported devices and Mac Catalyst.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->