### PR TITLE
Fix external notification control bindings

### DIFF
--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -107,7 +107,7 @@ struct ExternalNotificationConfig: View {
 				Toggle(isOn: $alertMessageBuzzer) {
 					Label("Alert GPIO buzzer when receiving a message", systemImage: "message")
 				}
-				Toggle(isOn: $alertMessageBuzzer) {
+				Toggle(isOn: $alertMessageVibra) {
 					Label("Alert GPIO vibra motor when receiving a message", systemImage: "message")
 				}
 				Picker("Output pin buzzer GPIO ", selection: $outputBuzzer) {
@@ -204,10 +204,10 @@ struct ExternalNotificationConfig: View {
 		.onChange(of: output) { _, newOutput in
 			if newOutput != node?.externalNotificationConfig?.output ?? -1 { hasChanges = true }
 		}
-		.onChange(of: output) { _, newOutputBuzzer in
+		.onChange(of: outputBuzzer) { _, newOutputBuzzer in
 			if newOutputBuzzer != node?.externalNotificationConfig?.outputBuzzer ?? -1 { hasChanges = true }
 		}
-		.onChange(of: output) { _, newOutputVibra in
+		.onChange(of: outputVibra) { _, newOutputVibra in
 			if newOutputVibra != node?.externalNotificationConfig?.outputVibra ?? -1 { hasChanges = true }
 		}
 		.onChange(of: outputMilliseconds) { _, newOutputMs in

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -202,16 +202,16 @@ struct ExternalNotificationConfig: View {
 			if newActive != node?.externalNotificationConfig?.active { hasChanges = true }
 		}
 		.onChange(of: output) { _, newOutput in
-			if newOutput != node?.externalNotificationConfig?.output ?? -1 { hasChanges = true }
+			if newOutput != Int(node?.externalNotificationConfig?.output ?? -1) { hasChanges = true }
 		}
 		.onChange(of: outputBuzzer) { _, newOutputBuzzer in
-			if newOutputBuzzer != node?.externalNotificationConfig?.outputBuzzer ?? -1 { hasChanges = true }
+			if newOutputBuzzer != Int(node?.externalNotificationConfig?.outputBuzzer ?? -1) { hasChanges = true }
 		}
 		.onChange(of: outputVibra) { _, newOutputVibra in
-			if newOutputVibra != node?.externalNotificationConfig?.outputVibra ?? -1 { hasChanges = true }
+			if newOutputVibra != Int(node?.externalNotificationConfig?.outputVibra ?? -1) { hasChanges = true }
 		}
 		.onChange(of: outputMilliseconds) { _, newOutputMs in
-			if newOutputMs != node?.externalNotificationConfig?.outputMilliseconds ?? -1 { hasChanges = true }
+			if newOutputMs != Int(node?.externalNotificationConfig?.outputMilliseconds ?? -1) { hasChanges = true }
 		}
 		.onChange(of: usePWM) { _, newPWM in
 			if newPWM != node?.externalNotificationConfig?.usePWM { hasChanges = true }


### PR DESCRIPTION
## What changed?

- Bind the message vibration toggle to `alertMessageVibra`.
- Track buzzer and vibration GPIO picker changes through `outputBuzzer` and `outputVibra`.
- Audit the remaining toggle, change observer, load, and save mappings in this view.

Fixes #2231.

## Why did it change?

The message vibration control was bound to the buzzer state, so both controls moved together and saving changed the wrong setting. The optional GPIO change observers also watched the primary output, so pin-only edits could fail to expose the Save button.

## How is this tested?

- `xcodebuild -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `swiftlint lint Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift` reports 0 violations.
- Manually audited all toggle, change observer, load, and save mappings in `ExternalNotificationConfig`.
- Runtime UI and radio interaction were not tested.

## Screenshots/Videos (when applicable)

Not applicable. This changes control bindings without changing the layout.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [ ] I have commented my code, particularly in complex areas. (Not applicable; no complex code was added.)
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed because documented labels and navigation are unchanged; add the **`skip-docs-check`** label.
- [ ] I have tested the change to ensure that it works as intended. (Build and static checks passed; runtime UI behavior was not tested.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the message-alert GPIO toggle to correctly control vibration alerts.
  * Improved settings change detection for buzzer and vibration outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->