### PR TITLE
Put the TV map type picker back to segmented

### DIFF
--- a/Meshtastic TV/App/SettingsView.swift
+++ b/Meshtastic TV/App/SettingsView.swift
@@ -36,7 +36,7 @@ struct SettingsView: View {
 					Text("Hybrid").tag(Int(MKMapType.hybrid.rawValue))
 					Text("Satellite").tag(Int(MKMapType.satellite.rawValue))
 				}
-				.pickerStyle(.inline)
+				.pickerStyle(.segmented)
 
 				Toggle("Mesh Stats", isOn: $statsBarEnabled)
 				Picker("Stats Position", selection: $statsBarEdge) {


### PR DESCRIPTION
## Summary

#2261 changed the TV settings Map Type picker to the inline style, which renders as a vertical list in the form. The segmented three-way control reads better and matches the Stats Position picker below it.

## What changed

Map Type picker style back to segmented in the TV SettingsView.

## Testing

Meshtastic TV scheme builds for the tvOS simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Map Type picker in Settings to use a more compact segmented control layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->