### PR TITLE
Show the node name once on the TV node detail

### DIFF
--- a/Meshtastic TV/Views/NodeDetailView.swift
+++ b/Meshtastic TV/Views/NodeDetailView.swift
@@ -25,7 +25,6 @@ struct NodeDetailView: View {
 				header
 
 				section("Identity") {
-					DetailRow("Name", node.displayName)
 					if !node.shortName.isEmpty {
 						DetailRow("Short", node.shortName)
 					}
@@ -60,7 +59,6 @@ struct NodeDetailView: View {
 			.padding(TVTheme.screenPadding)
 			.frame(maxWidth: .infinity, alignment: .leading)
 		}
-		.navigationTitle(node.displayName)
 	}
 
 	private var header: some View {


### PR DESCRIPTION
## Summary

The TV app's node detail showed the long name three times: in the header next to the avatar circle, as the navigation title, and again as a Name row in the Identity section.

## What changed

Kept the header next to the avatar; removed the navigation title and the Identity Name row.

## Testing

Meshtastic TV scheme builds for the tvOS simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the Identity section’s Name detail row from node details.
  * Removed the navigation title from the node details view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->