### PR TITLE
Fix tvOS header background seam

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -181,7 +181,7 @@ struct MapScreen: View {
 						endPoint: .bottom
 					)
 				)
-				.ignoresSafeArea(edges: .top)
+				.ignoresSafeArea(edges: [.top, .leading])
 		}
 	}
 


### PR DESCRIPTION
## What changed?

Extended the tvOS map header material through the leading safe area while keeping the header content inside the overscan-safe layout.

## Why did it change?

The frosted header background stopped at the leading safe-area boundary, leaving the untinted root background visible in the margin and creating a vertical seam.

## How is this tested?

- Built the `Meshtastic TV` scheme for the Apple TV 4K (3rd generation) tvOS 26.5 simulator.
- Ran SwiftLint on `Meshtastic TV/App/MapScreen.swift` with 0 violations.
- Compared 3840 × 2160 screenshots from the same simulator, connection, and focus state. The mean RGB delta across the header edge dropped from 3.93 to 0.53, while the wordmark and focused button positions stayed unchanged.

## Screenshots/Videos (when applicable)

### Before
<img width="3840" height="2160" alt="tvos-background-seam-before" src="https://github.com/user-attachments/assets/48019eac-a3b8-405c-b089-823b9d8b0b80" />

### After
<img width="3840" height="2160" alt="tvos-background-seam-after" src="https://github.com/user-attachments/assets/9176248d-a6a2-47d6-8d2a-97603792687f" />

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed for this visual fix.
- [x] I have tested the change to ensure that it works as intended.
