### PR TITLE
fix(tvos): prevent clipped map control focus

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -136,6 +136,8 @@ struct MapScreen: View {
 					Text("\(allNodes.count) nodes · \(locatedNodes.count) on map")
 				}
 			}
+			// Focused tvOS controls grow beyond their rows; keep them inside the List's clip.
+			.contentMargins(.horizontal, 16, for: .scrollContent)
 			.onChange(of: focusedNodeNum) { _, newValue in
 				if let newValue { selectedNodeNum = newValue }
 			}

--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -137,7 +137,7 @@ struct MapScreen: View {
 				}
 			}
 			// Focused tvOS controls grow beyond their rows; keep them inside the List's clip.
-			.contentMargins(.horizontal, 16, for: .scrollContent)
+			.contentMargins(.horizontal, TVTheme.nodeListContentMargin, for: .scrollContent)
 			.onChange(of: focusedNodeNum) { _, newValue in
 				if let newValue { selectedNodeNum = newValue }
 			}

--- a/Meshtastic TV/App/TVTheme.swift
+++ b/Meshtastic TV/App/TVTheme.swift
@@ -16,6 +16,9 @@ enum TVTheme {
 	/// Node side-list column width on the map screen.
 	static let sideListWidth: CGFloat = 520
 
+	/// Horizontal inset that keeps focused node-list controls inside the List clip.
+	static let nodeListContentMargin: CGFloat = 16
+
 	/// Node avatar (circle) diameters.
 	static let listAvatarSize: CGFloat = 56
 	static let detailAvatarSize: CGFloat = 68


### PR DESCRIPTION
## What changed?

Added horizontal scroll-content margins to the tvOS node/map list so focused map controls have room to expand.

## Why did it change?

The right side of Re-center Map, Settings, and Disconnect was clipped when focused. This applies the same container-margin fix used for tvOS focus clipping in PR #2299.

## How is this tested?

- Built the Meshtastic TV scheme for a tvOS simulator.
- Ran SwiftLint on `Meshtastic TV/App/MapScreen.swift` with no violations.
- Built, installed, and launched the change on a physical Apple TV.
- Confirmed all three focused controls render without clipping.

## Screenshots/Videos (when applicable)

Not included; no hardware capture is available. Verified on a physical Apple TV.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
