### PR TITLE
chore(about): move Need Hardware card into its own Hardware section

### DIFF
--- a/Meshtastic/Views/Settings/About.swift
+++ b/Meshtastic/Views/Settings/About.swift
@@ -19,8 +19,7 @@ struct AboutMeshtastic: View {
 						.font(.title3)
 
 				}
-				Section(header: Text("Apple Apps")) {
-
+				Section(header: Text("Hardware")) {
 					HStack {
 						RotatingHardwareImage()
 							.frame(width: 110, height: 130)
@@ -32,6 +31,8 @@ struct AboutMeshtastic: View {
 								.font(.callout)
 						}
 					}
+				}
+				Section(header: Text("Apple Apps")) {
 					Link("Sponsor App Development", destination: URL(string: "https://github.com/sponsors/garthvh")!)
 						.font(.title2)
 					Link("GitHub Repository", destination: URL(string: "https://github.com/meshtastic/Meshtastic-Apple")!)


### PR DESCRIPTION
## Summary
On the About page the Need Hardware? card sat inside the Apple Apps section, where it didn't belong.

## What changed
- Added a new Hardware section between What is Meshtastic? and Apple Apps containing only the hardware card (rotating device image, Need Hardware? link, description).
- Apple Apps keeps the sponsor, GitHub, review, and version rows unchanged.

## Testing
- Debug build for iOS Simulator succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Hardware section to the About screen with rotating device imagery, a hardware link, and descriptive text.
  * Retained the Apple Apps section below the new Hardware section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->