### PR TITLE
Fix tvOS Bonjour discovery after resume

### DIFF
--- a/Meshtastic TV/App/ConnectView.swift
+++ b/Meshtastic TV/App/ConnectView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct ConnectView: View {
 	@Bindable var client: MeshClient
+	@Environment(\.scenePhase) private var scenePhase
 	@StateObject private var discovery = NodeDiscovery()
 
 	@AppStorage("tv.lastHost") private var host: String = ""
@@ -59,6 +60,9 @@ struct ConnectView: View {
 			}
 			.padding(.top, TVTheme.screenPadding)
 		}
+		.onChange(of: scenePhase) { _, phase in
+			discovery.handle(scenePhase: phase)
+		}
 	}
 
 	private var hero: some View {
@@ -81,7 +85,11 @@ struct ConnectView: View {
 	@ViewBuilder
 	private var discoveredSection: some View {
 		Section {
-			if discovery.discovered.isEmpty {
+			if let errorMessage = discovery.errorMessage {
+				Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+					.foregroundStyle(Color("MeshtasticError"))
+				Button("Try Again") { discovery.retry() }
+			} else if discovery.discovered.isEmpty {
 				HStack(spacing: 16) {
 					ProgressView()
 					Text("Searching the local network…")

--- a/Meshtastic TV/Client/NodeDiscovery.swift
+++ b/Meshtastic TV/Client/NodeDiscovery.swift
@@ -14,51 +14,125 @@
 //
 
 import Foundation
+import OSLog
+import SwiftUI
+
+private let discoveryLogger = Logger(
+	subsystem: Bundle.main.bundleIdentifier ?? "org.meshtastic.tv",
+	category: "📡 Discovery"
+)
 
 struct DiscoveredNode: Identifiable, Hashable {
 	let id: String        // node id (e.g. !fa6c5fac) when advertised, else service name
+	let serviceName: String
 	let name: String      // shortname / service name for display
 	let host: String      // resolved hostname (e.g. Meshtastic.local)
 	let port: Int
 }
 
+protocol ServiceBrowsing: AnyObject {
+	func setDelegate(_ delegate: NetServiceBrowserDelegate?)
+	func searchForServices(ofType type: String, inDomain domainString: String)
+	func stop()
+}
+
+extension NetServiceBrowser: ServiceBrowsing {
+	func setDelegate(_ delegate: NetServiceBrowserDelegate?) {
+		self.delegate = delegate
+	}
+}
+
 @MainActor
-final class NodeDiscovery: NSObject, ObservableObject, NetServiceBrowserDelegate, NetServiceDelegate {
+final class NodeDiscovery: NSObject, ObservableObject, @preconcurrency NetServiceBrowserDelegate, @preconcurrency NetServiceDelegate {
 
 	@Published private(set) var discovered: [DiscoveredNode] = []
 	@Published private(set) var isBrowsing = false
+	@Published private(set) var errorMessage: String?
 
-	private let browser = NetServiceBrowser()
+	private let makeBrowser: @MainActor () -> any ServiceBrowsing
+	private var browser: (any ServiceBrowsing)?
 	private var resolving: Set<NetService> = []   // retain services while they resolve
+	private var shouldRestartWhenActive = false
 
-	override init() {
+	init(makeBrowser: @escaping @MainActor () -> any ServiceBrowsing = { NetServiceBrowser() }) {
+		self.makeBrowser = makeBrowser
 		super.init()
-		browser.delegate = self
 	}
 
 	func start() {
-		guard !isBrowsing else { return }
+		guard !isBrowsing else {
+			discoveryLogger.debug("📺 [Discovery] Bonjour browse already active")
+			return
+		}
 		discovered = []
+		errorMessage = nil
+		let browser = makeBrowser()
+		browser.setDelegate(self)
+		self.browser = browser
 		isBrowsing = true
+		discoveryLogger.info("📺 [Discovery] Starting Bonjour browse")
 		browser.searchForServices(ofType: "_meshtastic._tcp.", inDomain: "local.")
 	}
 
 	func stop() {
-		browser.stop()
+		discoveryLogger.info("📺 [Discovery] Stopping Bonjour browse")
+		browser?.stop()
+		browser?.setDelegate(nil)
+		browser = nil
+		for service in resolving {
+			service.stop()
+			service.delegate = nil
+		}
 		resolving.removeAll()
 		isBrowsing = false
+	}
+
+	func retry() {
+		stop()
+		start()
+	}
+
+	func handle(scenePhase: ScenePhase) {
+		switch scenePhase {
+		case .background:
+			// Only resume a browse that was active before suspension.
+			shouldRestartWhenActive = isBrowsing
+			stop()
+		case .active:
+			guard shouldRestartWhenActive else {
+				discoveryLogger.debug("📺 [Discovery] Active without a pending Bonjour restart")
+				return
+			}
+			shouldRestartWhenActive = false
+			discoveryLogger.info("📺 [Discovery] Restarting Bonjour browse after resume")
+			retry()
+		case .inactive:
+			break
+		@unknown default:
+			break
+		}
 	}
 
 	// MARK: - NetServiceBrowserDelegate
 
 	func netServiceBrowser(_ browser: NetServiceBrowser, didFind service: NetService, moreComing: Bool) {
+		discoveryLogger.info("📺 [Discovery] Found Bonjour service \(service.name, privacy: .public)")
 		service.delegate = self
 		resolving.insert(service)
 		service.resolve(withTimeout: 5)
 	}
 
 	func netServiceBrowser(_ browser: NetServiceBrowser, didRemove service: NetService, moreComing: Bool) {
-		discovered.removeAll { $0.id == Self.identity(for: service) || $0.name == service.name }
+		discoveryLogger.info("📺 [Discovery] Removed Bonjour service \(service.name, privacy: .public)")
+		discovered.removeAll { $0.serviceName == service.name }
+	}
+
+	func netServiceBrowser(_ browser: NetServiceBrowser, didNotSearch errorDict: [String: NSNumber]) {
+		discoveryLogger.error("📺 [Discovery] Bonjour browse failed: \(String(describing: errorDict), privacy: .public)")
+		self.browser?.setDelegate(nil)
+		self.browser = nil
+		isBrowsing = false
+		errorMessage = String(localized: "Local network discovery failed. Check permission in Settings.")
 	}
 
 	// MARK: - NetServiceDelegate
@@ -66,6 +140,7 @@ final class NodeDiscovery: NSObject, ObservableObject, NetServiceBrowserDelegate
 	func netServiceDidResolveAddress(_ service: NetService) {
 		defer { resolving.remove(service) }
 		guard let host = service.hostName, service.port > 0 else { return }
+		discoveryLogger.info("📺 [Discovery] Resolved Bonjour service \(service.name, privacy: .public)")
 
 		let txt = service.txtRecordData().map(NetService.dictionary(fromTXTRecord:)) ?? [:]
 		let shortname = txt["shortname"].flatMap { String(data: $0, encoding: .utf8) }
@@ -73,11 +148,17 @@ final class NodeDiscovery: NSObject, ObservableObject, NetServiceBrowserDelegate
 
 		let node = DiscoveredNode(
 			id: idString ?? service.name,
+			serviceName: service.name,
 			name: shortname?.isEmpty == false ? shortname! : service.name,
 			host: host.hasSuffix(".") ? String(host.dropLast()) : host,
 			port: service.port
 		)
 
+		record(node)
+	}
+
+	/// Internal so the existing cross-target test seam can verify list reconciliation.
+	func record(_ node: DiscoveredNode) {
 		if let index = discovered.firstIndex(where: { $0.id == node.id }) {
 			discovered[index] = node
 		} else {
@@ -86,10 +167,7 @@ final class NodeDiscovery: NSObject, ObservableObject, NetServiceBrowserDelegate
 	}
 
 	func netService(_ service: NetService, didNotResolve errorDict: [String: NSNumber]) {
+		discoveryLogger.error("📺 [Discovery] Failed to resolve \(service.name, privacy: .public): \(String(describing: errorDict), privacy: .public)")
 		resolving.remove(service)
-	}
-
-	private static func identity(for service: NetService) -> String {
-		service.name
 	}
 }

--- a/Meshtastic TV/Client/NodeDiscovery.swift
+++ b/Meshtastic TV/Client/NodeDiscovery.swift
@@ -30,6 +30,18 @@ struct DiscoveredNode: Identifiable, Hashable {
 	let port: Int
 }
 
+private struct BonjourServiceKey: Hashable {
+	let domain: String
+	let type: String
+	let name: String
+
+	init(_ service: NetService) {
+		self.domain = service.domain
+		self.type = service.type
+		self.name = service.name
+	}
+}
+
 protocol ServiceBrowsing: AnyObject {
 	func setDelegate(_ delegate: NetServiceBrowserDelegate?)
 	func searchForServices(ofType type: String, inDomain domainString: String)
@@ -51,7 +63,7 @@ final class NodeDiscovery: NSObject, ObservableObject, @preconcurrency NetServic
 
 	private let makeBrowser: @MainActor () -> any ServiceBrowsing
 	private var browser: (any ServiceBrowsing)?
-	private var resolving: Set<NetService> = []   // retain services while they resolve
+	private var resolving: [BonjourServiceKey: NetService] = [:]
 	private var shouldRestartWhenActive = false
 
 	init(makeBrowser: @escaping @MainActor () -> any ServiceBrowsing = { NetServiceBrowser() }) {
@@ -79,7 +91,7 @@ final class NodeDiscovery: NSObject, ObservableObject, @preconcurrency NetServic
 		browser?.stop()
 		browser?.setDelegate(nil)
 		browser = nil
-		for service in resolving {
+		for service in resolving.values {
 			service.stop()
 			service.delegate = nil
 		}
@@ -116,14 +128,29 @@ final class NodeDiscovery: NSObject, ObservableObject, @preconcurrency NetServic
 	// MARK: - NetServiceBrowserDelegate
 
 	func netServiceBrowser(_ browser: NetServiceBrowser, didFind service: NetService, moreComing: Bool) {
-		discoveryLogger.info("📺 [Discovery] Found Bonjour service \(service.name, privacy: .public)")
+		discoveryLogger.info("📺 [Discovery] Found Bonjour service \(service.name, privacy: .private(mask: .hash))")
 		service.delegate = self
-		resolving.insert(service)
+		let key = BonjourServiceKey(service)
+		if let previous = resolving.updateValue(service, forKey: key), previous !== service {
+			previous.stop()
+			previous.delegate = nil
+		}
 		service.resolve(withTimeout: 5)
 	}
 
 	func netServiceBrowser(_ browser: NetServiceBrowser, didRemove service: NetService, moreComing: Bool) {
-		discoveryLogger.info("📺 [Discovery] Removed Bonjour service \(service.name, privacy: .public)")
+		discoveryLogger.info("📺 [Discovery] Removed Bonjour service \(service.name, privacy: .private(mask: .hash))")
+		if let pending = resolving.removeValue(forKey: BonjourServiceKey(service)) {
+			pending.stop()
+			pending.delegate = nil
+			if pending !== service {
+				service.stop()
+				service.delegate = nil
+			}
+		} else {
+			service.stop()
+			service.delegate = nil
+		}
 		discovered.removeAll { $0.serviceName == service.name }
 	}
 
@@ -138,9 +165,17 @@ final class NodeDiscovery: NSObject, ObservableObject, @preconcurrency NetServic
 	// MARK: - NetServiceDelegate
 
 	func netServiceDidResolveAddress(_ service: NetService) {
-		defer { resolving.remove(service) }
+		let key = BonjourServiceKey(service)
+		guard resolving[key] === service else {
+			service.delegate = nil
+			return
+		}
+		defer {
+			resolving.removeValue(forKey: key)
+			service.delegate = nil
+		}
 		guard let host = service.hostName, service.port > 0 else { return }
-		discoveryLogger.info("📺 [Discovery] Resolved Bonjour service \(service.name, privacy: .public)")
+		discoveryLogger.info("📺 [Discovery] Resolved Bonjour service \(service.name, privacy: .private(mask: .hash))")
 
 		let txt = service.txtRecordData().map(NetService.dictionary(fromTXTRecord:)) ?? [:]
 		let shortname = txt["shortname"].flatMap { String(data: $0, encoding: .utf8) }
@@ -167,7 +202,11 @@ final class NodeDiscovery: NSObject, ObservableObject, @preconcurrency NetServic
 	}
 
 	func netService(_ service: NetService, didNotResolve errorDict: [String: NSNumber]) {
-		discoveryLogger.error("📺 [Discovery] Failed to resolve \(service.name, privacy: .public): \(String(describing: errorDict), privacy: .public)")
-		resolving.remove(service)
+		discoveryLogger.error("📺 [Discovery] Failed to resolve \(service.name, privacy: .private(mask: .hash)): \(String(describing: errorDict), privacy: .public)")
+		let key = BonjourServiceKey(service)
+		if resolving[key] === service {
+			resolving.removeValue(forKey: key)
+		}
+		service.delegate = nil
 	}
 }

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		066F0545C2EDA31CC6E95E4E /* PMTilesArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C4205D1043768766C64E87 /* PMTilesArchive.swift */; };
 		073B94B7F2F232C198151489 /* alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = E8849D542B45F20F349E004D /* alpha.png */; };
 		073D5EF20134D41DF2AC5993 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C15787882CA30C9787154D /* Logger.swift */; };
-		0B38990DF67A6FEDEE6AAAB3 /* NodeDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = F979D64D67F36D37B008E5E7 /* NodeDiscovery.swift */; };
 		0D14B1F2EE824455A78690F8 /* MVTTools in Frameworks */ = {isa = PBXBuildFile; productRef = 99BACD26F50E4FBA1E2FC365 /* MVTTools */; };
 		13FAC446423FF3C9AC737EA0 /* PMTilesMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB006125B378C5233BD0B731 /* PMTilesMapView.swift */; };
 		1A042BDE2702C7388CE867EF /* NordicDFU in Frameworks */ = {isa = PBXBuildFile; productRef = D83D0451F77A9D92FFC852CA /* NordicDFU */; };
@@ -54,6 +53,7 @@
 		EFEED2F4EF7D9B1BB657458A /* SwiftDraw in Frameworks */ = {isa = PBXBuildFile; productRef = 9D120B166CA191FC578A9978 /* SwiftDraw */; };
 		F05DFDBFD6588DFEB6AD621F /* MVTTools in Frameworks */ = {isa = PBXBuildFile; productRef = 4FB45004C563B59043C53EAA /* MVTTools */; };
 		F0F15E85A1D7193379E705C4 /* AppIcon_MPowered.icon in Resources */ = {isa = PBXBuildFile; fileRef = D744131C1600FC47CB596573 /* AppIcon_MPowered.icon */; };
+		F11D4AB6E3A799DEB883AC14 /* NodeDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074A4F4A084E3897FDDE16FB /* NodeDiscovery.swift */; };
 		F494AA4C9783F0E204B12D62 /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 43547F7F6DDB3842969DA369 /* DatadogCrashReporting */; };
 		F8D2F62028A2A100CDB80F82 /* MeshtasticProtobufs in Frameworks */ = {isa = PBXBuildFile; productRef = 4AF5AACBB64F141EF02FC7DC /* MeshtasticProtobufs */; };
 		F8E5A8CEE6E96D5D53F6F851 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = C853ED2A7F391E6F315F93B3 /* Markdown */; };
@@ -111,6 +111,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		074A4F4A084E3897FDDE16FB /* NodeDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NodeDiscovery.swift; path = "Meshtastic TV/Client/NodeDiscovery.swift"; sourceTree = "<group>"; };
 		0875C7B0694DBE671437CC1A /* Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
 		0AEAC3FF0190C3F8166D22E3 /* MeshtasticDataModelV 52.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 52.xcdatamodel"; sourceTree = "<group>"; };
 		0CC33262B2EA2E8463E8BE95 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -224,7 +225,6 @@
 		F17AFA19C2AAB3C3ADFB1E33 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		F19CCBB8245B82E769413099 /* MeshtasticDataModelV19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV19.xcdatamodel; sourceTree = "<group>"; };
 		F6D4ACC3C6BD92C9A04ED41D /* MeshtasticDataModelV10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV10.xcdatamodel; sourceTree = "<group>"; };
-		F979D64D67F36D37B008E5E7 /* NodeDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeDiscovery.swift; sourceTree = "<group>"; };
 		FAE5E6259410D2A524285D8F /* MeshtasticDataModelV 57.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 57.xcdatamodel"; sourceTree = "<group>"; };
 		FD9D5D4A334ED0C02B7F908F /* MeshtasticDataModelV 45.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 45.xcdatamodel"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -629,14 +629,6 @@
 			path = Transports;
 			sourceTree = "<group>";
 		};
-		55186F037915EF6BCEED2925 /* Client */ = {
-			isa = PBXGroup;
-			children = (
-				F979D64D67F36D37B008E5E7 /* NodeDiscovery.swift */,
-			);
-			path = Client;
-			sourceTree = "<group>";
-		};
 		5D4AFA4225AF7D85EE343B80 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -647,14 +639,6 @@
 				E4053FDE501FD7E0A02CEA8D /* WidgetsExtension.appex */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		615D439CBFAC4AA6EE6F0E34 /* Meshtastic TV */ = {
-			isa = PBXGroup;
-			children = (
-				55186F037915EF6BCEED2925 /* Client */,
-			);
-			path = "Meshtastic TV";
 			sourceTree = "<group>";
 		};
 		68569A5CFCF946568B4E32C5 /* Meshtastic */ = {
@@ -704,6 +688,14 @@
 			path = Map;
 			sourceTree = "<group>";
 		};
+		7CF5820C55D8305FCC1F8A13 /* TV Test Support */ = {
+			isa = PBXGroup;
+			children = (
+				074A4F4A084E3897FDDE16FB /* NodeDiscovery.swift */,
+			);
+			name = "TV Test Support";
+			sourceTree = "<group>";
+		};
 		8F644F7974EA8B14E77ED53A /* Packages */ = {
 			isa = PBXGroup;
 			children = (
@@ -750,13 +742,13 @@
 			children = (
 				26351F51CD01C94D8D82486A /* Localizable.xcstrings */,
 				68569A5CFCF946568B4E32C5 /* Meshtastic */,
-				615D439CBFAC4AA6EE6F0E34 /* Meshtastic TV */,
 				EA229AC7C87CBBD64EC61AA1 /* Meshtastic TV */,
 				F0E2A06151AF30290D808624 /* Meshtastic Watch App */,
 				867FD80926C4A4286D635BAD /* MeshtasticTests */,
 				8F644F7974EA8B14E77ED53A /* Packages */,
 				F15A1577564640951AD3EA40 /* Settings.bundle */,
 				456E28D41A9B7B1788FEE0CD /* Shared */,
+				7CF5820C55D8305FCC1F8A13 /* TV Test Support */,
 				0B1C4E352D6981242B97EF9C /* Widgets */,
 				5D4AFA4225AF7D85EE343B80 /* Products */,
 			);
@@ -1151,7 +1143,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B38990DF67A6FEDEE6AAAB3 /* NodeDiscovery.swift in Sources */,
+				F11D4AB6E3A799DEB883AC14 /* NodeDiscovery.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		066F0545C2EDA31CC6E95E4E /* PMTilesArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C4205D1043768766C64E87 /* PMTilesArchive.swift */; };
 		073B94B7F2F232C198151489 /* alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = E8849D542B45F20F349E004D /* alpha.png */; };
 		073D5EF20134D41DF2AC5993 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C15787882CA30C9787154D /* Logger.swift */; };
+		0B38990DF67A6FEDEE6AAAB3 /* NodeDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = F979D64D67F36D37B008E5E7 /* NodeDiscovery.swift */; };
 		0D14B1F2EE824455A78690F8 /* MVTTools in Frameworks */ = {isa = PBXBuildFile; productRef = 99BACD26F50E4FBA1E2FC365 /* MVTTools */; };
 		13FAC446423FF3C9AC737EA0 /* PMTilesMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB006125B378C5233BD0B731 /* PMTilesMapView.swift */; };
 		1A042BDE2702C7388CE867EF /* NordicDFU in Frameworks */ = {isa = PBXBuildFile; productRef = D83D0451F77A9D92FFC852CA /* NordicDFU */; };
@@ -223,6 +224,7 @@
 		F17AFA19C2AAB3C3ADFB1E33 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		F19CCBB8245B82E769413099 /* MeshtasticDataModelV19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV19.xcdatamodel; sourceTree = "<group>"; };
 		F6D4ACC3C6BD92C9A04ED41D /* MeshtasticDataModelV10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV10.xcdatamodel; sourceTree = "<group>"; };
+		F979D64D67F36D37B008E5E7 /* NodeDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeDiscovery.swift; sourceTree = "<group>"; };
 		FAE5E6259410D2A524285D8F /* MeshtasticDataModelV 57.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 57.xcdatamodel"; sourceTree = "<group>"; };
 		FD9D5D4A334ED0C02B7F908F /* MeshtasticDataModelV 45.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 45.xcdatamodel"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -627,6 +629,14 @@
 			path = Transports;
 			sourceTree = "<group>";
 		};
+		55186F037915EF6BCEED2925 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				F979D64D67F36D37B008E5E7 /* NodeDiscovery.swift */,
+			);
+			path = Client;
+			sourceTree = "<group>";
+		};
 		5D4AFA4225AF7D85EE343B80 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -637,6 +647,14 @@
 				E4053FDE501FD7E0A02CEA8D /* WidgetsExtension.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		615D439CBFAC4AA6EE6F0E34 /* Meshtastic TV */ = {
+			isa = PBXGroup;
+			children = (
+				55186F037915EF6BCEED2925 /* Client */,
+			);
+			path = "Meshtastic TV";
 			sourceTree = "<group>";
 		};
 		68569A5CFCF946568B4E32C5 /* Meshtastic */ = {
@@ -732,6 +750,7 @@
 			children = (
 				26351F51CD01C94D8D82486A /* Localizable.xcstrings */,
 				68569A5CFCF946568B4E32C5 /* Meshtastic */,
+				615D439CBFAC4AA6EE6F0E34 /* Meshtastic TV */,
 				EA229AC7C87CBBD64EC61AA1 /* Meshtastic TV */,
 				F0E2A06151AF30290D808624 /* Meshtastic Watch App */,
 				867FD80926C4A4286D635BAD /* MeshtasticTests */,
@@ -1132,6 +1151,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0B38990DF67A6FEDEE6AAAB3 /* NodeDiscovery.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MeshtasticTests/TVNodeDiscoveryLifecycleTests.swift
+++ b/MeshtasticTests/TVNodeDiscoveryLifecycleTests.swift
@@ -1,0 +1,147 @@
+//
+//  TVNodeDiscoveryLifecycleTests.swift
+//  MeshtasticTests
+//
+
+import Foundation
+import SwiftUI
+import Testing
+
+private final class ServiceBrowserSpy: ServiceBrowsing {
+	private(set) var searches: [(type: String, domain: String)] = []
+	private(set) var stopCallCount = 0
+	private weak var delegate: NetServiceBrowserDelegate?
+
+	func setDelegate(_ delegate: NetServiceBrowserDelegate?) {
+		self.delegate = delegate
+	}
+
+	func searchForServices(ofType type: String, inDomain domainString: String) {
+		searches.append((type, domainString))
+	}
+
+	func stop() {
+		stopCallCount += 1
+	}
+}
+
+@MainActor
+@Suite("tvOS node discovery lifecycle")
+struct TVNodeDiscoveryLifecycleTests {
+	@Test func backgroundResumeCreatesFreshBrowseAndDropsStaleNodes() {
+		var browsers: [ServiceBrowserSpy] = []
+		let discovery = NodeDiscovery {
+			let browser = ServiceBrowserSpy()
+			browsers.append(browser)
+			return browser
+		}
+		discovery.start()
+		discovery.record(
+			DiscoveredNode(
+				id: "!stale",
+				serviceName: "stale-service",
+				name: "Stale node",
+				host: "stale.local",
+				port: 4403
+			)
+		)
+
+		discovery.handle(scenePhase: .background)
+		discovery.handle(scenePhase: .active)
+
+		#expect(browsers.count == 2)
+		guard browsers.count == 2 else { return }
+		#expect(browsers[0].stopCallCount == 1)
+		#expect(browsers[1].searches.count == 1)
+		#expect(browsers[1].searches[0].type == "_meshtastic._tcp.")
+		#expect(browsers[1].searches[0].domain == "local.")
+		#expect(discovery.isBrowsing)
+		#expect(discovery.discovered.isEmpty)
+	}
+
+	@Test func activeAndInactiveWithoutBackgroundDoNotRestartColdLaunchBrowse() {
+		var browsers: [ServiceBrowserSpy] = []
+		let discovery = NodeDiscovery {
+			let browser = ServiceBrowserSpy()
+			browsers.append(browser)
+			return browser
+		}
+		discovery.start()
+
+		discovery.handle(scenePhase: .inactive)
+		discovery.handle(scenePhase: .active)
+
+		#expect(browsers.count == 1)
+		guard browsers.count == 1 else { return }
+		#expect(browsers[0].stopCallCount == 0)
+		#expect(browsers[0].searches.count == 1)
+		#expect(discovery.isBrowsing)
+	}
+
+	@Test func backgroundWhileNotBrowsingDoesNotStartHiddenBrowseOnResume() {
+		var browsers: [ServiceBrowserSpy] = []
+		let discovery = NodeDiscovery {
+			let browser = ServiceBrowserSpy()
+			browsers.append(browser)
+			return browser
+		}
+
+		discovery.handle(scenePhase: .background)
+		discovery.handle(scenePhase: .active)
+
+		#expect(browsers.isEmpty)
+		#expect(!discovery.isBrowsing)
+	}
+
+	@Test func repeatedBackgroundResumeCyclesCreateFreshBrowsers() {
+		var browsers: [ServiceBrowserSpy] = []
+		let discovery = NodeDiscovery {
+			let browser = ServiceBrowserSpy()
+			browsers.append(browser)
+			return browser
+		}
+		discovery.start()
+
+		for _ in 0..<2 {
+			discovery.handle(scenePhase: .background)
+			discovery.handle(scenePhase: .active)
+		}
+
+		#expect(browsers.count == 3)
+		guard browsers.count == 3 else { return }
+		#expect(browsers[0].stopCallCount == 1)
+		#expect(browsers[1].stopCallCount == 1)
+		#expect(browsers[2].searches.count == 1)
+	}
+
+	@Test func removalMatchesBonjourServiceName() {
+		let discovery = NodeDiscovery { ServiceBrowserSpy() }
+		discovery.record(
+			DiscoveredNode(
+				id: "!node-id",
+				serviceName: "bonjour-service",
+				name: "SHORT",
+				host: "node.local",
+				port: 4403
+			)
+		)
+		let service = NetService(domain: "local.", type: "_meshtastic._tcp.", name: "bonjour-service")
+
+		discovery.netServiceBrowser(NetServiceBrowser(), didRemove: service, moreComing: false)
+
+		#expect(discovery.discovered.isEmpty)
+	}
+
+	@Test func failedBrowseStopsSpinnerAndOffersRetryState() {
+		let discovery = NodeDiscovery { ServiceBrowserSpy() }
+		discovery.start()
+
+		discovery.netServiceBrowser(
+			NetServiceBrowser(),
+			didNotSearch: ["errorCode": NSNumber(value: -72000)]
+		)
+
+		#expect(!discovery.isBrowsing)
+		#expect(discovery.errorMessage != nil)
+	}
+}

--- a/MeshtasticTests/TVNodeDiscoveryLifecycleTests.swift
+++ b/MeshtasticTests/TVNodeDiscoveryLifecycleTests.swift
@@ -25,6 +25,21 @@ private final class ServiceBrowserSpy: ServiceBrowsing {
 	}
 }
 
+private final class ResolvingServiceSpy: NetService {
+	private(set) var resolveCallCount = 0
+	private(set) var stopCallCount = 0
+
+	override var hostName: String? { "node.local." }
+
+	override func resolve(withTimeout timeout: TimeInterval) {
+		resolveCallCount += 1
+	}
+
+	override func stop() {
+		stopCallCount += 1
+	}
+}
+
 @MainActor
 @Suite("tvOS node discovery lifecycle")
 struct TVNodeDiscoveryLifecycleTests {
@@ -132,8 +147,70 @@ struct TVNodeDiscoveryLifecycleTests {
 		#expect(discovery.discovered.isEmpty)
 	}
 
-	@Test func failedBrowseStopsSpinnerAndOffersRetryState() {
+	@Test func removalDuringResolutionCancelsPendingServiceAndIgnoresLateCallback() {
 		let discovery = NodeDiscovery { ServiceBrowserSpy() }
+		let pending = ResolvingServiceSpy(
+			domain: "local.",
+			type: "_meshtastic._tcp.",
+			name: "bonjour-service",
+			port: 4403
+		)
+		let removed = NetService(
+			domain: "local.",
+			type: "_meshtastic._tcp.",
+			name: "bonjour-service"
+		)
+
+		discovery.netServiceBrowser(NetServiceBrowser(), didFind: pending, moreComing: false)
+		#expect(pending.resolveCallCount == 1)
+
+		discovery.netServiceBrowser(NetServiceBrowser(), didRemove: removed, moreComing: false)
+		#expect(pending.stopCallCount == 1)
+		#expect(pending.delegate == nil)
+
+		discovery.netServiceDidResolveAddress(pending)
+		#expect(discovery.discovered.isEmpty)
+	}
+
+	@Test func rediscoverySupersedesOnlyThePreviousPendingService() {
+		let discovery = NodeDiscovery { ServiceBrowserSpy() }
+		let first = ResolvingServiceSpy(
+			domain: "local.",
+			type: "_meshtastic._tcp.",
+			name: "bonjour-service",
+			port: 4403
+		)
+		let replacement = ResolvingServiceSpy(
+			domain: "local.",
+			type: "_meshtastic._tcp.",
+			name: "bonjour-service",
+			port: 4403
+		)
+
+		discovery.netServiceBrowser(NetServiceBrowser(), didFind: first, moreComing: false)
+		discovery.netServiceBrowser(NetServiceBrowser(), didFind: replacement, moreComing: false)
+
+		#expect(first.stopCallCount == 1)
+		#expect(first.delegate == nil)
+		#expect(replacement.stopCallCount == 0)
+		#expect(replacement.resolveCallCount == 1)
+		#expect(replacement.delegate != nil)
+
+		discovery.netServiceDidResolveAddress(first)
+		#expect(discovery.discovered.isEmpty)
+
+		discovery.netServiceDidResolveAddress(replacement)
+		#expect(discovery.discovered.count == 1)
+		#expect(discovery.discovered.first?.serviceName == "bonjour-service")
+	}
+
+	@Test func failedBrowseStopsSpinnerAndRetryStartsFreshBrowse() {
+		var browsers: [ServiceBrowserSpy] = []
+		let discovery = NodeDiscovery {
+			let browser = ServiceBrowserSpy()
+			browsers.append(browser)
+			return browser
+		}
 		discovery.start()
 
 		discovery.netServiceBrowser(
@@ -143,5 +220,16 @@ struct TVNodeDiscoveryLifecycleTests {
 
 		#expect(!discovery.isBrowsing)
 		#expect(discovery.errorMessage != nil)
+
+		discovery.retry()
+
+		#expect(browsers.count == 2)
+		guard browsers.count == 2 else { return }
+		#expect(browsers[1].searches.count == 1)
+		guard browsers[1].searches.count == 1 else { return }
+		#expect(browsers[1].searches[0].type == "_meshtastic._tcp.")
+		#expect(browsers[1].searches[0].domain == "local.")
+		#expect(discovery.isBrowsing)
+		#expect(discovery.errorMessage == nil)
 	}
 }

--- a/project.yml
+++ b/project.yml
@@ -524,6 +524,8 @@ targets:
     sources:
       - path: "MeshtasticTests"
         type: syncedFolder
+      # Compile the pure Bonjour lifecycle into the existing test bundle; keep this file iOS-compatible.
+      - path: "Meshtastic TV/Client/NodeDiscovery.swift"
     dependencies:
       - target: Meshtastic
     settings:

--- a/project.yml
+++ b/project.yml
@@ -526,6 +526,7 @@ targets:
         type: syncedFolder
       # Compile the pure Bonjour lifecycle into the existing test bundle; keep this file iOS-compatible.
       - path: "Meshtastic TV/Client/NodeDiscovery.swift"
+        group: "TV Test Support"
     dependencies:
       - target: Meshtastic
     settings:


### PR DESCRIPTION
## What changed?

- Restart tvOS Bonjour discovery with a fresh browser after the app returns from the background.
- Stop browsing and cancel pending service resolutions while backgrounded so old callbacks cannot repopulate the list.
- Track the Bonjour service name separately so removal callbacks delete the correct node.
- Show Bonjour browse failures in the connection view with a **Try Again** action.
- Add six lifecycle regression tests and include the discovery source in the existing test target.

## Why did it change?

The tvOS connection view stays mounted while the app is backgrounded. Discovery previously started only when the view appeared, so its browser and discovered-node list could survive a suspend/resume cycle without refreshing. Stale nodes then remained visible until the app was terminated.

During debugging, a same-process background/resume test confirmed that discovery stopped on background but needed a fresh browse on resume. The removal callback also matched `NetService.name` against the node ID or short name, which meant normally resolved nodes were not removed by Bonjour service identity.

No documentation update is needed because the connection flow and user instructions are unchanged. This corrects discovery lifecycle handling and adds recovery UI for browse failures.

## How is this tested?

- Focused lifecycle suite:
  - `xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic -destination 'platform=iOS Simulator,id=0AE86A04-DF97-4372-BA68-0B69B2997A81' -only-testing:MeshtasticTests/TVNodeDiscoveryLifecycleTests CODE_SIGNING_ALLOWED=NO`
  - 6 tests passed.
- Mutation check:
  - Temporarily removing the resume `retry()` call caused the background/resume and repeated-cycle tests to fail.
  - Restoring the call returned the suite to green.
- Full `MeshtasticTests` comparison against `upstream/main`:
  - `upstream/main`: 2,869 total, 2,808 passed, 55 failed, 6 skipped.
  - This branch: 2,875 total, 2,814 passed, 55 failed, 6 skipped.
  - The pre-existing 55-test failure set is identical; this branch adds six passing tests and no failures.
- `Meshtastic TV` built successfully for the tvOS simulator.
- Strict SwiftLint passed for the changed Swift files.
- XcodeGen 2.46.0 regenerated the project without drift.
- Physical Apple TV validation on tvOS 27.0:
  - Advertised synthetic node A and confirmed it appeared.
  - Backgrounded the app by foregrounding tvOS Settings and confirmed the diagnostic app kept the same PID.
  - Removed A and advertised node B while the app was backgrounded.
  - Resumed the same process. Device logs showed the old browse stop, a fresh browse start, and B resolve while A was absent.
  - Stopping B produced the expected removal log and removed it from the UI.

Sanitized device log sequence:

```text
[Discovery] Found Bonjour service node A
[Discovery] Resolved Bonjour service node A
[Discovery] Stopping Bonjour browse
[Discovery] Restarting Bonjour browse after resume
[Discovery] Stopping Bonjour browse
[Discovery] Starting Bonjour browse
[Discovery] Found Bonjour service node B
[Discovery] Resolved Bonjour service node B
[Discovery] Removed Bonjour service node B
```

## Screenshots/Videos (when applicable)

Not attached. Physical before/after screenshots were used to inspect the discovered-node rows. The only new UI is the inline Bonjour error message and **Try Again** action.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
