### PR TITLE
Add the offline terrain layer spec kit

### DIFF
--- a/specs/018-offline-terrain-layer/contracts/mapterhorn-data-contract.md
+++ b/specs/018-offline-terrain-layer/contracts/mapterhorn-data-contract.md
@@ -1,0 +1,35 @@
+# Data Contract: Mapterhorn Elevation Tiles
+
+**Feature**: 018-offline-terrain-layer
+**Date**: 2026-08-16
+
+The app consumes Mapterhorn as published data; there is no API key or negotiated interface. This contract records the shapes the implementation depends on, so upstream changes are detectable.
+
+## Endpoints
+
+| Purpose | URL |
+|---|---|
+| Global archive (z0–z12) | `https://download.mapterhorn.com/planet.pmtiles` |
+| Regional archives (z13–z17) | `https://download.mapterhorn.com/{z}-{x}-{y}.pmtiles` (existence per their coverage page) |
+| Single-tile fallback | `https://tiles.mapterhorn.com/{z}/{x}/{y}.webp` |
+| TileJSON | `https://tiles.mapterhorn.com/tilejson.json` |
+
+Archives support HTTP range requests (Cloudflare R2), which is what `PMTilesExtractor` requires. The regional archive naming is a z6 tile id.
+
+## Tile format
+
+- Container: PMTiles v3 (same as the Protomaps basemap; existing `PMTilesArchive` reader applies)
+- Tile payload: WebP image, 512 × 512 px
+- Encoding: Terrarium terrain-RGB — `elevation_m = (R × 256 + G + B ÷ 256) − 32768`
+- Decoded on iOS with ImageIO (`CGImageSource`); WebP is natively supported on iOS 14+
+
+## Assumptions the implementation must not silently violate
+
+1. Elevation is meters; no vertical datum conversion is applied.
+2. A missing regional archive for a bbox is normal (coverage gaps) — fall back to global data, never fail the download.
+3. Tiles are north-up Web Mercator, matching the basemap tiling — no reprojection.
+4. Attribution: Mapterhorn credit required when terrain displays; upstream DEM credits via their attribution page. Verify LICENSE at github.com/mapterhorn/mapterhorn during implementation.
+
+## Change detection
+
+The extractor should record the archive `Last-Modified`/`ETag` at download time (the global archive showed `Last-Modified: 2026-05-11` during research). A future re-download of the same region compares these to decide whether terrain needs refreshing.

--- a/specs/018-offline-terrain-layer/data-model.md
+++ b/specs/018-offline-terrain-layer/data-model.md
@@ -1,0 +1,51 @@
+# Data Model: Offline Terrain Layer
+
+**Feature**: 018-offline-terrain-layer
+**Date**: 2026-08-16
+
+No SwiftData schema changes. All terrain state is file-based and scoped to the existing offline-region storage, extending the JSON metadata `OfflineMapManager` already keeps per region.
+
+## Region metadata (extended)
+
+`OfflineMapRegion` (existing JSON-backed record) gains a terrain component:
+
+| Field | Type | Notes |
+|---|---|---|
+| `terrain` | optional object | Absent for regions without terrain (pre-feature downloads) |
+| `terrain.globalArchive` | string (filename) | `terrain-global.pmtiles`, extract of the z0–12 planet archive |
+| `terrain.regionalArchive` | optional string | Extract of the intersecting z13+ archive when coverage exists |
+| `terrain.downloadedAt` | date | Drives cache invalidation |
+| `terrain.byteCount` | integer | Sum of archive sizes, shown in Offline Maps |
+| `terrain.maxZoom` | integer | 12 when global-only, per regional archive otherwise |
+
+## On-disk layout (per region directory)
+
+```text
+<region>/
+├── basemap.pmtiles                # existing
+├── terrain-global.pmtiles         # NEW (US1)
+├── terrain-regional.pmtiles       # NEW, optional (US1)
+├── hillshade-cache/               # NEW (US2) — {appearance}/{z}/{x}/{y}.png
+└── contour-cache/                 # NEW (US3) — {intervalSet}/{z}/{x}/{y}.geometry
+```
+
+Deleting the region directory removes every terrain artifact (FR-008). Cache directories are recreated on demand; both are invalidated whenever `terrain.downloadedAt` changes.
+
+## In-memory types (new, value types unless noted)
+
+- **`ElevationTile`**: decoded Terrarium grid — `zxy`, `Float` elevations (512×512 plus neighbor margin), `resolutionMeters`. Produced by `TerrariumDecoder`, consumed by hillshade and contour generation.
+- **`TerrainStore`** (actor): opens the region's archives, serves `ElevationTile`s with the neighbor margin stitched in, owns decode caching.
+- **`HillshadeTileOverlay`** (`MKTileOverlay` subclass): resolves tiles from `hillshade-cache/`, generating misses via `TerrainStore` off the main actor; keyed by appearance (light/dark).
+- **`ContourSet`**: generated polylines for one tile — interval metadata, index-contour flags, label anchor points; serialized into `contour-cache/`.
+- **`ContourIntervalTable`**: zoom → (minor, index) interval mapping, unit-aware (m/ft by locale).
+
+## Settings
+
+`@AppStorage` keys following existing map settings conventions:
+
+| Key | Type | Default |
+|---|---|---|
+| `map.terrain.hillshade` | Bool | false |
+| `map.terrain.contours` | Bool | false |
+
+Map-type gating (hillshade suppressed on hybrid/satellite) is derived at render time from the existing map-type setting, not stored.

--- a/specs/018-offline-terrain-layer/data-model.md
+++ b/specs/018-offline-terrain-layer/data-model.md
@@ -37,7 +37,14 @@ Deleting the region directory removes every terrain artifact (FR-008). Cache dir
 - **`TerrainStore`** (actor): opens the region's archives, serves `ElevationTile`s with the neighbor margin stitched in, owns decode caching.
 - **`HillshadeTileOverlay`** (`MKTileOverlay` subclass): resolves tiles from `hillshade-cache/`, generating misses via `TerrainStore` off the main actor; keyed by appearance (light/dark).
 - **`ContourSet`**: generated polylines for one tile — interval metadata, index-contour flags, label anchor points; serialized into `contour-cache/`.
-- **`ContourIntervalTable`**: zoom → (minor, index) interval mapping, unit-aware (m/ft by locale).
+- **`ContourIntervalTable`**: zoom → (minor, index) interval mapping, unit-aware (m/ft by locale). Starting values (tunable during implementation, index = every 5th minor):
+
+| Zoom | Minor interval | Index interval |
+|---|---|---|
+| ≤ 10 | 500 m / 2000 ft | 2500 m / 10000 ft |
+| 11–12 | 100 m / 500 ft | 500 m / 2500 ft |
+| 13–14 | 50 m / 200 ft | 250 m / 1000 ft |
+| ≥ 15 | 20 m / 100 ft | 100 m / 500 ft |
 
 ## Settings
 
@@ -45,7 +52,7 @@ Deleting the region directory removes every terrain artifact (FR-008). Cache dir
 
 | Key | Type | Default |
 |---|---|---|
-| `map.terrain.hillshade` | Bool | false |
-| `map.terrain.contours` | Bool | false |
+| `meshMapShowHillshade` | Bool | false |
+| `meshMapShowContours` | Bool | false |
 
 Map-type gating (hillshade suppressed on hybrid/satellite) is derived at render time from the existing map-type setting, not stored.

--- a/specs/018-offline-terrain-layer/plan.md
+++ b/specs/018-offline-terrain-layer/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Offline Terrain Layer
+
+**Branch**: `018-offline-terrain-layer` | **Date**: 2026-08-16 | **Spec**: `specs/018-offline-terrain-layer/spec.md`
+**Input**: Feature specification from `/specs/018-offline-terrain-layer/spec.md`
+
+## Summary
+
+Add hillshade and contour lines to offline map regions using Mapterhorn elevation data. The offline download gains a second bbox extract (Terrarium terrain-RGB tiles in PMTiles form, same range-request flow the basemap already uses). Rendering stays MapKit: hillshade is computed on device from the elevation tiles and served through a custom `MKTileOverlay`; contours are generated on device with marching squares and rendered as `MKMultiPolyline` overlays. Standard and the offline vector basemap show both; hybrid and satellite show contours only. Two phases: (1) terrain download + hillshade, which builds all shared plumbing (extraction, Terrarium decode, caches); (2) contours.
+
+## Technical Context
+
+**Language/Version**: Swift (latest stable), Swift Concurrency (`async`/`await`, actors for generation work)
+**Primary Dependencies**: MapKit (`MKTileOverlay`, `MKMultiPolyline`), Foundation, ImageIO/CoreGraphics (WebP decode), existing PMTiles machinery (`PMTilesArchive`, `PMTilesExtractor`), OSLog
+**Storage**: Per-region `.pmtiles` terrain extracts plus file-based hillshade/contour caches under the existing `OfflineMapManager` region directory; no SwiftData schema changes
+**Testing**: Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`) — Terrarium decode, contour generation (synthetic DEMs), interval selection, cache invalidation
+**Target Platform**: iOS 17+, iPadOS 17+, macOS 14+ (Catalyst); tvOS follow-on possible (shares the map files)
+**Project Type**: Mobile app (feature addition to the offline maps system)
+**Performance Goals**: Map pan/zoom at normal frame rate over cached terrain; first-view tile generation off the main thread with no basemap hitching; hillshade tile generation target < 50 ms/tile on device
+**Constraints**: Fully offline after download; no MapLibre; no 3D terrain; region delete reclaims all storage; generation must never block the main actor
+**Scale/Scope**: Typical region bbox (city to county scale), z0–12 global data plus z13–17 regional coverage where available; two new overlay types in the existing map pipeline
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. SwiftUI-Native | ✅ PASS | Settings toggles are SwiftUI; map rendering already lives in the MKMapView representable |
+| II. SwiftData Persistence | ✅ PASS | No app-data model changes; terrain artifacts are files scoped to offline regions, same pattern as the basemap extract |
+| III. Protocol-Oriented Transport | ✅ PASS | No transport changes; downloads reuse the existing extractor's URLSession flow |
+| IV. Structured Logging | ✅ PASS | `Logger` map/services categories for extract, decode, and generation |
+| V. Protobuf Contract Fidelity | ✅ PASS | No protobuf involvement |
+| VI. Lint-Clean Commits | ✅ PASS | SwiftLint applies as usual |
+| VII. Platform Parity | ✅ PASS | Catalyst works with the same MapKit code; tvOS can adopt later since map files are shared |
+| VIII. Design Standards | ✅ PASS | Toggles follow MapSettingsForm conventions; attribution surfaced per design |
+
+**Gate Result**: PASS — no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-offline-terrain-layer/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── mapterhorn-data-contract.md
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+Meshtastic/
+├── Helpers/Map/
+│   ├── PMTilesExtractor.swift            # extended: terrain extract alongside basemap
+│   ├── TerrainStore.swift                # NEW: per-region terrain archives + decode access
+│   ├── TerrariumDecoder.swift            # NEW: WebP tile → elevation grid
+│   ├── HillshadeTileOverlay.swift        # NEW: MKTileOverlay computing shaded relief locally
+│   ├── ContourGenerator.swift            # NEW: marching squares + interval selection + caching
+│   └── OfflineMapRegion.swift            # extended: terrain component + sizes
+├── Views/Nodes/
+│   └── MeshMapMK.swift / ClusterMapView  # extended: overlay wiring + map-type gating
+└── Views/Settings/
+    └── MapSettingsForm                   # extended: Terrain section (Hillshade / Contours toggles)
+
+MeshtasticTests/
+├── TerrariumDecoderTests.swift           # NEW
+├── ContourGeneratorTests.swift           # NEW
+└── TerrainStoreTests.swift               # NEW
+```
+
+## Phase Outline
+
+**Phase 0 (research)**: complete — see `research.md` (Mapterhorn distribution model, decode formula, WebP support, hillshade algorithm, contour approach, layering).
+
+**Phase 1 (design)**: complete — see `data-model.md`, `contracts/mapterhorn-data-contract.md`, `quickstart.md`.
+
+**Phase 2 (tasks)**: see `tasks.md`. Delivery order is US1 (terrain download) → US2 (hillshade) → US3 (contours); each user story is independently shippable.

--- a/specs/018-offline-terrain-layer/quickstart.md
+++ b/specs/018-offline-terrain-layer/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: Offline Terrain Layer
+
+**Feature**: 018-offline-terrain-layer
+
+How to verify the feature end to end once implemented. Pick a mountainous bbox with regional coverage (the Mapterhorn docs use Interlaken, `7.74,46.60,7.96,46.75`; any US mountain town works — USA has country-wide 10 m).
+
+## US1 — terrain downloads with a region
+
+1. Map tab → map settings → Offline Maps → download a new region over mountains.
+2. Confirm the download UI shows a terrain component and its size.
+3. After completion, the region row lists basemap and terrain sizes separately.
+4. Files exist under the region directory: `terrain-global.pmtiles` (always) and `terrain-regional.pmtiles` (when the coverage page lists the area).
+5. Delete the region → the whole directory including caches is gone.
+6. Regression: a region downloaded before this feature shows an "Add terrain" action instead of forcing a re-download.
+
+## US2 — hillshade
+
+1. Enable Settings → map settings → Terrain → Hillshade.
+2. Airplane mode on; map type standard or the offline basemap: shaded relief renders under labels and node markers.
+3. Pan beyond the region: hillshade ends at the boundary, no errors, no network.
+4. Switch to hybrid or satellite: hillshade disappears (toggle state unchanged).
+5. Dark mode: shading blends with the dark basemap rather than graying it out.
+6. Performance: pan/zoom over cached areas at normal frame rate; first view of a new area generates without hitching the basemap (watch for main-thread stalls with the app hang telemetry).
+
+## US3 — contours
+
+1. Enable Terrain → Contours (airplane mode still on).
+2. Contour lines render with emphasized, labeled index contours; labels use feet or meters per locale.
+3. Zoom in: intervals refine; lines stay continuous across tile boundaries (no combing at tile edges).
+4. Hybrid/satellite: contours remain — the only terrain treatment — in an imagery-legible color.
+5. Global-only coverage area (no regional archive): contours still render at intervals the 30 m data supports.
+
+## Attribution
+
+With either toggle on, the map attribution includes Mapterhorn.
+
+## Unit tests
+
+```bash
+xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -only-testing:MeshtasticTests/TerrariumDecoderTests \
+  -only-testing:MeshtasticTests/ContourGeneratorTests \
+  -only-testing:MeshtasticTests/TerrainStoreTests
+```
+
+Verify executed test counts — decode round-trips known Terrarium pixel values, contour generation against synthetic DEMs (cone, saddle, flat), interval-table selection, and cache invalidation on re-download.

--- a/specs/018-offline-terrain-layer/research.md
+++ b/specs/018-offline-terrain-layer/research.md
@@ -1,0 +1,64 @@
+# Research: Offline Terrain Layer
+
+**Feature**: 018-offline-terrain-layer
+**Date**: 2026-08-16
+**Status**: Complete
+
+## Research Questions & Findings
+
+### R1: Where does the elevation data come from, and does it fit our download flow?
+
+**Question**: Is there an open elevation source distributed in a form our existing PMTiles bbox-extraction flow can consume?
+
+**Decision**: Mapterhorn (https://mapterhorn.com).
+
+**Rationale**: Mapterhorn distributes Terrarium-encoded terrain-RGB tiles (512 px WebP) bundled into PMTiles archives on Cloudflare R2 — the identical distribution model to the Protomaps basemap the app already extracts by bbox with range requests. Verified from their Data Access page:
+
+- z/x/y endpoint: `https://tiles.mapterhorn.com/{z}/{x}/{y}.webp` (TileJSON at `/tilejson.json`)
+- Global archive: `https://download.mapterhorn.com/planet.pmtiles` (z0–z12; ~706 GB total, bbox extracts are small)
+- Regional z13–z17 archives named by tile id (e.g. `6-33-22.pmtiles`); a coverage page maps which exist
+- Their own documented extract flow is `pmtiles extract --bbox=…` — exactly what `PMTilesExtractor` implements in-app
+
+Coverage: global 30 m, with much finer regional data (USA country-wide 10 m and partial 1 m; most of Europe at 0.25–5 m; Japan, Australia, NZ, Canada partials). Project is open source (github.com/mapterhorn/mapterhorn), NLnet/NGI sponsored, with Protomaps' author involved — the ecosystem alignment is deliberate.
+
+**Alternatives considered**: AWS Terrain Tiles (Tilezen Joerd) — Mapterhorn exists specifically as its maintained successor and publishes a migration guide; no PMTiles distribution. USGS 3DEP direct — US-only and GeoTIFF-based, wrong shape for tile rendering.
+
+### R2: How are elevation values decoded?
+
+**Decision**: Terrarium encoding: `elevation_m = (R × 256 + G + B ÷ 256) − 32768`, decoded from 512 px WebP tiles.
+
+**Rationale**: Documented Mapterhorn format. iOS decodes WebP natively via ImageIO since iOS 14, so no third-party codec is needed — `CGImageSource` → raw RGBA buffer → elevation grid.
+
+### R3: Contours — precompute at download, or generate lazily?
+
+**Decision**: Generate lazily per visible tile with a disk cache, keyed by tile coordinate and interval set.
+
+**Rationale**: This is the approach maplibre-contour proved in production (their contour example is exactly this, client-side). Lazy generation keeps the download small and lets the interval set adapt to zoom instead of baking one interval at download time. Contour continuity across tile edges is handled the same way maplibre-contour does it: decode with a margin of neighbor-tile pixels so isolines meet at boundaries. Marching squares over a 512×512 grid is well within budget off the main actor, and results cache to disk so each tile+interval generates once.
+
+**Alternatives considered**: Precomputing contour geometry for the whole region at download time — simpler at render, but multiplies download-time CPU, fixes intervals forever, and bloats the region for areas never viewed.
+
+### R4: Hillshade algorithm and presentation
+
+**Decision**: Horn's method (standard 3×3 kernel) with fixed azimuth 315°/altitude 45°, rendered to grayscale-with-alpha tiles served by a custom `MKTileOverlay` subclass; drawn above the basemap fill at low alpha, below labels and annotations; a separate blend curve for dark appearance.
+
+**Rationale**: Horn shading is the de-facto standard (GDAL's default). Serving locally computed tiles through `MKTileOverlay` keeps MapKit's tile scheduling, caching, and reuse for free, and needs no changes to how the vector basemap renders. Layering above the basemap at low alpha avoids requiring transparency in the basemap fills.
+
+**Alternatives considered**: Pre-rendered hillshade into the basemap style (no runtime toggle, double storage); multidirectional shading (nicer, more CPU — possible later refinement without API change).
+
+### R5: Map-type behavior
+
+**Decision**: Hillshade renders on standard and the offline vector basemap only. Contours render on all map types; on hybrid/satellite they use an imagery-legible color and are the sole terrain treatment.
+
+**Rationale**: Satellite imagery already conveys relief; alpha-blended shading over imagery reads as murk. Contours over imagery are a classic, useful combination. Decided with the maintainer.
+
+### R6: Storage and lifecycle
+
+**Decision**: Terrain artifacts live inside the existing per-region directory managed by `OfflineMapManager`: the extract archives (`terrain-global.pmtiles`, optional `terrain-regional.pmtiles`) plus `hillshade-cache/` and `contour-cache/` subdirectories. Deleting the region deletes everything; region size reporting sums all components.
+
+**Rationale**: Matches the established region layout and makes FR-008/FR-009 (cache scoping, size accounting) fall out of directory structure rather than bookkeeping.
+
+### R7: Attribution and license
+
+**Decision**: When terrain is enabled, the map attribution surface adds Mapterhorn, linking to their attribution page (which carries upstream DEM credits: USGS 3DEP, swisstopo, national agencies).
+
+**Open item for implementation**: verify the exact license text in github.com/mapterhorn/mapterhorn LICENSE before ship; the site fetch for the attribution page was inconclusive during research.

--- a/specs/018-offline-terrain-layer/spec.md
+++ b/specs/018-offline-terrain-layer/spec.md
@@ -79,12 +79,12 @@ With terrain downloaded, the map can show elevation contour lines with labeled i
 
 ### Functional Requirements
 
-- **FR-001**: Offline region downloads MUST optionally include an elevation extract of the same bounding box from the Mapterhorn PMTiles archives (global z0–12 archive, plus the intersecting regional z13+ archive when available), stored with the region.
+- **FR-001**: Offline region downloads MUST optionally include a terrain extract of the same bounding box from the Mapterhorn PMTiles archives (global z0–12 archive, plus the intersecting regional z13+ archive when available), stored with the region.
 - **FR-002**: The app MUST decode Terrarium terrain-RGB tiles to elevation grids on device (`elevation = R×256 + G + B/256 − 32768`).
 - **FR-003**: Hillshade MUST render as a locally computed raster tile overlay on the standard map and the offline vector basemap only, beneath labels and annotations, with light/dark-appearance handling. No network access at render time.
 - **FR-004**: Contours MUST render as vector polylines on all map types; on hybrid and satellite they render without hillshade and in a color chosen for legibility over imagery.
 - **FR-005**: Contour intervals MUST adapt to zoom, with emphasized and labeled index contours; labels follow the user's locale elevation unit.
-- **FR-006**: Map settings MUST gain independent Hillshade and Contours toggles, off by default until terrain data exists for at least one region.
+- **FR-006**: Map settings MUST gain independent Hillshade and Contours toggles, defaulting to off. Both toggles are disabled until at least one region has terrain data downloaded.
 - **FR-007**: All terrain rendering MUST work fully offline once the extract is downloaded.
 - **FR-008**: Generated hillshade tiles and contour geometry MUST be cached on disk, scoped to the region, and deleted with it.
 - **FR-009**: The Offline Maps UI MUST show the terrain component's size per region and support adding terrain to a previously downloaded region.
@@ -111,6 +111,7 @@ With terrain downloaded, the map can show elevation contour lines with labeled i
 - Mapterhorn's license permits app use with attribution (open source project; attribution page lists upstream DEM requirements — verify exact license text during implementation).
 - Contour generation ports the marching-squares approach used by maplibre-contour (client-side generation from elevation tiles); no server-side contour data exists or is wanted.
 - 3D terrain is permanently out of scope for this feature; the map remains MKMapView.
+- tvOS terrain is an explicit follow-on: the TV app already reads the shared offline map files, so it can adopt the terrain layer once the iOS implementation lands.
 
 ## iOS Implementation Reference
 

--- a/specs/018-offline-terrain-layer/spec.md
+++ b/specs/018-offline-terrain-layer/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Offline Terrain Layer
+
+**Feature Branch**: `018-offline-terrain-layer`
+**Created**: 2026-08-16
+**Status**: Draft — approved direction, not yet implemented
+**Input**: User description: "Use Mapterhorn to get contour lines for our Protomaps offline downloads. I want hillshade and contours (Option D) on MapKit — not switching to MapLibre. On hybrid, contours only."
+
+## Overview
+
+The app already downloads an offline vector basemap by extracting a bounding box from the public Protomaps planet build into a local `.pmtiles` file. [Mapterhorn](https://mapterhorn.com) distributes global elevation data the same way — Terrarium-encoded terrain-RGB tiles (512px WebP) in PMTiles archives that support bbox range extraction — so an offline region can gain a terrain layer with one more extract of the same bounding box.
+
+Nothing about the map framework changes: rendering stays MapKit. Hillshade renders as a locally computed raster tile overlay; contours render as vector polylines through the same overlay pipeline the basemap uses. True 3D terrain is explicitly out of scope — that is a MapLibre feature and the map is not moving to MapLibre.
+
+Delivery is two phases sharing one foundation: Phase 1 is the terrain download plus hillshade (all shared plumbing: extraction, Terrarium decode, tile cache). Phase 2 is contour generation and rendering. A follow-on (not this spec) can reuse the on-device elevation data for site-planner line-of-sight and route elevation profiles.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Download terrain with an offline region (Priority: P1)
+
+When a user downloads (or re-downloads) an offline map region, the download includes elevation data for the same bounding box. The Offline Maps UI shows the terrain portion's size and completes both extracts as one operation.
+
+**Why this priority**: Nothing renders without the data on device; this is the foundation both phases sit on.
+
+**Independent Test**: Download a region with terrain enabled, put the device in airplane mode, and verify the terrain files exist in the region's storage and are listed with sizes in Offline Maps.
+
+**Acceptance Scenarios**:
+
+1. **Given** the offline region download form, **When** the user starts a download, **Then** the elevation extract for the same bbox is fetched alongside the basemap extract (global archive; plus the finer regional archive when the bbox has coverage) and stored with the region.
+2. **Given** a completed download, **When** the user views Offline Maps, **Then** the region lists the terrain data and its size separately from the basemap.
+3. **Given** a region is deleted, **Then** its terrain files and any generated hillshade/contour caches are removed with it.
+4. **Given** the terrain extract fails partway, **Then** the basemap remains usable, the failure is reported, and terrain can be retried without re-downloading the basemap.
+
+---
+
+### User Story 2 - Hillshade on the map (Priority: P2)
+
+With terrain downloaded, the standard map and the offline vector basemap show shaded relief beneath the map content. A Terrain setting in the map settings turns it on and off.
+
+**Why this priority**: Largest visual payoff for the smallest rendering surface; forces the decode and cache layers into existence for Phase 2.
+
+**Independent Test**: With a downloaded mountainous region and airplane mode on, enable hillshade and verify shaded relief renders on the offline basemap; toggle off and verify it disappears without disturbing the basemap.
+
+**Acceptance Scenarios**:
+
+1. **Given** terrain data for the visible area and hillshade enabled, **When** the map renders in standard or offline-basemap mode, **Then** shaded relief appears under labels and node annotations.
+2. **Given** hybrid or satellite map type is selected, **Then** hillshade does not render regardless of the toggle — imagery already conveys relief and blended shading muddies it.
+3. **Given** dark mode, **Then** the hillshade uses a dark-appearance blend (no washed-out gray film over the dark basemap).
+4. **Given** the map pans outside the downloaded region, **Then** hillshade simply ends at the region boundary; no errors and no network fetches.
+
+---
+
+### User Story 3 - Contour lines (Priority: P3)
+
+With terrain downloaded, the map can show elevation contour lines with labeled intervals appropriate to the zoom level. Contours render on every map type — on hybrid and satellite they are the only terrain treatment, drawn in a color legible over imagery.
+
+**Why this priority**: The full topo look and the headline user request, built on the Phase 1 foundation.
+
+**Independent Test**: Enable contours over a downloaded region, verify lines with elevation labels at sensible intervals, zoom in and verify intervals refine, switch to hybrid and verify contours (and only contours) remain.
+
+**Acceptance Scenarios**:
+
+1. **Given** contours enabled and terrain data present, **When** the map renders, **Then** contour lines appear with index contours emphasized and labeled in the user's elevation unit (feet/meters following locale).
+2. **Given** the map type is hybrid or satellite, **Then** contours render in an imagery-legible color and hillshade stays off.
+3. **Given** the user zooms, **Then** the contour interval adapts (coarser out, finer in) without seams at tile boundaries.
+4. **Given** terrain is downloaded but only at global 30 m resolution (no regional high-res coverage), **Then** contours still render, limited to intervals the data supports.
+
+---
+
+### Edge Cases
+
+- Bbox has no regional z13+ archive coverage: fall back to the global 30 m data alone; never fail the download for missing high-res.
+- Existing offline regions downloaded before this feature: offer terrain as an add-on download rather than forcing a full re-download.
+- Contour generation is CPU work: generate off the main thread, cache results per tile+interval, and invalidate caches when the region's terrain files change.
+- Tile-edge continuity: contour generation must read neighbor-pixel margins so lines join across tile boundaries.
+- Storage pressure: terrain extract size is shown before download; generated caches count toward the region's displayed size.
+- Attribution: Mapterhorn aggregates national DEMs (USGS 3DEP, swisstopo, and others); the map attribution surface must include it when terrain is enabled.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Offline region downloads MUST optionally include an elevation extract of the same bounding box from the Mapterhorn PMTiles archives (global z0–12 archive, plus the intersecting regional z13+ archive when available), stored with the region.
+- **FR-002**: The app MUST decode Terrarium terrain-RGB tiles to elevation grids on device (`elevation = R×256 + G + B/256 − 32768`).
+- **FR-003**: Hillshade MUST render as a locally computed raster tile overlay on the standard map and the offline vector basemap only, beneath labels and annotations, with light/dark-appearance handling. No network access at render time.
+- **FR-004**: Contours MUST render as vector polylines on all map types; on hybrid and satellite they render without hillshade and in a color chosen for legibility over imagery.
+- **FR-005**: Contour intervals MUST adapt to zoom, with emphasized and labeled index contours; labels follow the user's locale elevation unit.
+- **FR-006**: Map settings MUST gain independent Hillshade and Contours toggles, off by default until terrain data exists for at least one region.
+- **FR-007**: All terrain rendering MUST work fully offline once the extract is downloaded.
+- **FR-008**: Generated hillshade tiles and contour geometry MUST be cached on disk, scoped to the region, and deleted with it.
+- **FR-009**: The Offline Maps UI MUST show the terrain component's size per region and support adding terrain to a previously downloaded region.
+- **FR-010**: The attribution surface MUST credit Mapterhorn (and its upstream sources page) whenever terrain data is displayed.
+
+### Key Entities
+
+- **Terrain extract**: the per-region elevation `.pmtiles` file(s) — one from the global archive, optionally one regional high-res.
+- **Hillshade cache**: locally rendered raster tiles keyed by tile coordinate and appearance.
+- **Contour cache**: generated polylines keyed by tile coordinate and interval set.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can download a region and see hillshade and labeled contours on the offline basemap in airplane mode.
+- **SC-002**: Map pan/zoom over cached terrain sustains the map's normal frame rate; first-view generation happens off the main thread with no visible hitching of the basemap.
+- **SC-003**: Hybrid and satellite show contours only; standard and offline basemap can show both.
+- **SC-004**: Deleting a region reclaims all terrain and cache storage.
+
+## Assumptions
+
+- Mapterhorn's endpoints (`download.mapterhorn.com` archives, coverage listing) remain publicly available; the extract flow reuses the existing PMTilesExtractor range-request machinery.
+- Mapterhorn's license permits app use with attribution (open source project; attribution page lists upstream DEM requirements — verify exact license text during implementation).
+- Contour generation ports the marching-squares approach used by maplibre-contour (client-side generation from elevation tiles); no server-side contour data exists or is wanted.
+- 3D terrain is permanently out of scope for this feature; the map remains MKMapView.
+
+## iOS Implementation Reference
+
+- Extraction/storage: `Meshtastic/Helpers/Map/PMTilesExtractor.swift`, `OfflineMapRegion`/`OfflineMapManager` — the terrain extract is a second archive per region.
+- Rendering: `MeshMapMK`/`ClusterMapView` overlay pipeline; hillshade as a custom `MKTileOverlay` subclass rendering from the local extract; contours as `MKMultiPolyline` overlays.
+- Follow-on (separate spec): on-device elevation queries for site-planner line-of-sight and traceroute elevation profiles reuse the FR-002 decode layer.

--- a/specs/018-offline-terrain-layer/tasks.md
+++ b/specs/018-offline-terrain-layer/tasks.md
@@ -33,7 +33,7 @@
 
 - [ ] T201 Create `Meshtastic/Helpers/Map/HillshadeTileOverlay.swift` — `MKTileOverlay` subclass: Horn 3×3 shading (azimuth 315°, altitude 45°) from `TerrainStore`, disk cache per appearance under `hillshade-cache/`, generation off the main actor
 - [ ] T202 Wire the overlay into `MeshMapMK`/`ClusterMapView` above basemap fill, below labels/annotations; suppress on hybrid/satellite map types
-- [ ] T203 Map settings: Terrain section with Hillshade toggle (`map.terrain.hillshade`, default off); dark-appearance blend curve
+- [ ] T203 Map settings: Terrain section with Hillshade toggle (`meshMapShowHillshade`, default off, disabled until a region has terrain); dark-appearance blend curve
 - [ ] T204 Attribution: add Mapterhorn to the map attribution surface when terrain renders
 - [ ] T205 Verify quickstart US2 flow including airplane mode, region boundary, dark mode, and frame-rate check
 
@@ -41,7 +41,7 @@
 
 - [ ] T301 Create `Meshtastic/Helpers/Map/ContourGenerator.swift` — marching squares over margin-stitched tiles, `ContourIntervalTable` (zoom → minor/index interval, locale unit), serialized `ContourSet` cache under `contour-cache/`
 - [ ] T302 Render `ContourSet`s as `MKMultiPolyline` overlays with index-contour emphasis and elevation labels; imagery-legible color on hybrid/satellite
-- [ ] T303 Map settings: Contours toggle (`map.terrain.contours`, default off)
+- [ ] T303 Map settings: Contours toggle (`meshMapShowContours`, default off, disabled until a region has terrain)
 - [ ] T304 [P] `MeshtasticTests/ContourGeneratorTests.swift` — synthetic DEMs (cone, saddle, flat sea level), edge continuity across tiles, interval selection, cache invalidation on re-download
 - [ ] T305 Verify quickstart US3 flow: intervals refine with zoom, hybrid shows contours only, global-only areas degrade gracefully
 

--- a/specs/018-offline-terrain-layer/tasks.md
+++ b/specs/018-offline-terrain-layer/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Offline Terrain Layer
+
+**Input**: Design documents from `/specs/018-offline-terrain-layer/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Included — the spec's success criteria depend on decode and generation correctness that only unit tests pin down.
+
+**Organization**: Tasks are grouped by user story; US1 → US2 → US3 is the delivery order, each independently shippable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 = terrain download, US2 = hillshade, US3 = contours
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 Create `Meshtastic/Helpers/Map/TerrariumDecoder.swift` — WebP tile → `ElevationTile` grid (`(R×256 + G + B/256) − 32768`), with neighbor-margin stitching support
+- [ ] T002 [P] Create `Meshtastic/Helpers/Map/TerrainStore.swift` — actor opening a region's terrain archives via `PMTilesArchive`, serving margin-stitched `ElevationTile`s with an in-memory decode cache
+- [ ] T003 [P] `MeshtasticTests/TerrariumDecoderTests.swift` — known Terrarium pixel → elevation round-trips, margin stitching, malformed tile handling
+
+## Phase 2: US1 — terrain downloads with a region (P1)
+
+- [ ] T101 Extend `PMTilesExtractor` to run a terrain extract (global archive; regional archive when the bbox intersects published coverage) for the same bbox as the basemap, with independent retry
+- [ ] T102 Extend `OfflineMapRegion` metadata per data-model.md (`terrain` component: archives, byteCount, maxZoom, downloadedAt) and region-directory layout
+- [ ] T103 Offline Maps UI: show the terrain component size per region; add an "Add terrain" action for pre-feature regions; failure of the terrain extract leaves the basemap usable and retryable
+- [ ] T104 Record archive ETag/Last-Modified at download (contract change-detection)
+- [ ] T105 [P] `MeshtasticTests/TerrainStoreTests.swift` — region open, global-only fallback, delete reclaims caches
+- [ ] T106 Verify quickstart US1 flow on the simulator with a small mountain bbox
+
+## Phase 3: US2 — hillshade (P2)
+
+- [ ] T201 Create `Meshtastic/Helpers/Map/HillshadeTileOverlay.swift` — `MKTileOverlay` subclass: Horn 3×3 shading (azimuth 315°, altitude 45°) from `TerrainStore`, disk cache per appearance under `hillshade-cache/`, generation off the main actor
+- [ ] T202 Wire the overlay into `MeshMapMK`/`ClusterMapView` above basemap fill, below labels/annotations; suppress on hybrid/satellite map types
+- [ ] T203 Map settings: Terrain section with Hillshade toggle (`map.terrain.hillshade`, default off); dark-appearance blend curve
+- [ ] T204 Attribution: add Mapterhorn to the map attribution surface when terrain renders
+- [ ] T205 Verify quickstart US2 flow including airplane mode, region boundary, dark mode, and frame-rate check
+
+## Phase 4: US3 — contours (P3)
+
+- [ ] T301 Create `Meshtastic/Helpers/Map/ContourGenerator.swift` — marching squares over margin-stitched tiles, `ContourIntervalTable` (zoom → minor/index interval, locale unit), serialized `ContourSet` cache under `contour-cache/`
+- [ ] T302 Render `ContourSet`s as `MKMultiPolyline` overlays with index-contour emphasis and elevation labels; imagery-legible color on hybrid/satellite
+- [ ] T303 Map settings: Contours toggle (`map.terrain.contours`, default off)
+- [ ] T304 [P] `MeshtasticTests/ContourGeneratorTests.swift` — synthetic DEMs (cone, saddle, flat sea level), edge continuity across tiles, interval selection, cache invalidation on re-download
+- [ ] T305 Verify quickstart US3 flow: intervals refine with zoom, hybrid shows contours only, global-only areas degrade gracefully
+
+## Phase 5: Polish
+
+- [ ] T401 Cache invalidation when `terrain.downloadedAt` changes (re-download); size accounting includes generated caches
+- [ ] T402 Docs: update `docs/user/map.md` (terrain download, toggles, attribution) and regenerate bundled docs
+- [ ] T403 Confirm LICENSE terms in github.com/mapterhorn/mapterhorn and finalize attribution copy (research.md open item)
+- [ ] T404 Profile generation cost on device (hillshade < 50 ms/tile target); tune decode cache size


### PR DESCRIPTION
## Summary

Full spec kit for adding hillshade and contour lines to offline map regions using Mapterhorn elevation extracts — the same PMTiles bbox-extraction flow the offline basemap already uses. Rendering stays MapKit; 3D terrain and MapLibre are out of scope. Supersedes #2303, which carried the spec alone.

## What changed

Adds specs/018-offline-terrain-layer/ with spec.md, plan.md, research.md (Mapterhorn endpoints, formats, and decisions), data-model.md (region metadata and cache layout), contracts/mapterhorn-data-contract.md, quickstart.md, and tasks.md (US1 terrain download, US2 hillshade, US3 contours). Hybrid and satellite get contours only; standard and the offline basemap get both.

## Testing

Docs only.