### PR TITLE
Warn when a channel gets a reserved module name

### DIFF
--- a/Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift
+++ b/Meshtastic/Extensions/SwiftData/ChannelEntityExtension.swift
@@ -66,4 +66,13 @@ extension ChannelEntity {
 		channel.settings.moduleSettings.isMuted = self.mute
 		return channel
 	}
+
+	/// Channel names reserved for module traffic (legacy remote admin, GPIO, serial, MQTT).
+	/// Channels with these names carry module protocol data, so the Messages channel list
+	/// hides them and the channel editor warns when one is entered.
+	static let reservedModuleNames = ["admin", "gpio", "serial", "mqtt"]
+
+	static func isReservedModuleName(_ name: String) -> Bool {
+		reservedModuleNames.contains(name.lowercased())
+	}
 }

--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -20,8 +20,6 @@ struct ChannelList: View {
 	@State private var isPresentingTraceRouteSentAlert = false
 	@State private var showingHelp = false
 
-	var restrictedChannels = ["gpio", "mqtt", "serial", "admin"]
-
 	private var visibleChannels: [ChannelEntity] {
 		guard let myInfo = node?.myInfo else { return [] }
 
@@ -30,9 +28,12 @@ struct ChannelList: View {
 			channelsByIndex[channel.index] = channel
 		}
 
+		// Module channels (reserved names) carry protocol traffic, not messages.
+		// ChannelForm warns when one of these names is entered, since a hidden
+		// channel with no explanation reads as data loss (#2275).
 		return channelsByIndex
 			.values
-			.filter { !restrictedChannels.contains($0.name?.lowercased() ?? "") }
+			.filter { !ChannelEntity.isReservedModuleName($0.name ?? "") }
 			.sorted { $0.index < $1.index }
 	}
 

--- a/Meshtastic/Views/Settings/Channels/ChannelForm.swift
+++ b/Meshtastic/Views/Settings/Channels/ChannelForm.swift
@@ -48,6 +48,15 @@ struct ChannelForm: View {
 							hasChanges = true
 						}
 					}
+					if ChannelEntity.isReservedModuleName(channelName) {
+						Label {
+							Text("\"\(channelName)\" is a reserved module channel name and will not appear in the Messages channel list. Pick a different name for a messaging channel.")
+								.font(.callout)
+						} icon: {
+							Image(systemName: "exclamationmark.triangle.fill")
+						}
+						.foregroundColor(.orange)
+					}
 					HStack {
 						Picker("Key Size", selection: $channelKeySize) {
 							Text("Empty").tag(0)


### PR DESCRIPTION
## Summary

Naming a channel `admin`, `gpio`, `serial` or `mqtt` hides it from the Messages channel list — module channels carry protocol traffic, not messages — but nothing tells the user. In #2275 someone renamed their primary channel to `Admin` and factory-reset their radio trying to get it back.

## What changed

- The channel editor shows an orange warning under the name field when a reserved name is entered, saying the channel won't appear in the Messages list.
- The reserved list moved from a local array in `ChannelList` to `ChannelEntity.reservedModuleNames`, so the editor's warning and the list's filter can't drift apart.

The filter behavior itself is unchanged — reserved-name channels stay out of Messages by design.

## Testing

iOS build passes; the warning appears live while typing (case-insensitive match, same as the filter).