### PR TITLE
Fix MQTT map precision 15 reverting to 14

### DIFF
--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -337,6 +337,9 @@ struct MQTTConfig: View {
 			.onChange(of: mapPublishIntervalSecs.intValue) { oldMapInterval, newMapPublishIntervalSecs in
 				if oldMapInterval != newMapPublishIntervalSecs && newMapPublishIntervalSecs != node?.mqttConfig?.mapPublishIntervalSecs ?? -1 { hasChanges = true }
 			}
+			.onChange(of: mapPositionPrecision) { oldPrecision, newPrecision in
+				if oldPrecision != newPrecision && Int32(newPrecision) != node?.mqttConfig?.mapPositionPrecision ?? -1 { hasChanges = true }
+			}
 		}
 		.navigationTitle("MQTT Config")
 		.toolbar {
@@ -409,7 +412,10 @@ private extension MQTTConfig {
 		self.mapPublishIntervalSecs = UpdateInterval(from: max(3600, Int(node?.mqttConfig?.mapPublishIntervalSecs ?? 3600)))
 		self.mapPositionPrecision = Double(node?.mqttConfig?.mapPositionPrecision ?? 14)
 		self.mapReportingOptIn = UserDefaults.mapReportingOptIn
-		if mapPositionPrecision < 11 || mapPositionPrecision > 14 { self.mapPositionPrecision = 14 }
+		// Firmware accepts 12...15 for MQTT map reports (matches the slider); anything
+		// else falls back to 14. The old 11...14 clamp here converted a saved 15 back
+		// to 14 on every load (#2259).
+		if mapPositionPrecision < 12 || mapPositionPrecision > 15 { self.mapPositionPrecision = 14 }
 		self.hasChanges = false
 	}
 }


### PR DESCRIPTION
## Summary

Setting the MQTT map report precision to 15 (about 700 m) didn't stick: reopening the screen showed 14 again, and moving the slider never offered the Save button (#2259).

## What changed

Two small fixes in MQTTConfig:

- The load path clamped the value to 11...14, converting a saved 15 back to 14 on every open. The firmware and the slider both use 12...15; the clamp now matches.
- Moving the slider now sets `hasChanges` via the same `onChange` pattern every other control on the screen uses, so Save appears.

Replaces #2276, which fixed the same bug but wrapped it in value-preservation machinery the 12...15 range doesn't need.

## Testing

iOS build passes. Manual check: set precision to 15, save, reopen — it stays 15; moving the slider alone now shows Save.