### PR TITLE
Drop the underline on message links

### DIFF
--- a/Meshtastic/Views/Messages/MessageText.swift
+++ b/Meshtastic/Views/Messages/MessageText.swift
@@ -90,11 +90,10 @@ struct MessageText: View {
 		return AnyView(baseMessageContent)
 	}
 
-	private func underlineLinks(in source: AttributedString) -> AttributedString {
+	private func colorLinks(in source: AttributedString) -> AttributedString {
 		var result = source
 		let linkColor = Color("Colors/MeshtasticLink")
 		for run in result.runs where run.link != nil {
-			result[run.range].underlineStyle = .single
 			result[run.range].foregroundColor = linkColor
 		}
 		return result
@@ -104,7 +103,7 @@ struct MessageText: View {
 		let payload = message.displayedMarkdownPayload
 		return Group {
 			if let attributed = try? AttributedString(markdown: payload, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
-				Text(underlineLinks(in: attributed))
+				Text(colorLinks(in: attributed))
 			} else {
 				Text(LocalizedStringKey(payload))
 			}


### PR DESCRIPTION
## Summary

Links in message bubbles (URLs and @mentions) were underlined as well as colored. The underline looks heavy; the link color is enough.

## What changed

MessageText no longer applies an underline to link runs; they keep the MeshtasticLink color.

## Testing

iOS build passes; verified on device with mention links and URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated message link styling to use colored text without underlines.
  * Improved consistency in how links are displayed within messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->