### PR TITLE
Offline Protomaps basemap on Apple TV

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -26,6 +26,10 @@ struct MapScreen: View {
 	/// The persisted node store — the map and list read from here, not the client.
 	@Query private var allNodes: [MeshNode]
 
+	/// Decoded offline basemap. Held here (not in MeshTVMapView) so the decode survives
+	/// the representable's updates; it publishes nothing until a region is downloaded.
+	@StateObject private var offlineVectors = OfflineVectorTileProvider()
+
 	/// All nodes for the side list: located first, then alphabetically.
 	private var sortedNodes: [MeshNode] {
 		allNodes.sorted {
@@ -49,7 +53,8 @@ struct MapScreen: View {
 				nodes: locatedNodes,
 				selectedNodeNum: $selectedNodeNum,
 				recenterToken: recenterToken,
-				onMenuExit: escapeMap
+				onMenuExit: escapeMap,
+				offlineVectors: offlineVectors
 			)
 			.ignoresSafeArea()
 		}

--- a/Meshtastic TV/App/SettingsView.swift
+++ b/Meshtastic TV/App/SettingsView.swift
@@ -22,6 +22,8 @@ struct SettingsView: View {
 	@FocusState private var clearFocused: Bool
 	/// MKMapType raw value, shared with MeshTVMapView via the same key.
 	@AppStorage("tv.mapType") private var mapTypeRaw: Int = Int(MKMapType.standard.rawValue)
+	@StateObject private var offlineBasemap = TVOfflineBasemap()
+	@State private var estimate: (tiles: Int, bytes: Int64)?
 
 	var body: some View {
 		List {
@@ -35,6 +37,8 @@ struct SettingsView: View {
 			} header: {
 				Text("Map")
 			}
+
+			offlineMapSection
 
 			Section {
 				Button(role: .destructive) {
@@ -57,6 +61,70 @@ struct SettingsView: View {
 		} message: {
 			Text("This permanently removes all \(nodes.count) saved nodes from this device.")
 		}
+	}
+
+	/// Offline basemap for use without internet. The region is derived from the mesh's own
+	/// node positions rather than a map selector — there is no sane way to drag a bounding
+	/// box with a Siri Remote. See TVOfflineBasemap.
+	@ViewBuilder
+	private var offlineMapSection: some View {
+		Section {
+			switch offlineBasemap.state {
+			case .preparing:
+				Label("Preparing…", systemImage: "clock")
+			case .downloading(let fraction):
+				VStack(alignment: .leading, spacing: 8) {
+					Label("Downloading map…", systemImage: "arrow.down.circle")
+					ProgressView(value: fraction)
+				}
+			default:
+				Button {
+					Task { await offlineBasemap.download(for: nodes) }
+				} label: {
+					Label(
+						offlineBasemap.needsDownload ? "Download Map for This Mesh" : "Update Downloaded Map",
+						systemImage: "map"
+					)
+				}
+				.disabled(locatedNodeCount == 0)
+
+				if !offlineBasemap.needsDownload {
+					Button(role: .destructive) {
+						offlineBasemap.removeDownloadedRegion()
+					} label: {
+						Label("Remove Downloaded Map", systemImage: "trash")
+					}
+				}
+			}
+		} header: {
+			Text("Offline Map")
+		} footer: {
+			offlineMapFooter
+		}
+		.task {
+			estimate = await offlineBasemap.estimate(for: nodes)
+		}
+	}
+
+	@ViewBuilder
+	private var offlineMapFooter: some View {
+		if case .failed(let message) = offlineBasemap.state {
+			Text(message)
+		} else if locatedNodeCount == 0 {
+			Text("No node has reported a position yet. Once one does, the map covering your mesh can be downloaded.")
+		} else if let region = offlineBasemap.region {
+			Text("Covering \(locatedNodeCount) located nodes, \(byteText(region.fileSize)) from the \(region.sourceBuild) map build. Drawn instead of Apple's map when the Map Type is Standard.")
+		} else if let estimate {
+			Text("Downloads roughly \(byteText(estimate.bytes)) covering the area around your \(locatedNodeCount) located nodes, so the map still draws without internet.")
+		} else {
+			Text("Downloads the map around your mesh so it still draws without internet.")
+		}
+	}
+
+	private var locatedNodeCount: Int { nodes.filter(\.hasLocation).count }
+
+	private func byteText(_ bytes: Int64) -> String {
+		ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
 	}
 
 	private func clearDatabase() {

--- a/Meshtastic TV/Map/MeshTVMapView.swift
+++ b/Meshtastic TV/Map/MeshTVMapView.swift
@@ -176,6 +176,13 @@ struct MeshTVMapView: UIViewRepresentable {
 	@AppStorage("tv.mapType") private var mapTypeRaw: Int = Int(MKMapType.standard.rawValue)
 	private var mkMapType: MKMapType { MKMapType(rawValue: UInt(mapTypeRaw)) ?? .standard }
 
+	/// Decoded offline basemap, or nil when no region has been downloaded. Owned by
+	/// MapScreen so the decode survives view updates.
+	var offlineVectors: OfflineVectorTileProvider?
+
+	/// Drawn only over Standard — Hybrid and Satellite are imagery the vector basemap would hide.
+	private var offlineBasemapVisible: Bool { mkMapType == .standard && offlineVectors != nil }
+
 	func makeCoordinator() -> Coordinator { Coordinator(self) }
 
 	func makeUIView(context: Context) -> MKMapView {
@@ -208,6 +215,13 @@ struct MeshTVMapView: UIViewRepresentable {
 		context.coordinator.applyInitialRegion(mapView, nodes: nodes)
 		context.coordinator.applyRecenter(mapView, token: recenterToken, nodes: nodes)
 		context.coordinator.applySelection(mapView, selectedNodeNum: selectedNodeNum)
+		if let offlineVectors, offlineBasemapVisible {
+			offlineVectors.updateIfNeeded()
+			// tvOS renders against a dark interface, matching the iOS map's dark palette.
+			context.coordinator.applyOfflineBasemap(mapView, provider: offlineVectors, dark: true)
+		} else {
+			context.coordinator.clearOfflineBasemap(mapView)
+		}
 	}
 
 	// MARK: - Coordinator
@@ -443,6 +457,131 @@ struct MeshTVMapView: UIViewRepresentable {
 			)
 			(view as? NodeCircleAnnotationView)?.updateContent()
 			return view
+		}
+
+		func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+			guard let style = offlineStyles[ObjectIdentifier(overlay)] else {
+				return MKOverlayRenderer(overlay: overlay)
+			}
+			switch overlay {
+			case let polygon as MKPolygon:
+				let renderer = MKPolygonRenderer(polygon: polygon)
+				renderer.fillColor = style.fill
+				renderer.lineWidth = 0
+				return renderer
+			case let multi as MKMultiPolygon:
+				let renderer = MKMultiPolygonRenderer(multiPolygon: multi)
+				renderer.fillColor = style.fill
+				renderer.lineWidth = 0
+				return renderer
+			case let multi as MKMultiPolyline:
+				let renderer = MKMultiPolylineRenderer(multiPolyline: multi)
+				renderer.strokeColor = style.stroke
+				renderer.lineWidth = style.lineWidth
+				renderer.lineCap = .round
+				renderer.lineJoin = .round
+				return renderer
+			default:
+				return MKOverlayRenderer(overlay: overlay)
+			}
+		}
+
+		// MARK: Offline basemap
+
+		/// Style for each offline overlay, keyed by object identity — MapKit hands the renderer
+		/// callback an overlay, not our model, so this is the lookup back to how it should draw.
+		struct OfflineOverlayStyle {
+			var fill: UIColor?
+			var stroke: UIColor?
+			var lineWidth: CGFloat
+		}
+
+		private var offlineStyles: [ObjectIdentifier: OfflineOverlayStyle] = [:]
+		private var offlineOverlays: [MKOverlay] = []
+		private var lastOfflineRevision = -1
+
+		/// Rebuilds the offline basemap overlays from the provider's latest decode. Mirrors the
+		/// iOS map's layering: an earth fill per coverage box, then parks/water, then roads drawn
+		/// casing-first so the centrelines read as outlined roads.
+		func applyOfflineBasemap(_ mapView: MKMapView, provider: OfflineVectorTileProvider, dark: Bool) {
+			guard provider.revision != lastOfflineRevision else { return }
+			lastOfflineRevision = provider.revision
+
+			if !offlineOverlays.isEmpty {
+				mapView.removeOverlays(offlineOverlays)
+				offlineOverlays = []
+				offlineStyles = [:]
+			}
+			guard provider.isAvailable, !provider.coverageAreas.isEmpty else { return }
+
+			var added: [MKOverlay] = []
+			func add(_ overlay: MKOverlay, _ style: OfflineOverlayStyle) {
+				offlineStyles[ObjectIdentifier(overlay)] = style
+				added.append(overlay)
+			}
+
+			// Earth fill per coverage box, so uncovered gaps read as land rather than Apple's basemap.
+			for bounds in provider.coverageAreas {
+				var corners = [
+					CLLocationCoordinate2D(latitude: bounds.minLat, longitude: bounds.minLon),
+					CLLocationCoordinate2D(latitude: bounds.minLat, longitude: bounds.maxLon),
+					CLLocationCoordinate2D(latitude: bounds.maxLat, longitude: bounds.maxLon),
+					CLLocationCoordinate2D(latitude: bounds.maxLat, longitude: bounds.minLon)
+				]
+				add(MKPolygon(coordinates: &corners, count: corners.count),
+					OfflineOverlayStyle(fill: OfflineMapPalette.earth(dark: dark), stroke: nil, lineWidth: 0))
+			}
+
+			// Fills, batched per role (parks under water).
+			let fillsByRole = Dictionary(grouping: provider.polygons, by: { $0.role })
+			for role in [OfflineFeatureRole.park, .green, .water] {
+				guard let polys = fillsByRole[role], let fill = OfflineMapPalette.fill(role, dark: dark) else { continue }
+				let shapes = polys.compactMap { poly -> MKPolygon? in
+					guard poly.coordinates.count >= 3 else { return nil }
+					var coords = poly.coordinates
+					return MKPolygon(coordinates: &coords, count: coords.count)
+				}
+				guard !shapes.isEmpty else { continue }
+				add(MKMultiPolygon(shapes), OfflineOverlayStyle(fill: fill, stroke: nil, lineWidth: 0))
+			}
+
+			// Roads, batched per role so the whole grid is a handful of overlays.
+			let roadsByRole = Dictionary(grouping: provider.roads, by: { $0.role })
+			func multiPolyline(_ role: OfflineFeatureRole) -> MKMultiPolyline? {
+				guard let lines = roadsByRole[role] else { return nil }
+				let shapes = lines.compactMap { line -> MKPolyline? in
+					guard line.coordinates.count >= 2 else { return nil }
+					var coords = line.coordinates
+					return MKPolyline(coordinates: &coords, count: coords.count)
+				}
+				return shapes.isEmpty ? nil : MKMultiPolyline(shapes)
+			}
+			let roadClasses: [OfflineFeatureRole] = [.minorRoad, .mediumRoad, .majorRoad]
+			for role in roadClasses {
+				guard let casing = OfflineMapPalette.roadCasing(role, dark: dark), let multi = multiPolyline(role) else { continue }
+				add(multi, OfflineOverlayStyle(fill: nil, stroke: casing, lineWidth: OfflineMapPalette.roadCasingWidth(role)))
+			}
+			for role in roadClasses {
+				guard let fill = OfflineMapPalette.roadFill(role, dark: dark), let multi = multiPolyline(role) else { continue }
+				add(multi, OfflineOverlayStyle(fill: nil, stroke: fill, lineWidth: OfflineMapPalette.roadWidth(role)))
+			}
+			for role in [OfflineFeatureRole.rail, .boundary] {
+				guard let color = OfflineMapPalette.line(role, dark: dark), let multi = multiPolyline(role) else { continue }
+				add(multi, OfflineOverlayStyle(fill: nil, stroke: color, lineWidth: 1))
+			}
+
+			guard !added.isEmpty else { return }
+			mapView.addOverlays(added, level: .aboveRoads)
+			offlineOverlays = added
+		}
+
+		/// Drops the offline overlays (region deleted, or the user switched to Hybrid/Satellite).
+		func clearOfflineBasemap(_ mapView: MKMapView) {
+			guard !offlineOverlays.isEmpty else { return }
+			mapView.removeOverlays(offlineOverlays)
+			offlineOverlays = []
+			offlineStyles = [:]
+			lastOfflineRevision = -1
 		}
 
 	}

--- a/Meshtastic TV/Map/TVOfflineBasemap.swift
+++ b/Meshtastic TV/Map/TVOfflineBasemap.swift
@@ -1,0 +1,191 @@
+//
+//  TVOfflineBasemap.swift
+//  Meshtastic TV
+//
+//  Copyright(c) Garth Vander Houwen 8/14/26.
+//
+//  Downloads an offline Protomaps basemap covering the mesh, using the same
+//  PMTilesExtractor and OfflineMapManager as iOS.
+//
+//  There is no file picker and no map-dragging region selector on tvOS, so the
+//  region is derived from the mesh itself: take the bounding box of every node
+//  that has reported a position, pad it, and extract that. One button, no
+//  panning with the remote.
+//
+//  The archive lives in Caches (see OfflineMapManager.directoryURL), which tvOS
+//  may purge — `needsDownload` goes back to true if that happens and the user
+//  can re-download.
+//
+
+import Foundation
+import MapKit
+import OSLog
+import SwiftUI
+
+@MainActor
+final class TVOfflineBasemap: ObservableObject {
+
+	enum State: Equatable {
+		case idle
+		case preparing
+		case downloading(fraction: Double)
+		case ready
+		case failed(String)
+	}
+
+	@Published private(set) var state: State = .idle
+
+	/// Region the app downloaded for this mesh, if it is still on disk.
+	@Published private(set) var region: OfflineMapRegion?
+
+	/// Padding applied to the mesh bounding box so the map has context around the
+	/// outermost nodes rather than clipping at them.
+	private let paddingDegrees = 0.15
+
+	/// The smallest box worth extracting. A mesh whose nodes all sit on one spot
+	/// would otherwise produce a box of nearly zero area.
+	private let minimumSpanDegrees = 0.25
+
+	/// z0-z13 is the standard detail level: full road network without the z14/z15
+	/// building footprints, which multiply the download size for little value at
+	/// the viewing distance of a television.
+	private let detail = OfflineMapDetailLevel.standard
+
+	private let extractor = PMTilesExtractor()
+
+	init() {
+		refresh()
+	}
+
+	/// Adopts whatever the manager already has on disk. Called at launch and after
+	/// a download so the map picks the archive up without restarting the app.
+	func refresh() {
+		region = OfflineMapManager.shared.regions.first
+		if region != nil, case .idle = state {
+			state = .ready
+		}
+	}
+
+	var needsDownload: Bool { region == nil }
+
+	/// Bounding box covering every located node, padded, or nil when no node has a position yet.
+	static func bounds(for nodes: [MeshNode], padding: Double, minimumSpan: Double) -> GeoBounds? {
+		let coordinates = nodes.compactMap(\.coordinate)
+		guard !coordinates.isEmpty else { return nil }
+
+		var minLat = Double.greatestFiniteMagnitude
+		var maxLat = -Double.greatestFiniteMagnitude
+		var minLon = Double.greatestFiniteMagnitude
+		var maxLon = -Double.greatestFiniteMagnitude
+		for coordinate in coordinates {
+			minLat = min(minLat, coordinate.latitude)
+			maxLat = max(maxLat, coordinate.latitude)
+			minLon = min(minLon, coordinate.longitude)
+			maxLon = max(maxLon, coordinate.longitude)
+		}
+
+		// Pad, then widen to the minimum span around the centre if the mesh is tightly clustered.
+		minLat -= padding; maxLat += padding
+		minLon -= padding; maxLon += padding
+		if maxLat - minLat < minimumSpan {
+			let centre = (maxLat + minLat) / 2
+			minLat = centre - minimumSpan / 2
+			maxLat = centre + minimumSpan / 2
+		}
+		if maxLon - minLon < minimumSpan {
+			let centre = (maxLon + minLon) / 2
+			minLon = centre - minimumSpan / 2
+			maxLon = centre + minimumSpan / 2
+		}
+
+		return GeoBounds(
+			minLon: max(minLon, -180),
+			minLat: max(minLat, -85),
+			maxLon: min(maxLon, 180),
+			maxLat: min(maxLat, 85)
+		)
+	}
+
+	/// Size the download would be, for the confirmation prompt.
+	func estimate(for nodes: [MeshNode]) async -> (tiles: Int, bytes: Int64)? {
+		guard let bounds = Self.bounds(for: nodes, padding: paddingDegrees, minimumSpan: minimumSpanDegrees) else {
+			return nil
+		}
+		guard let result = try? await extractor.estimate(
+			bounds: bounds,
+			minZoom: detail.minZoom,
+			maxZoom: detail.maxZoom
+		) else { return nil }
+		return (result.tileCount, result.bytes)
+	}
+
+	/// Extracts the area around the mesh from the current Protomaps daily build.
+	func download(for nodes: [MeshNode]) async {
+		guard let bounds = Self.bounds(for: nodes, padding: paddingDegrees, minimumSpan: minimumSpanDegrees) else {
+			state = .failed(String(localized: "No node has reported a position yet."))
+			return
+		}
+		guard let directory = OfflineMapManager.shared.directoryURL() else {
+			state = .failed(String(localized: "Storage is unavailable."))
+			return
+		}
+
+		state = .preparing
+		do {
+			guard let build = await extractor.latestBuild() else {
+				state = .failed(String(localized: "Could not reach the map server."))
+				return
+			}
+			let plan = try await extractor.makePlan(
+				sourceURL: build.url,
+				sourceBuild: build.build,
+				bounds: bounds,
+				minZoom: detail.minZoom,
+				maxZoom: detail.maxZoom
+			)
+
+			let id = UUID()
+			let fileName = "\(id.uuidString).pmtiles"
+			let destination = directory.appendingPathComponent(fileName)
+
+			state = .downloading(fraction: 0)
+			try await extractor.extract(plan: plan, to: destination) { done, total in
+				guard total > 0 else { return }
+				let fraction = Double(done) / Double(total)
+				Task { @MainActor [weak self] in
+					self?.state = .downloading(fraction: fraction)
+				}
+			}
+
+			let newRegion = OfflineMapRegion(
+				id: id,
+				name: String(localized: "Mesh Area"),
+				fileName: fileName,
+				bounds: bounds,
+				minZoom: detail.minZoom,
+				maxZoom: detail.maxZoom,
+				fileSize: 0,
+				sourceBuild: build.build
+			)
+			// Only one region on tvOS — replace whatever was there.
+			for existing in OfflineMapManager.shared.regions {
+				OfflineMapManager.shared.remove(existing)
+			}
+			OfflineMapManager.shared.add(newRegion)
+			region = OfflineMapManager.shared.regions.first
+			state = .ready
+			Logger.services.info("🗺️ [Offline] tvOS region extracted from build \(build.build, privacy: .public)")
+		} catch {
+			Logger.services.error("🗺️ [Offline] tvOS extraction failed: \(error.localizedDescription, privacy: .public)")
+			state = .failed(error.localizedDescription)
+		}
+	}
+
+	func removeDownloadedRegion() {
+		for existing in OfflineMapManager.shared.regions {
+			OfflineMapManager.shared.remove(existing)
+		}
+		region = nil
+		state = .idle
+	}
+}

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -8,8 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		00C009E3665BFC69C7101C09 /* event_firmware.json in Resources */ = {isa = PBXBuildFile; fileRef = C0810161F73BC57A90E60D0C /* event_firmware.json */; };
+		066F0545C2EDA31CC6E95E4E /* PMTilesArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C4205D1043768766C64E87 /* PMTilesArchive.swift */; };
 		073B94B7F2F232C198151489 /* alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = E8849D542B45F20F349E004D /* alpha.png */; };
 		073D5EF20134D41DF2AC5993 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C15787882CA30C9787154D /* Logger.swift */; };
+		0D14B1F2EE824455A78690F8 /* MVTTools in Frameworks */ = {isa = PBXBuildFile; productRef = 99BACD26F50E4FBA1E2FC365 /* MVTTools */; };
+		13FAC446423FF3C9AC737EA0 /* PMTilesMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB006125B378C5233BD0B731 /* PMTilesMapView.swift */; };
 		1A042BDE2702C7388CE867EF /* NordicDFU in Frameworks */ = {isa = PBXBuildFile; productRef = D83D0451F77A9D92FFC852CA /* NordicDFU */; };
 		1F6C54C9333DB13E75830B91 /* CocoaMQTT in Frameworks */ = {isa = PBXBuildFile; productRef = 5F878D11CC8A8E494A4A51B5 /* CocoaMQTT */; };
 		252DC3E6757A4880B3F749E5 /* MeshtasticApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736C4EF819FC0D5D1A41F29F /* MeshtasticApp.swift */; };
@@ -19,8 +22,11 @@
 		3233E2EC4CCC91360E23F283 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17AFA19C2AAB3C3ADFB1E33 /* AppState.swift */; };
 		3F091ECD7900D90169754B93 /* DatadogTrace in Frameworks */ = {isa = PBXBuildFile; productRef = 3E5E35695D4334FDDA3BE8F2 /* DatadogTrace */; };
 		40510578B699E4E44B9F1A70 /* WidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E4053FDE501FD7E0A02CEA8D /* WidgetsExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4584CB8BEA4226A1154EB385 /* OfflineMapManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E531C14ABE7F1491959BBE3 /* OfflineMapManager.swift */; };
 		4701C2F3A8A60ADE516D7FA0 /* MeshtasticTAK in Frameworks */ = {isa = PBXBuildFile; productRef = F98E8431879FC7025B658B08 /* MeshtasticTAK */; };
 		4748BFF7E7AEF9C8EDA23D91 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = E2CAB95992E03077B24E30B5 /* AppIntentVocabulary.plist */; };
+		4B4240E283A5080CF7D246B1 /* OfflineMapRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D675F15EFB753FBC7DA78C1 /* OfflineMapRegion.swift */; };
+		4E0EA928F0EBE41EDA6FC93B /* OfflineMapImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7307ED073D77037E45EE89 /* OfflineMapImport.swift */; };
 		507A9C886BD3A8F135F15762 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A80E1960A69051EE698AAE97 /* Preview Assets.xcassets */; };
 		54D8BBD62304C5917AEE0C2B /* DatadogRUM in Frameworks */ = {isa = PBXBuildFile; productRef = E96998AD4B79F29AF1E2A6D2 /* DatadogRUM */; };
 		5631740093D563F017DA31D7 /* MeshtasticProtobufs in Frameworks */ = {isa = PBXBuildFile; productRef = 52CBDF2188BAF9E2FB8B10A1 /* MeshtasticProtobufs */; };
@@ -33,6 +39,7 @@
 		6CABB3DA5BDD75359320B657 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 985D21086E966D40C875F3CD /* InfoPlist.strings */; };
 		7443E9D2180568F2E62EDAB6 /* AppIcon_Ham.icon in Resources */ = {isa = PBXBuildFile; fileRef = DD9ED0AFED536B2EE5F32F23 /* AppIcon_Ham.icon */; };
 		78B74168A96E756F203F9D13 /* AppIcon_Chirpy.icon in Resources */ = {isa = PBXBuildFile; fileRef = DD8FE67D6F2C7F041F8E3C8C /* AppIcon_Chirpy.icon */; };
+		8DFCC830624F2D4607E87938 /* MBTilesArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82B439BEF9740A80E66097A /* MBTilesArchive.swift */; };
 		94F9F3199DB5429EBF21F9E9 /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0875C7B0694DBE671437CC1A /* Connection.swift */; };
 		977E69BC7382DA7EF386402F /* TCPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA5EE6E2E5628082C9CF53F /* TCPConnection.swift */; };
 		987BD8AFF176A9670F175E5C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 26351F51CD01C94D8D82486A /* Localizable.xcstrings */; };
@@ -44,6 +51,7 @@
 		BB73AFBEB76A7B00550C8F2F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A7443D3C9E82A023A4388EFC /* InfoPlist.strings */; };
 		C435B3FDDC80FBF45F9D6CDB /* Certificates in Resources */ = {isa = PBXBuildFile; fileRef = 25BA43A8304E6CC120811070 /* Certificates */; };
 		C5B1D5B4B38940E115D61856 /* DatadogCore in Frameworks */ = {isa = PBXBuildFile; productRef = 680CA066D5A5ECD529461B91 /* DatadogCore */; };
+		C6148418734B3ADB2741CB8E /* PMTilesExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9297A8F3E4AAC1F74C05844 /* PMTilesExtractor.swift */; };
 		E8FB4ED7F7A2130D43A6AD99 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C15787882CA30C9787154D /* Logger.swift */; };
 		ECF8A4938BAD87D6CD830F7A /* MeshtasticAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F2AD74F4ECBF91E5BE6275 /* MeshtasticAppDelegate.swift */; };
 		EDCFD0C1C551CC55DB34287B /* TCPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA5EE6E2E5628082C9CF53F /* TCPConnection.swift */; };
@@ -112,6 +120,7 @@
 		0AEAC3FF0190C3F8166D22E3 /* MeshtasticDataModelV 52.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 52.xcdatamodel"; sourceTree = "<group>"; };
 		0CC33262B2EA2E8463E8BE95 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0D3292ABF1A342707957A3F6 /* MeshtasticDataModelV4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV4.xcdatamodel; sourceTree = "<group>"; };
+		0E531C14ABE7F1491959BBE3 /* OfflineMapManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineMapManager.swift; sourceTree = "<group>"; };
 		1A740EACFF7FA4000F22EF4E /* Meshtastic.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Meshtastic.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		25A13454C9C85CEBBBC2DD1F /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = he; path = he.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		25BA43A8304E6CC120811070 /* Certificates */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Certificates; path = Meshtastic/Resources/Certificates; sourceTree = SOURCE_ROOT; };
@@ -121,6 +130,7 @@
 		2A155512081310861FE23F13 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = fr; path = fr.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		2AA9E468E8D0E86380F20A6A /* MeshtasticDataModelV 39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 39.xcdatamodel"; sourceTree = "<group>"; };
 		2C5E7F54370D8339E31FB9B2 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = ko; path = ko.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
+		2D675F15EFB753FBC7DA78C1 /* OfflineMapRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineMapRegion.swift; sourceTree = "<group>"; };
 		2DB746426A829F22BD20E07C /* MeshtasticDataModelV14.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV14.xcdatamodel; sourceTree = "<group>"; };
 		2FF177FE5C8FCBDA2FA8099C /* MeshtasticDataModelV33.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV33.xcdatamodel; sourceTree = "<group>"; };
 		2FFB527D0E181BCC550DB9CF /* MeshtasticDataModelV 27.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 27.xcdatamodel"; sourceTree = "<group>"; };
@@ -138,6 +148,7 @@
 		5927E5660D36A603597524F8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = "pt-BR"; path = "pt-BR.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
 		5BA3CC672324E58EF9DE407D /* MeshtasticDataModelV3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV3.xcdatamodel; sourceTree = "<group>"; };
 		5C2FBD422C4F7971B03CD973 /* MeshtasticDataModelV 35.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 35.xcdatamodel"; sourceTree = "<group>"; };
+		62C4205D1043768766C64E87 /* PMTilesArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PMTilesArchive.swift; sourceTree = "<group>"; };
 		6425CF180A063AAD20CB4FB2 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = it; path = it.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		649976FAB784BC6B013C0EEE /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = ja; path = ja.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		6776764BA24154B603C76018 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
@@ -161,6 +172,7 @@
 		86DF1A38BB3D864D1C8E2218 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = da; path = da.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		8A65FC7EC53BA21A8445C493 /* MeshtasticDataModelV20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV20.xcdatamodel; sourceTree = "<group>"; };
 		8C2B65919B1D40CF68FFA183 /* MeshtasticDataModelV21.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV21.xcdatamodel; sourceTree = "<group>"; };
+		8C7307ED073D77037E45EE89 /* OfflineMapImport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineMapImport.swift; sourceTree = "<group>"; };
 		8CECCEFF195A62DB523CAA7C /* MeshtasticDataModelV 49.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 49.xcdatamodel"; sourceTree = "<group>"; };
 		8D435BAD41909B80CB994A89 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
 		8FE3A1CD77F5784FDD51E1DE /* MeshtasticDataModelV 29.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 29.xcdatamodel"; sourceTree = "<group>"; };
@@ -176,6 +188,8 @@
 		A2B4D8B84124EC1D98F4065A /* se */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = se; path = se.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		A7443D3C9E82A023A4388EFC /* InfoPlist.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = uk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A80E1960A69051EE698AAE97 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		A82B439BEF9740A80E66097A /* MBTilesArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBTilesArchive.swift; sourceTree = "<group>"; };
+		A9297A8F3E4AAC1F74C05844 /* PMTilesExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PMTilesExtractor.swift; sourceTree = "<group>"; };
 		AD4AD147789715D94CB21B30 /* MeshtasticDataModelV18.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV18.xcdatamodel; sourceTree = "<group>"; };
 		ADF6BAC3992D05079F77B35C /* Meshtastic Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Meshtastic Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF7F16652B88E118C5CE9B57 /* MeshtasticDataModelV 46.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 46.xcdatamodel"; sourceTree = "<group>"; };
@@ -207,6 +221,7 @@
 		E81B359C631E51C6461AAE00 /* MeshtasticDataModelV12.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV12.xcdatamodel; sourceTree = "<group>"; };
 		E8849D542B45F20F349E004D /* alpha.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = alpha.png; sourceTree = "<group>"; };
 		E94055F00D3E29383E92FF74 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		EB006125B378C5233BD0B731 /* PMTilesMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PMTilesMapView.swift; sourceTree = "<group>"; };
 		EE69A594BA2FA1D1F536BC93 /* MeshtasticDataModelV 47.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 47.xcdatamodel"; sourceTree = "<group>"; };
 		EFF3AE2F57E58725578E0F1C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = en; path = en.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		F15A1577564640951AD3EA40 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = wrapper.cfbundle; path = Settings.bundle; sourceTree = "<group>"; };
@@ -638,6 +653,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5631740093D563F017DA31D7 /* MeshtasticProtobufs in Frameworks */,
+				0D14B1F2EE824455A78690F8 /* MVTTools in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -744,6 +760,7 @@
 				C21C46F8F2BCFF68F31B12C0 /* Export */,
 				10FE857786F2AD24047BFDED /* Extensions */,
 				11D3172B1FEF230630B7A990 /* Extensions */,
+				D5FFA7BDD46767B209390E97 /* Helpers */,
 				22FDA4B8722F2CC1F4B5A929 /* Helpers */,
 				1A7C0874097266C63EDD8A18 /* Import */,
 				A7443D3C9E82A023A4388EFC /* InfoPlist.strings */,
@@ -767,6 +784,14 @@
 			path = Meshtastic;
 			sourceTree = "<group>";
 		};
+		6F95C3402FDAFD342C18DE60 /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				EB006125B378C5233BD0B731 /* PMTilesMapView.swift */,
+			);
+			path = Map;
+			sourceTree = "<group>";
+		};
 		8F644F7974EA8B14E77ED53A /* Packages */ = {
 			isa = PBXGroup;
 			children = (
@@ -779,8 +804,25 @@
 			isa = PBXGroup;
 			children = (
 				BE994A834A388206BCD4EBE6 /* Helpers */,
+				B7D1F8CBD77A8C561E303582 /* Nodes */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		A9D21164B1CCA45A498E9AA9 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				6F95C3402FDAFD342C18DE60 /* Map */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		B7D1F8CBD77A8C561E303582 /* Nodes */ = {
+			isa = PBXGroup;
+			children = (
+				A9D21164B1CCA45A498E9AA9 /* Helpers */,
+			);
+			path = Nodes;
 			sourceTree = "<group>";
 		};
 		BE994A834A388206BCD4EBE6 /* Helpers */ = {
@@ -826,6 +868,27 @@
 				B079D165838E646EE754DC6E /* urls.json */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		D5FFA7BDD46767B209390E97 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				E23070A9CFE0B356E43BEAE8 /* Map */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		E23070A9CFE0B356E43BEAE8 /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				A82B439BEF9740A80E66097A /* MBTilesArchive.swift */,
+				8C7307ED073D77037E45EE89 /* OfflineMapImport.swift */,
+				0E531C14ABE7F1491959BBE3 /* OfflineMapManager.swift */,
+				2D675F15EFB753FBC7DA78C1 /* OfflineMapRegion.swift */,
+				62C4205D1043768766C64E87 /* PMTilesArchive.swift */,
+				A9297A8F3E4AAC1F74C05844 /* PMTilesExtractor.swift */,
+			);
+			path = Map;
 			sourceTree = "<group>";
 		};
 		F7C5E67022CD718D1F3D0A94 /* TCP */ = {
@@ -924,6 +987,7 @@
 			name = "Meshtastic TV";
 			packageProductDependencies = (
 				52CBDF2188BAF9E2FB8B10A1 /* MeshtasticProtobufs */,
+				99BACD26F50E4FBA1E2FC365 /* MVTTools */,
 			);
 			productName = "Meshtastic TV";
 			productReference = A127CADA4845100E1C10B022 /* Meshtastic TV.app */;
@@ -1246,6 +1310,13 @@
 				563422694131128F504A5E05 /* Color.swift in Sources */,
 				94F9F3199DB5429EBF21F9E9 /* Connection.swift in Sources */,
 				073D5EF20134D41DF2AC5993 /* Logger.swift in Sources */,
+				8DFCC830624F2D4607E87938 /* MBTilesArchive.swift in Sources */,
+				4E0EA928F0EBE41EDA6FC93B /* OfflineMapImport.swift in Sources */,
+				4584CB8BEA4226A1154EB385 /* OfflineMapManager.swift in Sources */,
+				4B4240E283A5080CF7D246B1 /* OfflineMapRegion.swift in Sources */,
+				066F0545C2EDA31CC6E95E4E /* PMTilesArchive.swift in Sources */,
+				C6148418734B3ADB2741CB8E /* PMTilesExtractor.swift in Sources */,
+				13FAC446423FF3C9AC737EA0 /* PMTilesMapView.swift in Sources */,
 				977E69BC7382DA7EF386402F /* TCPConnection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2024,6 +2095,11 @@
 		838679D32875D367B9FC8FBF /* MeshtasticProtobufs */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MeshtasticProtobufs;
+		};
+		99BACD26F50E4FBA1E2FC365 /* MVTTools */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9243D356FA56FD1728AC3D3 /* XCRemoteSwiftPackageReference "mvt-tools" */;
+			productName = MVTTools;
 		};
 		9D120B166CA191FC578A9978 /* SwiftDraw */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -345,13 +345,22 @@ final class OfflineMapManager: ObservableObject {
 
 	// MARK: - Locations
 
-	/// `Documents/OfflineMaps`, created on first use. `nil` only if Documents is unavailable.
+	/// `Documents/OfflineMaps`, created on first use. `nil` only if the container is unavailable.
+	///
+	/// tvOS uses Caches instead: Apple TV apps get no durable Documents storage, and anything
+	/// large has to be re-downloadable because the system may purge it under storage pressure.
+	/// The TV app re-extracts the region around the mesh when that happens.
 	func directoryURL() -> URL? {
-		guard let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-			Logger.services.error("🗺️ [Offline] Could not access documents directory")
+		#if os(tvOS)
+		let searchPath = FileManager.SearchPathDirectory.cachesDirectory
+		#else
+		let searchPath = FileManager.SearchPathDirectory.documentDirectory
+		#endif
+		guard let container = FileManager.default.urls(for: searchPath, in: .userDomainMask).first else {
+			Logger.services.error("🗺️ [Offline] Could not access the offline maps container")
 			return nil
 		}
-		let dir = documents.appendingPathComponent(Self.directoryName, isDirectory: true)
+		let dir = container.appendingPathComponent(Self.directoryName, isDirectory: true)
 		if !FileManager.default.fileExists(atPath: dir.path) {
 			do {
 				try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/Meshtastic/Views/Nodes/Helpers/Map/PMTilesMapView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/PMTilesMapView.swift
@@ -13,6 +13,7 @@ import MapKit
 import MVTTools
 import OSLog
 import SwiftUI
+import UIKit
 import Combine
 
 // MARK: - Native vector rendering of offline MVT tiles (drawn IN a SwiftUI Map)
@@ -698,5 +699,68 @@ extension OfflineVectorTileProvider {
 		let denominator = end.latitude - start.latitude
 		let t = denominator == 0 ? 0 : (lat - start.latitude) / denominator
 		return CLLocationCoordinate2D(latitude: lat, longitude: start.longitude + t * (end.longitude - start.longitude))
+	}
+}
+
+// MARK: - Offline basemap palette
+
+/// Colors and stroke widths for the decoded offline features, approximating Apple Maps
+/// Standard in light and dark. Shared so the iOS map and the tvOS map render identically.
+enum OfflineMapPalette {
+
+	static func earth(dark: Bool) -> UIColor {
+		dark ? UIColor(red: 0.137, green: 0.137, blue: 0.145, alpha: 1)
+			 : UIColor(red: 0.953, green: 0.945, blue: 0.929, alpha: 1)
+	}
+
+	static func fill(_ role: OfflineFeatureRole, dark: Bool) -> UIColor? {
+		switch role {
+		case .water: return dark ? UIColor(red: 0.094, green: 0.169, blue: 0.267, alpha: 1) : UIColor(red: 0.667, green: 0.831, blue: 0.953, alpha: 1)
+		case .park, .green: return dark ? UIColor(red: 0.122, green: 0.176, blue: 0.133, alpha: 1) : UIColor(red: 0.776, green: 0.882, blue: 0.706, alpha: 1)
+		case .land: return earth(dark: dark)
+		default: return nil
+		}
+	}
+
+	/// Road fill: white centerline (light) or a lighter-than-land gray (dark).
+	static func roadFill(_ role: OfflineFeatureRole, dark: Bool) -> UIColor? {
+		switch role {
+		case .majorRoad: return dark ? UIColor(red: 0.46, green: 0.46, blue: 0.49, alpha: 1) : .white
+		case .mediumRoad: return dark ? UIColor(red: 0.38, green: 0.38, blue: 0.41, alpha: 1) : .white
+		case .minorRoad: return dark ? UIColor(red: 0.31, green: 0.31, blue: 0.34, alpha: 1) : .white
+		default: return nil
+		}
+	}
+
+	/// Road casing (light mode only): a warm-gray outline that makes the white roads read on pale land.
+	static func roadCasing(_ role: OfflineFeatureRole, dark: Bool) -> UIColor? {
+		guard !dark else { return nil }
+		switch role {
+		case .majorRoad, .mediumRoad, .minorRoad: return UIColor(red: 0.835, green: 0.824, blue: 0.800, alpha: 1)
+		default: return nil
+		}
+	}
+
+	static func roadWidth(_ role: OfflineFeatureRole) -> CGFloat {
+		switch role {
+		case .majorRoad: return 3.0
+		case .mediumRoad: return 2.2
+		case .minorRoad: return 1.3
+		default: return 1.0
+		}
+	}
+
+	/// Casing is ~1.4 pt wider than the fill (about 0.7 pt of outline each side).
+	static func roadCasingWidth(_ role: OfflineFeatureRole) -> CGFloat {
+		roadWidth(role) + 1.4
+	}
+
+	/// Rail / admin-boundary stroke color (single dashed line, both modes).
+	static func line(_ role: OfflineFeatureRole, dark: Bool) -> UIColor? {
+		switch role {
+		case .rail: return dark ? UIColor(red: 0.45, green: 0.46, blue: 0.49, alpha: 1) : UIColor(red: 0.62, green: 0.62, blue: 0.64, alpha: 1)
+		case .boundary: return dark ? UIColor(red: 0.50, green: 0.46, blue: 0.56, alpha: 1) : UIColor(red: 0.66, green: 0.62, blue: 0.70, alpha: 1)
+		default: return nil
+		}
 	}
 }

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -1526,14 +1526,14 @@ struct MeshMapMK: View {
 			result.append(ClusterMapOverlay(
 				id: "offline-earth-\(index)",
 				overlay: MKPolygon(coordinates: &earth, count: earth.count),
-				style: ClusterMapOverlayStyle(strokeUIColor: nil, fillUIColor: Self.offlineEarthColor(dark: dark), lineWidth: 0, level: .aboveRoads)
+				style: ClusterMapOverlayStyle(strokeUIColor: nil, fillUIColor: OfflineMapPalette.earth(dark: dark), lineWidth: 0, level: .aboveRoads)
 			))
 		}
 
 		// 2) Water / park fills, batched per role (parks under water).
 		let fillsByRole = Dictionary(grouping: offlineVectors.polygons, by: { $0.role })
 		for role in [OfflineFeatureRole.park, .green, .water] {
-			guard let polys = fillsByRole[role], let fill = Self.offlineFillColor(role, dark: dark) else { continue }
+			guard let polys = fillsByRole[role], let fill = OfflineMapPalette.fill(role, dark: dark) else { continue }
 			let shapes = polys.compactMap { poly -> MKPolygon? in
 				guard poly.coordinates.count >= 3 else { return nil }
 				var coords = poly.coordinates
@@ -1561,25 +1561,25 @@ struct MeshMapMK: View {
 		let roadClasses: [OfflineFeatureRole] = [.minorRoad, .mediumRoad, .majorRoad]
 		// Casing pass (light mode only) gives the Apple white-road-with-outline look.
 		for role in roadClasses {
-			guard let casing = Self.offlineRoadCasingColor(role, dark: dark), let multi = roadMultiPolyline(role) else { continue }
+			guard let casing = OfflineMapPalette.roadCasing(role, dark: dark), let multi = roadMultiPolyline(role) else { continue }
 			result.append(ClusterMapOverlay(
 				id: "offline-road-casing-\(role)",
 				overlay: multi,
-				style: ClusterMapOverlayStyle(strokeUIColor: casing, fillUIColor: nil, lineWidth: Self.offlineRoadCasingWidth(role), lineCap: .round, level: .aboveRoads)
+				style: ClusterMapOverlayStyle(strokeUIColor: casing, fillUIColor: nil, lineWidth: OfflineMapPalette.roadCasingWidth(role), lineCap: .round, level: .aboveRoads)
 			))
 		}
 		// Fill pass — white centerlines (light) / lighter-than-land gray (dark).
 		for role in roadClasses {
-			guard let fill = Self.offlineRoadFillColor(role, dark: dark), let multi = roadMultiPolyline(role) else { continue }
+			guard let fill = OfflineMapPalette.roadFill(role, dark: dark), let multi = roadMultiPolyline(role) else { continue }
 			result.append(ClusterMapOverlay(
 				id: "offline-road-fill-\(role)",
 				overlay: multi,
-				style: ClusterMapOverlayStyle(strokeUIColor: fill, fillUIColor: nil, lineWidth: Self.offlineRoadWidth(role), lineCap: .round, level: .aboveRoads)
+				style: ClusterMapOverlayStyle(strokeUIColor: fill, fillUIColor: nil, lineWidth: OfflineMapPalette.roadWidth(role), lineCap: .round, level: .aboveRoads)
 			))
 		}
 		// Rail + admin boundaries (single dashed stroke, both modes).
 		for role in [OfflineFeatureRole.rail, .boundary] {
-			guard let color = Self.offlineLineColor(role, dark: dark), let multi = roadMultiPolyline(role) else { continue }
+			guard let color = OfflineMapPalette.line(role, dark: dark), let multi = roadMultiPolyline(role) else { continue }
 			result.append(ClusterMapOverlay(
 				id: "offline-line-\(role)",
 				overlay: multi,
@@ -1590,65 +1590,7 @@ struct MeshMapMK: View {
 		offlineVectorOverlays = result
 	}
 
-	// MARK: Offline basemap palette (approximates Apple Maps Standard, light + dark)
-
-	private static func offlineEarthColor(dark: Bool) -> UIColor {
-		dark ? UIColor(red: 0.137, green: 0.137, blue: 0.145, alpha: 1)
-			 : UIColor(red: 0.953, green: 0.945, blue: 0.929, alpha: 1)
-	}
-
-	private static func offlineFillColor(_ role: OfflineFeatureRole, dark: Bool) -> UIColor? {
-		switch role {
-		case .water: return dark ? UIColor(red: 0.094, green: 0.169, blue: 0.267, alpha: 1) : UIColor(red: 0.667, green: 0.831, blue: 0.953, alpha: 1)
-		case .park, .green: return dark ? UIColor(red: 0.122, green: 0.176, blue: 0.133, alpha: 1) : UIColor(red: 0.776, green: 0.882, blue: 0.706, alpha: 1)
-		case .land: return offlineEarthColor(dark: dark)
-		default: return nil
-		}
-	}
-
-	/// Road fill: white centerline (light) or a lighter-than-land gray (dark).
-	private static func offlineRoadFillColor(_ role: OfflineFeatureRole, dark: Bool) -> UIColor? {
-		switch role {
-		case .majorRoad: return dark ? UIColor(red: 0.46, green: 0.46, blue: 0.49, alpha: 1) : .white
-		case .mediumRoad: return dark ? UIColor(red: 0.38, green: 0.38, blue: 0.41, alpha: 1) : .white
-		case .minorRoad: return dark ? UIColor(red: 0.31, green: 0.31, blue: 0.34, alpha: 1) : .white
-		default: return nil
-		}
-	}
-
-	/// Road casing (light mode only): a warm-gray outline that makes the white roads read on pale land.
-	private static func offlineRoadCasingColor(_ role: OfflineFeatureRole, dark: Bool) -> UIColor? {
-		guard !dark else { return nil }
-		switch role {
-		case .majorRoad, .mediumRoad, .minorRoad: return UIColor(red: 0.835, green: 0.824, blue: 0.800, alpha: 1)
-		default: return nil
-		}
-	}
-
-	private static func offlineRoadWidth(_ role: OfflineFeatureRole) -> CGFloat {
-		switch role {
-		case .majorRoad: return 3.0
-		case .mediumRoad: return 2.2
-		case .minorRoad: return 1.3
-		default: return 1.0
-		}
-	}
-
-	/// Casing is ~1.4 pt wider than the fill (about 0.7 pt of outline each side).
-	private static func offlineRoadCasingWidth(_ role: OfflineFeatureRole) -> CGFloat {
-		offlineRoadWidth(role) + 1.4
-	}
-
-	/// Rail / admin-boundary stroke color (single dashed line, both modes).
-	private static func offlineLineColor(_ role: OfflineFeatureRole, dark: Bool) -> UIColor? {
-		switch role {
-		case .rail: return dark ? UIColor(red: 0.45, green: 0.46, blue: 0.49, alpha: 1) : UIColor(red: 0.62, green: 0.62, blue: 0.64, alpha: 1)
-		case .boundary: return dark ? UIColor(red: 0.50, green: 0.46, blue: 0.56, alpha: 1) : UIColor(red: 0.66, green: 0.62, blue: 0.70, alpha: 1)
-		default: return nil
-		}
-	}
-
-/// Rebuild the vector overlays (accuracy circles + convex hull) from the current snapshots.
+	/// Rebuild the vector overlays (accuracy circles + convex hull) from the current snapshots.
 	/// Called on data change so the overlay objects are stable between renders. Ports the styling
 	/// from MeshMapContent's reducedPrecisionMapCircles + convex hull.
 	private func rebuildOverlays() {

--- a/project.yml
+++ b/project.yml
@@ -663,9 +663,23 @@ targets:
       # Node-pin styling parity with the iOS map (CircleText + Color(hex:)/isLight).
       - path: "Meshtastic/Views/Helpers/CircleText.swift"
       - path: "Meshtastic/Extensions/Color.swift"
+      # Offline Protomaps basemap, shared verbatim with iOS. These files are pure
+      # Foundation/MapKit/CoreLocation — no UIKit, SwiftData or BLE — so the tvOS app
+      # reads the same .pmtiles archives and decodes them with the same code path.
+      - path: "Meshtastic/Helpers/Map/PMTilesArchive.swift"
+      - path: "Meshtastic/Helpers/Map/PMTilesExtractor.swift"
+      - path: "Meshtastic/Helpers/Map/MBTilesArchive.swift"
+      - path: "Meshtastic/Helpers/Map/OfflineMapRegion.swift"
+      - path: "Meshtastic/Helpers/Map/OfflineMapImport.swift"
+      - path: "Meshtastic/Helpers/Map/OfflineMapManager.swift"
+      # The MVT decoder that turns archive tiles into MapKit shapes. Despite the file
+      # name it holds no views — MeshTVMapView draws its output as MKOverlays.
+      - path: "Meshtastic/Views/Nodes/Helpers/Map/PMTilesMapView.swift"
     dependencies:
       - package: MeshtasticProtobufs
         product: MeshtasticProtobufs
+      - package: mvt-tools
+        product: MVTTools
     settings:
       configs:
         Debug:


### PR DESCRIPTION
## Summary

The Apple TV app can now download the Protomaps area around the mesh and draw it as the basemap, so the map still works with no internet — a base-camp Apple TV showing the mesh doesn't need a working uplink.

## What changed

The pmtiles stack is shared with iOS rather than reimplemented. `PMTilesArchive`, `PMTilesExtractor`, `OfflineMapManager` and the MVT decoder are all plain Foundation/MapKit with no UIKit or SwiftData, so the TV target just compiles the same files and picks up `MVTTools`. The feature palette moved out of `MeshMapMK` into the shared decoder file, so both maps colour water, parks and roads identically instead of drifting.

Two things are genuinely tvOS-specific:

- **Region choice.** There is no file picker and no way to drag a bounding box with a Siri Remote, so `TVOfflineBasemap` derives the region from the mesh itself: the bounding box of every node that has reported a position, padded, at the standard z0-13 detail. Settings gets one button, with a size estimate before you commit and a progress bar during the extract.
- **Storage.** Apple TV has no durable Documents directory, so `OfflineMapManager` uses Caches there. The archive is re-downloadable, which is what tvOS requires of anything large.

The overlays are drawn in the same order as the iOS map: an earth fill per coverage box, then parks and water, then roads casing-first. They render only over the Standard map type, since Hybrid and Satellite are imagery the vector basemap would cover.

## Testing

Ran against the DEFCON replay on a tvOS 26.5 simulator, with a temporary probe driving the real code path (removed before commit):

```
38 nodes, 38 located
bounds 35.975621,-115.308955 → 36.285108,-114.998083
estimate 119 tiles / 4564556 bytes
state ready region BC11080F-....pmtiles
decoded 1564 polygons / 19666 roads, available=true
overlays 6, styled renderers 6
```

The bounding box is Las Vegas, which is right for that replay. iOS still builds and its map is unchanged apart from the palette move.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline basemap support for the TV map.
  * Added settings to estimate, download, update, and remove offline map regions.
  * Offline maps include roads, boundaries, railways, and other geographic features.
  * Download progress, errors, storage details, and node-location requirements are displayed.
* **Improvements**
  * Offline map styling now adapts consistently to light and dark appearances.
  * Existing offline map data can be refreshed or reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->