### PR TITLE
fix(tvos): keep map stats within bounds

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -9941,6 +9941,9 @@
         }
       }
     },
+    "Air TX": {
+      "comment": "Metric label for airtime used to transmit packets."
+    },
     "Air Quality": {
       "comment": "Node detail section header for particulate-matter air quality readings."
     },

--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -61,7 +61,7 @@ struct MapScreen: View {
 						storeOnlineCount: allNodes.filter(\.isOnline).count,
 						storeTotalCount: allNodes.count
 					)
-					.padding(.vertical, TVTheme.statsStripMargin)
+					.padding(TVTheme.statsStripMargin)
 				}
 			}
 		}

--- a/Meshtastic TV/App/TVTheme.swift
+++ b/Meshtastic TV/App/TVTheme.swift
@@ -36,4 +36,18 @@ enum TVTheme {
 	/// (.ignoresSafeArea), so the strip supplies its own distance from the
 	/// screen edge — kept tight so the strip hugs the edge it's pinned to.
 	static let statsStripMargin: CGFloat = 24
+
+	/// Mesh stats strip layout.
+	static let statsStripColumnSpacing: CGFloat = 24
+	static let statsStripMetricSpacing: CGFloat = 6
+	static let statsStripPacketSpacing: CGFloat = 10
+	static let statsStripNodesWidth: CGFloat = 230
+	static let statsStripUtilizationWidth: CGFloat = 180
+	static let statsStripPacketsWidth: CGFloat = 439
+	static let statsStripHorizontalPadding: CGFloat = 48
+	static let statsStripVerticalPadding: CGFloat = 28
+	static let statsStripCornerRadius: CGFloat = 24
+	static let statsStripDividerWidth: CGFloat = 1
+	static let statsStripDividerHeight: CGFloat = 104
+	static let statsStripMetadataHeight: CGFloat = 27.5
 }

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -29,65 +29,118 @@ struct MeshStatsStrip: View {
 
 	@ScaledMetric(relativeTo: .caption) private var labelSize: CGFloat = 30
 	@ScaledMetric(relativeTo: .title) private var valueSize: CGFloat = 64
+	@ScaledMetric(relativeTo: .caption2) private var metadataSize: CGFloat = 22
 
 	var body: some View {
-		HStack(spacing: 56) {
+		HStack(spacing: 24) {
 			cell(label: "Nodes", value: nodesText)
+				.frame(idealWidth: 230, maxWidth: 230)
 
 			divider
 			cell(label: "Ch Util", value: percentText(stats?.channelUtilization), color: channelUtilColor)
+				.frame(idealWidth: 180, maxWidth: 180)
 
 			divider
 			cell(label: "Air TX", value: percentText(stats?.airUtilTx), color: airTxColor)
+				.frame(idealWidth: 180, maxWidth: 180)
 
 			divider
-			cell(label: "Packets", value: packetsText)
-
-			if let dupes = stats?.packetsRxDupe {
-				divider
-				cell(label: "Dupes", value: dupes.formatted())
-			}
-
-			if let receivedAt = stats?.receivedAt {
-				divider
-				VStack(alignment: .leading, spacing: 6) {
-					Text("Updated")
-						.font(.system(size: labelSize, weight: .medium))
-						.tracking(1.2)
-						.textCase(.uppercase)
-						.foregroundStyle(Color.gray)
-					Text(receivedAt, style: .relative)
-						.font(.system(size: valueSize, weight: .semibold, design: .rounded).monospacedDigit())
-				}
-			}
+			packetsCell
+				.frame(idealWidth: 439, maxWidth: .infinity)
 		}
-		.padding(.horizontal, 64)
-		.padding(.vertical, 36)
+		.padding(.horizontal, 48)
+		.padding(.vertical, 28)
+		.frame(maxWidth: .infinity)
 		.background(
 			RoundedRectangle(cornerRadius: 24, style: .continuous)
 				.fill(.regularMaterial)
 		)
+		.clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
 		.overlay(
 			RoundedRectangle(cornerRadius: 24, style: .continuous)
 				.stroke(.white.opacity(0.15), lineWidth: 1)
 		)
 		.shadow(color: .black.opacity(0.4), radius: 18, y: 8)
-		.fixedSize()
 	}
 
 	// MARK: Cells
 
 	private func cell(label: String, value: String, color: Color = .primary) -> some View {
 		VStack(alignment: .leading, spacing: 6) {
-			Text(label)
-				.font(.system(size: labelSize, weight: .medium))
-				.tracking(1.2)
-				.textCase(.uppercase)
-				.foregroundStyle(Color.gray)
-			Text(value)
-				.font(.system(size: valueSize, weight: .semibold, design: .rounded).monospacedDigit())
-				.foregroundStyle(color)
+			metricLabel(label)
+			metricValue(value, color: color)
 		}
+		.frame(maxWidth: .infinity, alignment: .leading)
+	}
+
+	private var packetsCell: some View {
+		VStack(alignment: .leading, spacing: 6) {
+			metricLabel("Packets")
+			packetCounts
+			packetMetadata
+				.font(.system(size: metadataSize, weight: .medium, design: .rounded))
+				.monospacedDigit()
+				.foregroundStyle(.secondary)
+				.lineLimit(1)
+				.minimumScaleFactor(0.75)
+				.frame(height: metadataSize * 1.25)
+		}
+		.frame(maxWidth: .infinity, alignment: .leading)
+	}
+
+	@ViewBuilder
+	private var packetCounts: some View {
+		if let tx = stats?.packetsTx, let rx = stats?.packetsRx {
+			HStack(spacing: 10) {
+				packetCount(tx, arrow: "↑")
+				packetCount(rx, arrow: "↓")
+			}
+		} else {
+			metricValue("—", scale: 0.8)
+		}
+	}
+
+	private func packetCount(_ value: UInt32, arrow: String) -> some View {
+		Text("\(value.formatted()) \(arrow)")
+			.font(.system(size: valueSize * 0.8, weight: .semibold, design: .rounded).monospacedDigit())
+			.lineLimit(1)
+			.minimumScaleFactor(0.3)
+			.frame(maxWidth: .infinity, alignment: .leading)
+	}
+
+	@ViewBuilder
+	private var packetMetadata: some View {
+		if let stats {
+			HStack(spacing: 10) {
+				if let dupes = stats.packetsRxDupe {
+					Text("\(dupes.formatted()) dupes")
+					Text("·")
+				}
+				Text("Updated")
+				Text(stats.receivedAt, style: .relative)
+			}
+		} else {
+			Text("Updated —")
+				.hidden()
+		}
+	}
+
+	private func metricLabel(_ text: String) -> some View {
+		Text(text)
+			.font(.system(size: labelSize, weight: .medium))
+			.tracking(1.2)
+			.textCase(.uppercase)
+			.foregroundStyle(Color.gray)
+			.lineLimit(1)
+			.minimumScaleFactor(0.8)
+	}
+
+	private func metricValue(_ text: String, color: Color = .primary, scale: CGFloat = 1) -> some View {
+		Text(text)
+			.font(.system(size: valueSize * scale, weight: .semibold, design: .rounded).monospacedDigit())
+			.foregroundStyle(color)
+			.lineLimit(1)
+			.minimumScaleFactor(0.5)
 	}
 
 	private var divider: some View {
@@ -105,11 +158,6 @@ struct MeshStatsStrip: View {
 			return "\(online) / \(total)"
 		}
 		return "\(storeOnlineCount) / \(storeTotalCount)"
-	}
-
-	private var packetsText: String {
-		guard let tx = stats?.packetsTx, let rx = stats?.packetsRx else { return "—" }
-		return "\(tx.formatted()) ↑ · \(rx.formatted()) ↓"
 	}
 
 	private func percentText(_ value: Float?) -> String {
@@ -132,7 +180,7 @@ struct MeshStatsStrip: View {
 	}
 }
 
-#Preview("All cells", traits: .fixedLayout(width: 1400, height: 300)) {
+#Preview("All cells", traits: .fixedLayout(width: 1240, height: 300)) {
 	ZStack {
 		Color.gray
 		MeshStatsStrip(
@@ -152,9 +200,29 @@ struct MeshStatsStrip: View {
 	}
 }
 
-#Preview("No telemetry yet", traits: .fixedLayout(width: 1400, height: 300)) {
+#Preview("No telemetry yet", traits: .fixedLayout(width: 1240, height: 300)) {
 	ZStack {
 		Color.gray
 		MeshStatsStrip(stats: nil, storeOnlineCount: 12, storeTotalCount: 40)
+	}
+}
+
+#Preview("Maximum packet counters", traits: .fixedLayout(width: 1240, height: 300)) {
+	ZStack {
+		Color.gray
+		MeshStatsStrip(
+			stats: MeshClient.ConnectedNodeStats(
+				channelUtilization: 99.9,
+				airUtilTx: 10,
+				packetsTx: .max,
+				packetsRx: .max,
+				packetsRxDupe: .max,
+				onlineNodes: 9_999,
+				totalNodes: 9_999,
+				receivedAt: Date()
+			),
+			storeOnlineCount: 9_999,
+			storeTotalCount: 9_999
+		)
 	}
 }

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -27,37 +27,36 @@ struct MeshStatsStrip: View {
 	let storeOnlineCount: Int
 	let storeTotalCount: Int
 
-	@ScaledMetric(relativeTo: .caption) private var labelSize: CGFloat = 30
-	@ScaledMetric(relativeTo: .title) private var valueSize: CGFloat = 64
-	@ScaledMetric(relativeTo: .caption2) private var metadataSize: CGFloat = 22
+	@ScaledMetric(relativeTo: .caption2)
+	private var metadataHeight: CGFloat = TVTheme.statsStripMetadataHeight
 
 	var body: some View {
-		HStack(spacing: 24) {
+		HStack(spacing: TVTheme.statsStripColumnSpacing) {
 			cell(label: "Nodes", value: nodesText)
-				.frame(idealWidth: 230, maxWidth: 230)
+				.frame(idealWidth: TVTheme.statsStripNodesWidth, maxWidth: TVTheme.statsStripNodesWidth)
 
 			divider
 			cell(label: "Ch Util", value: percentText(stats?.channelUtilization), color: channelUtilColor)
-				.frame(idealWidth: 180, maxWidth: 180)
+				.frame(idealWidth: TVTheme.statsStripUtilizationWidth, maxWidth: TVTheme.statsStripUtilizationWidth)
 
 			divider
 			cell(label: "Air TX", value: percentText(stats?.airUtilTx), color: airTxColor)
-				.frame(idealWidth: 180, maxWidth: 180)
+				.frame(idealWidth: TVTheme.statsStripUtilizationWidth, maxWidth: TVTheme.statsStripUtilizationWidth)
 
 			divider
 			packetsCell
-				.frame(idealWidth: 439, maxWidth: .infinity)
+				.frame(idealWidth: TVTheme.statsStripPacketsWidth, maxWidth: .infinity)
 		}
-		.padding(.horizontal, 48)
-		.padding(.vertical, 28)
+		.padding(.horizontal, TVTheme.statsStripHorizontalPadding)
+		.padding(.vertical, TVTheme.statsStripVerticalPadding)
 		.frame(maxWidth: .infinity)
 		.background(
-			RoundedRectangle(cornerRadius: 24, style: .continuous)
+			RoundedRectangle(cornerRadius: TVTheme.statsStripCornerRadius, style: .continuous)
 				.fill(.regularMaterial)
 		)
-		.clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+		.clipShape(RoundedRectangle(cornerRadius: TVTheme.statsStripCornerRadius, style: .continuous))
 		.overlay(
-			RoundedRectangle(cornerRadius: 24, style: .continuous)
+			RoundedRectangle(cornerRadius: TVTheme.statsStripCornerRadius, style: .continuous)
 				.stroke(.white.opacity(0.15), lineWidth: 1)
 		)
 		.shadow(color: .black.opacity(0.4), radius: 18, y: 8)
@@ -65,8 +64,8 @@ struct MeshStatsStrip: View {
 
 	// MARK: Cells
 
-	private func cell(label: String, value: String, color: Color = .primary) -> some View {
-		VStack(alignment: .leading, spacing: 6) {
+	private func cell(label: LocalizedStringKey, value: String, color: Color = .primary) -> some View {
+		VStack(alignment: .leading, spacing: TVTheme.statsStripMetricSpacing) {
 			metricLabel(label)
 			metricValue(value, color: color)
 		}
@@ -74,16 +73,15 @@ struct MeshStatsStrip: View {
 	}
 
 	private var packetsCell: some View {
-		VStack(alignment: .leading, spacing: 6) {
+		VStack(alignment: .leading, spacing: TVTheme.statsStripMetricSpacing) {
 			metricLabel("Packets")
 			packetCounts
 			packetMetadata
-				.font(.system(size: metadataSize, weight: .medium, design: .rounded))
-				.monospacedDigit()
+				.font(.caption2.weight(.medium).monospacedDigit())
 				.foregroundStyle(.secondary)
 				.lineLimit(1)
 				.minimumScaleFactor(0.75)
-				.frame(height: metadataSize * 1.25)
+				.frame(height: metadataHeight)
 		}
 		.frame(maxWidth: .infinity, alignment: .leading)
 	}
@@ -91,18 +89,18 @@ struct MeshStatsStrip: View {
 	@ViewBuilder
 	private var packetCounts: some View {
 		if let tx = stats?.packetsTx, let rx = stats?.packetsRx {
-			HStack(spacing: 10) {
+			HStack(spacing: TVTheme.statsStripPacketSpacing) {
 				packetCount(tx, arrow: "↑")
 				packetCount(rx, arrow: "↓")
 			}
 		} else {
-			metricValue("—", scale: 0.8)
+			metricValue("—", font: .title2)
 		}
 	}
 
 	private func packetCount(_ value: UInt32, arrow: String) -> some View {
 		Text("\(value.formatted()) \(arrow)")
-			.font(.system(size: valueSize * 0.8, weight: .semibold, design: .rounded).monospacedDigit())
+			.font(.title2.weight(.semibold).monospacedDigit())
 			.lineLimit(1)
 			.minimumScaleFactor(0.3)
 			.frame(maxWidth: .infinity, alignment: .leading)
@@ -111,7 +109,7 @@ struct MeshStatsStrip: View {
 	@ViewBuilder
 	private var packetMetadata: some View {
 		if let stats {
-			HStack(spacing: 10) {
+			HStack(spacing: TVTheme.statsStripPacketSpacing) {
 				if let dupes = stats.packetsRxDupe {
 					Text("\(dupes.formatted()) dupes")
 					Text("·")
@@ -125,9 +123,9 @@ struct MeshStatsStrip: View {
 		}
 	}
 
-	private func metricLabel(_ text: String) -> some View {
+	private func metricLabel(_ text: LocalizedStringKey) -> some View {
 		Text(text)
-			.font(.system(size: labelSize, weight: .medium))
+			.font(.caption.weight(.medium))
 			.tracking(1.2)
 			.textCase(.uppercase)
 			.foregroundStyle(Color.gray)
@@ -135,9 +133,9 @@ struct MeshStatsStrip: View {
 			.minimumScaleFactor(0.8)
 	}
 
-	private func metricValue(_ text: String, color: Color = .primary, scale: CGFloat = 1) -> some View {
+	private func metricValue(_ text: String, color: Color = .primary, font: Font = .title) -> some View {
 		Text(text)
-			.font(.system(size: valueSize * scale, weight: .semibold, design: .rounded).monospacedDigit())
+			.font(font.weight(.semibold).monospacedDigit())
 			.foregroundStyle(color)
 			.lineLimit(1)
 			.minimumScaleFactor(0.5)
@@ -146,7 +144,7 @@ struct MeshStatsStrip: View {
 	private var divider: some View {
 		Rectangle()
 			.fill(.secondary.opacity(0.4))
-			.frame(width: 1, height: 104)
+			.frame(width: TVTheme.statsStripDividerWidth, height: TVTheme.statsStripDividerHeight)
 	}
 
 	// MARK: Values

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		6CABB3DA5BDD75359320B657 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 985D21086E966D40C875F3CD /* InfoPlist.strings */; };
 		7443E9D2180568F2E62EDAB6 /* AppIcon_Ham.icon in Resources */ = {isa = PBXBuildFile; fileRef = DD9ED0AFED536B2EE5F32F23 /* AppIcon_Ham.icon */; };
 		78B74168A96E756F203F9D13 /* AppIcon_Chirpy.icon in Resources */ = {isa = PBXBuildFile; fileRef = DD8FE67D6F2C7F041F8E3C8C /* AppIcon_Chirpy.icon */; };
+		824834E7CD284E868BB3DDFF /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 26351F51CD01C94D8D82486A /* Localizable.xcstrings */; };
 		8DFCC830624F2D4607E87938 /* MBTilesArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82B439BEF9740A80E66097A /* MBTilesArchive.swift */; };
 		94F9F3199DB5429EBF21F9E9 /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0875C7B0694DBE671437CC1A /* Connection.swift */; };
 		977E69BC7382DA7EF386402F /* TCPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA5EE6E2E5628082C9CF53F /* TCPConnection.swift */; };
@@ -1104,6 +1105,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				824834E7CD284E868BB3DDFF /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project.yml
+++ b/project.yml
@@ -649,6 +649,7 @@ targets:
         type: syncedFolder
         excludes:
           - "Info.plist"
+      - path: "Localizable.xcstrings"
       # Reused portable transport primitives (Network.framework only, no UIKit/BLE/CoreLocation).
       # Explicit files rather than the whole Accessory folder so we do NOT pull in the
       # BLE/AccessoryManager/persistence stack. AccessoryError + NONCE_* are shimmed locally


### PR DESCRIPTION
## What changed?

- Keep the tvOS mesh stats strip inside the map column with full edge padding.
- Use four compressible metric cells and place duplicate/update metadata below packet counts.
- Scale TX and RX counts independently so growing values remain visible.

## Why did it change?

Large replay packet totals could truncate or push the stats strip beneath the left menu.

## How is this tested?

- Signed physical-device `Meshtastic TV` build with `xcodebuild`
- SwiftLint on both changed files: 0 violations
- Installed and visually checked on the Basement Apple TV with an 818-node replay
- Confirmed full six-digit packet counts and the final TX/RX presentation on device

## Screenshots/Videos (when applicable)
<img width="1920" height="1080" alt="tvos-stats-before-small" src="https://github.com/user-attachments/assets/bf9d7e11-2d60-4b5a-9294-3a88f143004a" />

<img width="1920" height="1080" alt="tvos-stats-after-small" src="https://github.com/user-attachments/assets/720b7479-3810-437f-863f-bd95576afc95" />


## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation. No documentation change is needed for this focused tvOS layout fix.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Improved the mesh statistics strip layout for better responsiveness and clipping on TV screens.
  - Packet transmit/receive counts, duplicate packets, and recent update times are now displayed in clearly separated sections.
  - Added placeholders when telemetry data is unavailable.
  - Standardized metric labels and values for more consistent sizing and styling.
  - Adjusted map screen spacing and refined statistics previews, including support for large counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->