### PR TITLE
Mesh stats strip on the Apple TV map

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -30,6 +30,10 @@ struct MapScreen: View {
 	/// the representable's updates; it publishes nothing until a region is downloaded.
 	@StateObject private var offlineVectors = OfflineVectorTileProvider()
 
+	/// Mesh stats strip visibility + position, shared with SettingsView via the same keys.
+	@AppStorage("tv.statsBar.enabled") private var statsBarEnabled = true
+	@AppStorage("tv.statsBar.edge") private var statsBarEdge: StatsStripEdge = .top
+
 	/// All nodes for the side list: located first, then alphabetically.
 	private var sortedNodes: [MeshNode] {
 		allNodes.sorted {
@@ -57,6 +61,18 @@ struct MapScreen: View {
 				offlineVectors: offlineVectors
 			)
 			.ignoresSafeArea()
+			// Overlay, not safeAreaInset: an inset resizes the MKMapView and re-triggers
+			// the representable's region framing every time the strip toggles or moves.
+			.overlay(alignment: statsBarEdge == .top ? .top : .bottom) {
+				if statsBarEnabled {
+					MeshStatsStrip(
+						stats: client.stats,
+						storeOnlineCount: allNodes.filter(\.isOnline).count,
+						storeTotalCount: allNodes.count
+					)
+					.padding(.vertical, TVTheme.statsStripMargin)
+				}
+			}
 		}
 	}
 

--- a/Meshtastic TV/App/RootView.swift
+++ b/Meshtastic TV/App/RootView.swift
@@ -38,7 +38,7 @@ struct RootView: View {
 			guard let index = CommandLine.arguments.firstIndex(of: "-tv-connect"),
 			      index + 1 < CommandLine.arguments.count else { return }
 			let parts = CommandLine.arguments[index + 1].split(separator: ":")
-			guard parts.count == 2, let port = Int(parts[1]) else { return }
+			guard parts.count == 2, let port = Int(parts[1]), (1...65535).contains(port) else { return }
 			client.connect(host: String(parts[0]), port: port)
 		}
 #endif

--- a/Meshtastic TV/App/RootView.swift
+++ b/Meshtastic TV/App/RootView.swift
@@ -31,6 +31,17 @@ struct RootView: View {
 		// Re-asserted on every active transition because the system can reset the
 		// flag when the app returns to the foreground.
 		.onAppear { UIApplication.shared.isIdleTimerDisabled = true }
+#if DEBUG
+		.task {
+			// Headless-testing hook (MarketingCapture / SwitchStress pattern): launch with
+			// `-tv-connect host:port` to connect without driving the remote. Debug only.
+			guard let index = CommandLine.arguments.firstIndex(of: "-tv-connect"),
+			      index + 1 < CommandLine.arguments.count else { return }
+			let parts = CommandLine.arguments[index + 1].split(separator: ":")
+			guard parts.count == 2, let port = Int(parts[1]) else { return }
+			client.connect(host: String(parts[0]), port: port)
+		}
+#endif
 		.onChange(of: scenePhase) { _, phase in
 			UIApplication.shared.isIdleTimerDisabled = (phase == .active)
 		}

--- a/Meshtastic TV/App/SettingsView.swift
+++ b/Meshtastic TV/App/SettingsView.swift
@@ -24,6 +24,9 @@ struct SettingsView: View {
 	@AppStorage("tv.mapType") private var mapTypeRaw: Int = Int(MKMapType.standard.rawValue)
 	@StateObject private var offlineBasemap = TVOfflineBasemap()
 	@State private var estimate: (tiles: Int, bytes: Int64)?
+	/// Mesh stats strip, shared with MapScreen via the same keys.
+	@AppStorage("tv.statsBar.enabled") private var statsBarEnabled = true
+	@AppStorage("tv.statsBar.edge") private var statsBarEdge: StatsStripEdge = .top
 
 	var body: some View {
 		List {
@@ -34,8 +37,18 @@ struct SettingsView: View {
 					Text("Satellite").tag(Int(MKMapType.satellite.rawValue))
 				}
 				.pickerStyle(.segmented)
+
+				Toggle("Mesh Stats", isOn: $statsBarEnabled)
+				Picker("Stats Position", selection: $statsBarEdge) {
+					Text("Top").tag(StatsStripEdge.top)
+					Text("Bottom").tag(StatsStripEdge.bottom)
+				}
+				.pickerStyle(.segmented)
+				.disabled(!statsBarEnabled)
 			} header: {
 				Text("Map")
+			} footer: {
+				Text("Mesh Stats shows the connected node's mesh totals, radio load and packet counters over the map.")
 			}
 
 			offlineMapSection

--- a/Meshtastic TV/App/TVTheme.swift
+++ b/Meshtastic TV/App/TVTheme.swift
@@ -31,4 +31,9 @@ enum TVTheme {
 
 	/// Wordmark logo height in the map header.
 	static let wordmarkHeight: CGFloat = 30
+
+	/// Vertical margin for the mesh stats strip. The map is full-bleed
+	/// (.ignoresSafeArea), so the strip supplies its own title-safe distance
+	/// from the screen edge (tvOS HIG: 60pt top/bottom).
+	static let statsStripMargin: CGFloat = 60
 }

--- a/Meshtastic TV/App/TVTheme.swift
+++ b/Meshtastic TV/App/TVTheme.swift
@@ -33,7 +33,7 @@ enum TVTheme {
 	static let wordmarkHeight: CGFloat = 30
 
 	/// Vertical margin for the mesh stats strip. The map is full-bleed
-	/// (.ignoresSafeArea), so the strip supplies its own title-safe distance
-	/// from the screen edge (tvOS HIG: 60pt top/bottom).
-	static let statsStripMargin: CGFloat = 60
+	/// (.ignoresSafeArea), so the strip supplies its own distance from the
+	/// screen edge — kept tight so the strip hugs the edge it's pinned to.
+	static let statsStripMargin: CGFloat = 24
 }

--- a/Meshtastic TV/Client/MeshClient.swift
+++ b/Meshtastic TV/Client/MeshClient.swift
@@ -37,6 +37,23 @@ final class MeshClient {
 	private(set) var myNodeNum: UInt32?
 	private(set) var host: String = ""
 
+	/// Latest health numbers for the CONNECTED node — the mesh stats strip's data.
+	/// In-memory only: session data, and adding fields to `MeshNode` would be a schema
+	/// change whose failure path wipes the store (see MeshtasticTVApp.makeContainer).
+	struct ConnectedNodeStats: Equatable {
+		var channelUtilization: Float
+		var airUtilTx: Float
+		/// Nil until the first LocalStats packet arrives — the DeviceMetrics
+		/// fallback and the NodeInfo seed only carry the two load fields above.
+		var packetsTx: UInt32?
+		var packetsRx: UInt32?
+		var packetsRxDupe: UInt32?
+		var onlineNodes: UInt32?
+		var totalNodes: UInt32?
+		var receivedAt: Date
+	}
+	private(set) var stats: ConnectedNodeStats?
+
 	/// The tvOS-local SwiftData store the map and list read via `@Query`. Every
 	/// upsert lands here; nothing is kept in memory, so the map survives relaunch.
 	private let context: ModelContext
@@ -59,6 +76,8 @@ final class MeshClient {
 		self.host = host
 		state = .connecting
 		myNodeNum = nil
+		// Stats describe one radio's session — they must not survive a switch.
+		stats = nil
 		// Note: the persisted node store is intentionally NOT cleared here — keeping
 		// it is what leaves the map populated across relaunches until the radio's
 		// fresh node-DB dump updates it.
@@ -195,6 +214,12 @@ final class MeshClient {
 		if info.hasDeviceMetrics {
 			let battery = Int(info.deviceMetrics.batteryLevel)
 			if node.batteryLevel != battery { node.batteryLevel = battery }
+			// The config dump includes the connected node's own entry; seeding here puts
+			// numbers in the stats strip at connect time instead of waiting out the first
+			// telemetry broadcast interval.
+			if info.num == myNodeNum {
+				applyDeviceMetrics(info.deviceMetrics)
+			}
 		}
 		if info.lastHeard > 0 {
 			let heard = Date(timeIntervalSince1970: TimeInterval(info.lastHeard))
@@ -205,8 +230,18 @@ final class MeshClient {
 
 	private func ingestPacket(_ packet: MeshPacket) {
 		guard case .decoded(let data) = packet.payloadVariant else { return }
-		guard data.portnum == .positionApp,
-		      let position = try? Position(serializedBytes: data.payload),
+		switch data.portnum {
+		case .positionApp:
+			ingestPosition(packet, data)
+		case .telemetryApp:
+			ingestTelemetry(packet, data)
+		default:
+			break
+		}
+	}
+
+	private func ingestPosition(_ packet: MeshPacket, _ data: DataMessage) {
+		guard let position = try? Position(serializedBytes: data.payload),
 		      position.hasLatitudeI, position.hasLongitudeI else { return }
 
 		let latitude = Double(position.latitudeI) * 1e-7
@@ -221,5 +256,45 @@ final class MeshClient {
 		node.latitude = latitude
 		node.longitude = longitude
 		node.lastHeard = Date()
+	}
+
+	/// Telemetry from the CONNECTED node feeds the stats strip. Other nodes' telemetry is
+	/// dropped: their LocalStats describe *their* node DB and radio load, not this mesh
+	/// session's, and this client keeps no per-node telemetry history.
+	private func ingestTelemetry(_ packet: MeshPacket, _ data: DataMessage) {
+		guard let myNodeNum, packet.from == myNodeNum,
+		      let telemetry = try? Telemetry(serializedBytes: data.payload) else { return }
+		switch telemetry.variant {
+		case .localStats(let localStats):
+			// No no-op guard, unlike the store writes above: `receivedAt` drives the
+			// strip's age text, so every arrival is a real update by definition.
+			stats = ConnectedNodeStats(
+				channelUtilization: localStats.channelUtilization,
+				airUtilTx: localStats.airUtilTx,
+				packetsTx: localStats.numPacketsTx,
+				packetsRx: localStats.numPacketsRx,
+				packetsRxDupe: localStats.numRxDupe,
+				onlineNodes: localStats.numOnlineNodes,
+				totalNodes: localStats.numTotalNodes,
+				receivedAt: Date()
+			)
+			Logger.transport.info("📺 [MeshClient] LocalStats: ch \(localStats.channelUtilization, privacy: .public)% air \(localStats.airUtilTx, privacy: .public)% tx \(localStats.numPacketsTx, privacy: .public) rx \(localStats.numPacketsRx, privacy: .public) nodes \(localStats.numOnlineNodes, privacy: .public)/\(localStats.numTotalNodes, privacy: .public)")
+		case .deviceMetrics(let deviceMetrics):
+			applyDeviceMetrics(deviceMetrics)
+		default:
+			break
+		}
+	}
+
+	/// Partial stats update from DeviceMetrics — the load fields only, keeping any
+	/// LocalStats counters already held. Also the seed path from the connected node's
+	/// NodeInfo, so the strip has numbers at connect time.
+	private func applyDeviceMetrics(_ metrics: DeviceMetrics) {
+		guard metrics.hasChannelUtilization || metrics.hasAirUtilTx else { return }
+		var updated = stats ?? ConnectedNodeStats(channelUtilization: 0, airUtilTx: 0, receivedAt: Date())
+		if metrics.hasChannelUtilization { updated.channelUtilization = metrics.channelUtilization }
+		if metrics.hasAirUtilTx { updated.airUtilTx = metrics.airUtilTx }
+		updated.receivedAt = Date()
+		stats = updated
 	}
 }

--- a/Meshtastic TV/Client/MeshClient.swift
+++ b/Meshtastic TV/Client/MeshClient.swift
@@ -41,10 +41,12 @@ final class MeshClient {
 	/// In-memory only: session data, and adding fields to `MeshNode` would be a schema
 	/// change whose failure path wipes the store (see MeshtasticTVApp.makeContainer).
 	struct ConnectedNodeStats: Equatable {
-		var channelUtilization: Float
-		var airUtilTx: Float
-		/// Nil until the first LocalStats packet arrives — the DeviceMetrics
-		/// fallback and the NodeInfo seed only carry the two load fields above.
+		/// Every field is nil until its telemetry actually arrives, so the strip
+		/// renders a dash rather than a fabricated zero. LocalStats fills them all;
+		/// the DeviceMetrics fallback and NodeInfo seed fill only the load fields
+		/// they carry.
+		var channelUtilization: Float?
+		var airUtilTx: Float?
 		var packetsTx: UInt32?
 		var packetsRx: UInt32?
 		var packetsRxDupe: UInt32?
@@ -291,7 +293,7 @@ final class MeshClient {
 	/// NodeInfo, so the strip has numbers at connect time.
 	private func applyDeviceMetrics(_ metrics: DeviceMetrics) {
 		guard metrics.hasChannelUtilization || metrics.hasAirUtilTx else { return }
-		var updated = stats ?? ConnectedNodeStats(channelUtilization: 0, airUtilTx: 0, receivedAt: Date())
+		var updated = stats ?? ConnectedNodeStats(receivedAt: Date())
 		if metrics.hasChannelUtilization { updated.channelUtilization = metrics.channelUtilization }
 		if metrics.hasAirUtilTx { updated.airUtilTx = metrics.airUtilTx }
 		updated.receivedAt = Date()

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -1,0 +1,153 @@
+//
+//  MeshStatsStrip.swift
+//  Meshtastic TV
+//
+//  Copyright(c) Garth Vander Houwen 8/14/26.
+//
+//  Compact mesh health strip over the map: nodes online/total, radio load, packet
+//  counters. Toggle and top/bottom position live in Settings ("tv.statsBar.*").
+//
+//  DISPLAY-ONLY by hard rule: no Button, no NavigationLink, no .focusable(). Any
+//  focus target right of the side list re-creates the focus trap documented in
+//  MeshTVMapView (the map column must hold nothing the focus engine can land on).
+//
+
+import SwiftUI
+
+/// Where the strip sits over the map. String raw values so @AppStorage stores it directly.
+enum StatsStripEdge: String, CaseIterable {
+	case top
+	case bottom
+}
+
+struct MeshStatsStrip: View {
+	/// Latest stats from the connected node, nil until telemetry arrives.
+	let stats: MeshClient.ConnectedNodeStats?
+	/// Store-derived fallbacks so the node count renders before any telemetry.
+	let storeOnlineCount: Int
+	let storeTotalCount: Int
+
+	@ScaledMetric(relativeTo: .caption) private var labelSize: CGFloat = 18
+	@ScaledMetric(relativeTo: .body) private var valueSize: CGFloat = 26
+
+	var body: some View {
+		HStack(spacing: 28) {
+			cell(label: "Nodes", value: nodesText)
+
+			divider
+			cell(label: "Ch Util", value: percentText(stats?.channelUtilization), color: channelUtilColor)
+
+			divider
+			cell(label: "Air TX", value: percentText(stats?.airUtilTx), color: airTxColor)
+
+			divider
+			cell(label: "Packets", value: packetsText)
+
+			if let dupes = stats?.packetsRxDupe {
+				divider
+				cell(label: "Dupes", value: dupes.formatted())
+			}
+
+			if let receivedAt = stats?.receivedAt {
+				divider
+				VStack(alignment: .leading, spacing: 2) {
+					Text("Updated")
+						.font(.system(size: labelSize))
+						.textCase(.uppercase)
+						.foregroundStyle(.secondary)
+					Text(receivedAt, style: .relative)
+						.font(.system(size: valueSize).monospacedDigit())
+				}
+			}
+		}
+		.padding(.horizontal, 32)
+		.padding(.vertical, 16)
+		.background(
+			RoundedRectangle(cornerRadius: TVTheme.rowCornerRadius, style: .continuous)
+				.fill(.ultraThinMaterial)
+		)
+		.fixedSize()
+	}
+
+	// MARK: Cells
+
+	private func cell(label: String, value: String, color: Color = .primary) -> some View {
+		VStack(alignment: .leading, spacing: 2) {
+			Text(label)
+				.font(.system(size: labelSize))
+				.textCase(.uppercase)
+				.foregroundStyle(.secondary)
+			Text(value)
+				.font(.system(size: valueSize).monospacedDigit())
+				.foregroundStyle(color)
+		}
+	}
+
+	private var divider: some View {
+		Rectangle()
+			.fill(.secondary.opacity(0.4))
+			.frame(width: 1, height: 44)
+	}
+
+	// MARK: Values
+
+	/// The radio's own node-DB view when LocalStats has arrived (authoritative for the
+	/// mesh), otherwise what this app has stored so far.
+	private var nodesText: String {
+		if let online = stats?.onlineNodes, let total = stats?.totalNodes {
+			return "\(online) / \(total)"
+		}
+		return "\(storeOnlineCount) / \(storeTotalCount)"
+	}
+
+	private var packetsText: String {
+		guard let tx = stats?.packetsTx, let rx = stats?.packetsRx else { return "—" }
+		return "\(tx.formatted()) ↑ · \(rx.formatted()) ↓"
+	}
+
+	private func percentText(_ value: Float?) -> String {
+		guard let value else { return "—" }
+		return String(format: "%.1f%%", value)
+	}
+
+	/// Firmware treats sustained channel utilization above 25% as a congested mesh.
+	private var channelUtilColor: Color {
+		guard let value = stats?.channelUtilization else { return .primary }
+		if value >= 50 { return Color("MeshtasticError") }
+		if value >= 25 { return Color("MeshtasticWarning") }
+		return .primary
+	}
+
+	/// 10% is the duty-cycle ceiling in most regions.
+	private var airTxColor: Color {
+		guard let value = stats?.airUtilTx, value >= 10 else { return .primary }
+		return Color("MeshtasticWarning")
+	}
+}
+
+#Preview("All cells", traits: .fixedLayout(width: 1400, height: 300)) {
+	ZStack {
+		Color.gray
+		MeshStatsStrip(
+			stats: MeshClient.ConnectedNodeStats(
+				channelUtilization: 31.4,
+				airUtilTx: 4.2,
+				packetsTx: 12_340,
+				packetsRx: 48_102,
+				packetsRxDupe: 512,
+				onlineNodes: 38,
+				totalNodes: 154,
+				receivedAt: Date().addingTimeInterval(-95)
+			),
+			storeOnlineCount: 30,
+			storeTotalCount: 140
+		)
+	}
+}
+
+#Preview("No telemetry yet", traits: .fixedLayout(width: 1400, height: 300)) {
+	ZStack {
+		Color.gray
+		MeshStatsStrip(stats: nil, storeOnlineCount: 12, storeTotalCount: 40)
+	}
+}

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -27,11 +27,11 @@ struct MeshStatsStrip: View {
 	let storeOnlineCount: Int
 	let storeTotalCount: Int
 
-	@ScaledMetric(relativeTo: .caption) private var labelSize: CGFloat = 18
-	@ScaledMetric(relativeTo: .body) private var valueSize: CGFloat = 26
+	@ScaledMetric(relativeTo: .caption) private var labelSize: CGFloat = 24
+	@ScaledMetric(relativeTo: .title) private var valueSize: CGFloat = 46
 
 	var body: some View {
-		HStack(spacing: 28) {
+		HStack(spacing: 44) {
 			cell(label: "Nodes", value: nodesText)
 
 			divider
@@ -50,35 +50,42 @@ struct MeshStatsStrip: View {
 
 			if let receivedAt = stats?.receivedAt {
 				divider
-				VStack(alignment: .leading, spacing: 2) {
+				VStack(alignment: .leading, spacing: 6) {
 					Text("Updated")
-						.font(.system(size: labelSize))
+						.font(.system(size: labelSize, weight: .medium))
+						.tracking(1.2)
 						.textCase(.uppercase)
 						.foregroundStyle(.secondary)
 					Text(receivedAt, style: .relative)
-						.font(.system(size: valueSize).monospacedDigit())
+						.font(.system(size: valueSize, weight: .semibold, design: .rounded).monospacedDigit())
 				}
 			}
 		}
-		.padding(.horizontal, 32)
-		.padding(.vertical, 16)
+		.padding(.horizontal, 52)
+		.padding(.vertical, 28)
 		.background(
-			RoundedRectangle(cornerRadius: TVTheme.rowCornerRadius, style: .continuous)
-				.fill(.ultraThinMaterial)
+			RoundedRectangle(cornerRadius: 24, style: .continuous)
+				.fill(.regularMaterial)
 		)
+		.overlay(
+			RoundedRectangle(cornerRadius: 24, style: .continuous)
+				.stroke(.white.opacity(0.15), lineWidth: 1)
+		)
+		.shadow(color: .black.opacity(0.4), radius: 18, y: 8)
 		.fixedSize()
 	}
 
 	// MARK: Cells
 
 	private func cell(label: String, value: String, color: Color = .primary) -> some View {
-		VStack(alignment: .leading, spacing: 2) {
+		VStack(alignment: .leading, spacing: 6) {
 			Text(label)
-				.font(.system(size: labelSize))
+				.font(.system(size: labelSize, weight: .medium))
+				.tracking(1.2)
 				.textCase(.uppercase)
 				.foregroundStyle(.secondary)
 			Text(value)
-				.font(.system(size: valueSize).monospacedDigit())
+				.font(.system(size: valueSize, weight: .semibold, design: .rounded).monospacedDigit())
 				.foregroundStyle(color)
 		}
 	}
@@ -86,7 +93,7 @@ struct MeshStatsStrip: View {
 	private var divider: some View {
 		Rectangle()
 			.fill(.secondary.opacity(0.4))
-			.frame(width: 1, height: 44)
+			.frame(width: 1, height: 76)
 	}
 
 	// MARK: Values

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -27,11 +27,11 @@ struct MeshStatsStrip: View {
 	let storeOnlineCount: Int
 	let storeTotalCount: Int
 
-	@ScaledMetric(relativeTo: .caption) private var labelSize: CGFloat = 24
-	@ScaledMetric(relativeTo: .title) private var valueSize: CGFloat = 46
+	@ScaledMetric(relativeTo: .caption) private var labelSize: CGFloat = 30
+	@ScaledMetric(relativeTo: .title) private var valueSize: CGFloat = 64
 
 	var body: some View {
-		HStack(spacing: 44) {
+		HStack(spacing: 56) {
 			cell(label: "Nodes", value: nodesText)
 
 			divider
@@ -55,14 +55,14 @@ struct MeshStatsStrip: View {
 						.font(.system(size: labelSize, weight: .medium))
 						.tracking(1.2)
 						.textCase(.uppercase)
-						.foregroundStyle(.secondary)
+						.foregroundStyle(Color.gray)
 					Text(receivedAt, style: .relative)
 						.font(.system(size: valueSize, weight: .semibold, design: .rounded).monospacedDigit())
 				}
 			}
 		}
-		.padding(.horizontal, 52)
-		.padding(.vertical, 28)
+		.padding(.horizontal, 64)
+		.padding(.vertical, 36)
 		.background(
 			RoundedRectangle(cornerRadius: 24, style: .continuous)
 				.fill(.regularMaterial)
@@ -83,7 +83,7 @@ struct MeshStatsStrip: View {
 				.font(.system(size: labelSize, weight: .medium))
 				.tracking(1.2)
 				.textCase(.uppercase)
-				.foregroundStyle(.secondary)
+				.foregroundStyle(Color.gray)
 			Text(value)
 				.font(.system(size: valueSize, weight: .semibold, design: .rounded).monospacedDigit())
 				.foregroundStyle(color)
@@ -93,7 +93,7 @@ struct MeshStatsStrip: View {
 	private var divider: some View {
 		Rectangle()
 			.fill(.secondary.opacity(0.4))
-			.frame(width: 1, height: 76)
+			.frame(width: 1, height: 104)
 	}
 
 	// MARK: Values


### PR DESCRIPTION
## Summary

A compact strip over the TV map showing the connected mesh's health at a glance: nodes online/total, channel utilization, air-util TX, and packet counters. Settings gets a toggle (default on) and a Top/Bottom position picker.

## What changed

- **MeshClient** now decodes `TELEMETRY_APP` packets, which it previously dropped. Only packets from the connected node are used — other nodes' LocalStats describe their radios, not this session. LocalStats fills every cell; DeviceMetrics and the connected node's NodeInfo entry fill the two load fields as a fallback, so numbers appear at connect time instead of waiting out the first telemetry interval. Stats are held in memory on the client — session data, and adding fields to `MeshNode` would risk the store's wipe-and-recreate migration fallback.
- **MeshStatsStrip** (new) renders the cells over the map with the same material as the header scrim. Channel utilization colors at the firmware's congestion thresholds (warning ≥ 25%, error ≥ 50%), air TX warns at the 10% duty-cycle ceiling, and a relative "updated" timestamp ages the data. It is display-only by hard rule — nothing focusable may sit right of the side list (see the focus-trap comments in MeshTVMapView).
- **MapScreen** attaches it as an overlay on the map column only, at the top or bottom title-safe margin. Overlay rather than safeAreaInset so toggling it never resizes the MKMapView and re-triggers its region framing.
- **SettingsView** gains the toggle and position picker in the Map section, using the same duplicated-`@AppStorage`-key pattern as `tv.mapType` (`tv.statsBar.enabled`, `tv.statsBar.edge`).
- **RootView** gains a DEBUG-only `-tv-connect host:port` launch argument so the TV app can be driven headlessly in the simulator (MarketingCapture pattern) — that's how this was verified.

## Testing

Against the DEFCON replay on a tvOS 26.5 simulator: strip verified in all three states (top, bottom, hidden) with node counts live from the store (56/64 online). The replay never emits LocalStats, so packet counters show an em dash there and the full-cell rendering is covered by the view's #Preview mocks; real LocalStats end-to-end needs a physical radio. Focus regression checked — the strip introduces no focusable content, so remote navigation is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional mesh statistics strip to the map, displaying node counts, channel utilization, transmissions, packet totals, duplicates, and telemetry age.
  * Added settings to enable or disable the strip and position it at the top or bottom of the map.
  * Added visual warnings for high channel utilization and clear indicators when metrics are unavailable.
  * Added a debug launch option to connect to a TV client using a host and port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->