### PR TITLE
Generate TestFlight What to Test notes automatically

### DIFF
--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -12,6 +12,29 @@ if [ -z "$CI_ARCHIVE_PATH" ]; then
 	exit 0
 fi
 
+# TestFlight "What to Test": generated from the PR titles merged recently, so every
+# TestFlight build carries notes without anyone writing them. Xcode Cloud picks up
+# TestFlight/WhatToTest.<locale>.txt from the repository root during an archive action.
+# Best effort — never fail the build over release notes.
+TESTFLIGHT_DIR="$CI_PRIMARY_REPOSITORY_PATH/TestFlight"
+mkdir -p "$TESTFLIGHT_DIR"
+# Xcode Cloud clones are shallow; deepen so the merge history is visible.
+git -C "$CI_PRIMARY_REPOSITORY_PATH" fetch --deepen 50 --quiet 2>/dev/null || true
+# GitHub merge commits carry the PR title in the body. Take the last 10 merges,
+# first line of each body, drop empties/trailers, de-duplicate.
+NOTES=$(git -C "$CI_PRIMARY_REPOSITORY_PATH" log --merges -10 --pretty=format:"%b%n---" 2>/dev/null \
+	| awk '/^---$/{first=0; next} !first++ && NF && !/^Co-authored|^Signed-off/ {print "• " $0}' \
+	| awk '!seen[$0]++' | head -12)
+if [ -z "$NOTES" ]; then
+	NOTES=$(git -C "$CI_PRIMARY_REPOSITORY_PATH" log -10 --no-merges --pretty=format:"• %s" 2>/dev/null)
+fi
+if [ -n "$NOTES" ]; then
+	printf "Recent changes in this build:\n\n%s\n" "$NOTES" > "$TESTFLIGHT_DIR/WhatToTest.en-US.txt"
+	echo "WhatToTest generated with $(printf '%s\n' "$NOTES" | wc -l | tr -d ' ') entries."
+else
+	echo "No commit history available — skipping WhatToTest generation."
+fi
+
 DSYM_DIR="$CI_ARCHIVE_PATH/dSYMs"
 
 if [ ! -d "$DSYM_DIR" ]; then


### PR DESCRIPTION
## Summary

TestFlight builds currently ship with no What to Test notes unless someone writes them by hand.

## What changed

`ci_post_xcodebuild.sh` now writes `TestFlight/WhatToTest.en-US.txt` during every archive action, built from the titles of the last ten merged PRs (GitHub merge commits carry the PR title in the body). Xcode Cloud picks that file up and attaches it to the build in TestFlight. Best effort: shallow clones are deepened first, a repo with no visible merges falls back to commit subjects, and an empty history skips the file rather than failing the build.

Sample output from current history:

```
Recent changes in this build:

• feat(import): cancellation-aware transport sends + shielded commit
• fix(widget): respect custom Number Format in Live Activity
• Mesh stats strip on the Apple TV map
• Fix MQTT map precision 15 reverting to 14
...
```

## Testing

Pipeline dry-run against the repo's real merge history produces the list above; `sh -n` passes. The end-to-end proof is the next Xcode Cloud build showing notes in TestFlight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic TestFlight release notes generation during archive builds.
  * Release notes summarize recent changes using deduplicated commit or merge titles.
* **Reliability**
  * Release-note generation is best effort and will not interrupt builds if history or notes are unavailable.
* **Unchanged**
  * Existing dSYM validation and Datadog upload processes continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->