### PR TITLE
Make the event domain row a tappable link

### DIFF
--- a/Meshtastic/Views/Connect/EventFirmwareInfoView.swift
+++ b/Meshtastic/Views/Connect/EventFirmwareInfoView.swift
@@ -163,8 +163,20 @@ struct EventFirmwareInfoView: View {
 			if let dates = info.formattedDateRange {
 				detailRow(icon: "calendar", text: dates)
 			}
-			if let domain = info.domain, !domain.isEmpty {
-				detailRow(icon: "globe", text: domain)
+			// The event domain (e.g. the custom web flasher) is a destination, not
+			// metadata — render it like the rows in the Links section.
+			if let domain = info.domain, !domain.isEmpty,
+			   let url = EventFirmwareURLPolicy.httpsURL(from: "https://\(domain)") {
+				Link(destination: url) {
+					HStack {
+						Label(domain, systemImage: "link")
+							.font(.callout)
+						Spacer()
+						Image(systemName: "arrow.up.right")
+							.font(.caption)
+							.foregroundColor(.secondary)
+					}
+				}
 			}
 		}
 	}

--- a/Meshtastic/Views/Connect/EventFirmwareInfoView.swift
+++ b/Meshtastic/Views/Connect/EventFirmwareInfoView.swift
@@ -164,8 +164,9 @@ struct EventFirmwareInfoView: View {
 				detailRow(icon: "calendar", text: dates)
 			}
 			// The event domain (e.g. the custom web flasher) is a destination, not
-			// metadata — render it like the rows in the Links section.
-			if let domain = info.domain, !domain.isEmpty,
+			// metadata — render it like the rows in the Links section. Trimmed before
+			// interpolation: whitespace after the scheme would fail URL validation.
+			if let domain = info.domain?.trimmingCharacters(in: .whitespacesAndNewlines), !domain.isEmpty,
 			   let url = EventFirmwareURLPolicy.httpsURL(from: "https://\(domain)") {
 				Link(destination: url) {
 					HStack {
@@ -176,6 +177,7 @@ struct EventFirmwareInfoView: View {
 							.font(.caption)
 							.foregroundColor(.secondary)
 					}
+					.frame(minHeight: 48)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

On the event sheet the domain row (the event's custom flasher, like defcon.meshtastic.org) showed as plain text with a globe icon while every other destination is a tappable row with a link icon.

## What changed

The domain renders like the Links section rows: a link icon, the trailing arrow, and it opens https://<domain>. The HTTPS-only URL policy still applies.

## Testing

iOS build passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event domains are now displayed as secure, tappable HTTPS links.
  * Links include an external-navigation indicator for clearer interaction.

* **Bug Fixes**
  * Invalid or empty event domains are no longer displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->