### PR TITLE
fix(widget): respect custom Number Format in Live Activity

### DIFF
--- a/MeshtasticTests/FixedFractionNumberFormatterTests.swift
+++ b/MeshtasticTests/FixedFractionNumberFormatterTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import Meshtastic
+
+@Suite("FixedFractionNumberFormatter")
+struct FixedFractionNumberFormatterTests {
+	// Synthetic Locale identifiers cannot represent the independent iOS Number Format override, which remains simulator-validated.
+	@Test func formatsFloatWithEnglishSeparatorsAndExactFractionDigits() {
+		let result = FixedFractionNumberFormatter.format(
+			Float(1_234.5),
+			fractionDigits: 2,
+			locale: Locale(identifier: "en_US")
+		)
+
+		#expect(result == "1,234.50")
+	}
+
+	@Test func formatsDoubleWithGermanSeparatorsAndExactFractionDigits() {
+		let result = FixedFractionNumberFormatter.format(
+			1_234.5,
+			fractionDigits: 1,
+			locale: Locale(identifier: "de_DE")
+		)
+
+		#expect(result == "1.234,5")
+	}
+
+	@Test func roundsHalfToEven() {
+		let locale = Locale(identifier: "en_US")
+
+		#expect(FixedFractionNumberFormatter.format(0.125, fractionDigits: 2, locale: locale) == "0.12")
+		#expect(FixedFractionNumberFormatter.format(0.375, fractionDigits: 2, locale: locale) == "0.38")
+	}
+}

--- a/Shared/FixedFractionNumberFormatter.swift
+++ b/Shared/FixedFractionNumberFormatter.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum FixedFractionNumberFormatter {
+	static func format<Value: BinaryFloatingPoint>(
+		_ value: Value,
+		fractionDigits: Int,
+		locale: Locale = .autoupdatingCurrent
+	) -> String {
+		let formatter = NumberFormatter()
+		formatter.locale = locale
+		formatter.numberStyle = .decimal
+		formatter.minimumFractionDigits = fractionDigits
+		formatter.maximumFractionDigits = fractionDigits
+		formatter.roundingMode = .halfEven
+
+		return formatter.string(from: NSNumber(value: Double(value)))
+			?? String(format: "%.\(fractionDigits)f", locale: locale, Double(value))
+	}
+}

--- a/Widgets/WidgetsLiveActivity.swift
+++ b/Widgets/WidgetsLiveActivity.swift
@@ -42,11 +42,11 @@ struct WidgetsLiveActivity: Widget {
 						.font(.caption2)
 						.foregroundStyle(.secondary)
 						.fixedSize()
-					Text("ChUtil: \(context.state.channelUtilization?.formatted(.number.precision(.fractionLength(2))) ?? Constants.nilValueIndicator)%")
+					Text("ChUtil: \(context.state.channelUtilization.map { FixedFractionNumberFormatter.format($0, fractionDigits: 2) } ?? Constants.nilValueIndicator)%")
 						.font(.caption2)
 						.foregroundStyle(.secondary)
 						.fixedSize()
-					Text("Airtime: \(context.state.airtime?.formatted(.number.precision(.fractionLength(2))) ?? Constants.nilValueIndicator)%")
+					Text("Airtime: \(context.state.airtime.map { FixedFractionNumberFormatter.format($0, fractionDigits: 2) } ?? Constants.nilValueIndicator)%")
 						.font(.caption2)
 						.foregroundStyle(.secondary)
 						.fixedSize()
@@ -131,7 +131,7 @@ struct WidgetsLiveActivity: Widget {
 				.accessibilityElement(children: .ignore)
 				.accessibilityLabel(String(localized: "\(context.state.nodesOnline) nodes online", comment: "VoiceOver: online node count in the Dynamic Island compact-leading region"))
             } compactTrailing: {
-				Text("\(context.state.channelUtilization?.formatted(.number.precision(.fractionLength(1))) ?? "--")%")
+				Text("\(context.state.channelUtilization.map { FixedFractionNumberFormatter.format($0, fractionDigits: 1) } ?? "--")%")
 					.font(.caption2)
 					.fontWeight(.medium)
 					.foregroundStyle(.primary)
@@ -236,13 +236,13 @@ struct LiveActivityView: View {
 			// Stats grid — two columns
 			HStack(alignment: .top, spacing: 12) {
 				VStack(alignment: .leading, spacing: 2) {
-					StatRow(label: "Ch. Utilization", value: "\(channelUtilization?.formatted(.number.precision(.fractionLength(1))) ?? "--")%")
-					StatRow(label: "Airtime", value: "\(airtime?.formatted(.number.precision(.fractionLength(1))) ?? "--")%")
+					StatRow(label: "Ch. Utilization", value: "\(channelUtilization.map { FixedFractionNumberFormatter.format($0, fractionDigits: 1) } ?? "--")%")
+					StatRow(label: "Airtime", value: "\(airtime.map { FixedFractionNumberFormatter.format($0, fractionDigits: 1) } ?? "--")%")
 					StatRow(label: "Sent", value: "\(sentPackets)")
 					StatRow(label: "Received", value: "\(receivedPackets)")
 				}
 				VStack(alignment: .leading, spacing: 2) {
-					StatRow(label: "Error Rate", value: "\(errorRate.formatted(.number.precision(.fractionLength(1))))%")
+					StatRow(label: "Error Rate", value: "\(FixedFractionNumberFormatter.format(errorRate, fractionDigits: 1))%")
 					StatRow(label: "Relayed", value: "\(packetsSentRelay)")
 					StatRow(label: "Relay Canceled", value: "\(packetsCanceledRelay)")
 					StatRow(label: "Duplicate", value: "\(dupeReceivedPackets)")


### PR DESCRIPTION
## What changed?

- Replaced the six Live Activity number-formatting calls with a `NumberFormatter`-based helper.
- Preserved the existing precision, rounding, nil values, and percent scaling.
- Added tests for US and German separators, fixed fraction digits, and half-even rounding.

Closes #2260

## Why did it change?

`FloatingPointFormatStyle` ignores the independent iOS Number Format override even when `Locale.current` reports the selected decimal separator. `NumberFormatter` honors the override.

This Foundation bug is tracked in [swift-foundation #135](https://github.com/swiftlang/swift-foundation/issues/135). The helper is a local workaround until that behavior is fixed upstream.

## How is this tested?

- `FixedFractionNumberFormatterTests`: 3 tests passed.
- Full `Meshtastic` iOS Simulator build passed.
- On an iOS 27.0 Simulator using the German region with a period Number Format override, the widget process produced `0.06` through the new helper while `FloatingPointFormatStyle` still produced `0,06`.

## Screenshots/Videos (when applicable)

Not applicable.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent fixed-decimal formatting for floating-point values.
  * Formatting now respects the device’s locale-specific decimal separators.
  * Values use predictable half-even rounding.

* **Bug Fixes**
  * Improved numeric display consistency for channel utilization, airtime, and error rates in Live Activities and Dynamic Island views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->