### PR TITLE
Fix tvOS connect row contrast and focus clipping

### DIFF
--- a/Meshtastic TV/App/ConnectView.swift
+++ b/Meshtastic TV/App/ConnectView.swift
@@ -94,15 +94,14 @@ struct ConnectView: View {
 					} label: {
 						HStack(spacing: 16) {
 							Image(systemName: "antenna.radiowaves.left.and.right")
-								.foregroundStyle(Color("AccentColor"))
 							VStack(alignment: .leading, spacing: 4) {
 								Text(node.name)
 								Text(verbatim: "\(node.host):\(String(node.port))")
 									.font(.caption)
-									.foregroundStyle(.secondary)
 							}
 						}
 					}
+					.tint(.primary)
 				}
 			}
 		} header: {

--- a/Meshtastic TV/App/ConnectView.swift
+++ b/Meshtastic TV/App/ConnectView.swift
@@ -56,6 +56,8 @@ struct ConnectView: View {
 						}
 					}
 				}
+				// Focused tvOS controls grow beyond their rows; keep them inside the Form's clip.
+				.contentMargins(.horizontal, 16, for: .scrollContent)
 			}
 			.padding(.top, TVTheme.screenPadding)
 		}


### PR DESCRIPTION
## What changed?

- Use the primary semantic tint for Bonjour-discovered node rows on tvOS.
- Let the antenna, node name, and host inherit the button's focus-aware foreground color.
- Add horizontal scroll-content margins so native focus highlights keep their rounded edges inside the connection form.

## Why did it change?

The accent-blue discovered-node label had about 1.27:1 contrast against the unfocused row background. The primary tint renders white on the dark unfocused row and black on the light focused row.

The form also clipped the left rounded edge of focused discovered-node and Settings rows at its scroll-content boundary.

No documentation update is needed because this only corrects the existing tvOS connection screen styling.

## How is this tested?

- Advertised a synthetic `_meshtastic._tcp` Bonjour node to the tvOS 26.5 simulator.
- Verified the unfocused discovered-node row renders at about 9.03:1 contrast.
- Verified the focused discovered-node row renders at about 20.65:1 contrast.
- Used a DEBUG-only focus selector for deterministic screenshots, then removed it from the final code.
- Verified the focused Settings highlight changed from a clipped 34-row left edge versus 10-row right edge to 10 rows on both sides.
- Built the exact committed `Meshtastic TV` tree successfully for the tvOS simulator.
- Ran SwiftLint on `Meshtastic TV/App/ConnectView.swift`.
- Ran `git diff --check`.

## Screenshots/Videos (when applicable)

### Discovered-node focus clipping

| Before | After |
| --- | --- |
|<img width="1920" height="1080" alt="before-node-selection-menu" src="https://github.com/user-attachments/assets/8bf9d8c0-87f4-40e1-81fe-d3f95d8b7492" />|<img width="1920" height="1080" alt="after-node-selection-menu" src="https://github.com/user-attachments/assets/c88acc0e-6d75-49eb-8672-19b7f369f4a1" />|

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.

No documentation update is needed for these tvOS styling corrections. The `skip-docs-check` label is applied.
