### PR TITLE
Fix the offline map size estimate for High detail

### DIFF
--- a/Meshtastic/Helpers/Map/PMTilesExtractor.swift
+++ b/Meshtastic/Helpers/Map/PMTilesExtractor.swift
@@ -360,11 +360,27 @@ final class PMTilesExtractor {
 		return count
 	}
 
-	/// A network-free size estimate for the UI. Real size is known only after planning,
-	/// but this tracks it closely enough to show while choosing an area. ~28 KB/tile is a
-	/// rough average for gzipped Protomaps MVT tiles across zooms.
+	/// A network-free size estimate for the UI. Real size is known only after planning —
+	/// this only needs to be in the ballpark while the exact plan computes. Per-tile
+	/// averages were measured against a real build for an urban region: high-zoom tiles
+	/// are much smaller than mid-zoom ones (a flat constant overstated High detail by
+	/// ~70%). Rural areas run far below these numbers, which is why the UI marks this
+	/// value as approximate until the exact plan replaces it.
 	static func roughByteEstimate(in bounds: GeoBounds, minZoom: Int, maxZoom: Int) -> Int64 {
-		Int64(tileCount(in: bounds, minZoom: minZoom, maxZoom: maxZoom)) * 28_672
+		guard minZoom <= maxZoom else { return 0 }
+		func perTileBytes(_ z: Int) -> Int64 {
+			switch z {
+			case ..<13: return 40_960
+			case 13: return 34_816
+			case 14: return 20_480
+			default: return 13_824
+			}
+		}
+		var total: Int64 = 0
+		for z in minZoom...maxZoom {
+			total += Int64(tileCount(in: bounds, minZoom: z, maxZoom: z)) * perTileBytes(z)
+		}
+		return total
 	}
 
 	/// Web-Mercator slippy tile coordinate for a lon/lat at zoom `z` (clamped to valid range).

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
@@ -67,6 +67,8 @@ struct RegionSelectorView: View {
 
 	/// Network-accurate size (exact for street, sampled for topo); nil until computed.
 	@State private var estimatedBytes: Int64?
+	/// Whether estimatedBytes came from the exact plan (vs the rough heuristic).
+	@State private var estimateIsExact = false
 	/// True while the accurate estimate is being (re)computed.
 	@State private var isEstimating = false
 
@@ -406,10 +408,16 @@ struct RegionSelectorView: View {
 		bounds.flatMap { manager.overlappingRegion(with: $0, excluding: replacing) }
 	}
 
-	/// The single most relevant warning to show (overlap → limit), or nil.
+	/// The single most relevant warning to show (overlap → tile cap → limit), or nil.
 	private var warning: String? {
 		if let overlap {
 			return String(localized: "Overlaps \u{201C}\(overlap.name)\u{201D}. Move or resize so it doesn\u{2019}t overlap an existing map.")
+		}
+		// Surface the extractor's tile cap here instead of letting the download fail
+		// after it starts. High detail multiplies the tile count ~20x over Standard.
+		if let bounds,
+		   PMTilesExtractor.tileCount(in: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom) > PMTilesExtractor.maxTiles {
+			return String(localized: "Area is too large for \(detail.label). Shrink the area or choose a lower detail level.")
 		}
 		if let bytes = displayedBytes {
 			return manager.downloadBlockReason(estimatedBytes: bytes, replacing: replacing)
@@ -435,7 +443,10 @@ struct RegionSelectorView: View {
 	private var sizeText: String {
 		guard let bytes = displayedBytes else { return "—" }
 		let formatted = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-		return isEstimating ? "\u{2248} \(formatted)" : formatted
+		// "≈" whenever the shown value is the rough heuristic — while the exact plan
+		// is still computing AND when it failed (previously a failed plan displayed
+		// the heuristic with no marker, as if it were exact).
+		return estimateIsExact ? formatted : "\u{2248} \(formatted)"
 	}
 
 	/// Re-runs whenever the framed area / detail settle (debounced via `.task(id:)`).
@@ -447,6 +458,7 @@ struct RegionSelectorView: View {
 
 	private func runEstimate() async {
 		estimatedBytes = nil
+		estimateIsExact = false
 		guard let bounds else { isEstimating = false; return }
 		isEstimating = true
 		// Debounce: cancelled (and restarted) by `.task(id:)` if the area keeps changing.
@@ -454,16 +466,17 @@ struct RegionSelectorView: View {
 		if Task.isCancelled { return }
 		let bytes = await Self.computeEstimate(bounds: bounds, detail: detail)
 		if Task.isCancelled { return }
-		estimatedBytes = bytes
+		if let bytes {
+			estimatedBytes = bytes
+			estimateIsExact = true
+		}
 		isEstimating = false
 	}
 
-	/// Network-accurate size (the exact plan the download uses), falling back to the rough estimate.
-	private static func computeEstimate(bounds: GeoBounds, detail: OfflineMapDetailLevel) async -> Int64 {
-		if let result = try? await PMTilesExtractor().estimate(bounds: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom) {
-			return result.bytes
-		}
-		return PMTilesExtractor.roughByteEstimate(in: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom)
+	/// Network-accurate size (the exact plan the download uses), or nil when planning
+	/// fails — the caller keeps showing the rough estimate, marked approximate.
+	private static func computeEstimate(bounds: GeoBounds, detail: OfflineMapDetailLevel) async -> Int64? {
+		(try? await PMTilesExtractor().estimate(bounds: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom))?.bytes
 	}
 
 	private func startDownload() {

--- a/MeshtasticTests/PMTilesExtractorTests.swift
+++ b/MeshtasticTests/PMTilesExtractorTests.swift
@@ -28,6 +28,18 @@ struct PMTilesExtractorTileMathTests {
 		#expect(y == 0) // clamped to the Web-Mercator limit, top row
 	}
 
+	@Test func roughByteEstimate_weightsHighZoomTilesLighter() {
+		let bounds = GeoBounds(minLon: -122.5, minLat: 47.4, maxLon: -122.2, maxLat: 47.8)
+		let standard = PMTilesExtractor.roughByteEstimate(in: bounds, minZoom: 0, maxZoom: 13)
+		let high = PMTilesExtractor.roughByteEstimate(in: bounds, minZoom: 0, maxZoom: 15)
+		#expect(high > standard)
+		// z14/z15 tiles average far smaller than mid-zoom tiles; the high-detail
+		// increment must reflect that rather than a flat per-tile constant.
+		let addedTiles = PMTilesExtractor.tileCount(in: bounds, minZoom: 14, maxZoom: 15)
+		let flatIncrement = Int64(addedTiles) * 34_816
+		#expect(high - standard < flatIncrement)
+	}
+
 	@Test func tileCount_matchesEnumeratedIDs() {
 		let bounds = GeoBounds(minLon: -122.3, minLat: 47.4, maxLon: -122.0, maxLat: 47.7)
 		let count = PMTilesExtractor.tileCount(in: bounds, minZoom: 0, maxZoom: 12)


### PR DESCRIPTION
## Summary

The offline download size estimate could read way off with High detail selected. Three causes: the rough heuristic used a flat 28 KB/tile constant that overstates High detail by ~70% (measured against a real Protomaps build — z14/15 tiles average far smaller than mid-zoom tiles, and shared empty tiles deduplicate); when the exact plan failed, the rough number was shown without any approximate marker, as if final; and a High-detail selection over the extractor's 600k-tile cap only failed after the download started.

## What changed

- The rough estimate uses per-zoom per-tile constants measured against a real build instead of one flat constant.
- The size label shows an approximate marker whenever the heuristic is displayed — both while the exact plan computes and when it fails. The exact plan remains the number normally shown.
- Selecting an area over the tile cap shows a warning and blocks the download at selection time.

## Testing

PMTilesExtractorTests pass, including a new regression test that the high-detail increment is weighted lighter than mid-zoom tiles. Verified estimator math against the live 2026-08-15 Protomaps build for urban and rural bounding boxes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved offline map download size estimates by accounting for differences between zoom levels.
  - Estimates now clearly indicate when they are approximate.
  - If an exact estimate cannot be calculated, the app preserves the best available estimate instead of showing no value.
  - Added warnings when a selected map area exceeds the maximum supported tile limit, helping prevent failed downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->