### PR TITLE
Fix MQTT approximate location precision saving

### DIFF
--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -9,6 +9,27 @@ import MeshtasticProtobufs
 import OSLog
 import SwiftUI
 
+enum MQTTMapPositionPrecision {
+	// Firmware MQTT map reports accept 12...15 and otherwise use 14.
+	static let defaultValue = 14.0
+	static let validRange = 12.0...15.0
+
+	static func normalized(_ value: Double) -> Double {
+		validRange.contains(value) ? value : defaultValue
+	}
+
+	static func hasChanged(from oldValue: Double, to newValue: Double, storedValue: Double) -> Bool {
+		oldValue != newValue && normalized(newValue) != normalized(storedValue)
+	}
+
+	static func valueForSave(displayedValue: Double, storedValue: Int32?, wasEdited: Bool) -> UInt32 {
+		if !wasEdited, let storedValue {
+			return UInt32(truncatingIfNeeded: storedValue)
+		}
+		return UInt32(normalized(displayedValue))
+	}
+}
+
 struct MQTTConfig: View {
 	
 	@Environment(\.modelContext) private var context
@@ -35,6 +56,7 @@ struct MQTTConfig: View {
 	@AppStorage("mapReportingOptIn") private var mapReportingOptIn: Bool = false
 	@State private var mapPublishIntervalSecs: UpdateInterval = UpdateInterval(from: 3600)
 	@State var mapPositionPrecision: Double = 14.0
+	@State private var mapPositionPrecisionWasEdited = false
 	
 	let locale = Locale.current
 	
@@ -113,7 +135,7 @@ struct MQTTConfig: View {
 							Text("To comply with privacy laws like CCPA and GDPR, we avoid sharing exact location data. Instead, we use anonymized or approximate (imprecise) location information to protect your privacy.")
 								.foregroundColor(.gray)
 								.font(.callout)
-							Slider(value: $mapPositionPrecision, in: 12...15, step: 1) {
+							Slider(value: $mapPositionPrecision, in: MQTTMapPositionPrecision.validRange, step: 1) {
 							} minimumValueLabel: {
 								Image(systemName: "plus")
 									.accessibilityHidden(true)
@@ -273,7 +295,11 @@ struct MQTTConfig: View {
 						mqtt.tlsEnabled = self.tlsEnabled
 						mqtt.mapReportingEnabled = self.mapReportingEnabled
 						mqtt.mapReportSettings.shouldReportLocation = UserDefaults.mapReportingOptIn
-						mqtt.mapReportSettings.positionPrecision = UInt32(self.mapPositionPrecision)
+						mqtt.mapReportSettings.positionPrecision = MQTTMapPositionPrecision.valueForSave(
+							displayedValue: self.mapPositionPrecision,
+							storedValue: node?.mqttConfig?.mapPositionPrecision,
+							wasEdited: self.mapPositionPrecisionWasEdited
+						)
 						mqtt.mapReportSettings.publishIntervalSecs = UInt32(self.mapPublishIntervalSecs.intValue)
 						_ = try await accessoryManager.saveMQTTConfig(config: mqtt, fromUser: fromUser, toUser: toUser)
 					}
@@ -333,6 +359,16 @@ struct MQTTConfig: View {
 			}
 			.onChange(of: mapReportingEnabled) { oldMapReporting, newMapReportingEnabled in
 				if oldMapReporting != newMapReportingEnabled && newMapReportingEnabled != node?.mqttConfig?.mapReportingEnabled { hasChanges = true }
+			}
+			.onChange(of: mapPositionPrecision) { oldPrecision, newPrecision in
+				if MQTTMapPositionPrecision.hasChanged(
+					from: oldPrecision,
+					to: newPrecision,
+					storedValue: Double(node?.mqttConfig?.mapPositionPrecision ?? 14)
+				) {
+					hasChanges = true
+					mapPositionPrecisionWasEdited = true
+				}
 			}
 			.onChange(of: mapPublishIntervalSecs.intValue) { oldMapInterval, newMapPublishIntervalSecs in
 				if oldMapInterval != newMapPublishIntervalSecs && newMapPublishIntervalSecs != node?.mqttConfig?.mapPublishIntervalSecs ?? -1 { hasChanges = true }
@@ -407,9 +443,9 @@ private extension MQTTConfig {
 		self.mqttConnected = accessoryManager.mqttProxyConnected
 		self.mapReportingEnabled = node?.mqttConfig?.mapReportingEnabled ?? false
 		self.mapPublishIntervalSecs = UpdateInterval(from: max(3600, Int(node?.mqttConfig?.mapPublishIntervalSecs ?? 3600)))
-		self.mapPositionPrecision = Double(node?.mqttConfig?.mapPositionPrecision ?? 14)
+		self.mapPositionPrecision = MQTTMapPositionPrecision.normalized(Double(node?.mqttConfig?.mapPositionPrecision ?? 14))
+		self.mapPositionPrecisionWasEdited = false
 		self.mapReportingOptIn = UserDefaults.mapReportingOptIn
-		if mapPositionPrecision < 11 || mapPositionPrecision > 14 { self.mapPositionPrecision = 14 }
 		self.hasChanges = false
 	}
 }

--- a/MeshtasticTests/MQTTMapPositionPrecisionTests.swift
+++ b/MeshtasticTests/MQTTMapPositionPrecisionTests.swift
@@ -1,0 +1,86 @@
+// Issue #2259: MQTT map precision 15 (about 700 m) must be saveable and survive readback.
+// Firmware accepts values 12...15 and defaults unsupported values to 14.
+
+import Foundation
+import MeshtasticProtobufs
+import SwiftData
+import Testing
+
+@testable import Meshtastic
+
+@Suite("MQTT map position precision")
+struct MQTTMapPositionPrecisionTests {
+	@Test(arguments: [12.0, 13.0, 14.0, 15.0])
+	func acceptsFirmwareSupportedValues(_ value: Double) {
+		#expect(MQTTMapPositionPrecision.normalized(value) == value)
+	}
+
+	@Test(arguments: [0.0, 11.0, 16.0, 32.0])
+	func defaultsUnsupportedValues(_ value: Double) {
+		#expect(MQTTMapPositionPrecision.normalized(value) == MQTTMapPositionPrecision.defaultValue)
+	}
+
+	@Test func userChangesFromStoredValueMarkConfigDirty() {
+		#expect(MQTTMapPositionPrecision.hasChanged(from: 14, to: 15, storedValue: 14))
+		#expect(MQTTMapPositionPrecision.hasChanged(from: 15, to: 12, storedValue: 15))
+	}
+
+	@Test func loadingStoredValueDoesNotMarkConfigDirty() {
+		#expect(MQTTMapPositionPrecision.hasChanged(from: 14, to: 15, storedValue: 15) == false)
+	}
+
+	@Test func normalizingUnsupportedValueDoesNotMarkConfigDirty() {
+		#expect(MQTTMapPositionPrecision.hasChanged(from: 14, to: 14, storedValue: 11) == false)
+		#expect(MQTTMapPositionPrecision.hasChanged(from: 14, to: 14, storedValue: 32) == false)
+	}
+
+	@Test func editingUnsupportedStoredValueKeepsConfigDirtyAfterReturningToEffectiveDefault() {
+		var hasChanges = false
+		if MQTTMapPositionPrecision.hasChanged(from: 14, to: 15, storedValue: 0) {
+			hasChanges = true
+		}
+		if MQTTMapPositionPrecision.hasChanged(from: 15, to: 14, storedValue: 0) {
+			hasChanges = true
+		}
+
+		#expect(hasChanges)
+	}
+
+	@Test func savingUnrelatedChangePreservesStoredPrecisionUntilSliderIsEdited() {
+		#expect(MQTTMapPositionPrecision.valueForSave(displayedValue: 14, storedValue: 0, wasEdited: false) == 0)
+		#expect(MQTTMapPositionPrecision.valueForSave(displayedValue: 14, storedValue: 11, wasEdited: false) == 11)
+		#expect(MQTTMapPositionPrecision.valueForSave(displayedValue: 14, storedValue: 32, wasEdited: false) == 32)
+		#expect(MQTTMapPositionPrecision.valueForSave(displayedValue: 15, storedValue: 0, wasEdited: true) == 15)
+		#expect(MQTTMapPositionPrecision.valueForSave(displayedValue: 14, storedValue: 0, wasEdited: true) == 14)
+	}
+
+	@Test @MainActor func sevenHundredMeterPrecisionSurvivesProtoAndPersistenceRoundTrip() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let node = NodeInfoEntity()
+		node.num = 2_259
+		context.insert(node)
+		try context.save()
+
+		var config = ModuleConfig.MQTTConfig()
+		config.mapReportSettings.positionPrecision = 15
+		#expect(config.hasMapReportSettings)
+
+		let decoded = try ModuleConfig.MQTTConfig(serializedData: config.serializedData())
+		let mesh = MeshPackets(modelContainer: container)
+		await mesh.upsertMqttModuleConfigPacket(config: decoded, nodeNum: node.num)
+		await mesh.flushDebouncedSaves()
+
+		let nodeNum = node.num
+		var descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == nodeNum })
+		descriptor.fetchLimit = 1
+		let persistedNodes = try ModelContext(container).fetch(descriptor)
+		let persistedConfig = try #require(persistedNodes.first?.mqttConfig)
+
+		#expect(persistedConfig.mapPositionPrecision == 15)
+		#expect(MQTTMapPositionPrecision.normalized(Double(persistedConfig.mapPositionPrecision)) == 15)
+	}
+}


### PR DESCRIPTION
## What changed?

- Mark MQTT approximate-location precision edits as configuration changes so the Save button appears.
- Preserve firmware-supported precision `15` (about 700 m) when loading and saving map report settings.
- Render unsupported precision values using firmware fallback `14` while preserving the stored value until the slider is edited.
- Add regression coverage for dirty tracking, protobuf presence, value preservation, and the production SwiftData persistence path.

## Why did it change?

Changing only the Approximate Location slider did not prompt the user to save. If saving was forced through another setting, reopening MQTT configuration converted precision `15` back to `14`, so about 700 m displayed as about 1.5 km. Meshtastic firmware and Android both define the MQTT map-report range as `12...15`, with `14` as the display fallback for unsupported values.

Closes #2259

## How is this tested?

- `xcodebuild build -quiet -project Meshtastic.xcodeproj -scheme Meshtastic -destination id=D1D4B4CD-EC40-4A3B-9614-8A11B903E3E2`: passed.
- `xcodebuild test -quiet -project Meshtastic.xcodeproj -scheme Meshtastic -destination id=D1D4B4CD-EC40-4A3B-9614-8A11B903E3E2 -only-testing:MeshtasticTests/MQTTMapPositionPrecisionTests`: 8 passed, 0 failed.
- SwiftLint on both changed Swift files: 0 violations.
- Full `MeshtasticTests` on this branch: 2,827 passed and 4 failed. Clean `upstream/main` at `26584cd5` produced 2,819 passed and the same 4 failures, so this PR adds eight passing tests and no new failures:
  - `CoreDataMigrationServiceTests.testLegacyCoreDataModelIsInAppBundle`
  - `CoreDataMigrationServiceTests.testMigrationFillsGapsWithoutDuplicatingLiveData`
  - `IntervalConfigurationDetailedTests.allCases_count`
  - `PersistenceErrorTests.validNumCreatesUserWithDefaults`
- No physical-radio UI run was performed. The regression suite exercises the production SwiftData MQTT config ingestion path.

## Screenshots/Videos (when applicable)

Not applicable. No layout or string changes; behavior only.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.

No documentation page describes this control's save behavior, so no documentation content changed. The `skip-docs-check` label is applied.
