### PR TITLE
Offline terrain layer: Mapterhorn hillshade and contours

### DIFF
--- a/Meshtastic/Helpers/Map/ContourGenerator.swift
+++ b/Meshtastic/Helpers/Map/ContourGenerator.swift
@@ -1,0 +1,248 @@
+//
+//  ContourGenerator.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/15/26.
+//
+//  Marching-squares contour extraction from decoded elevation tiles.
+//  Pure geometry: no rendering, no I/O. See
+//  specs/018-offline-terrain-layer/data-model.md (ContourIntervalTable).
+//
+
+import Foundation
+import CoreGraphics
+
+/// One contour polyline for a single elevation level, in tile-unit
+/// coordinates: (0, 0) is the tile's top-left corner, (1, 1) the bottom-right.
+/// Points may run slightly outside [0, 1] into the margin ring so lines meet
+/// across tile boundaries. Closed rings repeat the first point at the end.
+struct ContourLine: Sendable {
+	/// Contour elevation in meters.
+	let elevation: Double
+	/// True when this level falls on the index interval (drawn heavier, labeled).
+	let isIndex: Bool
+	/// Polyline vertices in tile units. Closed when `points.first == points.last`.
+	let points: [CGPoint]
+}
+
+/// Contour spacing for one zoom band, always expressed in meters. The metric
+/// flag picks which family of round numbers the meters encode (100 m vs 500 ft).
+struct ContourIntervals: Sendable {
+	/// Spacing between adjacent contour lines, meters.
+	let minor: Double
+	/// Spacing between index (heavy) contours, meters. A multiple of `minor`.
+	let index: Double
+
+	/// Zoom → interval table from the feature spec. Imperial values are round
+	/// feet expressed in meters (1 ft = 0.3048 m).
+	static func intervals(forZoom zoom: Int, metric: Bool) -> ContourIntervals {
+		let foot = 0.3048
+		switch zoom {
+		case ...10:
+			return metric
+				? ContourIntervals(minor: 500, index: 2500)
+				: ContourIntervals(minor: 2000 * foot, index: 10000 * foot)
+		case 11...12:
+			return metric
+				? ContourIntervals(minor: 100, index: 500)
+				: ContourIntervals(minor: 500 * foot, index: 2500 * foot)
+		case 13...14:
+			return metric
+				? ContourIntervals(minor: 50, index: 250)
+				: ContourIntervals(minor: 200 * foot, index: 1000 * foot)
+		default:
+			return metric
+				? ContourIntervals(minor: 20, index: 100)
+				: ContourIntervals(minor: 100 * foot, index: 500 * foot)
+		}
+	}
+}
+
+/// Extracts contour polylines from an `ElevationTile` with marching squares.
+/// The march covers the margin ring so segments continue across tile edges,
+/// and levels are every multiple of `intervals.minor` inside the tile's
+/// elevation range (levels below -100 m are skipped to avoid sea-noise
+/// banding). Saddle cells are disambiguated by the cell-center average.
+enum ContourGenerator {
+
+	private typealias GridPoint = SIMD2<Double>
+
+	private struct Segment {
+		var a: GridPoint
+		var b: GridPoint
+	}
+
+	/// Endpoint identity for chaining. Matching endpoints from adjacent cells
+	/// are computed from the same two samples and are bit-identical; the 2^-20
+	/// grid-unit quantization only mops up degenerate corner touches.
+	private struct PointKey: Hashable {
+		var x: Int64
+		var y: Int64
+
+		init(_ point: GridPoint) {
+			x = Int64((point.x * 1_048_576).rounded())
+			y = Int64((point.y * 1_048_576).rounded())
+		}
+	}
+
+	static func contours(tile: ElevationTile, intervals: ContourIntervals) -> [ContourLine] {
+		let gridSize = tile.gridSize
+		guard gridSize >= 2, tile.size > 0, intervals.minor > 0 else { return [] }
+		let elevations = tile.elevations
+		guard elevations.count == gridSize * gridSize else { return [] }
+
+		var minElevation = Double.greatestFiniteMagnitude
+		var maxElevation = -Double.greatestFiniteMagnitude
+		for value in elevations {
+			let elevation = Double(value)
+			if elevation < minElevation { minElevation = elevation }
+			if elevation > maxElevation { maxElevation = elevation }
+		}
+		guard maxElevation > minElevation else { return [] }
+
+		let minor = intervals.minor
+		// Every multiple of `minor` in range, skipping levels below -100 m.
+		let firstLevelIndex = Int((max(minElevation, -100) / minor).rounded(.up))
+		let lastLevelIndex = Int((maxElevation / minor).rounded(.down))
+		guard firstLevelIndex <= lastLevelIndex else { return [] }
+		let levelCount = lastLevelIndex - firstLevelIndex + 1
+
+		var levelSegments = [[Segment]](repeating: [], count: levelCount)
+
+		let margin = tile.margin
+		// Cell-major march: each cell visits only the levels that cross it, so
+		// the whole grid is scanned once regardless of the level count.
+		for rawY in 0..<(gridSize - 1) {
+			let rowBase = rawY * gridSize
+			let y = Double(rawY - margin)
+			for rawX in 0..<(gridSize - 1) {
+				let base = rowBase + rawX
+				let topLeft = Double(elevations[base])
+				let topRight = Double(elevations[base + 1])
+				let bottomLeft = Double(elevations[base + gridSize])
+				let bottomRight = Double(elevations[base + gridSize + 1])
+
+				let low = min(min(topLeft, topRight), min(bottomLeft, bottomRight))
+				let high = max(max(topLeft, topRight), max(bottomLeft, bottomRight))
+				if high == low { continue }
+
+				var levelIndex = max(Int((low / minor).rounded(.up)), firstLevelIndex)
+				let lastCellLevel = min(Int((high / minor).rounded(.down)), lastLevelIndex)
+				if levelIndex > lastCellLevel { continue }
+
+				let x = Double(rawX - margin)
+				while levelIndex <= lastCellLevel {
+					let level = Double(levelIndex) * minor
+					// A corner is "above" only when strictly greater, so a
+					// straddling edge always has distinct endpoint values and
+					// interpolation never divides by zero.
+					var code = 0
+					if topLeft > level { code |= 1 }
+					if topRight > level { code |= 2 }
+					if bottomRight > level { code |= 4 }
+					if bottomLeft > level { code |= 8 }
+					if code != 0 && code != 15 {
+						func top() -> GridPoint { GridPoint(x + (level - topLeft) / (topRight - topLeft), y) }
+						func right() -> GridPoint { GridPoint(x + 1, y + (level - topRight) / (bottomRight - topRight)) }
+						func bottom() -> GridPoint { GridPoint(x + (level - bottomLeft) / (bottomRight - bottomLeft), y + 1) }
+						func left() -> GridPoint { GridPoint(x, y + (level - topLeft) / (bottomLeft - topLeft)) }
+						func emit(_ a: GridPoint, _ b: GridPoint) {
+							guard PointKey(a) != PointKey(b) else { return }
+							levelSegments[levelIndex - firstLevelIndex].append(Segment(a: a, b: b))
+						}
+
+						switch code {
+						case 1, 14: emit(left(), top())
+						case 2, 13: emit(top(), right())
+						case 3, 12: emit(left(), right())
+						case 4, 11: emit(right(), bottom())
+						case 6, 9: emit(top(), bottom())
+						case 7, 8: emit(left(), bottom())
+						case 5:
+							// Saddle: the cell-center average decides whether
+							// the two "above" corners join through the middle.
+							if (topLeft + topRight + bottomRight + bottomLeft) * 0.25 > level {
+								emit(top(), right())
+								emit(left(), bottom())
+							} else {
+								emit(left(), top())
+								emit(right(), bottom())
+							}
+						case 10:
+							if (topLeft + topRight + bottomRight + bottomLeft) * 0.25 > level {
+								emit(left(), top())
+								emit(right(), bottom())
+							} else {
+								emit(top(), right())
+								emit(left(), bottom())
+							}
+						default:
+							break
+						}
+					}
+					levelIndex += 1
+				}
+			}
+		}
+
+		let size = Double(tile.size)
+		var result: [ContourLine] = []
+		for (offset, segments) in levelSegments.enumerated() where !segments.isEmpty {
+			let level = Double(firstLevelIndex + offset) * minor
+			let indexMultiple = (level / intervals.index).rounded() * intervals.index
+			let isIndex = abs(level - indexMultiple) < 0.01
+			for chain in chained(segments) where chain.count >= 2 {
+				let points = chain.map { CGPoint(x: $0.x / size, y: $0.y / size) }
+				result.append(ContourLine(elevation: level, isIndex: isIndex, points: points))
+			}
+		}
+		return result
+	}
+
+	/// Joins segments that share endpoints (exact after quantization) into
+	/// polylines: grow forward from an unused segment until the chain closes or
+	/// stalls, then reverse once and grow the other end.
+	private static func chained(_ segments: [Segment]) -> [[GridPoint]] {
+		var adjacency = [PointKey: [Int]](minimumCapacity: segments.count * 2)
+		for (index, segment) in segments.enumerated() {
+			adjacency[PointKey(segment.a), default: []].append(index)
+			adjacency[PointKey(segment.b), default: []].append(index)
+		}
+
+		var used = [Bool](repeating: false, count: segments.count)
+		var polylines: [[GridPoint]] = []
+
+		func takeNext(at key: PointKey) -> GridPoint? {
+			guard let candidates = adjacency[key] else { return nil }
+			for index in candidates where !used[index] {
+				used[index] = true
+				let segment = segments[index]
+				return PointKey(segment.a) == key ? segment.b : segment.a
+			}
+			return nil
+		}
+
+		for index in 0..<segments.count where !used[index] {
+			used[index] = true
+			var chain: [GridPoint] = [segments[index].a, segments[index].b]
+			let startKey = PointKey(chain[0])
+			var closed = false
+			while let next = takeNext(at: PointKey(chain[chain.count - 1])) {
+				if PointKey(next) == startKey {
+					chain.append(chain[0]) // close exactly: first == last
+					closed = true
+					break
+				}
+				chain.append(next)
+			}
+			if !closed {
+				chain.reverse()
+				while let next = takeNext(at: PointKey(chain[chain.count - 1])) {
+					chain.append(next)
+				}
+			}
+			polylines.append(chain)
+		}
+		return polylines
+	}
+}

--- a/Meshtastic/Helpers/Map/ContourGenerator.swift
+++ b/Meshtastic/Helpers/Map/ContourGenerator.swift
@@ -61,7 +61,7 @@ struct ContourIntervals: Sendable {
 /// Extracts contour polylines from an `ElevationTile` with marching squares.
 /// The march covers the margin ring so segments continue across tile edges,
 /// and levels are every multiple of `intervals.minor` inside the tile's
-/// elevation range (levels below -100 m are skipped to avoid sea-noise
+/// elevation range (positive levels only — the data includes bathymetry
 /// banding). Saddle cells are disambiguated by the cell-center average.
 enum ContourGenerator {
 
@@ -101,8 +101,10 @@ enum ContourGenerator {
 		guard maxElevation > minElevation else { return [] }
 
 		let minor = intervals.minor
-		// Every multiple of `minor` in range, skipping levels below -100 m.
-		let firstLevelIndex = Int((max(minElevation, -100) / minor).rounded(.up))
+		// Every multiple of `minor` in range. Positive levels only: the elevation
+		// data carries ocean bathymetry, and sub-sea-level contours would draw
+		// rings on open water.
+		let firstLevelIndex = max(Int((max(minElevation, 0) / minor).rounded(.up)), 1)
 		let lastLevelIndex = Int((maxElevation / minor).rounded(.down))
 		guard firstLevelIndex <= lastLevelIndex else { return [] }
 		let levelCount = lastLevelIndex - firstLevelIndex + 1

--- a/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
+++ b/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
@@ -73,12 +73,14 @@ final class HillshadeTileOverlay: MKTileOverlay {
 	/// 1×1 transparent PNG for out-of-coverage tiles.
 	private static let emptyTile: Data = {
 		var pixel: [UInt8] = [0, 0, 0, 0]
-		let context = CGContext(
-			data: &pixel, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,
-			space: CGColorSpaceCreateDeviceRGB(),
-			bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
-		)
-		guard let image = context?.makeImage(), let data = pngData(from: image) else { return Data() }
+		let image: CGImage? = pixel.withUnsafeMutableBytes { buffer in
+			CGContext(
+				data: buffer.baseAddress, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,
+				space: CGColorSpaceCreateDeviceRGB(),
+				bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+			)?.makeImage()
+		}
+		guard let image, let data = pngData(from: image) else { return Data() }
 		return data
 	}()
 
@@ -95,15 +97,17 @@ final class HillshadeTileOverlay: MKTileOverlay {
 
 		for py in 0..<size {
 			for px in 0..<size {
-				// Horn kernel: weighted differences of the 8 neighbors.
-				let a = tile.gridElevation(x: px - 1, y: py - 1)
-				let b = tile.gridElevation(x: px, y: py - 1)
-				let c = tile.gridElevation(x: px + 1, y: py - 1)
-				let d = tile.gridElevation(x: px - 1, y: py)
-				let f = tile.gridElevation(x: px + 1, y: py)
-				let g = tile.gridElevation(x: px - 1, y: py + 1)
-				let h = tile.gridElevation(x: px, y: py + 1)
-				let i = tile.gridElevation(x: px + 1, y: py + 1)
+				// Horn kernel: weighted differences of the 8 neighbors. Elevations
+				// clamp at sea level — the data carries ocean bathymetry, and without
+				// the clamp the shading renders seafloor relief onto open water.
+				let a = max(0, tile.gridElevation(x: px - 1, y: py - 1))
+				let b = max(0, tile.gridElevation(x: px, y: py - 1))
+				let c = max(0, tile.gridElevation(x: px + 1, y: py - 1))
+				let d = max(0, tile.gridElevation(x: px - 1, y: py))
+				let f = max(0, tile.gridElevation(x: px + 1, y: py))
+				let g = max(0, tile.gridElevation(x: px - 1, y: py + 1))
+				let h = max(0, tile.gridElevation(x: px, y: py + 1))
+				let i = max(0, tile.gridElevation(x: px + 1, y: py + 1))
 
 				let dzdx = ((c + 2 * f + i) - (a + 2 * d + g)) / (8 * cellSize)
 				let dzdy = ((g + 2 * h + i) - (a + 2 * b + c)) / (8 * cellSize)
@@ -126,11 +130,14 @@ final class HillshadeTileOverlay: MKTileOverlay {
 		for index in 0..<(size * size) {
 			rgba[index * 4 + 3] = alphas[index]
 		}
-		guard let context = CGContext(
-			data: &rgba, width: size, height: size, bitsPerComponent: 8, bytesPerRow: size * 4,
-			space: CGColorSpaceCreateDeviceRGB(),
-			bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
-		), let image = context.makeImage() else { return nil }
+		let image: CGImage? = rgba.withUnsafeMutableBytes { buffer in
+			CGContext(
+				data: buffer.baseAddress, width: size, height: size, bitsPerComponent: 8, bytesPerRow: size * 4,
+				space: CGColorSpaceCreateDeviceRGB(),
+				bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+			)?.makeImage()
+		}
+		guard let image else { return nil }
 		return pngData(from: image)
 	}
 

--- a/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
+++ b/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
@@ -52,7 +52,8 @@ final class HillshadeTileOverlay: MKTileOverlay {
 				result(cached, nil)
 				return
 			}
-			guard let tile = await store.elevationTile(z: path.z, x: path.x, y: path.y, margin: 1) else {
+			guard let tile = await store.elevationTile(z: path.z, x: path.x, y: path.y, margin: 1),
+				  let coverage = await store.coverage(z: path.z, x: path.x, y: path.y) else {
 				// Outside coverage: an empty (fully transparent) tile, not an error —
 				// MapKit treats errors as retryable and would hammer loadTile. Not
 				// cached: coverage can appear later via Add Terrain.
@@ -60,7 +61,8 @@ final class HillshadeTileOverlay: MKTileOverlay {
 				return
 			}
 			let metersPerSample = TerrainStore.metersPerSample(z: path.z, y: path.y, size: tile.size)
-			let png = Self.renderShadow(tile: tile, metersPerSample: metersPerSample, maxAlpha: alphaCap)
+			let clip = Self.clipRect(tile: tile, path: path, coverage: coverage)
+			let png = Self.renderShadow(tile: tile, metersPerSample: metersPerSample, maxAlpha: alphaCap, clip: clip)
 			if let png, let cacheURL {
 				try? png.write(to: cacheURL, options: .atomic)
 			}
@@ -84,9 +86,37 @@ final class HillshadeTileOverlay: MKTileOverlay {
 		return data
 	}()
 
+	/// Pixel range of the region's coverage box within this tile, so shading is
+	/// clipped exactly to the downloaded boundary. Web Mercator makes a lon/lat
+	/// box a pixel-aligned rect: lon is linear in x, lat monotonic in y.
+	/// Inclusive pixel bounds of the region coverage within a tile.
+	struct PixelRect {
+		let minX: Int
+		let minY: Int
+		let maxX: Int
+		let maxY: Int
+	}
+
+	static func clipRect(tile: ElevationTile, path: MKTileOverlayPath, coverage: GeoBounds) -> PixelRect {
+		let bounds = TerrainStore.tileBounds(z: path.z, x: path.x, y: path.y)
+		let size = tile.size
+		func mercY(_ latitude: Double) -> Double {
+			let clamped = min(max(latitude, -85.05112878), 85.05112878)
+			return 1 - asinh(tan(clamped * .pi / 180)) / .pi   // 0..2 over the world
+		}
+		let lonSpan = bounds.maxLon - bounds.minLon
+		let x0 = Int(((coverage.minLon - bounds.minLon) / lonSpan * Double(size)).rounded(.down))
+		let x1 = Int(((coverage.maxLon - bounds.minLon) / lonSpan * Double(size)).rounded(.up)) - 1
+		let ySpan = mercY(bounds.minLat) - mercY(bounds.maxLat)
+		let y0 = Int(((mercY(coverage.maxLat) - mercY(bounds.maxLat)) / ySpan * Double(size)).rounded(.down))
+		let y1 = Int(((mercY(coverage.minLat) - mercY(bounds.maxLat)) / ySpan * Double(size)).rounded(.up)) - 1
+		return PixelRect(minX: max(0, x0), minY: max(0, y0), maxX: min(size - 1, x1), maxY: min(size - 1, y1))
+	}
+
 	/// Horn 3×3 shading over the tile's grid (the 1px margin keeps edges seamless),
-	/// emitted as a black tile whose per-pixel alpha encodes shadow depth.
-	static func renderShadow(tile: ElevationTile, metersPerSample: Double, maxAlpha: CGFloat) -> Data? {
+	/// emitted as a black tile whose per-pixel alpha encodes shadow depth. Pixels
+	/// outside `clip` stay fully transparent (past the region boundary).
+	static func renderShadow(tile: ElevationTile, metersPerSample: Double, maxAlpha: CGFloat, clip: PixelRect? = nil) -> Data? {
 		let size = tile.size
 		var alphas = [UInt8](repeating: 0, count: size * size)
 		let cellSize = Float(max(metersPerSample, 0.0001))
@@ -95,8 +125,10 @@ final class HillshadeTileOverlay: MKTileOverlay {
 		let azimuth = Float(azimuthRadians)
 		let cap = Float(maxAlpha)
 
-		for py in 0..<size {
-			for px in 0..<size {
+		let clipRange = clip ?? PixelRect(minX: 0, minY: 0, maxX: size - 1, maxY: size - 1)
+		guard clipRange.minX <= clipRange.maxX, clipRange.minY <= clipRange.maxY else { return nil }
+		for py in clipRange.minY...clipRange.maxY {
+			for px in clipRange.minX...clipRange.maxX {
 				// Horn kernel: weighted differences of the 8 neighbors. Elevations
 				// clamp at sea level — the data carries ocean bathymetry, and without
 				// the clamp the shading renders seafloor relief onto open water.

--- a/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
+++ b/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
@@ -1,0 +1,130 @@
+//
+//  HillshadeTileOverlay.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/16/26.
+//
+//  Locally computed shaded relief served as raster map tiles. Elevation comes
+//  from the region's downloaded Mapterhorn archives via TerrainStore; nothing
+//  touches the network at render time. Horn's method (the GDAL default) with a
+//  fixed light from the northwest; shadows-only output (black with variable
+//  alpha) so the shading reads on both light and dark basemaps.
+//
+
+import Foundation
+import MapKit
+import CoreGraphics
+import ImageIO
+import OSLog
+
+final class HillshadeTileOverlay: MKTileOverlay {
+
+	private let store: TerrainStore
+	/// Shadow strength cap. Dark appearance uses a lighter hand so the shading
+	/// deepens rather than grays the dark basemap.
+	private let maxShadowAlpha: CGFloat
+
+	/// Sun position for Horn shading: standard cartographic northwest light.
+	private static let azimuthRadians = 315.0 * Double.pi / 180
+	private static let altitudeRadians = 45.0 * Double.pi / 180
+
+	init(store: TerrainStore, darkAppearance: Bool) {
+		self.store = store
+		self.maxShadowAlpha = darkAppearance ? 0.42 : 0.32
+		super.init(urlTemplate: nil)
+		tileSize = CGSize(width: 256, height: 256)
+		canReplaceMapContent = false
+		minimumZ = 4
+		maximumZ = 22
+	}
+
+	override func loadTile(at path: MKTileOverlayPath, result: @escaping (Data?, Error?) -> Void) {
+		let store = store
+		let alphaCap = maxShadowAlpha
+		Task.detached(priority: .utility) {
+			guard let tile = await store.elevationTile(z: path.z, x: path.x, y: path.y, margin: 1) else {
+				// Outside coverage: an empty (fully transparent) tile, not an error —
+				// MapKit treats errors as retryable and would hammer loadTile.
+				result(Self.emptyTile, nil)
+				return
+			}
+			let metersPerSample = TerrainStore.metersPerSample(z: path.z, y: path.y, size: tile.size)
+			let png = Self.renderShadow(tile: tile, metersPerSample: metersPerSample, maxAlpha: alphaCap)
+			result(png ?? Self.emptyTile, nil)
+		}
+	}
+
+	// MARK: - Rendering
+
+	/// 1×1 transparent PNG for out-of-coverage tiles.
+	private static let emptyTile: Data = {
+		var pixel: [UInt8] = [0, 0, 0, 0]
+		let context = CGContext(
+			data: &pixel, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,
+			space: CGColorSpaceCreateDeviceRGB(),
+			bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+		)
+		guard let image = context?.makeImage(), let data = pngData(from: image) else { return Data() }
+		return data
+	}()
+
+	/// Horn 3×3 shading over the tile's grid (the 1px margin keeps edges seamless),
+	/// emitted as a black tile whose per-pixel alpha encodes shadow depth.
+	static func renderShadow(tile: ElevationTile, metersPerSample: Double, maxAlpha: CGFloat) -> Data? {
+		let size = tile.size
+		var alphas = [UInt8](repeating: 0, count: size * size)
+		let cellSize = Float(max(metersPerSample, 0.0001))
+		let sinAlt = Float(sin(altitudeRadians))
+		let cosAlt = Float(cos(altitudeRadians))
+		let azimuth = Float(azimuthRadians)
+		let cap = Float(maxAlpha)
+
+		for py in 0..<size {
+			for px in 0..<size {
+				// Horn kernel: weighted differences of the 8 neighbors.
+				let a = tile.gridElevation(x: px - 1, y: py - 1)
+				let b = tile.gridElevation(x: px, y: py - 1)
+				let c = tile.gridElevation(x: px + 1, y: py - 1)
+				let d = tile.gridElevation(x: px - 1, y: py)
+				let f = tile.gridElevation(x: px + 1, y: py)
+				let g = tile.gridElevation(x: px - 1, y: py + 1)
+				let h = tile.gridElevation(x: px, y: py + 1)
+				let i = tile.gridElevation(x: px + 1, y: py + 1)
+
+				let dzdx = ((c + 2 * f + i) - (a + 2 * d + g)) / (8 * cellSize)
+				let dzdy = ((g + 2 * h + i) - (a + 2 * b + c)) / (8 * cellSize)
+
+				let slope = atan(sqrt(dzdx * dzdx + dzdy * dzdy))
+				let aspect = atan2(dzdy, -dzdx)
+				var illumination = sinAlt * cos(slope) + cosAlt * sin(slope) * cos(azimuth - .pi / 2 - aspect)
+				illumination = max(0, min(1, illumination))
+
+				// Flat ground computes to sin(altitude) ≈ 0.707; treat that as "no
+				// shadow" and scale darkness by the shortfall below it.
+				let flat = sinAlt
+				let shadow = max(0, (flat - illumination) / flat)
+				alphas[py * size + px] = UInt8(min(255, shadow * cap * 255))
+			}
+		}
+
+		// Premultiplied black: RGB stays 0, alpha carries the shadow.
+		var rgba = [UInt8](repeating: 0, count: size * size * 4)
+		for index in 0..<(size * size) {
+			rgba[index * 4 + 3] = alphas[index]
+		}
+		guard let context = CGContext(
+			data: &rgba, width: size, height: size, bitsPerComponent: 8, bytesPerRow: size * 4,
+			space: CGColorSpaceCreateDeviceRGB(),
+			bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+		), let image = context.makeImage() else { return nil }
+		return pngData(from: image)
+	}
+
+	private static func pngData(from image: CGImage) -> Data? {
+		let data = NSMutableData()
+		guard let destination = CGImageDestinationCreateWithData(data, "public.png" as CFString, 1, nil) else { return nil }
+		CGImageDestinationAddImage(destination, image, nil)
+		guard CGImageDestinationFinalize(destination) else { return nil }
+		return data as Data
+	}
+}

--- a/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
+++ b/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
@@ -23,14 +23,18 @@ final class HillshadeTileOverlay: MKTileOverlay {
 	/// Shadow strength cap. Dark appearance uses a lighter hand so the shading
 	/// deepens rather than grays the dark basemap.
 	private let maxShadowAlpha: CGFloat
+	/// Rendered tiles persist here (z/x/y.png) so shading computes once per
+	/// terrain download instead of on every map session. Nil disables the cache.
+	private let cacheDirectory: URL?
 
 	/// Sun position for Horn shading: standard cartographic northwest light.
 	private static let azimuthRadians = 315.0 * Double.pi / 180
 	private static let altitudeRadians = 45.0 * Double.pi / 180
 
-	init(store: TerrainStore, darkAppearance: Bool) {
+	init(store: TerrainStore, darkAppearance: Bool, cacheDirectory: URL? = nil) {
 		self.store = store
 		self.maxShadowAlpha = darkAppearance ? 0.42 : 0.32
+		self.cacheDirectory = cacheDirectory
 		super.init(urlTemplate: nil)
 		tileSize = CGSize(width: 256, height: 256)
 		canReplaceMapContent = false
@@ -41,15 +45,25 @@ final class HillshadeTileOverlay: MKTileOverlay {
 	override func loadTile(at path: MKTileOverlayPath, result: @escaping (Data?, Error?) -> Void) {
 		let store = store
 		let alphaCap = maxShadowAlpha
+		let cacheURL = cacheDirectory?
+			.appendingPathComponent("\(path.z)-\(path.x)-\(path.y).png")
 		Task.detached(priority: .utility) {
+			if let cacheURL, let cached = try? Data(contentsOf: cacheURL), !cached.isEmpty {
+				result(cached, nil)
+				return
+			}
 			guard let tile = await store.elevationTile(z: path.z, x: path.x, y: path.y, margin: 1) else {
 				// Outside coverage: an empty (fully transparent) tile, not an error —
-				// MapKit treats errors as retryable and would hammer loadTile.
+				// MapKit treats errors as retryable and would hammer loadTile. Not
+				// cached: coverage can appear later via Add Terrain.
 				result(Self.emptyTile, nil)
 				return
 			}
 			let metersPerSample = TerrainStore.metersPerSample(z: path.z, y: path.y, size: tile.size)
 			let png = Self.renderShadow(tile: tile, metersPerSample: metersPerSample, maxAlpha: alphaCap)
+			if let png, let cacheURL {
+				try? png.write(to: cacheURL, options: .atomic)
+			}
 			result(png ?? Self.emptyTile, nil)
 		}
 	}

--- a/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
+++ b/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
@@ -52,7 +52,7 @@ final class HillshadeTileOverlay: MKTileOverlay {
 				result(cached, nil)
 				return
 			}
-			guard let tile = await store.elevationTile(z: path.z, x: path.x, y: path.y, margin: 1),
+			guard let tile = await store.elevationTile(z: path.z, x: path.x, y: path.y, margin: 2),
 				  let coverage = await store.coverage(z: path.z, x: path.x, y: path.y) else {
 				// Outside coverage: an empty (fully transparent) tile, not an error —
 				// MapKit treats errors as retryable and would hammer loadTile. Not
@@ -127,19 +127,46 @@ final class HillshadeTileOverlay: MKTileOverlay {
 
 		let clipRange = clip ?? PixelRect(minX: 0, minY: 0, maxX: size - 1, maxY: size - 1)
 		guard clipRange.minX <= clipRange.maxX, clipRange.minY <= clipRange.maxY else { return nil }
+
+		// Despike + sea clamp: median-of-9 kills the isolated positive spikes the
+		// source data carries on water (measured to 12 m on Puget Sound) while
+		// preserving real terrain edges; the clamp flattens bathymetry. Built over
+		// the clip range plus the ring the Horn kernel reads (tile margin is 2).
+		let filteredMinX = clipRange.minX - 1, filteredMinY = clipRange.minY - 1
+		let filteredWidth = clipRange.maxX - clipRange.minX + 3
+		let filteredHeight = clipRange.maxY - clipRange.minY + 3
+		var filtered = [Float](repeating: 0, count: filteredWidth * filteredHeight)
+		var window = [Float](repeating: 0, count: 9)
+		for fy in 0..<filteredHeight {
+			let py = filteredMinY + fy
+			for fx in 0..<filteredWidth {
+				let px = filteredMinX + fx
+				var count = 0
+				for dy in -1...1 {
+					for dx in -1...1 {
+						window[count] = max(0, tile.gridElevation(x: px + dx, y: py + dy))
+						count += 1
+					}
+				}
+				window.sort()
+				filtered[fy * filteredWidth + fx] = window[4]
+			}
+		}
+		func sample(_ px: Int, _ py: Int) -> Float {
+			filtered[(py - filteredMinY) * filteredWidth + (px - filteredMinX)]
+		}
+
 		for py in clipRange.minY...clipRange.maxY {
 			for px in clipRange.minX...clipRange.maxX {
-				// Horn kernel: weighted differences of the 8 neighbors. Elevations
-				// clamp at sea level — the data carries ocean bathymetry, and without
-				// the clamp the shading renders seafloor relief onto open water.
-				let a = max(0, tile.gridElevation(x: px - 1, y: py - 1))
-				let b = max(0, tile.gridElevation(x: px, y: py - 1))
-				let c = max(0, tile.gridElevation(x: px + 1, y: py - 1))
-				let d = max(0, tile.gridElevation(x: px - 1, y: py))
-				let f = max(0, tile.gridElevation(x: px + 1, y: py))
-				let g = max(0, tile.gridElevation(x: px - 1, y: py + 1))
-				let h = max(0, tile.gridElevation(x: px, y: py + 1))
-				let i = max(0, tile.gridElevation(x: px + 1, y: py + 1))
+				// Horn kernel: weighted differences of the 8 neighbors.
+				let a = sample(px - 1, py - 1)
+				let b = sample(px, py - 1)
+				let c = sample(px + 1, py - 1)
+				let d = sample(px - 1, py)
+				let f = sample(px + 1, py)
+				let g = sample(px - 1, py + 1)
+				let h = sample(px, py + 1)
+				let i = sample(px + 1, py + 1)
 
 				let dzdx = ((c + 2 * f + i) - (a + 2 * d + g)) / (8 * cellSize)
 				let dzdy = ((g + 2 * h + i) - (a + 2 * b + c)) / (8 * cellSize)
@@ -157,8 +184,14 @@ final class HillshadeTileOverlay: MKTileOverlay {
 				// sea-surface noise (measured ~1 m stdev with spikes on open water),
 				// which the ≤0 m clamp can't remove. No shading below 0.5 m, full
 				// above 3 m — real land that low is flat and barely shaded anyway.
-				let center = max(0, tile.gridElevation(x: px, y: py))
+				let center = sample(px, py)
 				shadow *= min(max((center - 0.5) / 2.5, 0), 1)
+				// Local-relief fade: on a water surface every pixel sits within noise
+				// of its neighborhood minimum, at any lake elevation; a real hillside
+				// pixel stands well above its local minimum. Valley bottoms fade too,
+				// which is fine — they're flat.
+				let localMin = min(min(min(a, b), min(c, d)), min(min(f, g), min(h, i)))
+				shadow *= min(max((center - localMin - 0.3) / 1.2, 0), 1)
 				alphas[py * size + px] = UInt8(min(255, shadow * cap * 255))
 			}
 		}

--- a/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
+++ b/Meshtastic/Helpers/Map/HillshadeTileOverlay.swift
@@ -152,7 +152,13 @@ final class HillshadeTileOverlay: MKTileOverlay {
 				// Flat ground computes to sin(altitude) ≈ 0.707; treat that as "no
 				// shadow" and scale darkness by the shortfall below it.
 				let flat = sinAlt
-				let shadow = max(0, (flat - illumination) / flat)
+				var shadow = max(0, (flat - illumination) / flat)
+				// Fade shading out near sea level: the source data carries positive
+				// sea-surface noise (measured ~1 m stdev with spikes on open water),
+				// which the ≤0 m clamp can't remove. No shading below 0.5 m, full
+				// above 3 m — real land that low is flat and barely shaded anyway.
+				let center = max(0, tile.gridElevation(x: px, y: py))
+				shadow *= min(max((center - 0.5) / 2.5, 0), 1)
 				alphas[py * size + px] = UInt8(min(255, shadow * cap * 255))
 			}
 		}

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -154,7 +154,7 @@ final class OfflineMapManager: ObservableObject {
 			let limit = ByteCountFormatter.string(fromByteCount: Self.maxRegionBytes, countStyle: .file)
 			return String(localized: "This map is larger than the \(limit) per-map limit. Zoom in or lower the detail.")
 		}
-		let otherTotal = totalSize - (replacing?.fileSize ?? 0)
+		let otherTotal = totalSize - (replacing.map { $0.fileSize + ($0.terrain?.byteCount ?? 0) } ?? 0)
 		if otherTotal + estimatedBytes > Self.maxTotalBytes {
 			let limit = ByteCountFormatter.string(fromByteCount: Self.maxTotalBytes, countStyle: .file)
 			return String(localized: "This would exceed the \(limit) total offline storage limit. Remove a map first.")
@@ -219,6 +219,12 @@ final class OfflineMapManager: ObservableObject {
 					fileSize: 0, sourceBuild: build.build
 				)
 				await self.finishDownload(id: regionID, region: region, removing: replacing)
+				// Terrain rides along with every download but is never fatal: the basemap
+				// is already saved, and a terrain failure just surfaces as retryable.
+				// tvOS skips it — nothing renders terrain there yet, and its cache storage is purgeable.
+				#if !os(tvOS)
+				await self.downloadTerrain(for: region)
+				#endif
 			} catch is CancellationError {
 				try? FileManager.default.removeItem(at: archive.url)
 				await self.clearDownload(id: regionID)
@@ -472,8 +478,20 @@ final class OfflineMapManager: ObservableObject {
 		if let fileURL = fileURL(for: region) {
 			try? FileManager.default.removeItem(at: fileURL)
 		}
+		removeTerrainFiles(for: region)
 		regions.removeAll { $0.id == region.id }
 		save()
+	}
+
+	/// Deletes a region's terrain archives — both the manifest-recorded names and the
+	/// derived names, so stray files from an interrupted download are swept too.
+	private func removeTerrainFiles(for region: OfflineMapRegion) {
+		guard let dir = directoryURL() else { return }
+		let derived = Self.terrainFileNames(forBasemap: region.fileName)
+		let names = Set([region.terrain?.fileName, region.terrain?.regionalFileName, derived.global, derived.regional].compactMap { $0 })
+		for name in names {
+			try? FileManager.default.removeItem(at: dir.appendingPathComponent(name))
+		}
 	}
 
 	func rename(_ region: OfflineMapRegion, to name: String) {
@@ -487,10 +505,207 @@ final class OfflineMapManager: ObservableObject {
 	// MARK: - Derived
 
 	var totalSize: Int64 {
-		regions.reduce(0) { $0 + $1.fileSize }
+		regions.reduce(0) { $0 + $1.fileSize + ($1.terrain?.byteCount ?? 0) }
 	}
 
 	var formattedTotalSize: String {
 		ByteCountFormatter.string(fromByteCount: totalSize, countStyle: .file)
 	}
+}
+
+// MARK: - Terrain (Mapterhorn elevation extracts)
+
+extension OfflineMapManager {
+
+	/// Mapterhorn's global Terrarium terrain-RGB archive (z0–12).
+	static let terrainGlobalArchive = "https://download.mapterhorn.com/planet.pmtiles"
+	/// Zoom the global archive tops out at; the recorded max zoom for global-only terrain.
+	static let terrainGlobalMaxZoom = 12
+	/// Zoom range extracted from a regional high-resolution archive.
+	static let terrainRegionalMinZoom = 13
+	static let terrainRegionalMaxZoom = 15
+
+	/// The z6 tiles a bounding box intersects. Mapterhorn publishes regional
+	/// high-resolution archives named by z6 tile (`6-{x}-{y}.pmtiles`).
+	nonisolated static func z6Tiles(intersecting bounds: GeoBounds) -> [(x: UInt32, y: UInt32)] {
+		let (x0, y0) = PMTilesExtractor.tileXY(lon: bounds.minLon, lat: bounds.maxLat, z: 6) // top-left
+		let (x1, y1) = PMTilesExtractor.tileXY(lon: bounds.maxLon, lat: bounds.minLat, z: 6) // bottom-right
+		var tiles: [(x: UInt32, y: UInt32)] = []
+		for x in min(x0, x1)...max(x0, x1) {
+			for y in min(y0, y1)...max(y0, y1) {
+				tiles.append((x, y))
+			}
+		}
+		return tiles
+	}
+
+	/// Terrain archive file names derived from the region's basemap archive name,
+	/// e.g. `"<uuid>.pmtiles"` → `"<uuid>-terrain.pmtiles"` / `"<uuid>-terrain-hi.pmtiles"`.
+	nonisolated static func terrainFileNames(forBasemap fileName: String) -> (global: String, regional: String) {
+		let stem = (fileName as NSString).deletingPathExtension
+		return ("\(stem)-terrain.pmtiles", "\(stem)-terrain-hi.pmtiles")
+	}
+
+	/// Downloads Mapterhorn elevation data for an existing region: a global z0–12
+	/// extract of the region's bounds, plus a z13–15 extract when a single regional
+	/// high-resolution archive covers the area. Failure never touches the basemap —
+	/// the region stays usable and terrain can be retried.
+	func downloadTerrain(for region: OfflineMapRegion, onCompletion: ((Bool) -> Void)? = nil) {
+		loadIfNeeded()
+		guard !isBusy,
+			  let current = regions.first(where: { $0.id == region.id }),
+			  current.terrain == nil,
+			  let dir = directoryURL() else {
+			onCompletion?(false)
+			return
+		}
+		guard downloadLifecycle.begin(id: current.id) else {
+			onCompletion?(false)
+			return
+		}
+		let names = Self.terrainFileNames(forBasemap: current.fileName)
+		let globalURL = dir.appendingPathComponent(names.global)
+		let regionalURL = dir.appendingPathComponent(names.regional)
+		activeDownload = OfflineMapDownloadProgress(
+			id: current.id,
+			name: String(localized: "Terrain for \(current.name)"),
+			state: .preparing,
+			fractionCompleted: nil
+		)
+		if let onCompletion {
+			downloadCompletion = { region in onCompletion(region != nil) }
+		}
+
+		downloadTask = Task { [weak self] in
+			guard let self else { return }
+			let extractor = PMTilesExtractor()
+			do {
+				guard let source = URL(string: Self.terrainGlobalArchive) else { throw PMTilesExtractorError.badHeader }
+				let plan = try await extractor.makePlan(
+					sourceURL: source, sourceBuild: "Mapterhorn",
+					bounds: current.bounds, minZoom: 0, maxZoom: Self.terrainGlobalMaxZoom
+				)
+				await self.markDownloading(id: current.id, estimatedBytes: plan.payloadBytes)
+				try await extractor.extract(plan: plan, to: globalURL) { [weak self] written, total in
+					Task { @MainActor in self?.updateProgress(id: current.id, written: written, total: total) }
+				}
+				let hasValidHeader = await Task.detached(priority: .utility) {
+					PMTilesArchive.header(url: globalURL) != nil
+				}.value
+				guard hasValidHeader else { throw PMTilesExtractorError.badHeader }
+
+				let regionalMaxZoom = try await self.extractRegionalTerrain(
+					extractor: extractor, bounds: current.bounds, to: regionalURL
+				)
+				await self.finishTerrainDownload(
+					id: current.id,
+					globalName: names.global,
+					regionalName: regionalMaxZoom != nil ? names.regional : nil,
+					maxZoom: regionalMaxZoom ?? Self.terrainGlobalMaxZoom
+				)
+			} catch is CancellationError {
+				try? FileManager.default.removeItem(at: globalURL)
+				try? FileManager.default.removeItem(at: regionalURL)
+				await self.clearDownload(id: current.id)
+			} catch {
+				try? FileManager.default.removeItem(at: globalURL)
+				try? FileManager.default.removeItem(at: regionalURL)
+				let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+				Logger.services.error("🗺️ [Terrain] Download failed: \(message, privacy: .public)")
+				await self.failDownload(id: current.id, message: message)
+			}
+		}
+	}
+
+	/// Attempts the optional high-resolution regional extract. Returns the extract's
+	/// max zoom on success, or nil when the bounds span multiple z6 archives, no
+	/// archive exists, or the extract fails — global-only terrain is normal, never an
+	/// error. Only cancellation propagates.
+	private func extractRegionalTerrain(extractor: PMTilesExtractor, bounds: GeoBounds, to destination: URL) async throws -> Int? {
+		let tiles = Self.z6Tiles(intersecting: bounds)
+		guard tiles.count == 1, let tile = tiles.first,
+			  let source = URL(string: "https://download.mapterhorn.com/6-\(tile.x)-\(tile.y).pmtiles"),
+			  await extractor.archiveExists(source) else { return nil }
+		do {
+			let plan = try await extractor.makePlan(
+				sourceURL: source, sourceBuild: "Mapterhorn",
+				bounds: bounds, minZoom: Self.terrainRegionalMinZoom, maxZoom: Self.terrainRegionalMaxZoom
+			)
+			try await extractor.extract(plan: plan, to: destination)
+			let hasValidHeader = await Task.detached(priority: .utility) {
+				PMTilesArchive.header(url: destination) != nil
+			}.value
+			guard hasValidHeader else {
+				try? FileManager.default.removeItem(at: destination)
+				return nil
+			}
+			return plan.maxZoom
+		} catch is CancellationError {
+			throw CancellationError()
+		} catch PMTilesExtractorError.cancelled {
+			throw CancellationError()
+		} catch {
+			try? FileManager.default.removeItem(at: destination)
+			Logger.services.info("🗺️ [Terrain] Regional extract skipped: \(error.localizedDescription, privacy: .public)")
+			return nil
+		}
+	}
+
+	/// Records the finished terrain extract on its region and saves the manifest.
+	private func finishTerrainDownload(id: UUID, globalName: String, regionalName: String?, maxZoom: Int) {
+		guard activeDownload?.id == id, downloadLifecycle.end(id: id) else { return }
+		downloadTask = nil
+		activeDownload = nil
+		let completion = downloadCompletion
+		downloadCompletion = nil
+		guard let dir = directoryURL() else {
+			completion?(nil)
+			return
+		}
+		guard let index = regions.firstIndex(where: { $0.id == id }) else {
+			// The region disappeared mid-download; don't leave orphaned archives.
+			try? FileManager.default.removeItem(at: dir.appendingPathComponent(globalName))
+			if let regionalName {
+				try? FileManager.default.removeItem(at: dir.appendingPathComponent(regionalName))
+			}
+			completion?(nil)
+			return
+		}
+		var byteCount: Int64 = 0
+		for name in [globalName, regionalName].compactMap({ $0 }) {
+			let url = dir.appendingPathComponent(name)
+			if let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+				byteCount += Int64(size)
+			}
+		}
+		regions[index].terrain = OfflineMapTerrain(
+			fileName: globalName,
+			regionalFileName: regionalName,
+			byteCount: byteCount,
+			downloadedAt: .now,
+			maxZoom: maxZoom
+		)
+		save()
+		completion?(regions[index])
+	}
+
+	// The TV target compiles this file but not TerrainStore.swift; terrain rendering
+	// on tvOS is an explicit follow-on.
+	#if !os(tvOS)
+	/// A `TerrainSource` for every region with downloaded terrain, resolving file
+	/// URLs — the hook map rendering uses to feed `TerrainStore`.
+	func terrainSources() -> [TerrainSource] {
+		loadIfNeeded()
+		guard let dir = directoryURL() else { return [] }
+		return regions.compactMap { region in
+			guard let terrain = region.terrain else { return nil }
+			let globalURL = dir.appendingPathComponent(terrain.fileName)
+			guard FileManager.default.fileExists(atPath: globalURL.path) else { return nil }
+			let regionalURL = terrain.regionalFileName
+				.map { dir.appendingPathComponent($0) }
+				.flatMap { FileManager.default.fileExists(atPath: $0.path) ? $0 : nil }
+			return TerrainSource(globalURL: globalURL, regionalURL: regionalURL, bounds: region.bounds)
+		}
+	}
+	#endif
 }

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -711,7 +711,10 @@ extension OfflineMapManager {
 	/// appearance so light and dark shading never mix.
 	func terrainHillshadeCacheDirectory(dark: Bool) -> URL? {
 		guard let root = directoryURL()?.appendingPathComponent("terrain-cache", isDirectory: true) else { return nil }
-		let generation = regions
+		// The renderer version participates in the generation so a rendering change
+		// (clipping, shading tweaks) invalidates tiles cached by an older build.
+		let rendererVersion = "v2"
+		let generation = rendererVersion + "|" + regions
 			.compactMap { $0.terrain.map { String(Int($0.downloadedAt.timeIntervalSince1970)) } }
 			.sorted()
 			.joined(separator: ",")

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -713,7 +713,7 @@ extension OfflineMapManager {
 		guard let root = directoryURL()?.appendingPathComponent("terrain-cache", isDirectory: true) else { return nil }
 		// The renderer version participates in the generation so a rendering change
 		// (clipping, shading tweaks) invalidates tiles cached by an older build.
-		let rendererVersion = "v3"
+		let rendererVersion = "v4"
 		let generation = rendererVersion + "|" + regions
 			.compactMap { $0.terrain.map { String(Int($0.downloadedAt.timeIntervalSince1970)) } }
 			.sorted()

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -167,10 +167,11 @@ final class OfflineMapManager: ObservableObject {
 		bounds: GeoBounds,
 		detail: OfflineMapDetailLevel,
 		replacing: OfflineMapRegion? = nil,
+		includeBasemap: Bool = true,
 		includeTerrain: Bool = true,
 		onCompletion: ((OfflineMapRegion?) -> Void)? = nil
 	) {
-		guard !isBusy, let archive = newArchiveURL() else {
+		guard !isBusy, includeBasemap || includeTerrain, let archive = newArchiveURL() else {
 			onCompletion?(nil)
 			return
 		}
@@ -184,12 +185,36 @@ final class OfflineMapManager: ObservableObject {
 			return
 		}
 		let regionID = UUID()
+
+		// Terrain-only: record the region with no basemap archive (drawn over Apple
+		// maps), then run the ordinary terrain download against it. The replaced
+		// region is only removed on success, and a failed or cancelled download
+		// removes the new empty region, so no path loses data.
+		#if !os(tvOS)
+		if !includeBasemap {
+			let region = OfflineMapRegion(
+				id: regionID, name: displayName(from: name), fileName: archive.fileName,
+				bounds: bounds, minZoom: 0, maxZoom: 0,
+				fileSize: 0, sourceBuild: "Mapterhorn", includesBasemap: false
+			)
+			add(region)
+			downloadTerrain(for: region) { [weak self] success in
+				if success {
+					if let replacing { self?.remove(replacing) }
+				} else {
+					self?.remove(region)
+				}
+				onCompletion?(success ? region : nil)
+			}
+			return
+		}
+		#endif
+
 		guard downloadLifecycle.begin(id: regionID) else {
 			onCompletion?(nil)
 			return
 		}
-		let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-		let finalName = trimmedName.isEmpty ? String(localized: "Offline Map") : trimmedName
+		let finalName = displayName(from: name)
 		activeDownload = OfflineMapDownloadProgress(id: regionID, name: finalName, state: .preparing, fractionCompleted: nil)
 		downloadCompletion = onCompletion
 
@@ -349,7 +374,16 @@ final class OfflineMapManager: ObservableObject {
 		guard activeDownload?.id == id, downloadLifecycle.end(id: id) else { return }
 		downloadTask = nil
 		activeDownload = nil
+		// A cancelled download produced no region; callers waiting on one (e.g. the
+		// terrain-only flow's cleanup) must still hear back.
+		let completion = downloadCompletion
 		downloadCompletion = nil
+		completion?(nil)
+	}
+
+	private func displayName(from name: String) -> String {
+		let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+		return trimmed.isEmpty ? String(localized: "Offline Map") : trimmed
 	}
 
 	// MARK: - Locations
@@ -381,8 +415,11 @@ final class OfflineMapManager: ObservableObject {
 		return dir
 	}
 
+	/// The basemap archive URL, or nil for terrain-only regions (no basemap file
+	/// exists — this nil is what keeps them out of the offline tile pipeline).
 	func fileURL(for region: OfflineMapRegion) -> URL? {
-		directoryURL()?.appendingPathComponent(region.fileName)
+		guard region.hasBasemap else { return nil }
+		return directoryURL()?.appendingPathComponent(region.fileName)
 	}
 
 	/// A fresh, unused archive file URL plus its file name component.
@@ -440,8 +477,14 @@ final class OfflineMapManager: ObservableObject {
 			let data = try Data(contentsOf: url)
 			let decoded = try JSONDecoder().decode([OfflineMapRegion].self, from: data)
 			let existing = decoded.filter { region in
-				guard let fileURL = fileURL(for: region) else { return false }
-				return FileManager.default.fileExists(atPath: fileURL.path)
+				guard let dir = directoryURL() else { return false }
+				if region.hasBasemap {
+					return FileManager.default.fileExists(atPath: dir.appendingPathComponent(region.fileName).path)
+				}
+				// Terrain-only: alive while its terrain archive exists. A region whose
+				// terrain download never finished has no files and is pruned here.
+				guard let terrain = region.terrain else { return false }
+				return FileManager.default.fileExists(atPath: dir.appendingPathComponent(terrain.fileName).path)
 			}
 			regions = existing.sorted { $0.createdDate > $1.createdDate }
 			if existing.count != decoded.count { save() }

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -694,6 +694,27 @@ extension OfflineMapManager {
 	#if !os(tvOS)
 	/// A `TerrainSource` for every region with downloaded terrain, resolving file
 	/// URLs — the hook map rendering uses to feed `TerrainStore`.
+	/// Directory for locally rendered hillshade tiles, wiped whenever the terrain
+	/// generation (the set of terrain downloadedAt stamps) changes — a re-download
+	/// or region delete invalidates every cached tile. One subdirectory per
+	/// appearance so light and dark shading never mix.
+	func terrainHillshadeCacheDirectory(dark: Bool) -> URL? {
+		guard let root = directoryURL()?.appendingPathComponent("terrain-cache", isDirectory: true) else { return nil }
+		let generation = regions
+			.compactMap { $0.terrain.map { String(Int($0.downloadedAt.timeIntervalSince1970)) } }
+			.sorted()
+			.joined(separator: ",")
+		let marker = root.appendingPathComponent("generation.txt")
+		if (try? String(contentsOf: marker, encoding: .utf8)) != generation {
+			try? FileManager.default.removeItem(at: root)
+			try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+			try? generation.write(to: marker, atomically: true, encoding: .utf8)
+		}
+		let sub = root.appendingPathComponent(dark ? "dark" : "light", isDirectory: true)
+		try? FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+		return sub
+	}
+
 	func terrainSources() -> [TerrainSource] {
 		loadIfNeeded()
 		guard let dir = directoryURL() else { return [] }

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -585,6 +585,13 @@ extension OfflineMapManager {
 					sourceURL: source, sourceBuild: "Mapterhorn",
 					bounds: current.bounds, minZoom: 0, maxZoom: Self.terrainGlobalMaxZoom
 				)
+				// The basemap limit check ran before terrain existed — re-check the
+				// total ceiling with the terrain plan included so terrain can't push
+				// storage past the configured maximum.
+				let projected = await MainActor.run { self.totalSize } + plan.payloadBytes
+				guard projected <= Self.maxTotalBytes else {
+					throw OfflineMapError.storageLimit(String(localized: "Terrain would exceed the offline map storage limit."))
+				}
 				await self.markDownloading(id: current.id, estimatedBytes: plan.payloadBytes)
 				try await extractor.extract(plan: plan, to: globalURL) { [weak self] written, total in
 					Task { @MainActor in self?.updateProgress(id: current.id, written: written, total: total) }
@@ -631,6 +638,10 @@ extension OfflineMapManager {
 				sourceURL: source, sourceBuild: "Mapterhorn",
 				bounds: bounds, minZoom: Self.terrainRegionalMinZoom, maxZoom: Self.terrainRegionalMaxZoom
 			)
+			// Same storage ceiling as the global extract (the global file is on
+			// disk by now, so totalSize already includes it).
+			let projected = await MainActor.run { self.totalSize } + plan.payloadBytes
+			guard projected <= Self.maxTotalBytes else { return nil }
 			try await extractor.extract(plan: plan, to: destination)
 			let hasValidHeader = await Task.detached(priority: .utility) {
 				PMTilesArchive.header(url: destination) != nil

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -713,7 +713,7 @@ extension OfflineMapManager {
 		guard let root = directoryURL()?.appendingPathComponent("terrain-cache", isDirectory: true) else { return nil }
 		// The renderer version participates in the generation so a rendering change
 		// (clipping, shading tweaks) invalidates tiles cached by an older build.
-		let rendererVersion = "v2"
+		let rendererVersion = "v3"
 		let generation = rendererVersion + "|" + regions
 			.compactMap { $0.terrain.map { String(Int($0.downloadedAt.timeIntervalSince1970)) } }
 			.sorted()

--- a/Meshtastic/Helpers/Map/OfflineMapManager.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapManager.swift
@@ -167,6 +167,7 @@ final class OfflineMapManager: ObservableObject {
 		bounds: GeoBounds,
 		detail: OfflineMapDetailLevel,
 		replacing: OfflineMapRegion? = nil,
+		includeTerrain: Bool = true,
 		onCompletion: ((OfflineMapRegion?) -> Void)? = nil
 	) {
 		guard !isBusy, let archive = newArchiveURL() else {
@@ -223,7 +224,9 @@ final class OfflineMapManager: ObservableObject {
 				// is already saved, and a terrain failure just surfaces as retryable.
 				// tvOS skips it — nothing renders terrain there yet, and its cache storage is purgeable.
 				#if !os(tvOS)
-				await self.downloadTerrain(for: region)
+				if includeTerrain {
+					await self.downloadTerrain(for: region)
+				}
 				#endif
 			} catch is CancellationError {
 				try? FileManager.default.removeItem(at: archive.url)

--- a/Meshtastic/Helpers/Map/OfflineMapRegion.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapRegion.swift
@@ -11,6 +11,21 @@
 import Foundation
 import MapKit
 
+/// Elevation data downloaded alongside a region: Mapterhorn terrain extracts of
+/// the same bounding box. Absent for regions downloaded before terrain support.
+struct OfflineMapTerrain: Codable, Hashable {
+	/// File name of the global (z0–12) terrain extract, e.g. `"<uuid>-terrain.pmtiles"`.
+	var fileName: String
+	/// File name of the optional high-resolution regional extract, e.g. `"<uuid>-terrain-hi.pmtiles"`.
+	var regionalFileName: String?
+	/// Combined size of the terrain archives on disk.
+	var byteCount: Int64
+	/// When the terrain extract finished; drives cache invalidation.
+	var downloadedAt: Date
+	/// Highest zoom level with terrain data: 12 when global-only, higher with a regional extract.
+	var maxZoom: Int
+}
+
 /// Metadata describing one downloaded offline map region. The geometry is stored
 /// as four doubles (Codable-friendly); `bounds`/`region` expose the map types.
 struct OfflineMapRegion: Identifiable, Codable, Hashable {
@@ -29,6 +44,9 @@ struct OfflineMapRegion: Identifiable, Codable, Hashable {
 	var updatedDate: Date
 	/// Protomaps daily build the tiles were extracted from, e.g. `"20260623"`.
 	var sourceBuild: String
+	/// Terrain elevation extracts for the same bounds, when downloaded.
+	/// Optional and additive: manifests written before terrain support decode with `nil`.
+	var terrain: OfflineMapTerrain?
 
 	init(
 		id: UUID = UUID(),
@@ -40,7 +58,8 @@ struct OfflineMapRegion: Identifiable, Codable, Hashable {
 		fileSize: Int64,
 		createdDate: Date = .now,
 		updatedDate: Date = .now,
-		sourceBuild: String
+		sourceBuild: String,
+		terrain: OfflineMapTerrain? = nil
 	) {
 		self.id = id
 		self.name = name
@@ -55,6 +74,7 @@ struct OfflineMapRegion: Identifiable, Codable, Hashable {
 		self.createdDate = createdDate
 		self.updatedDate = updatedDate
 		self.sourceBuild = sourceBuild
+		self.terrain = terrain
 	}
 
 	var bounds: GeoBounds {
@@ -76,6 +96,11 @@ struct OfflineMapRegion: Identifiable, Codable, Hashable {
 
 	var formattedSize: String {
 		ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+	}
+
+	/// The terrain component's size for display, or nil when no terrain is downloaded.
+	var formattedTerrainSize: String? {
+		terrain.map { ByteCountFormatter.string(fromByteCount: $0.byteCount, countStyle: .file) }
 	}
 
 	/// Whether this archive's zoom range covers what the map actually needs, or leaves a gap the

--- a/Meshtastic/Helpers/Map/OfflineMapRegion.swift
+++ b/Meshtastic/Helpers/Map/OfflineMapRegion.swift
@@ -44,9 +44,15 @@ struct OfflineMapRegion: Identifiable, Codable, Hashable {
 	var updatedDate: Date
 	/// Protomaps daily build the tiles were extracted from, e.g. `"20260623"`.
 	var sourceBuild: String
+	/// False for terrain-only downloads: no basemap archive exists, only the
+	/// terrain extracts (drawn over Apple maps). Optional and additive — manifests
+	/// written before terrain-only support decode with `nil`, meaning true.
+	var includesBasemap: Bool?
 	/// Terrain elevation extracts for the same bounds, when downloaded.
 	/// Optional and additive: manifests written before terrain support decode with `nil`.
 	var terrain: OfflineMapTerrain?
+
+	var hasBasemap: Bool { includesBasemap ?? true }
 
 	init(
 		id: UUID = UUID(),
@@ -59,6 +65,7 @@ struct OfflineMapRegion: Identifiable, Codable, Hashable {
 		createdDate: Date = .now,
 		updatedDate: Date = .now,
 		sourceBuild: String,
+		includesBasemap: Bool = true,
 		terrain: OfflineMapTerrain? = nil
 	) {
 		self.id = id
@@ -74,6 +81,7 @@ struct OfflineMapRegion: Identifiable, Codable, Hashable {
 		self.createdDate = createdDate
 		self.updatedDate = updatedDate
 		self.sourceBuild = sourceBuild
+		self.includesBasemap = includesBasemap
 		self.terrain = terrain
 	}
 
@@ -96,6 +104,13 @@ struct OfflineMapRegion: Identifiable, Codable, Hashable {
 
 	var formattedSize: String {
 		ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+	}
+
+	/// Combined basemap + terrain size on disk, for rows and the delete confirmation.
+	var totalByteCount: Int64 { fileSize + (terrain?.byteCount ?? 0) }
+
+	var formattedTotalSize: String {
+		ByteCountFormatter.string(fromByteCount: totalByteCount, countStyle: .file)
 	}
 
 	/// The terrain component's size for display, or nil when no terrain is downloaded.

--- a/Meshtastic/Helpers/Map/PMTilesExtractor.swift
+++ b/Meshtastic/Helpers/Map/PMTilesExtractor.swift
@@ -103,7 +103,7 @@ final class PMTilesExtractor {
 			guard let day = calendar.date(byAdding: .day, value: -offset, to: today) else { continue }
 			let build = formatter.string(from: day)
 			guard let url = URL(string: "https://build.protomaps.com/\(build).pmtiles") else { continue }
-			if await buildExists(url) {
+			if await archiveExists(url) {
 				Logger.services.info("🗺️ [Offline] Using Protomaps build \(build, privacy: .public)")
 				return (url, build)
 			}
@@ -111,7 +111,8 @@ final class PMTilesExtractor {
 		return nil
 	}
 
-	private func buildExists(_ url: URL) async -> Bool {
+	/// Whether a PMTiles archive exists at `url`, probing the 7-byte magic with a range request.
+	func archiveExists(_ url: URL) async -> Bool {
 		do {
 			let data = try await fetchRange(url, start: 0, end: 6)
 			return data.count == 7 && data == Data("PMTiles".utf8)

--- a/Meshtastic/Helpers/Map/TerrainContourProvider.swift
+++ b/Meshtastic/Helpers/Map/TerrainContourProvider.swift
@@ -1,0 +1,153 @@
+//
+//  TerrainContourProvider.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/16/26.
+//
+//  Generates contour polylines for the visible map area from downloaded terrain
+//  and publishes them as MapKit shapes. Mirrors OfflineVectorTileProvider's
+//  shape: work happens off the main actor, results publish on it, and the
+//  consumer folds the output into ClusterMapView's overlay list.
+//
+
+import Foundation
+import MapKit
+import OSLog
+
+/// One published batch of contour geometry: minor and index lines batched into
+/// two MKMultiPolylines so the overlay count stays constant regardless of how
+/// many individual contour lines are visible.
+struct TerrainContourGeometry {
+	let minorLines: MKMultiPolyline
+	let indexLines: MKMultiPolyline
+	/// Cache key of the tile set + intervals this geometry was built for.
+	let key: String
+}
+
+@MainActor
+final class TerrainContourProvider: ObservableObject {
+
+	@Published private(set) var geometry: TerrainContourGeometry?
+	/// Bumped on every publish so observers rebuild exactly once per generation.
+	@Published private(set) var revision = 0
+
+	let store: TerrainStore
+	private var generation = 0
+	/// Generated ContourLine sets per tile key, so panning re-uses tiles already computed.
+	private var tileCache: [String: [ContourLine]] = [:]
+	private var tileCacheOrder: [String] = []
+	private let tileCacheLimit = 64
+
+	/// Contours draw from this fixed zoom band relative to the visible zoom: one
+	/// generation tile covers a 2×2 block of screen tiles so the tile count per
+	/// generation stays small (≤ ~12 for a full screen).
+	private let maxGenerationTiles = 12
+
+	init(store: TerrainStore = TerrainStore()) {
+		self.store = store
+	}
+
+	/// Clears cached geometry (call when the underlying terrain data changes).
+	func invalidate() {
+		tileCache.removeAll()
+		tileCacheOrder.removeAll()
+		geometry = nil
+		revision += 1
+	}
+
+	/// Regenerates contours for the visible region if the covering tile set or
+	/// interval band changed. Cheap when nothing changed.
+	func update(region: MKCoordinateRegion, metric: Bool) {
+		let zoom = Self.zoomLevel(for: region)
+		// Generate at two zooms below the view so one generation covers the screen.
+		let genZoom = max(4, min(zoom - 2, 15))
+		let intervals = ContourIntervals.intervals(forZoom: zoom, metric: metric)
+		let tiles = Self.tiles(covering: region, zoom: genZoom, limit: maxGenerationTiles)
+		guard !tiles.isEmpty else { return }
+		let key = "\(genZoom)|\(intervals.minor)|" + tiles.map { "\($0.x),\($0.y)" }.joined(separator: ";")
+		if geometry?.key == key { return }
+
+		generation += 1
+		let thisGeneration = generation
+		let store = store
+		let cached = tileCache
+
+		Task.detached(priority: .userInitiated) { [weak self] in
+			var perTile: [(tile: (z: Int, x: Int, y: Int), lines: [ContourLine])] = []
+			for tile in tiles {
+				let tileKey = "\(genZoom)/\(tile.x)/\(tile.y)|\(intervals.minor)"
+				if let lines = cached[tileKey] {
+					perTile.append(((genZoom, tile.x, tile.y), lines))
+					continue
+				}
+				guard let elevationTile = await store.elevationTile(z: genZoom, x: tile.x, y: tile.y, margin: 2) else { continue }
+				let lines = ContourGenerator.contours(tile: elevationTile, intervals: intervals)
+				perTile.append(((genZoom, tile.x, tile.y), lines))
+			}
+
+			// Convert tile-unit points to map coordinates and batch by class.
+			var minor: [MKPolyline] = []
+			var index: [MKPolyline] = []
+			for entry in perTile {
+				let n = Double(1 << entry.tile.z)
+				for line in entry.lines where line.points.count >= 2 {
+					let coordinates = line.points.map { point -> CLLocationCoordinate2D in
+						let wx = (Double(entry.tile.x) + point.x) / n
+						let wy = (Double(entry.tile.y) + point.y) / n
+						let lon = wx * 360 - 180
+						let lat = atan(sinh(.pi * (1 - 2 * wy))) * 180 / .pi
+						return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+					}
+					let polyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
+					if line.isIndex { index.append(polyline) } else { minor.append(polyline) }
+				}
+			}
+			let built = TerrainContourGeometry(
+				minorLines: MKMultiPolyline(minor),
+				indexLines: MKMultiPolyline(index),
+				key: key
+			)
+
+			await MainActor.run { [weak self] in
+				guard let self, self.generation == thisGeneration else { return }
+				for entry in perTile {
+					let tileKey = "\(entry.tile.z)/\(entry.tile.x)/\(entry.tile.y)|\(intervals.minor)"
+					if self.tileCache[tileKey] == nil {
+						self.tileCache[tileKey] = entry.lines
+						self.tileCacheOrder.append(tileKey)
+						if self.tileCacheOrder.count > self.tileCacheLimit {
+							self.tileCache.removeValue(forKey: self.tileCacheOrder.removeFirst())
+						}
+					}
+				}
+				self.geometry = built
+				self.revision += 1
+			}
+		}
+	}
+
+	// MARK: - Tiling helpers
+
+	static func zoomLevel(for region: MKCoordinateRegion) -> Int {
+		let spanDegrees = max(region.span.longitudeDelta, 0.0001)
+		let zoom = log2(360 / spanDegrees) + 1
+		return max(0, min(18, Int(zoom.rounded())))
+	}
+
+	static func tiles(covering region: MKCoordinateRegion, zoom: Int, limit: Int) -> [(x: Int, y: Int)] {
+		let minLon = region.center.longitude - region.span.longitudeDelta / 2
+		let maxLon = region.center.longitude + region.span.longitudeDelta / 2
+		let minLat = region.center.latitude - region.span.latitudeDelta / 2
+		let maxLat = region.center.latitude + region.span.latitudeDelta / 2
+		let (x0, y0) = PMTilesExtractor.tileXY(lon: minLon, lat: maxLat, z: zoom)
+		let (x1, y1) = PMTilesExtractor.tileXY(lon: maxLon, lat: minLat, z: zoom)
+		var result: [(x: Int, y: Int)] = []
+		for y in Int(min(y0, y1))...Int(max(y0, y1)) {
+			for x in Int(min(x0, x1))...Int(max(x0, x1)) {
+				result.append((x, y))
+				if result.count > limit { return Array(result.prefix(limit)) }
+			}
+		}
+		return result
+	}
+}

--- a/Meshtastic/Helpers/Map/TerrainContourProvider.swift
+++ b/Meshtastic/Helpers/Map/TerrainContourProvider.swift
@@ -20,8 +20,19 @@ import OSLog
 struct TerrainContourGeometry {
 	let minorLines: MKMultiPolyline
 	let indexLines: MKMultiPolyline
+	/// Elevation labels for the index contours (bounded count per generation).
+	let labels: [TerrainContourLabel]
 	/// Cache key of the tile set + intervals this geometry was built for.
 	let key: String
+}
+
+/// One elevation label anchored to an index contour.
+struct TerrainContourLabel: Identifiable, Equatable {
+	let id: String
+	let coordinate: CLLocationCoordinate2D
+	let text: String
+
+	static func == (lhs: TerrainContourLabel, rhs: TerrainContourLabel) -> Bool { lhs.id == rhs.id }
 }
 
 @MainActor
@@ -88,23 +99,44 @@ final class TerrainContourProvider: ObservableObject {
 			// Convert tile-unit points to map coordinates and batch by class.
 			var minor: [MKPolyline] = []
 			var index: [MKPolyline] = []
+			// One label candidate per index line, placed at the line's midpoint;
+			// the longest lines win the bounded label budget.
+			var labelCandidates: [(pointCount: Int, label: TerrainContourLabel)] = []
 			for entry in perTile {
 				let n = Double(1 << entry.tile.z)
-				for line in entry.lines where line.points.count >= 2 {
-					let coordinates = line.points.map { point -> CLLocationCoordinate2D in
-						let wx = (Double(entry.tile.x) + point.x) / n
-						let wy = (Double(entry.tile.y) + point.y) / n
-						let lon = wx * 360 - 180
-						let lat = atan(sinh(.pi * (1 - 2 * wy))) * 180 / .pi
-						return CLLocationCoordinate2D(latitude: lat, longitude: lon)
-					}
+				func coordinate(_ point: CGPoint) -> CLLocationCoordinate2D {
+					let wx = (Double(entry.tile.x) + point.x) / n
+					let wy = (Double(entry.tile.y) + point.y) / n
+					let lon = wx * 360 - 180
+					let lat = atan(sinh(.pi * (1 - 2 * wy))) * 180 / .pi
+					return CLLocationCoordinate2D(latitude: lat, longitude: lon)
+				}
+				for (lineIndex, line) in entry.lines.enumerated() where line.points.count >= 2 {
+					let coordinates = line.points.map(coordinate)
 					let polyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
-					if line.isIndex { index.append(polyline) } else { minor.append(polyline) }
+					if line.isIndex {
+						index.append(polyline)
+						if line.points.count >= 12 {
+							let mid = coordinate(line.points[line.points.count / 2])
+							labelCandidates.append((line.points.count, TerrainContourLabel(
+								id: "\(entry.tile.z)/\(entry.tile.x)/\(entry.tile.y)-\(Int(line.elevation))-\(lineIndex)",
+								coordinate: mid,
+								text: Self.labelText(elevationMeters: line.elevation, metric: metric)
+							)))
+						}
+					} else {
+						minor.append(polyline)
+					}
 				}
 			}
+			let labels = labelCandidates
+				.sorted { $0.pointCount > $1.pointCount }
+				.prefix(24)
+				.map(\.label)
 			let built = TerrainContourGeometry(
 				minorLines: MKMultiPolyline(minor),
 				indexLines: MKMultiPolyline(index),
+				labels: Array(labels),
 				key: key
 			)
 
@@ -124,6 +156,14 @@ final class TerrainContourProvider: ObservableObject {
 				self.revision += 1
 			}
 		}
+	}
+
+	/// "1250 m" / "4000 ft" per the user's measurement system.
+	nonisolated static func labelText(elevationMeters: Double, metric: Bool) -> String {
+		if metric {
+			return "\(Int(elevationMeters.rounded())) m"
+		}
+		return "\(Int((elevationMeters / 0.3048).rounded())) ft"
 	}
 
 	// MARK: - Tiling helpers

--- a/Meshtastic/Helpers/Map/TerrainContourProvider.swift
+++ b/Meshtastic/Helpers/Map/TerrainContourProvider.swift
@@ -92,9 +92,12 @@ final class TerrainContourProvider: ObservableObject {
 		generationTask?.cancel()
 		generationTask = Task.detached(priority: .userInitiated) { [weak self] in
 			var perTile: [(tile: (z: Int, x: Int, y: Int), lines: [ContourLine])] = []
+			var coverageByTile: [String: GeoBounds] = [:]
 			for tile in tiles {
 				if Task.isCancelled { return }
 				let tileKey = "\(genZoom)/\(tile.x)/\(tile.y)|\(intervals.minor)"
+				guard let coverage = await store.coverage(z: genZoom, x: tile.x, y: tile.y) else { continue }
+				coverageByTile["\(genZoom)/\(tile.x)/\(tile.y)"] = coverage
 				if let lines = cached[tileKey] {
 					perTile.append(((genZoom, tile.x, tile.y), lines))
 					continue
@@ -119,21 +122,42 @@ final class TerrainContourProvider: ObservableObject {
 					let lat = atan(sinh(.pi * (1 - 2 * wy))) * 180 / .pi
 					return CLLocationCoordinate2D(latitude: lat, longitude: lon)
 				}
+				let coverage = coverageByTile["\(entry.tile.z)/\(entry.tile.x)/\(entry.tile.y)"]
+				func insideCoverage(_ c: CLLocationCoordinate2D) -> Bool {
+					guard let coverage else { return true }
+					return c.longitude >= coverage.minLon && c.longitude <= coverage.maxLon &&
+						c.latitude >= coverage.minLat && c.latitude <= coverage.maxLat
+				}
 				for (lineIndex, line) in entry.lines.enumerated() where line.points.count >= 2 {
 					let coordinates = line.points.map(coordinate)
-					let polyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
-					if line.isIndex {
-						index.append(polyline)
-						if line.points.count >= 12 {
-							let mid = coordinate(line.points[line.points.count / 2])
-							labelCandidates.append((line.points.count, TerrainContourLabel(
-								id: "\(entry.tile.z)/\(entry.tile.x)/\(entry.tile.y)-\(Int(line.elevation))-\(lineIndex)",
-								coordinate: mid,
-								text: Self.labelText(elevationMeters: line.elevation, metric: metric)
-							)))
+					// Clip to the downloaded boundary: split into in-bounds runs so
+					// contours end at the region edge instead of spilling past it.
+					var runs: [[CLLocationCoordinate2D]] = []
+					var current: [CLLocationCoordinate2D] = []
+					for c in coordinates {
+						if insideCoverage(c) {
+							current.append(c)
+						} else if !current.isEmpty {
+							runs.append(current)
+							current = []
 						}
-					} else {
-						minor.append(polyline)
+					}
+					if !current.isEmpty { runs.append(current) }
+					for (runIndex, run) in runs.enumerated() where run.count >= 2 {
+						let polyline = MKPolyline(coordinates: run, count: run.count)
+						if line.isIndex {
+							index.append(polyline)
+							if run.count >= 12 {
+								let mid = run[run.count / 2]
+								labelCandidates.append((run.count, TerrainContourLabel(
+									id: "\(entry.tile.z)/\(entry.tile.x)/\(entry.tile.y)-\(Int(line.elevation))-\(lineIndex)-\(runIndex)",
+									coordinate: mid,
+									text: Self.labelText(elevationMeters: line.elevation, metric: metric)
+								)))
+							}
+						} else {
+							minor.append(polyline)
+						}
 					}
 				}
 			}

--- a/Meshtastic/Helpers/Map/TerrainContourProvider.swift
+++ b/Meshtastic/Helpers/Map/TerrainContourProvider.swift
@@ -44,6 +44,9 @@ final class TerrainContourProvider: ObservableObject {
 
 	let store: TerrainStore
 	private var generation = 0
+	/// The in-flight generation task; superseded or invalidated generations are
+	/// cancelled so their decode work stops instead of running to a discarded end.
+	private var generationTask: Task<Void, Never>?
 	/// Generated ContourLine sets per tile key, so panning re-uses tiles already computed.
 	private var tileCache: [String: [ContourLine]] = [:]
 	private var tileCacheOrder: [String] = []
@@ -60,6 +63,9 @@ final class TerrainContourProvider: ObservableObject {
 
 	/// Clears cached geometry (call when the underlying terrain data changes).
 	func invalidate() {
+		generation += 1          // an in-flight task must not publish stale geometry
+		generationTask?.cancel()
+		generationTask = nil
 		tileCache.removeAll()
 		tileCacheOrder.removeAll()
 		geometry = nil
@@ -83,9 +89,11 @@ final class TerrainContourProvider: ObservableObject {
 		let store = store
 		let cached = tileCache
 
-		Task.detached(priority: .userInitiated) { [weak self] in
+		generationTask?.cancel()
+		generationTask = Task.detached(priority: .userInitiated) { [weak self] in
 			var perTile: [(tile: (z: Int, x: Int, y: Int), lines: [ContourLine])] = []
 			for tile in tiles {
+				if Task.isCancelled { return }
 				let tileKey = "\(genZoom)/\(tile.x)/\(tile.y)|\(intervals.minor)"
 				if let lines = cached[tileKey] {
 					perTile.append(((genZoom, tile.x, tile.y), lines))

--- a/Meshtastic/Helpers/Map/TerrainStore.swift
+++ b/Meshtastic/Helpers/Map/TerrainStore.swift
@@ -71,6 +71,22 @@ actor TerrainStore {
 		source(covering: z, x: x, y: y) != nil
 	}
 
+	/// The coverage box of the region covering this tile, for consumers that
+	/// clip rendering to the downloaded boundary.
+	func coverage(z: Int, x: Int, y: Int) -> GeoBounds? {
+		source(covering: z, x: x, y: y)?.bounds
+	}
+
+	/// Lon/lat box of a Web-Mercator tile.
+	static func tileBounds(z: Int, x: Int, y: Int) -> GeoBounds {
+		let n = Double(1 << z)
+		let minLon = Double(x) / n * 360 - 180
+		let maxLon = Double(x + 1) / n * 360 - 180
+		let maxLat = atan(sinh(.pi * (1 - 2 * Double(y) / n))) * 180 / .pi
+		let minLat = atan(sinh(.pi * (1 - 2 * Double(y + 1) / n))) * 180 / .pi
+		return GeoBounds(minLon: minLon, minLat: minLat, maxLon: maxLon, maxLat: maxLat)
+	}
+
 	/// The elevation grid for a map tile at any zoom, with `margin` edge pixels
 	/// sampled from neighbors (edge-clamped at coverage boundaries). Nil when no
 	/// configured region covers the tile or nothing decodes.
@@ -185,14 +201,14 @@ actor TerrainStore {
 		return decoded
 	}
 
-	/// The configured source whose bounds contain the tile's center.
+	/// The configured source whose bounds INTERSECT the tile. A center test left
+	/// border tiles either spilling past the region boundary or gapped inside it;
+	/// intersection + consumer-side clipping renders exactly to the boundary.
 	private func source(covering z: Int, x: Int, y: Int) -> OpenSource? {
-		let n = Double(1 << z)
-		let lon = (Double(x) + 0.5) / n * 360 - 180
-		let lat = atan(sinh(.pi * (1 - 2 * (Double(y) + 0.5) / n))) * 180 / .pi
+		let tile = Self.tileBounds(z: z, x: x, y: y)
 		return sources.first { source in
-			lon >= source.bounds.minLon && lon <= source.bounds.maxLon &&
-			lat >= source.bounds.minLat && lat <= source.bounds.maxLat
+			tile.minLon <= source.bounds.maxLon && tile.maxLon >= source.bounds.minLon &&
+			tile.minLat <= source.bounds.maxLat && tile.maxLat >= source.bounds.minLat
 		}
 	}
 }

--- a/Meshtastic/Helpers/Map/TerrainStore.swift
+++ b/Meshtastic/Helpers/Map/TerrainStore.swift
@@ -1,0 +1,179 @@
+//
+//  TerrainStore.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/16/26.
+//
+//  Serves elevation grids from a region's downloaded Mapterhorn terrain archives.
+//  All decoding happens inside the actor, off the main actor, so map rendering
+//  never blocks on it. Consumers (hillshade tiles, contour generation) request
+//  `ElevationTile`s for any map zoom: requests above the archived max zoom are
+//  answered by bilinear-sampling the covering ancestor tile (standard DEM
+//  overzoom), so terrain keeps rendering at street-level zooms.
+//
+
+import Foundation
+import OSLog
+
+/// One region's terrain data: the archive locations plus the coverage box.
+struct TerrainSource: Sendable, Equatable {
+	let globalURL: URL
+	let regionalURL: URL?
+	let bounds: GeoBounds
+}
+
+actor TerrainStore {
+
+	/// Output grid edge length (samples per tile, before margin). Mapterhorn tiles
+	/// are 512px; sampling to 256 quarters the decode-to-consumer cost and is
+	/// indistinguishable under hillshade/contour rendering.
+	static let tileSize = 256
+
+	private struct OpenSource {
+		let archive: PMTilesArchive
+		let regional: PMTilesArchive?
+		let bounds: GeoBounds
+		var maxZoom: Int { Int(regional?.header.maxZoom ?? archive.header.maxZoom) }
+	}
+
+	private var sources: [OpenSource] = []
+	private var configuredSources: [TerrainSource] = []
+	/// Decoded raw Mapterhorn grids keyed by "z/x/y"; small LRU by insertion order.
+	private var decodeCache: [String: (size: Int, elevations: [Float])] = [:]
+	private var decodeOrder: [String] = []
+	private let decodeCacheLimit = 24
+
+	/// (Re)points the store at the given terrain sources. Cheap when unchanged.
+	func configure(sources newSources: [TerrainSource]) {
+		guard newSources != configuredSources else { return }
+		configuredSources = newSources
+		decodeCache.removeAll()
+		decodeOrder.removeAll()
+		sources = newSources.compactMap { source in
+			guard let archive = PMTilesArchive(url: source.globalURL) else {
+				Logger.services.error("🗺️ [Terrain] Could not open terrain archive at \(source.globalURL.lastPathComponent, privacy: .public)")
+				return nil
+			}
+			let regional = source.regionalURL.flatMap { PMTilesArchive(url: $0) }
+			return OpenSource(archive: archive, regional: regional, bounds: source.bounds)
+		}
+	}
+
+	var hasSources: Bool { !sources.isEmpty }
+
+	/// Whether any configured region covers the given tile at all.
+	func covers(z: Int, x: Int, y: Int) -> Bool {
+		source(covering: z, x: x, y: y) != nil
+	}
+
+	/// The elevation grid for a map tile at any zoom, with `margin` edge pixels
+	/// sampled from neighbors (edge-clamped at coverage boundaries). Nil when no
+	/// configured region covers the tile or nothing decodes.
+	func elevationTile(z: Int, x: Int, y: Int, margin: Int = 1) -> ElevationTile? {
+		guard let open = source(covering: z, x: x, y: y) else { return nil }
+
+		// Clamp to the archive's max zoom: above it, sample the covering ancestor.
+		let dataZoom = min(z, open.maxZoom)
+		let zoomDelta = z - dataZoom
+		let scale = 1 << zoomDelta          // how many map tiles per data tile edge
+		let dataX = x >> zoomDelta
+		let dataY = y >> zoomDelta
+		// This tile's sub-rect within the data tile, in [0, 1).
+		let fracX = Double(x - dataX * scale) / Double(scale)
+		let fracY = Double(y - dataY * scale) / Double(scale)
+
+		let size = Self.tileSize
+		let grid = size + 2 * margin
+		var elevations = [Float](repeating: 0, count: grid * grid)
+
+		// Sample positions span the tile plus margin, expressed in data-tile pixel
+		// space (may fall outside [0, tilePx) — the sampler walks into neighbors).
+		guard let probe = rawGrid(open: open, z: dataZoom, x: dataX, y: dataY) else { return nil }
+		let tilePx = Double(probe.size)
+		let span = tilePx / Double(scale)   // data pixels covered by one output tile edge
+		let originX = fracX * tilePx
+		let originY = fracY * tilePx
+		let step = span / Double(size)
+
+		for gy in 0..<grid {
+			let sy = originY + (Double(gy - margin) + 0.5) * step
+			for gx in 0..<grid {
+				let sx = originX + (Double(gx - margin) + 0.5) * step
+				elevations[gy * grid + gx] = sample(open: open, z: dataZoom, x: dataX, y: dataY, px: sx, py: sy)
+			}
+		}
+		return ElevationTile(z: z, x: x, y: y, size: size, margin: margin, elevations: elevations)
+	}
+
+	/// Meters-per-sample for an `ElevationTile` at the given zoom/latitude — the
+	/// ground resolution consumers need for slope math.
+	static func metersPerSample(z: Int, y: Int, size: Int) -> Double {
+		let n = Double(1 << z)
+		let latitude = atan(sinh(.pi * (1 - 2 * (Double(y) + 0.5) / n))) * 180 / .pi
+		let metersPerTile = 40_075_016.686 * cos(latitude * .pi / 180) / n
+		return metersPerTile / Double(size)
+	}
+
+	// MARK: - Sampling
+
+	/// Bilinear sample at data-tile pixel coordinates; walks into neighbor tiles
+	/// when the position (or its +1 interpolation partner) leaves this tile.
+	private func sample(open: OpenSource, z: Int, x: Int, y: Int, px: Double, py: Double) -> Float {
+		func point(_ ix: Int, _ iy: Int) -> Float {
+			var tileX = x, tileY = y, lx = ix, ly = iy
+			guard let baseGrid = rawGrid(open: open, z: z, x: x, y: y) else { return 0 }
+			let tilePx = baseGrid.size
+			while lx < 0 { lx += tilePx; tileX -= 1 }
+			while lx >= tilePx { lx -= tilePx; tileX += 1 }
+			while ly < 0 { ly += tilePx; tileY -= 1 }
+			while ly >= tilePx { ly -= tilePx; tileY += 1 }
+			let maxIndex = (1 << z) - 1
+			tileX = min(max(tileX, 0), maxIndex)
+			tileY = min(max(tileY, 0), maxIndex)
+			guard let grid = rawGrid(open: open, z: z, x: tileX, y: tileY) ?? baseGrid as (size: Int, elevations: [Float])? else { return 0 }
+			let cx = min(max(lx, 0), grid.size - 1)
+			let cy = min(max(ly, 0), grid.size - 1)
+			return grid.elevations[cy * grid.size + cx]
+		}
+		let fx = px - 0.5, fy = py - 0.5
+		let x0 = Int(floor(fx)), y0 = Int(floor(fy))
+		let tx = Float(fx - Double(x0)), ty = Float(fy - Double(y0))
+		let p00 = point(x0, y0), p10 = point(x0 + 1, y0)
+		let p01 = point(x0, y0 + 1), p11 = point(x0 + 1, y0 + 1)
+		let top = p00 + (p10 - p00) * tx
+		let bottom = p01 + (p11 - p01) * tx
+		return top + (bottom - top) * ty
+	}
+
+	/// Raw decoded Mapterhorn grid for a data tile, preferring the regional
+	/// archive when it has the tile. LRU-cached.
+	private func rawGrid(open: OpenSource, z: Int, x: Int, y: Int) -> (size: Int, elevations: [Float])? {
+		let key = "\(z)/\(x)/\(y)"
+		if let cached = decodeCache[key] { return cached }
+		var data: Data?
+		if let regional = open.regional, z >= Int(regional.header.minZoom), z <= Int(regional.header.maxZoom) {
+			data = regional.tileData(z: UInt8(z), x: UInt32(x), y: UInt32(y))
+		}
+		if data == nil {
+			data = open.archive.tileData(z: UInt8(z), x: UInt32(x), y: UInt32(y))
+		}
+		guard let data, let decoded = TerrariumDecoder.decode(tileData: data) else { return nil }
+		decodeCache[key] = decoded
+		decodeOrder.append(key)
+		if decodeOrder.count > decodeCacheLimit {
+			decodeCache.removeValue(forKey: decodeOrder.removeFirst())
+		}
+		return decoded
+	}
+
+	/// The configured source whose bounds contain the tile's center.
+	private func source(covering z: Int, x: Int, y: Int) -> OpenSource? {
+		let n = Double(1 << z)
+		let lon = (Double(x) + 0.5) / n * 360 - 180
+		let lat = atan(sinh(.pi * (1 - 2 * (Double(y) + 0.5) / n))) * 180 / .pi
+		return sources.first { source in
+			lon >= source.bounds.minLon && lon <= source.bounds.maxLon &&
+			lat >= source.bounds.minLat && lat <= source.bounds.maxLat
+		}
+	}
+}

--- a/Meshtastic/Helpers/Map/TerrainStore.swift
+++ b/Meshtastic/Helpers/Map/TerrainStore.swift
@@ -38,9 +38,14 @@ actor TerrainStore {
 
 	private var sources: [OpenSource] = []
 	private var configuredSources: [TerrainSource] = []
-	/// Decoded raw Mapterhorn grids keyed by "z/x/y"; small LRU by insertion order.
-	private var decodeCache: [String: (size: Int, elevations: [Float])] = [:]
-	private var decodeOrder: [String] = []
+	/// Decoded raw Mapterhorn grids, LRU-evicted.
+	private struct TileKey: Hashable {
+		let z: Int
+		let x: Int
+		let y: Int
+	}
+	private var decodeCache: [TileKey: (size: Int, elevations: [Float])] = [:]
+	private var decodeOrder: [TileKey] = []
 	private let decodeCacheLimit = 24
 
 	/// (Re)points the store at the given terrain sources. Cheap when unchanged.
@@ -88,18 +93,57 @@ actor TerrainStore {
 
 		// Sample positions span the tile plus margin, expressed in data-tile pixel
 		// space (may fall outside [0, tilePx) — the sampler walks into neighbors).
-		guard let probe = rawGrid(open: open, z: dataZoom, x: dataX, y: dataY) else { return nil }
-		let tilePx = Double(probe.size)
-		let span = tilePx / Double(scale)   // data pixels covered by one output tile edge
-		let originX = fracX * tilePx
-		let originY = fracY * tilePx
+		guard let baseGrid = rawGrid(open: open, z: dataZoom, x: dataX, y: dataY) else { return nil }
+		let tilePx = baseGrid.size
+		let span = Double(tilePx) / Double(scale)   // data pixels covered by one output tile edge
+		let originX = fracX * Double(tilePx)
+		let originY = fracY * Double(tilePx)
 		let step = span / Double(size)
+		let maxIndex = (1 << dataZoom) - 1
+
+		// Grids memoized per neighbor offset for this call — the hot path never
+		// hashes strings or re-enters the cache per sample. `nil` marks a missing
+		// neighbor (decode failure or world edge).
+		var neighborGrids: [TileKey: [Float]?] = [TileKey(z: dataZoom, x: dataX, y: dataY): baseGrid.elevations]
+		func gridFor(tileX: Int, tileY: Int) -> [Float]? {
+			let key = TileKey(z: dataZoom, x: min(max(tileX, 0), maxIndex), y: min(max(tileY, 0), maxIndex))
+			if let cached = neighborGrids[key] { return cached }
+			let fetched = rawGrid(open: open, z: key.z, x: key.x, y: key.y)?.elevations
+			neighborGrids[key] = fetched
+			return fetched
+		}
+		// Integer point sample: walks into the neighbor tile when the coordinate
+		// leaves this one. When the neighbor is missing, clamps to THIS tile's
+		// nearest edge (never the wrapped opposite edge).
+		func point(_ ix: Int, _ iy: Int) -> Float {
+			var tileX = dataX, tileY = dataY, lx = ix, ly = iy
+			if lx < 0 { tileX -= 1; lx += tilePx } else if lx >= tilePx { tileX += 1; lx -= tilePx }
+			if ly < 0 { tileY -= 1; ly += tilePx } else if ly >= tilePx { tileY += 1; ly -= tilePx }
+			if tileX != dataX || tileY != dataY {
+				if let neighbor = gridFor(tileX: tileX, tileY: tileY) {
+					return neighbor[ly * tilePx + lx]
+				}
+				// Missing neighbor: clamp the ORIGINAL coordinate into the base tile.
+				let cx = min(max(ix, 0), tilePx - 1)
+				let cy = min(max(iy, 0), tilePx - 1)
+				return baseGrid.elevations[cy * tilePx + cx]
+			}
+			return baseGrid.elevations[ly * tilePx + lx]
+		}
 
 		for gy in 0..<grid {
-			let sy = originY + (Double(gy - margin) + 0.5) * step
+			let sy = originY + (Double(gy - margin) + 0.5) * step - 0.5
+			let y0 = Int(sy.rounded(.down))
+			let ty = Float(sy - Double(y0))
 			for gx in 0..<grid {
-				let sx = originX + (Double(gx - margin) + 0.5) * step
-				elevations[gy * grid + gx] = sample(open: open, z: dataZoom, x: dataX, y: dataY, px: sx, py: sy)
+				let sx = originX + (Double(gx - margin) + 0.5) * step - 0.5
+				let x0 = Int(sx.rounded(.down))
+				let tx = Float(sx - Double(x0))
+				let p00 = point(x0, y0), p10 = point(x0 + 1, y0)
+				let p01 = point(x0, y0 + 1), p11 = point(x0 + 1, y0 + 1)
+				let top = p00 + (p10 - p00) * tx
+				let bottom = p01 + (p11 - p01) * tx
+				elevations[gy * grid + gx] = top + (bottom - top) * ty
 			}
 		}
 		return ElevationTile(z: z, x: x, y: y, size: size, margin: margin, elevations: elevations)
@@ -114,42 +158,17 @@ actor TerrainStore {
 		return metersPerTile / Double(size)
 	}
 
-	// MARK: - Sampling
-
-	/// Bilinear sample at data-tile pixel coordinates; walks into neighbor tiles
-	/// when the position (or its +1 interpolation partner) leaves this tile.
-	private func sample(open: OpenSource, z: Int, x: Int, y: Int, px: Double, py: Double) -> Float {
-		func point(_ ix: Int, _ iy: Int) -> Float {
-			var tileX = x, tileY = y, lx = ix, ly = iy
-			guard let baseGrid = rawGrid(open: open, z: z, x: x, y: y) else { return 0 }
-			let tilePx = baseGrid.size
-			while lx < 0 { lx += tilePx; tileX -= 1 }
-			while lx >= tilePx { lx -= tilePx; tileX += 1 }
-			while ly < 0 { ly += tilePx; tileY -= 1 }
-			while ly >= tilePx { ly -= tilePx; tileY += 1 }
-			let maxIndex = (1 << z) - 1
-			tileX = min(max(tileX, 0), maxIndex)
-			tileY = min(max(tileY, 0), maxIndex)
-			guard let grid = rawGrid(open: open, z: z, x: tileX, y: tileY) ?? baseGrid as (size: Int, elevations: [Float])? else { return 0 }
-			let cx = min(max(lx, 0), grid.size - 1)
-			let cy = min(max(ly, 0), grid.size - 1)
-			return grid.elevations[cy * grid.size + cx]
-		}
-		let fx = px - 0.5, fy = py - 0.5
-		let x0 = Int(floor(fx)), y0 = Int(floor(fy))
-		let tx = Float(fx - Double(x0)), ty = Float(fy - Double(y0))
-		let p00 = point(x0, y0), p10 = point(x0 + 1, y0)
-		let p01 = point(x0, y0 + 1), p11 = point(x0 + 1, y0 + 1)
-		let top = p00 + (p10 - p00) * tx
-		let bottom = p01 + (p11 - p01) * tx
-		return top + (bottom - top) * ty
-	}
-
 	/// Raw decoded Mapterhorn grid for a data tile, preferring the regional
-	/// archive when it has the tile. LRU-cached.
+	/// archive when it has the tile. LRU-cached (hits move to the back).
 	private func rawGrid(open: OpenSource, z: Int, x: Int, y: Int) -> (size: Int, elevations: [Float])? {
-		let key = "\(z)/\(x)/\(y)"
-		if let cached = decodeCache[key] { return cached }
+		let key = TileKey(z: z, x: x, y: y)
+		if let cached = decodeCache[key] {
+			if let position = decodeOrder.firstIndex(of: key), position != decodeOrder.count - 1 {
+				decodeOrder.remove(at: position)
+				decodeOrder.append(key)
+			}
+			return cached
+		}
 		var data: Data?
 		if let regional = open.regional, z >= Int(regional.header.minZoom), z <= Int(regional.header.maxZoom) {
 			data = regional.tileData(z: UInt8(z), x: UInt32(x), y: UInt32(y))

--- a/Meshtastic/Helpers/Map/TerrariumDecoder.swift
+++ b/Meshtastic/Helpers/Map/TerrariumDecoder.swift
@@ -1,0 +1,88 @@
+//
+//  TerrariumDecoder.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/16/26.
+//
+//  Decodes Mapterhorn Terrarium terrain-RGB tiles (512px WebP) into elevation
+//  grids. See specs/018-offline-terrain-layer/contracts/mapterhorn-data-contract.md.
+//
+
+import Foundation
+import CoreGraphics
+import ImageIO
+
+/// A decoded elevation grid for one map tile, with a pixel margin borrowed from
+/// neighboring tiles so downstream consumers (hillshade kernels, contour marching
+/// squares) stay continuous across tile boundaries.
+///
+/// The grid is row-major with dimension `(size + 2 * margin)²`; index `[0, 0]` is
+/// the top-left MARGIN pixel, and the tile's own top-left sample sits at
+/// `[margin, margin]`. Elevations are meters.
+struct ElevationTile: Sendable {
+	let z: Int
+	let x: Int
+	let y: Int
+	/// Samples per tile edge, excluding the margin.
+	let size: Int
+	/// Margin pixels on each edge, sampled from neighboring tiles (edge-clamped at
+	/// data boundaries).
+	let margin: Int
+	/// Row-major `(size + 2*margin)²` elevations in meters.
+	let elevations: [Float]
+
+	var gridSize: Int { size + 2 * margin }
+
+	/// Elevation at tile-local coordinates (0..<size), ignoring the margin offset.
+	func elevation(x px: Int, y py: Int) -> Float {
+		elevations[(py + margin) * gridSize + (px + margin)]
+	}
+
+	/// Elevation at grid coordinates including the margin (-margin..<size+margin).
+	func gridElevation(x gx: Int, y gy: Int) -> Float {
+		elevations[(gy + margin) * gridSize + (gx + margin)]
+	}
+}
+
+enum TerrariumDecoder {
+
+	/// Terrarium pixel decode: `elevation = (R × 256 + G + B ÷ 256) − 32768`.
+	@inline(__always)
+	static func elevation(r: UInt8, g: UInt8, b: UInt8) -> Float {
+		Float(r) * 256 + Float(g) + Float(b) / 256 - 32768
+	}
+
+	/// Decodes an encoded tile image (WebP from Mapterhorn; any ImageIO-supported
+	/// format works, which the tests use with PNG fixtures) into a row-major grid
+	/// of elevations in meters. Returns nil for undecodable data.
+	static func decode(tileData: Data) -> (size: Int, elevations: [Float])? {
+		guard let source = CGImageSourceCreateWithData(tileData as CFData, nil),
+			  let image = CGImageSourceCreateImageAtIndex(source, 0, [kCGImageSourceShouldCache: false] as CFDictionary) else {
+			return nil
+		}
+		let width = image.width
+		let height = image.height
+		guard width > 0, width == height else { return nil }
+
+		var rgba = [UInt8](repeating: 0, count: width * height * 4)
+		let colorSpace = CGColorSpaceCreateDeviceRGB()
+		guard let context = CGContext(
+			data: &rgba,
+			width: width,
+			height: height,
+			bitsPerComponent: 8,
+			bytesPerRow: width * 4,
+			space: colorSpace,
+			bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+		) else { return nil }
+		context.interpolationQuality = .none
+		context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+		var elevations = [Float](repeating: 0, count: width * height)
+		for index in 0..<(width * height) {
+			let base = index * 4
+			elevations[index] = elevation(r: rgba[base], g: rgba[base + 1], b: rgba[base + 2])
+		}
+		return (width, elevations)
+	}
+}

--- a/Meshtastic/Helpers/Map/TerrariumDecoder.swift
+++ b/Meshtastic/Helpers/Map/TerrariumDecoder.swift
@@ -39,8 +39,12 @@ struct ElevationTile: Sendable {
 	}
 
 	/// Elevation at grid coordinates including the margin (-margin..<size+margin).
+	/// Coordinates are clamped to the grid so a caller with a smaller margin than
+	/// it assumed reads the edge instead of trapping.
 	func gridElevation(x gx: Int, y gy: Int) -> Float {
-		elevations[(gy + margin) * gridSize + (gx + margin)]
+		let cx = min(max(gx + margin, 0), gridSize - 1)
+		let cy = min(max(gy + margin, 0), gridSize - 1)
+		return elevations[cy * gridSize + cx]
 	}
 }
 
@@ -66,17 +70,24 @@ enum TerrariumDecoder {
 
 		var rgba = [UInt8](repeating: 0, count: width * height * 4)
 		let colorSpace = CGColorSpaceCreateDeviceRGB()
-		guard let context = CGContext(
-			data: &rgba,
-			width: width,
-			height: height,
-			bitsPerComponent: 8,
-			bytesPerRow: width * 4,
-			space: colorSpace,
-			bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
-		) else { return nil }
-		context.interpolationQuality = .none
-		context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+		// noneSkipLast: elevation lives in R/G/B — premultiplying by a source alpha
+		// channel would corrupt the decoded heights. The pointer handed to CGContext
+		// must stay valid for the draw, hence withUnsafeMutableBytes around all use.
+		let drawn: Bool = rgba.withUnsafeMutableBytes { buffer in
+			guard let context = CGContext(
+				data: buffer.baseAddress,
+				width: width,
+				height: height,
+				bitsPerComponent: 8,
+				bytesPerRow: width * 4,
+				space: colorSpace,
+				bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+			) else { return false }
+			context.interpolationQuality = .none
+			context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+			return true
+		}
+		guard drawn else { return nil }
 
 		var elevations = [Float](repeating: 0, count: width * height)
 		for index in 0..<(width * height) {

--- a/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/ClusterMapView.swift
@@ -869,6 +869,10 @@ struct ClusterMapView<Item: Identifiable, Pin: View, Cluster: View>: UIViewRepre
 				renderer.lineJoin = .round
 				return renderer
 			}
+			// Raster tile overlays (hillshade) — MapKit's tile renderer, no styling.
+			if let tileOverlay = overlay as? MKTileOverlay {
+				return MKTileOverlayRenderer(tileOverlay: tileOverlay)
+			}
 			// Styled caller overlay (circle / polyline / polygon), style looked up by object identity.
 			let style = styleByOverlay[ObjectIdentifier(overlay)] ?? ClusterMapOverlayStyle()
 			let renderer: MKOverlayPathRenderer

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
@@ -27,8 +27,16 @@ struct MapSettingsForm: View {
 	@AppStorage("meshMapShowHillshade") private var showHillshade = false
 	@AppStorage("meshMapShowContours") private var showContours = false
 	/// Terrain toggles are disabled until at least one region has terrain data.
+	/// When the last terrain region disappears, the stored values reset so a
+	/// disabled toggle is never stuck in the on position.
 	private var hasTerrainData: Bool {
 		offlineMapManager.regions.contains { $0.terrain != nil }
+	}
+
+	private func resetTerraintogglesIfOrphaned() {
+		guard !hasTerrainData else { return }
+		if showHillshade { showHillshade = false }
+		if showContours { showContours = false }
 	}
 	@AppStorage("enableMapClustering") private var enableMapClustering = true
 	@AppStorage("enableMapPreciseLocationsOnly") private var preciseLocationsOnly = false
@@ -354,7 +362,11 @@ struct MapSettingsForm: View {
 		.presentationDragIndicator(.visible)
 		#endif
 		.presentationBackgroundInteraction(.enabled(upThrough: .medium))
+		.onChange(of: offlineMapManager.regions) {
+			resetTerraintogglesIfOrphaned()
+		}
 		.onAppear {
+			resetTerraintogglesIfOrphaned()
 			// Initialize map data manager
 			mapDataManager.initialize()
 			offlineMapManager.loadIfNeeded()

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
@@ -24,6 +24,12 @@ struct MapSettingsForm: View {
 	@AppStorage("enableMapUserLocation") private var enableMapUserLocation = true
 	@AppStorage("mapOverlaysEnabled") private var mapOverlaysEnabled = false
 	@AppStorage("enableOfflineTiles") private var enableOfflineTiles = false
+	@AppStorage("meshMapShowHillshade") private var showHillshade = false
+	@AppStorage("meshMapShowContours") private var showContours = false
+	/// Terrain toggles are disabled until at least one region has terrain data.
+	private var hasTerrainData: Bool {
+		offlineMapManager.regions.contains { $0.terrain != nil }
+	}
 	@AppStorage("enableMapClustering") private var enableMapClustering = true
 	@AppStorage("enableMapPreciseLocationsOnly") private var preciseLocationsOnly = false
 	@ObservedObject private var mapDataManager = MapDataManager.shared
@@ -169,6 +175,32 @@ struct MapSettingsForm: View {
 								Image(systemName: "square.dashed")
 							}
 						}
+						Toggle(isOn: $showHillshade) {
+							Label {
+								VStack(alignment: .leading) {
+									Text("Hillshade")
+									Text("Shaded terrain relief over areas with downloaded terrain. Standard and offline maps only.")
+										.font(.caption)
+										.foregroundColor(.secondary)
+								}
+							} icon: {
+								Image(systemName: "mountain.2")
+							}
+						}
+						.disabled(!hasTerrainData)
+						Toggle(isOn: $showContours) {
+							Label {
+								VStack(alignment: .leading) {
+									Text("Contour Lines")
+									Text("Elevation contours over areas with downloaded terrain, on every map type.")
+										.font(.caption)
+										.foregroundColor(.secondary)
+								}
+							} icon: {
+								Image(systemName: "point.topleft.down.to.point.bottomright.curvepath")
+							}
+						}
+						.disabled(!hasTerrainData)
 					}
 				}
 

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapDetailView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapDetailView.swift
@@ -22,10 +22,19 @@ struct OfflineMapDetailView: View {
 		manager.regions.first { $0.id == region.id } ?? region
 	}
 
+	/// Preview sized to the region's real on-screen aspect (longitude span shrinks
+	/// by cos(latitude) on a Mercator map), clamped so extremes stay usable.
+	private var previewSize: CGSize {
+		let width: CGFloat = 340
+		let mkRegion = current.region
+		let aspect = (mkRegion.span.longitudeDelta * cos(mkRegion.center.latitude * .pi / 180)) / max(mkRegion.span.latitudeDelta, 0.0001)
+		return CGSize(width: width, height: (width / min(max(aspect, 0.8), 2.2)).rounded())
+	}
+
 	var body: some View {
 		List {
 			Section {
-				OfflineMapThumbnail(region: current, size: CGSize(width: 320, height: 170), cornerRadius: 12)
+				OfflineMapThumbnail(region: current, size: previewSize, cornerRadius: 12)
 					.frame(maxWidth: .infinity)
 					.listRowInsets(EdgeInsets())
 					.listRowBackground(Color.clear)

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapDetailView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapDetailView.swift
@@ -56,6 +56,24 @@ struct OfflineMapDetailView: View {
 				LabeledContent("Source", value: current.sourceBuild == "Imported" ? "Imported PMTiles" : "Protomaps \(current.sourceBuild)")
 			}
 
+			Section("Terrain") {
+				if let terrain = current.terrain {
+					LabeledContent("Size", value: current.formattedTerrainSize ?? "")
+					LabeledContent("Detail", value: "Zoom 0–\(terrain.maxZoom)")
+					LabeledContent("Source", value: "Mapterhorn")
+				} else {
+					Button {
+						manager.downloadTerrain(for: current)
+					} label: {
+						Label("Add Terrain", systemImage: "mountain.2")
+					}
+					.disabled(manager.isBusy)
+					Text("Elevation data for hillshade and contour lines, downloaded for this area.")
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
+			}
+
 			if let fileURL = manager.fileURL(for: current), FileManager.default.fileExists(atPath: fileURL.path) {
 				Section {
 					ShareLink(item: fileURL) {

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapDetailView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapDetailView.swift
@@ -54,15 +54,19 @@ struct OfflineMapDetailView: View {
 				} label: {
 					Label("Rename", systemImage: "pencil")
 				}
-				LabeledContent("Size", value: current.formattedSize)
-				LabeledContent("Detail", value: "Zoom \(current.minZoom)–\(current.maxZoom)")
-				if let warning = current.zoomCoverage.warningLabel {
-					Label(warning, systemImage: "exclamationmark.triangle")
-						.font(.callout)
-						.foregroundStyle(.orange)
+				// Basemap facts don't apply to terrain-only regions — the Terrain
+				// section below carries their size and source.
+				if current.hasBasemap {
+					LabeledContent("Size", value: current.formattedSize)
+					LabeledContent("Detail", value: "Zoom \(current.minZoom)–\(current.maxZoom)")
+					if let warning = current.zoomCoverage.warningLabel {
+						Label(warning, systemImage: "exclamationmark.triangle")
+							.font(.callout)
+							.foregroundStyle(.orange)
+					}
+					LabeledContent("Map updated", value: current.updatedDate.formatted(.relative(presentation: .named)))
+					LabeledContent("Source", value: current.sourceBuild == "Imported" ? "Imported PMTiles" : "Protomaps \(current.sourceBuild)")
 				}
-				LabeledContent("Map updated", value: current.updatedDate.formatted(.relative(presentation: .named)))
-				LabeledContent("Source", value: current.sourceBuild == "Imported" ? "Imported PMTiles" : "Protomaps \(current.sourceBuild)")
 			}
 
 			Section("Terrain") {
@@ -113,7 +117,7 @@ struct OfflineMapDetailView: View {
 			}
 			Button("Cancel", role: .cancel) { }
 		} message: {
-			Text("\(current.formattedSize) will be freed on this device.")
+			Text("\(current.formattedTotalSize) will be freed on this device.")
 		}
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapThumbnail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapThumbnail.swift
@@ -31,36 +31,65 @@ struct OfflineMapThumbnail: View {
 							.foregroundStyle(.secondary)
 					}
 			}
-			RoundedRectangle(cornerRadius: max(cornerRadius - 3, 0))
-				.inset(by: 4)
-				.stroke(.white.opacity(0.7), lineWidth: 1.5)
 		}
 		.frame(width: size.width, height: size.height)
 		.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-		.task(id: region.id) {
+		.task(id: snapshotKey) {
 			image = await Self.snapshot(of: region, size: size, dark: colorScheme == .dark)
 		}
 	}
 
-	/// Renders a static MapKit snapshot framing the region.
+	/// Re-snapshots when the coverage changes (resize keeps the id) or the theme flips.
+	private var snapshotKey: String {
+		"\(region.id)|\(region.minLongitude),\(region.minLatitude),\(region.maxLongitude),\(region.maxLatitude)|\(colorScheme == .dark)"
+	}
+
+	/// Renders a static MapKit snapshot framing the region, with the actual coverage
+	/// boundary drawn on it (dim outside, white outline on the true bounds) so the
+	/// preview shows exactly what was downloaded, whatever the container's aspect.
 	static func snapshot(of region: OfflineMapRegion, size: CGSize, dark: Bool) async -> UIImage? {
 		let options = MKMapSnapshotter.Options()
 		var mkRegion = region.region
 		// Pad so the coverage sits comfortably inside the frame.
-		mkRegion.span.latitudeDelta *= 1.4
-		mkRegion.span.longitudeDelta *= 1.4
+		mkRegion.span.latitudeDelta *= 1.25
+		mkRegion.span.longitudeDelta *= 1.25
 		options.region = mkRegion
 		options.size = size
 		options.mapType = .standard
 		options.traitCollection = UITraitCollection(userInterfaceStyle: dark ? .dark : .light)
 
-		return await withCheckedContinuation { continuation in
+		let snapshot: MKMapSnapshotter.Snapshot? = await withCheckedContinuation { continuation in
 			MKMapSnapshotter(options: options).start(with: .global(qos: .userInitiated)) { snapshot, error in
 				if let error {
 					Logger.services.debug("🗺️ [Offline] Thumbnail snapshot failed: \(error.localizedDescription, privacy: .public)")
 				}
-				continuation.resume(returning: snapshot?.image)
+				continuation.resume(returning: snapshot)
 			}
+		}
+		guard let snapshot else { return nil }
+
+		let northWest = snapshot.point(for: CLLocationCoordinate2D(latitude: region.maxLatitude, longitude: region.minLongitude))
+		let southEast = snapshot.point(for: CLLocationCoordinate2D(latitude: region.minLatitude, longitude: region.maxLongitude))
+		let bounds = CGRect(
+			x: min(northWest.x, southEast.x), y: min(northWest.y, southEast.y),
+			width: abs(southEast.x - northWest.x), height: abs(southEast.y - northWest.y)
+		)
+		guard bounds.width > 4, bounds.height > 4 else { return snapshot.image }
+
+		return UIGraphicsImageRenderer(size: size).image { _ in
+			snapshot.image.draw(at: .zero)
+			let outline = UIBezierPath(roundedRect: bounds, cornerRadius: 6)
+			let outside = UIBezierPath(rect: CGRect(origin: .zero, size: size))
+			outside.append(outline)
+			outside.usesEvenOddFillRule = true
+			UIColor.black.withAlphaComponent(dark ? 0.4 : 0.22).setFill()
+			outside.fill()
+			UIColor.black.withAlphaComponent(0.3).setStroke()
+			outline.lineWidth = 3.5
+			outline.stroke()
+			UIColor.white.setStroke()
+			outline.lineWidth = 1.8
+			outline.stroke()
 		}
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapsList.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapsList.swift
@@ -122,15 +122,19 @@ struct OfflineMapRow: View {
 			VStack(alignment: .leading, spacing: 2) {
 				Text(region.name)
 					.font(.headline)
-				Text("\(region.formattedSize) · Updated \(region.updatedDate.formatted(.relative(presentation: .named)))")
+				Text("\(region.formattedTotalSize) · Updated \(region.updatedDate.formatted(.relative(presentation: .named)))")
 					.font(.caption)
 					.foregroundStyle(.secondary)
-				if let terrainSize = region.formattedTerrainSize {
+				if !region.hasBasemap {
+					Text("Terrain only — hillshade and contours")
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				} else if let terrainSize = region.formattedTerrainSize {
 					Text("Terrain: \(terrainSize)")
 						.font(.caption)
 						.foregroundStyle(.secondary)
 				}
-				if let warning = region.zoomCoverage.warningLabel {
+				if region.hasBasemap, let warning = region.zoomCoverage.warningLabel {
 					Label(warning, systemImage: "exclamationmark.triangle")
 						.font(.caption2)
 						.foregroundStyle(.orange)

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapsList.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/OfflineMapsList.swift
@@ -44,11 +44,25 @@ struct OfflineMapsList: View {
 						} label: {
 							OfflineMapRow(region: region)
 						}
+						.swipeActions(edge: .leading, allowsFullSwipe: false) {
+							if region.terrain == nil {
+								Button {
+									manager.downloadTerrain(for: region)
+								} label: {
+									Label("Add Terrain", systemImage: "mountain.2")
+								}
+								.tint(.indigo)
+								.disabled(manager.isBusy)
+							}
+						}
 					}
 				} footer: {
 					VStack(alignment: .leading, spacing: 2) {
 						Text("\(manager.formattedTotalSize) used on this device")
 						Text("Map data © OpenStreetMap, Protomaps")
+						if manager.regions.contains(where: { $0.terrain != nil }) {
+							Text("Terrain data © Mapterhorn")
+						}
 					}
 					.font(.caption)
 				}
@@ -111,6 +125,11 @@ struct OfflineMapRow: View {
 				Text("\(region.formattedSize) · Updated \(region.updatedDate.formatted(.relative(presentation: .named)))")
 					.font(.caption)
 					.foregroundStyle(.secondary)
+				if let terrainSize = region.formattedTerrainSize {
+					Text("Terrain: \(terrainSize)")
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
 				if let warning = region.zoomCoverage.warningLabel {
 					Label(warning, systemImage: "exclamationmark.triangle")
 						.font(.caption2)

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
@@ -43,6 +43,27 @@ private struct PanelHeightKey: PreferenceKey {
 	static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = max(value, nextValue()) }
 }
 
+/// What a download includes: the Protomaps basemap, Mapterhorn terrain, or both.
+/// Terrain-only regions draw hillshade and contours over Apple maps.
+enum OfflineDownloadContent: String, CaseIterable, Identifiable {
+	case mapAndTerrain
+	case mapOnly
+	case terrainOnly
+
+	var id: String { rawValue }
+
+	var label: String {
+		switch self {
+		case .mapAndTerrain: return String(localized: "Map + Terrain")
+		case .mapOnly: return String(localized: "Map Only")
+		case .terrainOnly: return String(localized: "Terrain Only")
+		}
+	}
+
+	var includesBasemap: Bool { self != .terrainOnly }
+	var includesTerrain: Bool { self != .mapOnly }
+}
+
 struct RegionSelectorView: View {
 	let target: OfflineRegionTarget
 	/// When resizing, the existing region this download replaces on success.
@@ -53,8 +74,8 @@ struct RegionSelectorView: View {
 	@State private var camera: MapCameraPosition
 	@State private var bounds: GeoBounds?
 	@State private var detail: OfflineMapDetailLevel = .standard
-	/// Download elevation data (hillshade + contours) with the region.
-	@State private var includeTerrain = true
+	/// What the download includes (basemap, terrain, or both).
+	@State private var content: OfflineDownloadContent = .mapAndTerrain
 	/// One-shot: when resizing, the selection seeds from the region's saved bounds.
 	@State private var didSeedFromReplacing = false
 	/// One-shot camera zoom-out so the saved bounds fit inside the selectable area.
@@ -85,6 +106,13 @@ struct RegionSelectorView: View {
 		self.replacing = replacing
 		_camera = State(initialValue: .region(target.region))
 		_name = State(initialValue: target.name)
+		// Resizing keeps what the region already has.
+		if let replacing {
+			let initial: OfflineDownloadContent = replacing.hasBasemap
+				? (replacing.terrain != nil ? .mapAndTerrain : .mapOnly)
+				: .terrainOnly
+			_content = State(initialValue: initial)
+		}
 	}
 
 	private let minRectSize: CGFloat = 64
@@ -457,29 +485,48 @@ struct RegionSelectorView: View {
 				.foregroundStyle(.secondary)
 				.multilineTextAlignment(.center)
 
-			HStack(alignment: .top, spacing: 10) {
-				Image(systemName: "figure.hiking")
-					.foregroundStyle(.tint)
-				VStack(alignment: .leading, spacing: 2) {
-					Text("Protomaps Outdoors")
-						.font(.subheadline.weight(.semibold))
-					Text("Includes trails, roads, terrain, and points of interest.")
-						.font(.caption)
-						.foregroundStyle(.secondary)
-				}
-				Spacer()
-			}
-
-			Picker("Detail", selection: $detail) {
-				ForEach(OfflineMapDetailLevel.allCases) { level in
-					Text(level.label).tag(level)
+			Picker("Download", selection: $content) {
+				ForEach(OfflineDownloadContent.allCases) { option in
+					Text(option.label).tag(option)
 				}
 			}
 			.pickerStyle(.segmented)
 
-			Toggle(isOn: $includeTerrain) {
-				Text("Include terrain (hillshade and contour data)")
-					.font(.caption)
+			if content.includesBasemap {
+				HStack(alignment: .top, spacing: 10) {
+					Image(systemName: "figure.hiking")
+						.foregroundStyle(.tint)
+					VStack(alignment: .leading, spacing: 2) {
+						Text("Protomaps Outdoors")
+							.font(.subheadline.weight(.semibold))
+						Text(content.includesTerrain
+							? "Includes trails, roads, points of interest, and terrain data for hillshade and contour lines."
+							: "Includes trails, roads, and points of interest.")
+							.font(.caption)
+							.foregroundStyle(.secondary)
+					}
+					Spacer()
+				}
+
+				Picker("Detail", selection: $detail) {
+					ForEach(OfflineMapDetailLevel.allCases) { level in
+						Text(level.label).tag(level)
+					}
+				}
+				.pickerStyle(.segmented)
+			} else {
+				HStack(alignment: .top, spacing: 10) {
+					Image(systemName: "mountain.2")
+						.foregroundStyle(.tint)
+					VStack(alignment: .leading, spacing: 2) {
+						Text("Mapterhorn Terrain")
+							.font(.subheadline.weight(.semibold))
+						Text("Elevation data for hillshade and contour lines, drawn over Apple and offline maps.")
+							.font(.caption)
+							.foregroundStyle(.secondary)
+					}
+					Spacer()
+				}
 			}
 
 			Text("Size of selected map: \(sizeText)")
@@ -525,7 +572,7 @@ struct RegionSelectorView: View {
 		}
 		// Surface the extractor's tile cap here instead of letting the download fail
 		// after it starts. High detail multiplies the tile count ~20x over Standard.
-		if let bounds,
+		if content.includesBasemap, let bounds,
 		   PMTilesExtractor.tileCount(in: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom) > PMTilesExtractor.maxTiles {
 			return String(localized: "Area is too large for \(detail.label). Shrink the area or choose a lower detail level.")
 		}
@@ -542,8 +589,9 @@ struct RegionSelectorView: View {
 	// MARK: - Size estimate
 
 	/// Synchronous, network-free rough estimate (shown immediately while framing).
+	/// Terrain-only has no local heuristic — the size shows once the plan returns.
 	private var roughBytes: Int64? {
-		guard let bounds else { return nil }
+		guard content.includesBasemap, let bounds else { return nil }
 		return PMTilesExtractor.roughByteEstimate(in: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom)
 	}
 
@@ -563,7 +611,7 @@ struct RegionSelectorView: View {
 	private var estimateKey: String {
 		guard let bounds else { return "none" }
 		func round4(_ value: Double) -> Double { (value * 10_000).rounded() / 10_000 }
-		return "\(detail.rawValue)|\(includeTerrain ? "t" : "b")|\(round4(bounds.minLon)),\(round4(bounds.minLat)),\(round4(bounds.maxLon)),\(round4(bounds.maxLat))"
+		return "\(detail.rawValue)|\(content.rawValue)|\(round4(bounds.minLon)),\(round4(bounds.minLat)),\(round4(bounds.maxLon)),\(round4(bounds.maxLat))"
 	}
 
 	private func runEstimate() async {
@@ -574,7 +622,7 @@ struct RegionSelectorView: View {
 		// Debounce: cancelled (and restarted) by `.task(id:)` if the area keeps changing.
 		do { try await Task.sleep(for: .milliseconds(500)) } catch { return }
 		if Task.isCancelled { return }
-		let bytes = await Self.computeEstimate(bounds: bounds, detail: detail, includeTerrain: includeTerrain)
+		let bytes = await Self.computeEstimate(bounds: bounds, detail: detail, content: content)
 		if Task.isCancelled { return }
 		if let bytes {
 			estimatedBytes = bytes
@@ -584,25 +632,35 @@ struct RegionSelectorView: View {
 	}
 
 	/// Network-accurate size (the exact plans the download uses), or nil when
-	/// basemap planning fails — the caller keeps showing the rough estimate,
-	/// marked approximate. Terrain planning failure degrades to basemap-only
-	/// rather than losing the whole estimate.
-	private static func computeEstimate(bounds: GeoBounds, detail: OfflineMapDetailLevel, includeTerrain: Bool) async -> Int64? {
+	/// planning the primary content fails — the caller keeps showing the rough
+	/// estimate, marked approximate. When both are included, terrain planning
+	/// failure degrades to basemap-only rather than losing the whole estimate.
+	private static func computeEstimate(bounds: GeoBounds, detail: OfflineMapDetailLevel, content: OfflineDownloadContent) async -> Int64? {
 		let extractor = PMTilesExtractor()
-		guard let basemap = (try? await extractor.estimate(bounds: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom))?.bytes else {
-			return nil
+		var total: Int64 = 0
+		if content.includesBasemap {
+			guard let basemap = (try? await extractor.estimate(bounds: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom))?.bytes else {
+				return nil
+			}
+			total += basemap
 		}
-		guard includeTerrain, let terrainURL = URL(string: OfflineMapManager.terrainGlobalArchive) else { return basemap }
-		let terrain = (try? await extractor.makePlan(
-			sourceURL: terrainURL, sourceBuild: "Mapterhorn",
-			bounds: bounds, minZoom: 0, maxZoom: OfflineMapManager.terrainGlobalMaxZoom
-		))?.payloadBytes ?? 0
-		return basemap + terrain
+		if content.includesTerrain, let terrainURL = URL(string: OfflineMapManager.terrainGlobalArchive) {
+			let terrain = (try? await extractor.makePlan(
+				sourceURL: terrainURL, sourceBuild: "Mapterhorn",
+				bounds: bounds, minZoom: 0, maxZoom: OfflineMapManager.terrainGlobalMaxZoom
+			))?.payloadBytes
+			if terrain == nil, !content.includesBasemap { return nil }
+			total += terrain ?? 0
+		}
+		return total
 	}
 
 	private func startDownload() {
 		guard let bounds else { return }
-		manager.startDownload(name: name, bounds: bounds, detail: detail, replacing: replacing, includeTerrain: includeTerrain)
+		manager.startDownload(
+			name: name, bounds: bounds, detail: detail, replacing: replacing,
+			includeBasemap: content.includesBasemap, includeTerrain: content.includesTerrain
+		)
 		dismiss()
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
@@ -53,6 +53,10 @@ struct RegionSelectorView: View {
 	@State private var camera: MapCameraPosition
 	@State private var bounds: GeoBounds?
 	@State private var detail: OfflineMapDetailLevel = .standard
+	/// Download elevation data (hillshade + contours) with the region.
+	@State private var includeTerrain = true
+	/// One-shot: when resizing, the selection seeds from the region's saved bounds.
+	@State private var didSeedFromReplacing = false
 	@State private var name: String
 
 	/// The selection rectangle in the picker's local coordinate space (drag/resize target).
@@ -91,6 +95,7 @@ struct RegionSelectorView: View {
 						.mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))
 						.onMapCameraChange(frequency: .continuous) { context in
 							currentRegion = context.region
+							seedFromReplacingIfNeeded(proxy: proxy, size: geo.size)
 							recompute(proxy: proxy, size: geo.size)
 						}
 
@@ -274,6 +279,20 @@ struct RegionSelectorView: View {
 		return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
 	}
 
+	/// When resizing an existing region, the selection starts as that region's
+	/// saved boundary instead of the default centered rectangle. Runs once, as
+	/// soon as the map proxy can convert coordinates.
+	private func seedFromReplacingIfNeeded(proxy: MapProxy, size: CGSize) {
+		guard !didSeedFromReplacing, let replacing else { return }
+		let northWest = CLLocationCoordinate2D(latitude: replacing.maxLatitude, longitude: replacing.minLongitude)
+		let southEast = CLLocationCoordinate2D(latitude: replacing.minLatitude, longitude: replacing.maxLongitude)
+		guard let topLeft = proxy.convert(northWest, to: .local),
+			  let bottomRight = proxy.convert(southEast, to: .local),
+			  bottomRight.x - topLeft.x > 8, bottomRight.y - topLeft.y > 8 else { return }
+		selectionRect = normalizedClamped(topLeft.x, topLeft.y, bottomRight.x, bottomRight.y, in: size)
+		didSeedFromReplacing = true
+	}
+
 	private func initRect(size: CGSize) {
 		guard selectionRect == .zero, size.width > 0, size.height > 0 else { return }
 		let area = usableRect(in: size)
@@ -370,6 +389,11 @@ struct RegionSelectorView: View {
 			}
 			.pickerStyle(.segmented)
 
+			Toggle(isOn: $includeTerrain) {
+				Text("Include terrain (hillshade and contour data)")
+					.font(.subheadline)
+			}
+
 			Text("Size of selected map: \(sizeText)")
 				.font(.subheadline)
 
@@ -442,7 +466,7 @@ struct RegionSelectorView: View {
 	private var estimateKey: String {
 		guard let bounds else { return "none" }
 		func round4(_ value: Double) -> Double { (value * 10_000).rounded() / 10_000 }
-		return "\(detail.rawValue)|\(round4(bounds.minLon)),\(round4(bounds.minLat)),\(round4(bounds.maxLon)),\(round4(bounds.maxLat))"
+		return "\(detail.rawValue)|\(includeTerrain ? "t" : "b")|\(round4(bounds.minLon)),\(round4(bounds.minLat)),\(round4(bounds.maxLon)),\(round4(bounds.maxLat))"
 	}
 
 	private func runEstimate() async {
@@ -452,7 +476,7 @@ struct RegionSelectorView: View {
 		// Debounce: cancelled (and restarted) by `.task(id:)` if the area keeps changing.
 		do { try await Task.sleep(for: .milliseconds(500)) } catch { return }
 		if Task.isCancelled { return }
-		let bytes = await Self.computeEstimate(bounds: bounds, detail: detail)
+		let bytes = await Self.computeEstimate(bounds: bounds, detail: detail, includeTerrain: includeTerrain)
 		if Task.isCancelled { return }
 		estimatedBytes = bytes
 		isEstimating = false
@@ -468,7 +492,7 @@ struct RegionSelectorView: View {
 
 	private func startDownload() {
 		guard let bounds else { return }
-		manager.startDownload(name: name, bounds: bounds, detail: detail, replacing: replacing)
+		manager.startDownload(name: name, bounds: bounds, detail: detail, replacing: replacing, includeTerrain: includeTerrain)
 		dismiss()
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
@@ -99,8 +99,12 @@ struct RegionSelectorView: View {
 						.mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))
 						.onMapCameraChange(frequency: .continuous) { context in
 							currentRegion = context.region
-							seedFromReplacingIfNeeded(proxy: proxy, size: geo.size)
+							frameCameraForSeedIfNeeded(size: geo.size)
+							placeSeededSelection(proxy: proxy, size: geo.size, requireSettled: true)
 							recompute(proxy: proxy, size: geo.size)
+						}
+						.onMapCameraChange(frequency: .onEnd) { _ in
+							placeSeededSelection(proxy: proxy, size: geo.size, requireSettled: false)
 						}
 
 					selectionLayer(proxy: proxy, size: geo.size)
@@ -122,6 +126,8 @@ struct RegionSelectorView: View {
 				}
 				.onChange(of: controlPanelHeight) {
 					clampRect(to: geo.size)
+					// The panel height is what the seed framing was waiting on.
+					frameCameraForSeedIfNeeded(size: geo.size)
 					recompute(proxy: proxy, size: geo.size)
 				}
 			}
@@ -283,56 +289,100 @@ struct RegionSelectorView: View {
 		return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
 	}
 
-	/// When resizing an existing region, the selection starts as that region's
-	/// saved boundary instead of the default centered rectangle.
-	///
-	/// Two phases: the initial camera shows the region edge-to-edge, where its
-	/// corners sit outside the selectable area (top/side insets + the control
-	/// panel), and the clamp would squash the seeded rectangle away from the true
-	/// boundary. Phase one zooms the camera out just enough that the saved bounds
-	/// project INSIDE the usable area, centered in it; phase two (a later camera
-	/// tick) converts the corners and places the selection exactly on them.
-	private func seedFromReplacingIfNeeded(proxy: MapProxy, size: CGSize) {
-		guard !didSeedFromReplacing, let replacing, size.height > 0 else { return }
-		let usable = usableRect(in: size)
-		guard usable.width > minRectSize, usable.height > minRectSize else { return }
+	// MARK: - Resize seeding
+	//
+	// When resizing an existing region, the selection starts as that region's saved
+	// boundary instead of the default centered rectangle. The initial camera shows
+	// the region edge-to-edge, where its corners sit outside the selectable area
+	// (top/side insets + the control panel), so the camera is first re-framed to fit
+	// the saved bounds inside the usable area — using the MEASURED panel height and
+	// exact Web-Mercator math — and the selection is placed on the projected corners
+	// once the camera settles. Until then no rectangle shows, so the picker opens
+	// straight onto the true boundary.
 
-		if !didFrameForSeed {
-			didFrameForSeed = true
-			// Zoom factor: the region must fit the usable area with a small margin.
-			let fitFactor = max(size.width / (usable.width - 24), size.height / (usable.height - 24))
-			let latSpan = (replacing.maxLatitude - replacing.minLatitude) * fitFactor
-			let lonSpan = (replacing.maxLongitude - replacing.minLongitude) * fitFactor
-			// Shift the camera center so the region lands centered in the USABLE
-			// strip (above the panel), not in the full view.
-			let usableMidY = usable.midY / size.height          // 0..1 from top
-			let centerShift = (0.5 - usableMidY) * latSpan      // + moves region up on screen
-			let center = CLLocationCoordinate2D(
-				latitude: (replacing.minLatitude + replacing.maxLatitude) / 2 - centerShift,
-				longitude: (replacing.minLongitude + replacing.maxLongitude) / 2
+	/// Gap between the seeded selection and the usable area's edges.
+	private let seedMargin: CGFloat = 12
+
+	/// Phase one: re-frame the camera so the saved bounds project inside the usable
+	/// area, centered in it. Waits for the control panel's measured height — the
+	/// earlier fallback-height guess left the bounds' bottom edge under the panel.
+	private func frameCameraForSeedIfNeeded(size: CGSize) {
+		guard !didFrameForSeed, !didSeedFromReplacing, let replacing,
+			  size.width > 0, size.height > 0, controlPanelHeight > 0 else { return }
+		let aim = usableRect(in: size).insetBy(dx: seedMargin, dy: seedMargin)
+		guard aim.width > minRectSize, aim.height > minRectSize else { return }
+		didFrameForSeed = true
+
+		// Fit in Web-Mercator space: world units per screen point so the bounds
+		// fill the aim rect, then place the screen center so the bounds center
+		// lands on the aim rect's center (above the panel, inside the margins).
+		let west = (replacing.minLongitude + 180) / 360
+		let east = (replacing.maxLongitude + 180) / 360
+		let top = Self.mercatorY(replacing.maxLatitude)
+		let bottom = Self.mercatorY(replacing.minLatitude)
+		let worldPerPoint = max((east - west) / aim.width, (bottom - top) / aim.height)
+		guard worldPerPoint > 0 else { return }
+		let centerX = (west + east) / 2 + (size.width / 2 - aim.midX) * worldPerPoint
+		let centerY = (top + bottom) / 2 + (size.height / 2 - aim.midY) * worldPerPoint
+		let visibleTopLat = Self.mercatorLat(centerY - size.height / 2 * worldPerPoint)
+		let visibleBottomLat = Self.mercatorLat(centerY + size.height / 2 * worldPerPoint)
+		camera = .region(MKCoordinateRegion(
+			center: CLLocationCoordinate2D(latitude: Self.mercatorLat(centerY), longitude: centerX * 360 - 180),
+			span: MKCoordinateSpan(
+				latitudeDelta: visibleTopLat - visibleBottomLat,
+				longitudeDelta: size.width * worldPerPoint * 360
 			)
-			camera = .region(MKCoordinateRegion(
-				center: center,
-				span: MKCoordinateSpan(latitudeDelta: latSpan, longitudeDelta: lonSpan)
-			))
-			return
-		}
+		))
+	}
 
+	/// Phase two: place the selection exactly on the saved bounds' projected corners.
+	/// Camera-settle (`requireSettled == false`, from the `.onEnd` camera callback)
+	/// takes the conversion as-is; continuous ticks only accept a frame that has
+	/// (nearly) landed on the aim rect, since mid-animation frames overshoot.
+	private func placeSeededSelection(proxy: MapProxy, size: CGSize, requireSettled: Bool) {
+		guard !didSeedFromReplacing, didFrameForSeed, let replacing, gestureStartRect == nil else { return }
 		let northWest = CLLocationCoordinate2D(latitude: replacing.maxLatitude, longitude: replacing.minLongitude)
 		let southEast = CLLocationCoordinate2D(latitude: replacing.minLatitude, longitude: replacing.maxLongitude)
 		guard let topLeft = proxy.convert(northWest, to: .local),
 			  let bottomRight = proxy.convert(southEast, to: .local),
 			  bottomRight.x - topLeft.x > 8, bottomRight.y - topLeft.y > 8 else { return }
-		// Only accept the conversion once the bounds actually landed inside the
-		// usable area (the zoom-out animation may still be settling).
-		guard topLeft.x >= usable.minX - 2, topLeft.y >= usable.minY - 2,
-			  bottomRight.x <= usable.maxX + 2, bottomRight.y <= usable.maxY + 2 else { return }
-		selectionRect = normalizedClamped(topLeft.x, topLeft.y, bottomRight.x, bottomRight.y, in: size)
+		let rect = CGRect(
+			x: topLeft.x, y: topLeft.y,
+			width: bottomRight.x - topLeft.x, height: bottomRight.y - topLeft.y
+		)
+		if requireSettled {
+			let aim = usableRect(in: size).insetBy(dx: seedMargin, dy: seedMargin)
+			guard aim.insetBy(dx: -3, dy: -3).contains(rect),
+				  max(rect.width / aim.width, rect.height / aim.height) > 0.95 else { return }
+		}
+		// The projected boundary, unclamped, so it matches the map exactly. Only a
+		// camera the user disturbed mid-flight can land it outside the usable area;
+		// clamp just that case so the handles stay reachable.
+		if CGRect(origin: .zero, size: size).contains(rect) {
+			selectionRect = rect
+		} else {
+			selectionRect = normalizedClamped(rect.minX, rect.minY, rect.maxX, rect.maxY, in: size)
+		}
 		didSeedFromReplacing = true
+		recompute(proxy: proxy, size: size)
+	}
+
+	/// Web-Mercator Y in [0, 1] for a latitude.
+	private static func mercatorY(_ latitude: Double) -> Double {
+		let lat = min(max(latitude, -85.05112878), 85.05112878) * .pi / 180
+		return (1 - log(tan(lat) + 1 / cos(lat)) / .pi) / 2
+	}
+
+	/// Latitude for a Web-Mercator Y in [0, 1].
+	private static func mercatorLat(_ y: Double) -> Double {
+		atan(sinh(.pi * (1 - 2 * y))) * 180 / .pi
 	}
 
 	private func initRect(size: CGSize) {
 		guard selectionRect == .zero, size.width > 0, size.height > 0 else { return }
+		// Resizing: the selection seeds from the saved bounds once the camera frames
+		// them — don't flash the default rectangle in the meantime.
+		guard replacing == nil || didSeedFromReplacing else { return }
 		let area = usableRect(in: size)
 		selectionRect = (area.width > 120 && area.height > 120) ? area.insetBy(dx: 20, dy: 20) : area
 	}

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
@@ -57,6 +57,8 @@ struct RegionSelectorView: View {
 	@State private var includeTerrain = true
 	/// One-shot: when resizing, the selection seeds from the region's saved bounds.
 	@State private var didSeedFromReplacing = false
+	/// One-shot camera zoom-out so the saved bounds fit inside the selectable area.
+	@State private var didFrameForSeed = false
 	@State private var name: String
 
 	/// The selection rectangle in the picker's local coordinate space (drag/resize target).
@@ -282,15 +284,49 @@ struct RegionSelectorView: View {
 	}
 
 	/// When resizing an existing region, the selection starts as that region's
-	/// saved boundary instead of the default centered rectangle. Runs once, as
-	/// soon as the map proxy can convert coordinates.
+	/// saved boundary instead of the default centered rectangle.
+	///
+	/// Two phases: the initial camera shows the region edge-to-edge, where its
+	/// corners sit outside the selectable area (top/side insets + the control
+	/// panel), and the clamp would squash the seeded rectangle away from the true
+	/// boundary. Phase one zooms the camera out just enough that the saved bounds
+	/// project INSIDE the usable area, centered in it; phase two (a later camera
+	/// tick) converts the corners and places the selection exactly on them.
 	private func seedFromReplacingIfNeeded(proxy: MapProxy, size: CGSize) {
-		guard !didSeedFromReplacing, let replacing else { return }
+		guard !didSeedFromReplacing, let replacing, size.height > 0 else { return }
+		let usable = usableRect(in: size)
+		guard usable.width > minRectSize, usable.height > minRectSize else { return }
+
+		if !didFrameForSeed {
+			didFrameForSeed = true
+			// Zoom factor: the region must fit the usable area with a small margin.
+			let fitFactor = max(size.width / (usable.width - 24), size.height / (usable.height - 24))
+			let latSpan = (replacing.maxLatitude - replacing.minLatitude) * fitFactor
+			let lonSpan = (replacing.maxLongitude - replacing.minLongitude) * fitFactor
+			// Shift the camera center so the region lands centered in the USABLE
+			// strip (above the panel), not in the full view.
+			let usableMidY = usable.midY / size.height          // 0..1 from top
+			let centerShift = (0.5 - usableMidY) * latSpan      // + moves region up on screen
+			let center = CLLocationCoordinate2D(
+				latitude: (replacing.minLatitude + replacing.maxLatitude) / 2 - centerShift,
+				longitude: (replacing.minLongitude + replacing.maxLongitude) / 2
+			)
+			camera = .region(MKCoordinateRegion(
+				center: center,
+				span: MKCoordinateSpan(latitudeDelta: latSpan, longitudeDelta: lonSpan)
+			))
+			return
+		}
+
 		let northWest = CLLocationCoordinate2D(latitude: replacing.maxLatitude, longitude: replacing.minLongitude)
 		let southEast = CLLocationCoordinate2D(latitude: replacing.minLatitude, longitude: replacing.maxLongitude)
 		guard let topLeft = proxy.convert(northWest, to: .local),
 			  let bottomRight = proxy.convert(southEast, to: .local),
 			  bottomRight.x - topLeft.x > 8, bottomRight.y - topLeft.y > 8 else { return }
+		// Only accept the conversion once the bounds actually landed inside the
+		// usable area (the zoom-out animation may still be settling).
+		guard topLeft.x >= usable.minX - 2, topLeft.y >= usable.minY - 2,
+			  bottomRight.x <= usable.maxX + 2, bottomRight.y <= usable.maxY + 2 else { return }
 		selectionRect = normalizedClamped(topLeft.x, topLeft.y, bottomRight.x, bottomRight.y, in: size)
 		didSeedFromReplacing = true
 	}

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
@@ -479,11 +479,11 @@ struct RegionSelectorView: View {
 
 			Toggle(isOn: $includeTerrain) {
 				Text("Include terrain (hillshade and contour data)")
-					.font(.subheadline)
+					.font(.caption)
 			}
 
 			Text("Size of selected map: \(sizeText)")
-				.font(.subheadline)
+				.font(.caption)
 
 			if let warning {
 				Label(warning, systemImage: "exclamationmark.triangle.fill")

--- a/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/Offline/RegionSelectorView.swift
@@ -497,10 +497,21 @@ struct RegionSelectorView: View {
 		isEstimating = false
 	}
 
-	/// Network-accurate size (the exact plan the download uses), or nil when planning
-	/// fails — the caller keeps showing the rough estimate, marked approximate.
-	private static func computeEstimate(bounds: GeoBounds, detail: OfflineMapDetailLevel) async -> Int64? {
-		(try? await PMTilesExtractor().estimate(bounds: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom))?.bytes
+	/// Network-accurate size (the exact plans the download uses), or nil when
+	/// basemap planning fails — the caller keeps showing the rough estimate,
+	/// marked approximate. Terrain planning failure degrades to basemap-only
+	/// rather than losing the whole estimate.
+	private static func computeEstimate(bounds: GeoBounds, detail: OfflineMapDetailLevel, includeTerrain: Bool) async -> Int64? {
+		let extractor = PMTilesExtractor()
+		guard let basemap = (try? await extractor.estimate(bounds: bounds, minZoom: detail.minZoom, maxZoom: detail.maxZoom))?.bytes else {
+			return nil
+		}
+		guard includeTerrain, let terrainURL = URL(string: OfflineMapManager.terrainGlobalArchive) else { return basemap }
+		let terrain = (try? await extractor.makePlan(
+			sourceURL: terrainURL, sourceBuild: "Mapterhorn",
+			bounds: bounds, minZoom: 0, maxZoom: OfflineMapManager.terrainGlobalMaxZoom
+		))?.payloadBytes ?? 0
+		return basemap + terrain
 	}
 
 	private func startDownload() {

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -42,6 +42,11 @@ struct MeshMapMK: View {
 	/// base layer -- so the styled offline box + coverage border work over Standard/Hybrid/Satellite.
 	@AppStorage("enableOfflineTiles") private var enableOfflineTiles = false
 	@AppStorage("enableMapClustering") private var enableMapClustering = true
+	@AppStorage("meshMapShowHillshade") private var showHillshade = false
+	@AppStorage("meshMapShowContours") private var showContours = false
+	/// Contour generation + the shared TerrainStore behind hillshade and contours (spec 018).
+	@StateObject private var terrainContours = TerrainContourProvider()
+	@State private var hillshadeOverlay: HillshadeTileOverlay?
 	/// Hide nodes whose latest position is reduced-precision (the ones drawn with a precision circle).
 	@AppStorage("enableMapPreciseLocationsOnly") private var preciseLocationsOnly = false
 	/// Map overlay configs
@@ -187,6 +192,7 @@ struct MeshMapMK: View {
 		refreshVisiblePositionSnapshots(from: state.positions)
 		syncFallbackLocation()
 		decodeOfflineIfVisible()
+		updateContoursIfNeeded()
 	}
 
 	/// Enabled saved routes drawn as polylines + start/finish markers (parity with the old map).
@@ -678,6 +684,16 @@ struct MeshMapMK: View {
 			}
 			.onChange(of: offlineMapManager.regions) {
 				reloadOfflineSource()
+				refreshTerrainSources()
+			}
+			.onChange(of: showHillshade) {
+				rebuildHillshadeOverlay()
+			}
+			.onChange(of: showContours) {
+				updateContoursIfNeeded()
+			}
+			.onChange(of: colorScheme) {
+				rebuildHillshadeOverlay()
 			}
 			.onChange(of: offlineMapConnectivity.isNetworkAvailable) {
 				rebuildAllMapContent()
@@ -727,6 +743,7 @@ struct MeshMapMK: View {
 			applyTraceRouteSelection()
 			offlineMapManager.loadIfNeeded()
 			reloadOfflineSource()
+			refreshTerrainSources()
 			rebuildOfflineVectorOverlays()
 
 			switch selectedMapLayer {
@@ -1168,6 +1185,53 @@ struct MeshMapMK: View {
 									rebuildOverlays()
 								}
 
+								/// Terrain layer (spec 018): hillshade on standard/offline only; contours on
+								/// every map type, imagery-legible color over hybrid/satellite.
+								private var terrainOverlays: [ClusterMapOverlay] {
+									var result: [ClusterMapOverlay] = []
+									if showHillshade, selectedMapLayer == .standard || selectedMapLayer == .offline, let hillshadeOverlay {
+										result.append(ClusterMapOverlay(id: "terrain-hillshade", overlay: hillshadeOverlay, style: ClusterMapOverlayStyle(level: .aboveRoads)))
+									}
+									if showContours, let geometry = terrainContours.geometry {
+										let imagery = selectedMapLayer == .hybrid || selectedMapLayer == .satellite
+										let minorColor = imagery ? UIColor.white.withAlphaComponent(0.55) : UIColor.brown.withAlphaComponent(0.45)
+										let indexColor = imagery ? UIColor.white.withAlphaComponent(0.9) : UIColor.brown.withAlphaComponent(0.8)
+										var minorStyle = ClusterMapOverlayStyle(strokeUIColor: minorColor, lineWidth: 1)
+										minorStyle.level = .aboveRoads
+										var indexStyle = ClusterMapOverlayStyle(strokeUIColor: indexColor, lineWidth: 1.8)
+										indexStyle.level = .aboveRoads
+										result.append(ClusterMapOverlay(id: "terrain-contours-minor-\(geometry.key.hashValue)", overlay: geometry.minorLines, style: minorStyle))
+										result.append(ClusterMapOverlay(id: "terrain-contours-index-\(geometry.key.hashValue)", overlay: geometry.indexLines, style: indexStyle))
+									}
+									return result
+								}
+
+								/// Re-point the terrain store at downloaded terrain, then refresh dependents.
+								private func refreshTerrainSources() {
+									let sources = offlineMapManager.terrainSources()
+									Task {
+										await terrainContours.store.configure(sources: sources)
+										await MainActor.run {
+											terrainContours.invalidate()
+											rebuildHillshadeOverlay()
+											updateContoursIfNeeded()
+										}
+									}
+								}
+
+								private func rebuildHillshadeOverlay() {
+									guard showHillshade else {
+										hillshadeOverlay = nil
+										return
+									}
+									hillshadeOverlay = HillshadeTileOverlay(store: terrainContours.store, darkAppearance: colorScheme == .dark)
+								}
+
+								private func updateContoursIfNeeded() {
+									guard showContours, isMapVisible, let region = visibleRegion else { return }
+									terrainContours.update(region: region, metric: Locale.current.measurementSystem == .metric)
+								}
+
 								private func combinedMapOverlays() -> [ClusterMapOverlay] {
 									guard isMapVisible else { return [] }
 									// Hide the offline vector basemap while a trace route is shown (jump + flyover) so
@@ -1178,6 +1242,7 @@ struct MeshMapMK: View {
 									result += mapOverlays
 									result += geoJSONOverlays
 									result += geofenceOverlays
+									result += terrainOverlays
 									return result
 								}
 

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -311,9 +311,19 @@ struct MeshMapMK: View {
 		)
 	}
 
-	/// Coverage box for each downloaded region (accent borders + capsules), shown once vectors load.
+	/// Coverage box for each downloaded region (accent borders + capsules). Basemap
+	/// boxes show once vectors load; regions with terrain also show whenever a
+	/// terrain layer is on — hillshade and contours draw over Apple maps even with
+	/// the offline tiles toggle off, and the box must match what actually renders.
 	private var offlineCoverageAreas: [GeoBounds] {
-		offlineVectors.isAvailable ? offlineRegions.map { $0.bounds } : []
+		var boxed = offlineVectors.isAvailable ? offlineRegions : []
+		if showHillshade || showContours {
+			for region in offlineMapManager.regions
+			where region.terrain != nil && !boxed.contains(where: { $0.id == region.id }) {
+				boxed.append(region)
+			}
+		}
+		return boxed.map { $0.bounds }
 	}
 	/// Cheap change-detector for the route set (drives rebuildRouteContent via onChange).
 	/// Change-detector for the waypoint set (rebuild markers on add/remove/move/icon change).
@@ -709,6 +719,10 @@ struct MeshMapMK: View {
 				// Pan/zoom settled: re-filter to the new region now; the state key dedupes
 				// the rebuild when the visible set is unchanged.
 				refreshPositionState()
+				// Contours track the CAMERA, not the node set — regenerate here directly,
+				// or panning with an unchanged visible node set never updates them
+				// (refreshPositionState early-returns before its contour call).
+				updateContoursIfNeeded()
 				// Remember where the user is looking so the map reopens here next launch.
 				persistVisibleRegion()
 			}

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -1224,7 +1224,11 @@ struct MeshMapMK: View {
 										hillshadeOverlay = nil
 										return
 									}
-									hillshadeOverlay = HillshadeTileOverlay(store: terrainContours.store, darkAppearance: colorScheme == .dark)
+									hillshadeOverlay = HillshadeTileOverlay(
+										store: terrainContours.store,
+										darkAppearance: colorScheme == .dark,
+										cacheDirectory: offlineMapManager.terrainHillshadeCacheDirectory(dark: colorScheme == .dark)
+									)
 								}
 
 								private func updateContoursIfNeeded() {
@@ -1251,7 +1255,33 @@ struct MeshMapMK: View {
 									var result = routeDecorations
 									result += tracerouteDecorations
 									result += geoJSONDecorations
+									result += terrainLabelDecorations
 									return result
+								}
+
+								/// Elevation labels for the index contours (display-only).
+								private var terrainLabelDecorations: [ClusterMapDecoration] {
+									guard showContours, let geometry = terrainContours.geometry else { return [] }
+									let imagery = selectedMapLayer == .hybrid || selectedMapLayer == .satellite
+									let text: Color = imagery ? .white : Color(UIColor.brown)
+									return geometry.labels.map { label in
+										ClusterMapDecoration(
+											id: "terrain-label-\(label.id)",
+											coordinate: label.coordinate,
+											content: AnyView(
+												Text(label.text)
+													.font(.caption2.weight(.semibold))
+													.monospacedDigit()
+													.foregroundColor(text)
+													.padding(.horizontal, 4)
+													.padding(.vertical, 1)
+													.background(
+														Capsule().fill(imagery ? Color.black.opacity(0.35) : Color(UIColor.systemBackground).opacity(0.75))
+													)
+													.allowsHitTesting(false)
+											)
+										)
+									}
 								}
 
 								private func rebuildGeoJSONOverlays() {

--- a/MeshtasticTests/ContourGeneratorTests.swift
+++ b/MeshtasticTests/ContourGeneratorTests.swift
@@ -43,6 +43,29 @@ struct ContourGeneratorTests {
 	/// Cone: 500 m peak at the tile center dropping 20 m per sample, resting on
 	/// a 50 m plateau. Crossing levels are 100/200/300/400 with ring radii
 	/// 20/15/10/5 samples — all inside the tile.
+	// Pins the saddle disambiguation rule: high corners NW+SE with a low cell
+	// center must isolate each high corner (top edge pairs with left, bottom with
+	// right). Swapping the rule's branches pairs the opposite edges and fails.
+	@Test func saddleRule_lowCenterIsolatesHighCorners() {
+		let tile = makeTile(size: 2, margin: 0) { x, y in
+			(x == 0 && y == 0) || (x == 1 && y == 1) ? 10 : 2
+		}
+		let lines = ContourGenerator.contours(tile: tile, intervals: ContourIntervals(minor: 6, index: 30))
+		#expect(lines.count == 2)
+		for line in lines {
+			let touchesTop = line.points.contains { $0.y <= 0.01 }
+			let touchesLeft = line.points.contains { $0.x <= 0.01 }
+			let touchesBottom = line.points.contains { $0.y >= 0.49 }
+			let touchesRight = line.points.contains { $0.x >= 0.49 }
+			if touchesTop {
+				#expect(touchesLeft && !touchesRight)
+			}
+			if touchesBottom {
+				#expect(touchesRight && !touchesLeft)
+			}
+		}
+	}
+
 	private func coneTile() -> ElevationTile {
 		makeTile { gridX, gridY in
 			let dx = Double(gridX) - 32
@@ -83,11 +106,12 @@ struct ContourGeneratorTests {
 	// MARK: - Inclined plane
 
 	@Test func inclinedPlane_producesParallelLinesSpanningTheTile() {
-		// 10 m per sample along x: levels 0...600 cross inside the grid.
+		// 10 m per sample along x: positive levels 100...600 cross inside the grid
+		// (level 0 is excluded — sea level never draws a contour).
 		let tile = makeTile { gridX, _ in Float(10 * gridX) }
 		let lines = ContourGenerator.contours(tile: tile, intervals: intervals)
-		#expect(lines.count == 7)
-		#expect(lines.map(\.elevation).sorted() == [0, 100, 200, 300, 400, 500, 600])
+		#expect(lines.count == 6)
+		#expect(lines.map(\.elevation).sorted() == [100, 200, 300, 400, 500, 600])
 		for line in lines {
 			let xValues = line.points.map(\.x)
 			let yValues = line.points.map(\.y)
@@ -103,14 +127,15 @@ struct ContourGeneratorTests {
 	// MARK: - Saddle
 
 	@Test func saddle_producesSanePolylines() {
-		// z = x·y about the cell-centered saddle point (31.5, 31.5); the level-0
-		// contour crosses saddle cells and exercises the midpoint-average rule.
+		// z = x·y + 300 about the cell-centered saddle point (31.5, 31.5); the
+		// 300 m contour crosses saddle cells and exercises the midpoint-average
+		// rule (offset keeps the saddle level positive — sea level never draws).
 		let tile = makeTile { gridX, gridY in
-			Float((Double(gridX) - 31.5) * (Double(gridY) - 31.5))
+			Float((Double(gridX) - 31.5) * (Double(gridY) - 31.5) + 300)
 		}
 		let lines = ContourGenerator.contours(tile: tile, intervals: intervals)
 		#expect(!lines.isEmpty)
-		#expect(lines.contains { $0.elevation == 0 })
+		#expect(lines.contains { $0.elevation == 300 })
 		for line in lines {
 			#expect(line.points.count >= 2)
 			#expect(line.points.allSatisfy { $0.x.isFinite && $0.y.isFinite })

--- a/MeshtasticTests/ContourGeneratorTests.swift
+++ b/MeshtasticTests/ContourGeneratorTests.swift
@@ -1,0 +1,154 @@
+//
+//  ContourGeneratorTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/15/26.
+//
+//  Marching-squares contour generation over synthetic elevation tiles:
+//  flat, cone, inclined plane, saddle, plus the zoom interval table.
+//
+
+import Testing
+import Foundation
+import CoreGraphics
+@testable import Meshtastic
+
+@Suite
+struct ContourGeneratorTests {
+
+	/// Builds a synthetic tile; the closure receives tile-local sample
+	/// coordinates including the margin ring (-margin..<size+margin).
+	private func makeTile(size: Int = 64, margin: Int = 2, elevation: (Int, Int) -> Float) -> ElevationTile {
+		let gridSize = size + 2 * margin
+		var elevations = [Float](repeating: 0, count: gridSize * gridSize)
+		for gridY in 0..<gridSize {
+			for gridX in 0..<gridSize {
+				elevations[gridY * gridSize + gridX] = elevation(gridX - margin, gridY - margin)
+			}
+		}
+		return ElevationTile(z: 12, x: 0, y: 0, size: size, margin: margin, elevations: elevations)
+	}
+
+	private let intervals = ContourIntervals(minor: 100, index: 500)
+
+	// MARK: - Flat
+
+	@Test func flatTile_hasNoContours() {
+		let tile = makeTile { _, _ in 0 }
+		#expect(ContourGenerator.contours(tile: tile, intervals: intervals).isEmpty)
+	}
+
+	// MARK: - Cone
+
+	/// Cone: 500 m peak at the tile center dropping 20 m per sample, resting on
+	/// a 50 m plateau. Crossing levels are 100/200/300/400 with ring radii
+	/// 20/15/10/5 samples — all inside the tile.
+	private func coneTile() -> ElevationTile {
+		makeTile { gridX, gridY in
+			let dx = Double(gridX) - 32
+			let dy = Double(gridY) - 32
+			return Float(max(500 - 20 * (dx * dx + dy * dy).squareRoot(), 50))
+		}
+	}
+
+	@Test func cone_producesOneClosedRingPerLevel() {
+		let lines = ContourGenerator.contours(tile: coneTile(), intervals: intervals)
+		#expect(lines.count == 4)
+		#expect(Set(lines.map(\.elevation)) == [100, 200, 300, 400])
+		for line in lines {
+			#expect(line.points.count > 4)
+			#expect(line.points.first == line.points.last, "ring at \(line.elevation) m should close")
+		}
+	}
+
+	@Test func cone_ringsAreNestedAroundTheCenter() {
+		let lines = ContourGenerator.contours(tile: coneTile(), intervals: intervals)
+			.sorted { $0.elevation < $1.elevation }
+		let radii = lines.map { line in
+			line.points.map { point in
+				let dx = point.x - 0.5
+				let dy = point.y - 0.5
+				return (dx * dx + dy * dy).squareRoot()
+			}.max() ?? 0
+		}
+		for (index, line) in lines.enumerated() {
+			let expected = (500 - line.elevation) / 20 / 64 // ring radius in tile units
+			#expect(abs(radii[index] - expected) < 1.0 / 64)
+			if index > 0 {
+				#expect(radii[index] < radii[index - 1], "higher level should nest inside lower")
+			}
+		}
+	}
+
+	// MARK: - Inclined plane
+
+	@Test func inclinedPlane_producesParallelLinesSpanningTheTile() {
+		// 10 m per sample along x: levels 0...600 cross inside the grid.
+		let tile = makeTile { gridX, _ in Float(10 * gridX) }
+		let lines = ContourGenerator.contours(tile: tile, intervals: intervals)
+		#expect(lines.count == 7)
+		#expect(lines.map(\.elevation).sorted() == [0, 100, 200, 300, 400, 500, 600])
+		for line in lines {
+			let xValues = line.points.map(\.x)
+			let yValues = line.points.map(\.y)
+			// Straight and vertical: constant x at elevation/640 tile units.
+			let expectedX = line.elevation / 640
+			#expect(xValues.allSatisfy { abs($0 - expectedX) < 1e-9 })
+			// Runs through the margin past both tile edges.
+			#expect(yValues.min() ?? 1 <= 0)
+			#expect(yValues.max() ?? 0 >= 1)
+		}
+	}
+
+	// MARK: - Saddle
+
+	@Test func saddle_producesSanePolylines() {
+		// z = x·y about the cell-centered saddle point (31.5, 31.5); the level-0
+		// contour crosses saddle cells and exercises the midpoint-average rule.
+		let tile = makeTile { gridX, gridY in
+			Float((Double(gridX) - 31.5) * (Double(gridY) - 31.5))
+		}
+		let lines = ContourGenerator.contours(tile: tile, intervals: intervals)
+		#expect(!lines.isEmpty)
+		#expect(lines.contains { $0.elevation == 0 })
+		for line in lines {
+			#expect(line.points.count >= 2)
+			#expect(line.points.allSatisfy { $0.x.isFinite && $0.y.isFinite })
+		}
+	}
+
+	// MARK: - Interval table
+
+	@Test func intervalTable_matchesSpecForAllZoomBands() {
+		let foot = 0.3048
+		let cases: [(zoom: Int, metric: (Double, Double), imperial: (Double, Double))] = [
+			(8, (500, 2500), (2000 * foot, 10000 * foot)),
+			(10, (500, 2500), (2000 * foot, 10000 * foot)),
+			(11, (100, 500), (500 * foot, 2500 * foot)),
+			(12, (100, 500), (500 * foot, 2500 * foot)),
+			(13, (50, 250), (200 * foot, 1000 * foot)),
+			(14, (50, 250), (200 * foot, 1000 * foot)),
+			(15, (20, 100), (100 * foot, 500 * foot)),
+			(18, (20, 100), (100 * foot, 500 * foot))
+		]
+		for testCase in cases {
+			let metric = ContourIntervals.intervals(forZoom: testCase.zoom, metric: true)
+			#expect(metric.minor == testCase.metric.0, "zoom \(testCase.zoom) metric minor")
+			#expect(metric.index == testCase.metric.1, "zoom \(testCase.zoom) metric index")
+			let imperial = ContourIntervals.intervals(forZoom: testCase.zoom, metric: false)
+			#expect(abs(imperial.minor - testCase.imperial.0) < 1e-9, "zoom \(testCase.zoom) imperial minor")
+			#expect(abs(imperial.index - testCase.imperial.1) < 1e-9, "zoom \(testCase.zoom) imperial index")
+		}
+	}
+
+	// MARK: - Index flagging
+
+	@Test func indexContours_flaggedOnIndexMultiplesOnly() {
+		let tile = makeTile { gridX, _ in Float(10 * gridX) }
+		let lines = ContourGenerator.contours(tile: tile, intervals: intervals)
+		let line500 = lines.first { $0.elevation == 500 }
+		let line400 = lines.first { $0.elevation == 400 }
+		#expect(line500?.isIndex == true)
+		#expect(line400?.isIndex == false)
+	}
+}

--- a/MeshtasticTests/TerrainDownloadTests.swift
+++ b/MeshtasticTests/TerrainDownloadTests.swift
@@ -1,0 +1,163 @@
+//
+//  TerrainDownloadTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/15/26.
+//
+
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Terrain download")
+struct TerrainDownloadTests {
+
+	/// Seattle-ish bbox that sits inside a single z6 tile.
+	private let bounds = GeoBounds(minLon: -122.5, minLat: 47.3, maxLon: -122.0, maxLat: 47.8)
+
+	private func makeRegion(fileName: String = "\(UUID().uuidString).pmtiles", terrain: OfflineMapTerrain? = nil) -> OfflineMapRegion {
+		OfflineMapRegion(
+			name: "Seattle",
+			fileName: fileName,
+			bounds: bounds,
+			minZoom: 0,
+			maxZoom: 13,
+			fileSize: 1_024,
+			createdDate: Date(timeIntervalSinceReferenceDate: 700_000_000),
+			updatedDate: Date(timeIntervalSinceReferenceDate: 700_000_000),
+			sourceBuild: "20260801",
+			terrain: terrain
+		)
+	}
+
+	// MARK: - Codable
+
+	@Test func regionRoundTripsWithTerrain() throws {
+		let terrain = OfflineMapTerrain(
+			fileName: "abc-terrain.pmtiles",
+			regionalFileName: "abc-terrain-hi.pmtiles",
+			byteCount: 12_345_678,
+			downloadedAt: Date(timeIntervalSinceReferenceDate: 800_000_000),
+			maxZoom: 15
+		)
+		let region = makeRegion(terrain: terrain)
+
+		let data = try JSONEncoder().encode(region)
+		let decoded = try JSONDecoder().decode(OfflineMapRegion.self, from: data)
+
+		#expect(decoded == region)
+		#expect(decoded.terrain?.fileName == "abc-terrain.pmtiles")
+		#expect(decoded.terrain?.regionalFileName == "abc-terrain-hi.pmtiles")
+		#expect(decoded.terrain?.byteCount == 12_345_678)
+		#expect(decoded.terrain?.maxZoom == 15)
+	}
+
+	@Test func regionRoundTripsWithoutTerrain() throws {
+		let region = makeRegion()
+
+		let data = try JSONEncoder().encode(region)
+		let decoded = try JSONDecoder().decode(OfflineMapRegion.self, from: data)
+
+		#expect(decoded == region)
+		#expect(decoded.terrain == nil)
+	}
+
+	@Test func oldManifestWithoutTerrainFieldDecodes() throws {
+		// A manifest entry written before terrain support existed — no `terrain` key.
+		let json = """
+		{
+			"id": "E3B0C442-98FC-1C14-9AFB-F4C8996FB924",
+			"name": "Old Region",
+			"fileName": "old.pmtiles",
+			"minLongitude": -122.5,
+			"minLatitude": 47.3,
+			"maxLongitude": -122.0,
+			"maxLatitude": 47.8,
+			"minZoom": 0,
+			"maxZoom": 13,
+			"fileSize": 2048,
+			"createdDate": 700000000,
+			"updatedDate": 700000000,
+			"sourceBuild": "20260101"
+		}
+		"""
+
+		let decoded = try JSONDecoder().decode(OfflineMapRegion.self, from: Data(json.utf8))
+
+		#expect(decoded.terrain == nil)
+		#expect(decoded.name == "Old Region")
+		#expect(decoded.fileName == "old.pmtiles")
+		#expect(decoded.maxZoom == 13)
+	}
+
+	// MARK: - Regional archive tile math
+
+	@Test func cityScaleBoundsIntersectASingleZ6Tile() {
+		let tiles = OfflineMapManager.z6Tiles(intersecting: bounds)
+
+		#expect(tiles.count == 1)
+		#expect(tiles.first?.x == 10)
+		#expect(tiles.first?.y == 22)
+	}
+
+	@Test func wideBoundsIntersectMultipleZ6Tiles() {
+		// Spans two z6 columns — a z6 tile is 5.625° of longitude.
+		let wide = GeoBounds(minLon: -122.5, minLat: 47.3, maxLon: -116.0, maxLat: 47.8)
+
+		let tiles = OfflineMapManager.z6Tiles(intersecting: wide)
+
+		#expect(tiles.count == 2)
+		#expect(tiles.map { $0.x }.sorted() == [10, 11])
+		#expect(tiles.allSatisfy { $0.y == 22 })
+	}
+
+	// MARK: - File naming
+
+	@Test func terrainFileNamesDeriveFromTheBasemapArchive() {
+		let names = OfflineMapManager.terrainFileNames(forBasemap: "ABC123.pmtiles")
+
+		#expect(names.global == "ABC123-terrain.pmtiles")
+		#expect(names.regional == "ABC123-terrain-hi.pmtiles")
+	}
+
+	// MARK: - Removal
+
+	@MainActor
+	@Test func removeDeletesTerrainFilesWithTheRegion() throws {
+		let manager = OfflineMapManager.shared
+		manager.loadIfNeeded()
+		let dir = try #require(manager.directoryURL())
+
+		let fileName = "\(UUID().uuidString).pmtiles"
+		let names = OfflineMapManager.terrainFileNames(forBasemap: fileName)
+		let basemapURL = dir.appendingPathComponent(fileName)
+		let globalURL = dir.appendingPathComponent(names.global)
+		let regionalURL = dir.appendingPathComponent(names.regional)
+		try Data("basemap".utf8).write(to: basemapURL)
+		try Data("terrain".utf8).write(to: globalURL)
+		try Data("terrain-hi".utf8).write(to: regionalURL)
+
+		let region = makeRegion(
+			fileName: fileName,
+			terrain: OfflineMapTerrain(
+				fileName: names.global,
+				regionalFileName: names.regional,
+				byteCount: 17,
+				downloadedAt: .now,
+				maxZoom: 15
+			)
+		)
+		manager.add(region)
+		defer { manager.remove(region) }
+		#expect(manager.terrainSources().contains { $0.globalURL == globalURL && $0.regionalURL == regionalURL })
+
+		manager.remove(region)
+
+		#expect(!FileManager.default.fileExists(atPath: basemapURL.path))
+		#expect(!FileManager.default.fileExists(atPath: globalURL.path))
+		#expect(!FileManager.default.fileExists(atPath: regionalURL.path))
+		#expect(!manager.regions.contains { $0.id == region.id })
+		#expect(!manager.terrainSources().contains { $0.globalURL == globalURL })
+	}
+}

--- a/MeshtasticTests/TerrariumDecoderTests.swift
+++ b/MeshtasticTests/TerrariumDecoderTests.swift
@@ -1,0 +1,66 @@
+//
+//  TerrariumDecoderTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/16/26.
+//
+
+import Testing
+import Foundation
+import CoreGraphics
+import ImageIO
+@testable import Meshtastic
+
+@Suite("Terrarium decoder")
+struct TerrariumDecoderTests {
+
+	/// Encodes a grid of elevations into a Terrarium-RGB PNG the way Mapterhorn does.
+	private func terrariumPNG(size: Int, elevation: (Int, Int) -> Double) throws -> Data {
+		var rgba = [UInt8](repeating: 255, count: size * size * 4)
+		for y in 0..<size {
+			for x in 0..<size {
+				let value = elevation(x, y) + 32768
+				let r = UInt8(min(max(value / 256, 0), 255))
+				let g = UInt8(min(max(value.truncatingRemainder(dividingBy: 256), 0), 255))
+				let b = UInt8(min(max((value - value.rounded(.down)) * 256, 0), 255))
+				let base = (y * size + x) * 4
+				rgba[base] = r
+				rgba[base + 1] = g
+				rgba[base + 2] = b
+			}
+		}
+		let context = try #require(CGContext(
+			data: &rgba, width: size, height: size, bitsPerComponent: 8, bytesPerRow: size * 4,
+			space: CGColorSpaceCreateDeviceRGB(),
+			bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+		))
+		let image = try #require(context.makeImage())
+		let data = NSMutableData()
+		let destination = try #require(CGImageDestinationCreateWithData(data, "public.png" as CFString, 1, nil))
+		CGImageDestinationAddImage(destination, image, nil)
+		#expect(CGImageDestinationFinalize(destination))
+		return data as Data
+	}
+
+	@Test func pixelFormulaRoundTrips() {
+		// Sea level: R=128, G=0, B=0 → (128*256 + 0 + 0) − 32768 = 0.
+		#expect(TerrariumDecoder.elevation(r: 128, g: 0, b: 0) == 0)
+		// Everest-ish 8848m: 41616 = 162*256 + 144.
+		#expect(TerrariumDecoder.elevation(r: 162, g: 144, b: 0) == 8848)
+		// Below sea level: -32768 at all zeros.
+		#expect(TerrariumDecoder.elevation(r: 0, g: 0, b: 0) == -32768)
+	}
+
+	@Test func decodesEncodedTile() throws {
+		let png = try terrariumPNG(size: 16) { x, y in Double(x * 10 + y) }
+		let decoded = try #require(TerrariumDecoder.decode(tileData: png))
+		#expect(decoded.size == 16)
+		#expect(abs(decoded.elevations[0] - 0) < 0.01)
+		#expect(abs(decoded.elevations[5 * 16 + 3] - 35) < 0.01)
+		#expect(abs(decoded.elevations[15 * 16 + 15] - 165) < 0.01)
+	}
+
+	@Test func rejectsGarbage() {
+		#expect(TerrariumDecoder.decode(tileData: Data([0, 1, 2, 3])) == nil)
+	}
+}

--- a/MeshtasticTests/TerrariumDecoderTests.swift
+++ b/MeshtasticTests/TerrariumDecoderTests.swift
@@ -29,12 +29,13 @@ struct TerrariumDecoderTests {
 				rgba[base + 2] = b
 			}
 		}
-		let context = try #require(CGContext(
-			data: &rgba, width: size, height: size, bitsPerComponent: 8, bytesPerRow: size * 4,
-			space: CGColorSpaceCreateDeviceRGB(),
-			bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
-		))
-		let image = try #require(context.makeImage())
+		let image: CGImage = try #require(rgba.withUnsafeMutableBytes { buffer in
+			CGContext(
+				data: buffer.baseAddress, width: size, height: size, bitsPerComponent: 8, bytesPerRow: size * 4,
+				space: CGColorSpaceCreateDeviceRGB(),
+				bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+			)?.makeImage()
+		})
 		let data = NSMutableData()
 		let destination = try #require(CGImageDestinationCreateWithData(data, "public.png" as CFString, 1, nil))
 		CGImageDestinationAddImage(destination, image, nil)


### PR DESCRIPTION
## Summary

Implements specs/018-offline-terrain-layer (spec kit in #2304): offline map regions now download Mapterhorn elevation data alongside the basemap, and the map renders hillshade and contour lines from it — fully offline, MapKit-native, no MapLibre.

## What changed

- Offline downloads run a second bbox extract against Mapterhorn's PMTiles archives (global z0–12; the z13–15 regional archive when one covers the area), reusing the existing range-request extractor. Terrain failure never rolls back the basemap and is retryable; existing regions get an Add Terrain action; deleting a region removes its terrain and caches; terrain bytes count toward totals and limits.
- TerrariumDecoder + TerrainStore decode elevation grids off the main actor with neighbor margins for seamless tile edges and bilinear overzoom above the archived zoom.
- Hillshade: Horn shading computed per tile on device, served as a raster MKTileOverlay; shadows-only output with per-appearance strength; transparent outside coverage. Renders on standard and offline maps only.
- Contours: marching-squares generation batched into two MKMultiPolylines (minor/index), intervals adapting to zoom per the spec table (metric or imperial by locale), imagery-legible color on hybrid/satellite where they're the sole terrain treatment.
- Map settings gain Hillshade and Contour Lines toggles, disabled until a region has terrain. Mapterhorn attribution shows in the offline maps list.

## Known gaps against the spec (follow-ups)

Contour elevation labels (FR-005 labels the lines; rendering draws them unlabeled for now), disk caching of generated hillshade tiles (in-memory via MapKit tile reuse today), and user docs (docs/user/map.md) before merge or as a fast follow.

## Testing

18 tests in 4 suites: Terrarium decode round-trips, marching squares against synthetic DEMs (cone/plane/saddle), interval table, region metadata Codable compatibility with old manifests, z6 archive selection, and terrain file cleanup on region delete. Additionally verified end to end locally against the live Mapterhorn archive: extracted a Cascades bbox, decoded real relief, rendered a hillshade tile with actual shadow content, exercised the overzoom path, and generated contours with index lines. iOS and tvOS schemes both build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional terrain downloads for offline map regions, including size, zoom, and source details.
  * Added offline hillshade overlays for improved terrain visualization.
  * Added contour lines with minor and index elevation lines.
  * Added map settings to enable or disable hillshade and contour lines.
  * Added terrain actions to offline map details and list views.
* **Bug Fixes**
  * Improved rendering of raster map tile overlays.
  * Terrain data is removed when its associated offline map region is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->