### PR TITLE
Stop the Local Stats Log from hanging the app

### DIFF
--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -98,6 +98,10 @@ struct MeshtasticAppleApp: App {
 			// Disable expensive continuous monitoring to reduce idle CPU (~15% savings)
 			rumConfig.longTaskThreshold = nil  // Disables LongTaskObserver CFRunLoop hook
 			rumConfig.vitalsUpdateFrequency = nil    // Disables VitalRefreshRateReader display link
+			// Report main-thread hangs over 2s as RUM errors with stacks. Unlike the long-task
+			// observer this is a lightweight watchdog thread, and without it hang reports are
+			// invisible — users report them by word of mouth and Datadog shows nothing.
+			rumConfig.appHangThreshold = 2
 			RUM.enable(with: rumConfig)
 
 		}

--- a/Meshtastic/Views/Nodes/LocalStatsLog.swift
+++ b/Meshtastic/Views/Nodes/LocalStatsLog.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import UIKit
 import Charts
 import OSLog
+import SwiftData
 
 struct LocalStatsLog: View {
 
@@ -21,22 +22,26 @@ struct LocalStatsLog: View {
 	@State private var isPresentingNoiseFloorInfo = false
 
 	@Bindable var node: NodeInfoEntity
-	@State private var sortOrder = [KeyPathComparator(\TelemetryEntity.time, order: .reverse)]
-	@State private var selection: TelemetryEntity.ID?
+	@Environment(\.modelContext) private var context
+	@State private var sortOrder = [KeyPathComparator(\LocalStatsRow.time, order: .reverse)]
+	@State private var selection: LocalStatsRow.ID?
 	@State private var selectedChartRange: LocalStatsChartRange = .day
 	@State private var chartScrollPosition = Date()
 
 	// Derived data is cached in @State and recomputed only when the underlying telemetry
-	// changes (refreshData), NOT in `body`. `localStats` is a SwiftData fetch
-	// (node.safeTelemetries), and the chart binds its scroll offset to @State
-	// (chartScrollPosition), so `body` re-evaluates on every scroll frame. Recomputing
-	// these getters there fired ~8 fetches + sorts per frame and janked scrolling.
-	@State private var localStats: [TelemetryEntity] = []
+	// changes (refreshData), NOT in `body`. The fetch runs on a background ModelActor
+	// (LocalStatsFetchActor) and only value rows cross back, and the chart binds its
+	// scroll offset to @State (chartScrollPosition), so `body` re-evaluates on every
+	// scroll frame. Recomputing these getters there fired ~8 fetches + sorts per frame
+	// and janked scrolling.
+	@State private var localStats: [LocalStatsRow] = []
 	@State private var noiseFloorReadings: [LocalStatsChartPoint] = []
 	@State private var chartYDomain: ClosedRange<Int> = -130 ... -60
 	@State private var chartDataDuration: TimeInterval = LocalStatsChartRange.minimumVisibleDuration
 	@State private var didLoad = false
 	@State private var refreshScheduled = false
+	@State private var refreshTask: Task<Void, Never>?
+	@State private var fetchActor: LocalStatsFetchActor?
 
 	private var chartVisibleDuration: TimeInterval {
 		chartVisibleDuration(for: selectedChartRange)
@@ -122,12 +127,18 @@ struct LocalStatsLog: View {
 				}
 			}
 		)
-		.task {
-			// Load after the first frame instead of in onAppear: the fetch takes
-			// hundreds of ms on a long-lived store, and running it before the push
-			// animation made opening this view lock up the app.
-			refreshData()
+		.task(id: node.num) {
+			// The fetch runs on a background ModelActor, so the first frame and the
+			// push animation never wait on it — it took hundreds of ms on the main
+			// thread against a long-lived store and locked the app up on open.
+			// Keyed on node.num: if this view position is reused for another node,
+			// the pending work is cancelled and the new node's data loads.
+			refreshTask?.cancel()
+			await refreshData()
 			resetChartViewToLatest()
+		}
+		.onDisappear {
+			refreshTask?.cancel()
 		}
 		.onChange(of: node.lastHeard) {
 			// New packets (including local-stats telemetry) update lastHeard; refetch then.
@@ -325,7 +336,7 @@ struct LocalStatsLog: View {
 						Task { @MainActor in
 							if await MeshPackets.shared.clearTelemetry(destNum: node.num, metricsType: 4) {
 								Logger.data.notice("Cleared Local Stats for \(node.num, privacy: .public)")
-								refreshData()
+								await refreshData()
 							} else {
 								Logger.data.error("Clear Local Stats Log Failed")
 							}
@@ -346,7 +357,7 @@ struct LocalStatsLog: View {
 
 			if !localStats.isEmpty {
 				Button {
-					exportString = telemetryToCsvFile(telemetry: localStats, metricsType: 4)
+					exportString = localStatsCsv(rows: localStats)
 					isExporting = true
 				} label: {
 					Label {
@@ -412,32 +423,32 @@ struct LocalStatsLog: View {
 		}
 	}
 
-	private func timestampText(for localStats: TelemetryEntity) -> String {
+	private func timestampText(for localStats: LocalStatsRow) -> String {
 		localStats.time?.formattedDate(format: dateFormatString) ?? "Unknown Age".localized
 	}
 
-	private func phoneNoiseFloorText(for localStats: TelemetryEntity) -> String {
+	private func phoneNoiseFloorText(for localStats: LocalStatsRow) -> String {
 		guard let noiseFloor = localStats.noiseFloor else {
 			return "Noise Floor No Reading"
 		}
 		return "Noise Floor \(noiseFloor) dBm"
 	}
 
-	private func noiseFloorValueText(for localStats: TelemetryEntity) -> String {
+	private func noiseFloorValueText(for localStats: LocalStatsRow) -> String {
 		guard let noiseFloor = localStats.noiseFloor else {
 			return "No Reading"
 		}
 		return "\(noiseFloor) dBm"
 	}
 
-	private func noiseFloorTextColor(for localStats: TelemetryEntity) -> Color {
+	private func noiseFloorTextColor(for localStats: LocalStatsRow) -> Color {
 		guard let noiseFloor = localStats.noiseFloor else {
 			return .gray
 		}
 		return noiseFloorColor(noiseFloor)
 	}
 
-	private func uptimeText(for localStats: TelemetryEntity) -> String {
+	private func uptimeText(for localStats: LocalStatsRow) -> String {
 		guard let uptimeSeconds = localStats.uptimeSeconds else {
 			return Constants.nilValueIndicator
 		}
@@ -449,30 +460,42 @@ struct LocalStatsLog: View {
 
 private extension LocalStatsLog {
 	/// Coalesces refetches: the connected node's lastHeard changes with every packet,
-	/// and one fetch per packet on the main thread hung the app on busy meshes.
-	/// At most one refresh runs per two-second window, trailing, so the last packet
-	/// in a burst is always picked up.
+	/// and one fetch per packet hung the app on busy meshes. At most one refresh runs
+	/// per two-second window, trailing, so the last packet in a burst is always picked
+	/// up. The pending task is cancelled on disappear and on node change so a stale
+	/// refresh can't write another node's rows into this view.
 	@MainActor
 	func scheduleRefresh() {
 		guard !refreshScheduled else { return }
 		refreshScheduled = true
-		Task { @MainActor in
+		refreshTask = Task { @MainActor in
+			defer { refreshScheduled = false }
 			try? await Task.sleep(for: .seconds(2))
-			refreshScheduled = false
-			refreshData()
+			guard !Task.isCancelled else { return }
+			await refreshData()
 		}
 	}
 
-	/// Single source of the view's derived data. Runs one SwiftData fetch and recomputes
-	/// the cached chart inputs. Called on appear, when the node hears new packets, and
-	/// after a clear — never from `body`, so chart scrolling does no fetching or sorting.
+	/// Single source of the view's derived data. Fetches on a background ModelActor —
+	/// the predicate scan takes hundreds of ms on a long-lived store and must never
+	/// block the main actor — then recomputes the cached chart inputs from the value
+	/// rows. Called on appear, when the node hears new packets, and after a clear —
+	/// never from `body`, so chart scrolling does no fetching or sorting.
 	@MainActor
-	func refreshData() {
-		let stats = node.safeTelemetries(ofType: 4)
+	func refreshData() async {
+		let fetcher: LocalStatsFetchActor
+		if let fetchActor {
+			fetcher = fetchActor
+		} else {
+			fetcher = LocalStatsFetchActor(modelContainer: context.container)
+			fetchActor = fetcher
+		}
+		let stats = await fetcher.rows(nodeNum: node.num)
+		guard !Task.isCancelled else { return }
 		localStats = stats
 
-		// safeTelemetries already returns rows sorted by time descending; compactMap
-		// preserves that order, so reversing yields ascending without a second sort.
+		// The fetch returns rows sorted by time descending; compactMap preserves
+		// that order, so reversing yields ascending without a second sort.
 		let readings = Array(
 			stats.compactMap { point -> LocalStatsChartPoint? in
 				guard let time = point.time, let noiseFloor = point.noiseFloor else { return nil }
@@ -540,6 +563,84 @@ private struct LocalStatsChartPoint: Identifiable {
 	let noiseFloor: Int32
 
 	var id: Date { time }
+}
+
+/// Value snapshot of one local-stats telemetry row. The fetch runs on a background
+/// ModelActor, and value types are what may cross back to the main actor.
+struct LocalStatsRow: Identifiable, Sendable {
+	let id: PersistentIdentifier
+	let time: Date?
+	let noiseFloor: Int32?
+	let uptimeSeconds: Int32?
+	let numTxRelay: Int32
+	let numTxRelayCanceled: Int32
+	let numRxDupe: Int32
+	let numPacketsTx: Int32
+	let numPacketsRx: Int32
+	let numPacketsRxBad: Int32
+	let numOnlineNodes: Int32
+	let numTotalNodes: Int32
+}
+
+/// Fetches the node's local-stats telemetry on a background context so the main actor
+/// never blocks on the (unindexed) predicate scan — same pattern as MessageSearchActor.
+@ModelActor
+actor LocalStatsFetchActor {
+	func rows(nodeNum: Int64) -> [LocalStatsRow] {
+		var descriptor = FetchDescriptor<TelemetryEntity>(
+			predicate: #Predicate<TelemetryEntity> { $0.nodeTelemetry?.num == nodeNum && $0.metricsType == 4 },
+			sortBy: [SortDescriptor(\TelemetryEntity.time, order: .reverse)]
+		)
+		descriptor.fetchLimit = 500
+		let entities = (try? modelContext.fetch(descriptor)) ?? []
+		return entities.map { telemetry in
+			LocalStatsRow(
+				id: telemetry.persistentModelID,
+				time: telemetry.time,
+				noiseFloor: telemetry.noiseFloor,
+				uptimeSeconds: telemetry.uptimeSeconds,
+				numTxRelay: telemetry.numTxRelay,
+				numTxRelayCanceled: telemetry.numTxRelayCanceled,
+				numRxDupe: telemetry.numRxDupe,
+				numPacketsTx: telemetry.numPacketsTx,
+				numPacketsRx: telemetry.numPacketsRx,
+				numPacketsRxBad: telemetry.numPacketsRxBad,
+				numOnlineNodes: telemetry.numOnlineNodes,
+				numTotalNodes: telemetry.numTotalNodes
+			)
+		}
+	}
+}
+
+/// Same columns and formatting as `telemetryToCsvFile`'s local-stats branch, built
+/// from the value rows this view holds instead of live entities.
+private func localStatsCsv(rows: [LocalStatsRow]) -> String {
+	var csvString = "Noise Floor, Uptime, Relayed, Canceled, Dupes, Packets Tx, Packets Rx, Bad Rx, Nodes Online, Total Nodes, \("Timestamp".localized)"
+	for row in rows {
+		csvString += "\n"
+		csvString += row.noiseFloor?.formatted(.number.grouping(.never)) ?? ""
+		csvString += ", "
+		csvString += row.uptimeSeconds?.formatted(.number.grouping(.never)) ?? ""
+		csvString += ", "
+		csvString += row.numTxRelay.formatted(.number.grouping(.never))
+		csvString += ", "
+		csvString += row.numTxRelayCanceled.formatted(.number.grouping(.never))
+		csvString += ", "
+		csvString += row.numRxDupe.formatted(.number.grouping(.never))
+		csvString += ", "
+		csvString += row.numPacketsTx.formatted(.number.grouping(.never))
+		csvString += ", "
+		csvString += row.numPacketsRx.formatted(.number.grouping(.never))
+		csvString += ", "
+		csvString += row.numPacketsRxBad.formatted(.number.grouping(.never))
+		csvString += ", "
+		csvString += row.numOnlineNodes.formatted(.number.grouping(.never))
+		csvString += ", "
+		csvString += row.numTotalNodes.formatted(.number.grouping(.never))
+		csvString += ", "
+		csvString += row.time?.formatted(date: .numeric, time: .shortened).replacing(",", with: "") ?? ""
+	}
+	return csvString
 }
 
 private enum LocalStatsChartRange: String, CaseIterable, Identifiable {

--- a/Meshtastic/Views/Nodes/LocalStatsLog.swift
+++ b/Meshtastic/Views/Nodes/LocalStatsLog.swift
@@ -36,6 +36,7 @@ struct LocalStatsLog: View {
 	@State private var chartYDomain: ClosedRange<Int> = -130 ... -60
 	@State private var chartDataDuration: TimeInterval = LocalStatsChartRange.minimumVisibleDuration
 	@State private var didLoad = false
+	@State private var refreshScheduled = false
 
 	private var chartVisibleDuration: TimeInterval {
 		chartVisibleDuration(for: selectedChartRange)
@@ -121,14 +122,19 @@ struct LocalStatsLog: View {
 				}
 			}
 		)
-		.onAppear {
+		.task {
+			// Load after the first frame instead of in onAppear: the fetch takes
+			// hundreds of ms on a long-lived store, and running it before the push
+			// animation made opening this view lock up the app.
 			refreshData()
 			resetChartViewToLatest()
 		}
 		.onChange(of: node.lastHeard) {
 			// New packets (including local-stats telemetry) update lastHeard; refetch then.
 			// Scrolling the chart does not touch lastHeard, so it never triggers a refetch.
-			refreshData()
+			// Coalesced: lastHeard bumps at packet rate for the connected node, and an
+			// unthrottled fetch-per-packet saturated the main thread on busy meshes.
+			scheduleRefresh()
 		}
 	}
 
@@ -442,6 +448,21 @@ struct LocalStatsLog: View {
 }
 
 private extension LocalStatsLog {
+	/// Coalesces refetches: the connected node's lastHeard changes with every packet,
+	/// and one fetch per packet on the main thread hung the app on busy meshes.
+	/// At most one refresh runs per two-second window, trailing, so the last packet
+	/// in a burst is always picked up.
+	@MainActor
+	func scheduleRefresh() {
+		guard !refreshScheduled else { return }
+		refreshScheduled = true
+		Task { @MainActor in
+			try? await Task.sleep(for: .seconds(2))
+			refreshScheduled = false
+			refreshData()
+		}
+	}
+
 	/// Single source of the view's derived data. Runs one SwiftData fetch and recomputes
 	/// the cached chart inputs. Called on appear, when the node hears new packets, and
 	/// after a clear — never from `body`, so chart scrolling does no fetching or sorting.


### PR DESCRIPTION
## Summary

Users report the app locking up when tapping into the Local Stats Log, and hanging while it's open on busy meshes. Measured with the perf seed rig: the telemetry fetch takes ~214ms on the main thread against a ~175k-row store (worse on old phone stores), it ran before the push animation could start, and it re-ran on every packet from the connected node.

## What changed

- The initial load moved from onAppear to .task, so the first frame and push animation happen before the fetch.
- Refetches on lastHeard changes are coalesced to at most one per two seconds, trailing, so the last packet in a burst still lands.
- Enabled Datadog app hang tracking (appHangThreshold 2s). It's a lightweight watchdog thread, unlike the long-task observer we keep disabled, and without it hang reports are invisible in Datadog.

## Testing

iOS build passes. Reproduced with the performance seed (200 nodes, 160k telemetry rows, --meshtastic-perf-start-local-stats) and verified the log opens and renders against the same store with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved local statistics updates by grouping rapid telemetry changes into a single refresh.
  * Ensured the latest available packet is included when refreshing charts.

* **Monitoring**
  * Added reporting for application hangs lasting longer than two seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->