### PR TITLE
Event mode: bigger connect logo, contrast-safe header, markdown release notes

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -439,7 +439,6 @@ struct Connect: View {
 						.textCase(nil)
 					}
 				}
-				.scrollContentBackground(.hidden)
 				HStack(alignment: .center) {
 					Spacer()
 #if targetEnvironment(macCatalyst)

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -154,16 +154,19 @@ struct Connect: View {
 												Button {
 													openEventFirmwareInfo()
 												} label: {
-													HStack(spacing: 6) {
+													HStack(spacing: 12) {
 														EventFirmwareIcon(
 															edition: eventPresentation.edition,
 															iconURL: eventPresentation.info.iconURL,
-															size: 22
+															size: 88
 														)
-														Text("Firmware Edition").font(.callout)
-															+ Text(": \(eventPresentation.info.displayName ?? accessoryManager.firmwareEdition.name)")
-															.font(.callout)
-															.foregroundColor(Color.gray)
+														VStack(alignment: .leading, spacing: 2) {
+															Text(eventPresentation.info.displayName ?? accessoryManager.firmwareEdition.name)
+																.font(.headline)
+															Text("Firmware Edition")
+																.font(.callout)
+																.foregroundColor(Color.gray)
+														}
 														Image(systemName: "chevron.right")
 															.font(.caption2)
 															.foregroundColor(.gray)

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -154,22 +154,19 @@ struct Connect: View {
 												Button {
 													openEventFirmwareInfo()
 												} label: {
-													HStack(spacing: 12) {
+													VStack(alignment: .leading, spacing: 6) {
+														HStack(spacing: 4) {
+															Text(eventPresentation.info.displayName ?? accessoryManager.firmwareEdition.name)
+																.font(.headline)
+															Image(systemName: "chevron.right")
+																.font(.caption2)
+																.foregroundColor(.gray)
+														}
 														EventFirmwareIcon(
 															edition: eventPresentation.edition,
 															iconURL: eventPresentation.info.iconURL,
 															size: 88
 														)
-														VStack(alignment: .leading, spacing: 2) {
-															Text(eventPresentation.info.displayName ?? accessoryManager.firmwareEdition.name)
-																.font(.headline)
-															Text("Firmware Edition")
-																.font(.callout)
-																.foregroundColor(Color.gray)
-														}
-														Image(systemName: "chevron.right")
-															.font(.caption2)
-															.foregroundColor(.gray)
 													}
 												}
 												.buttonStyle(.plain)

--- a/Meshtastic/Views/Connect/EventFirmwareInfoView.swift
+++ b/Meshtastic/Views/Connect/EventFirmwareInfoView.swift
@@ -77,6 +77,11 @@ struct EventFirmwareInfoView: View {
 				.background(Color(.systemGroupedBackground))
 			}
 			.tint(useEventTheme ? highlight : .accentColor)
+			// The accent-colored header extends behind the navigation bar, but the bar's
+			// title and close button follow the SYSTEM scheme — black over DEF CON's navy
+			// in light mode, well under the 4.5:1 text contrast minimum. Force the bar's
+			// content scheme to match the header foreground instead.
+			.toolbarColorScheme(headerForeground == .black ? .light : .dark, for: .navigationBar)
 			.navigationTitle(Text("Event"))
 			.navigationBarTitleDisplayMode(.inline)
 			.toolbar {
@@ -180,11 +185,13 @@ struct EventFirmwareInfoView: View {
 				}
 				firmwareComparisonRow
 				if let notes = info.firmwareReleaseNotes, !notes.isEmpty {
-					DisclosureGroup("Release Notes") {
-						Text(notes)
-							.font(.footnote)
-							.foregroundColor(.secondary)
-							.padding(.vertical, 2)
+					// Same markdown rendering as the firmware updates screen, instead of the
+					// raw markdown source this used to dump as plain text.
+					NavigationLink("Release Notes") {
+						FirmwareReleaseNotesView(
+							markdown: notes,
+							versionId: info.firmwareVersion ?? displayName
+						)
 					}
 				}
 			} header: {


### PR DESCRIPTION
## Summary

Three event-mode fixes, prompted by the DEF CON sheet failing contrast in light mode.

## What changed

- **Connect screen logo is 4x larger.** The event icon in the connected-device box goes from 22pt inline with the text to 88pt with the edition name stacked beside it. Still the tappable entry to the event sheet.
- **The event sheet's navigation bar follows the header color.** The accent-colored header extends behind the nav bar, but the bar's title and close button rendered in the system scheme — black over DEF CON's navy in light mode, roughly 1.6:1 against the 4.5:1 text minimum. The bar's color scheme is now forced to match the same `prefersDarkForeground` decision the header content already uses, so any event accent gets a passing title. Theme tints for controls already go through `accessibleTintHex`, which enforces 3:1 against the surface.
- **Release notes render as markdown** via the same `FirmwareReleaseNotesView` the firmware updates screen uses, instead of dumping the raw markdown source as plain text.

## Testing

Verified in the simulator against the DEFCON replay in light mode: the sheet's title and close button now render white over the navy header (screenshots in the session; previously black-on-navy). Connect box shows the large icon with the edition name. iOS build passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the connected-device event firmware display with a larger icon and clearer vertical layout.
  * Improved navigation bar contrast in the event firmware details view.
  * Replaced inline release-note text with a dedicated release notes screen supporting formatted content and firmware version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->