### PR TITLE
Fix offline water rendering: island holes and missing rivers

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/PMTilesMapView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/PMTilesMapView.swift
@@ -479,15 +479,16 @@ extension OfflineVectorTileProvider {
 			guard let kind, parkKinds.contains(kind) else { continue } // parks only, skip generic land
 			appendPolygons(feature.geometry, role: .park, bounds: bounds, into: &polys, id: nextID)
 		}
+		// The water layer carries every polygonal water body (ocean, lake, dock,
+		// reef, basin…) plus river/stream/canal CENTERLINES as LineStrings — in
+		// current basemap builds there is no separate physical_line layer, so
+		// waterway lines must come from here too or narrow rivers render as land.
 		for feature in vector.features(for: "water") {
 			appendPolygons(feature.geometry, role: .water, bounds: bounds, into: &polys, id: nextID)
-		}
-		// Rivers and streams as centerlines — narrower waterways have no polygon
-		// in the water layer and vanished entirely without these.
-		for feature in vector.features(for: "physical_line") {
 			let kind = (feature.properties["kind"] as? String) ?? (feature.properties["pmap:kind"] as? String)
-			guard kind == "river" || kind == "stream" || kind == "canal" else { continue }
-			appendPolylines(feature.geometry, role: .river, bounds: bounds, into: &lines, id: nextID)
+			if kind == "river" || kind == "stream" || kind == "canal" {
+				appendPolylines(feature.geometry, role: .river, bounds: bounds, into: &lines, id: nextID)
+			}
 		}
 		// All roads (incl. the residential/neighborhood street grid); footpaths are still skipped.
 		for feature in vector.features(for: "roads") {

--- a/Meshtastic/Views/Nodes/Helpers/Map/PMTilesMapView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/PMTilesMapView.swift
@@ -27,7 +27,7 @@ import Combine
 /// Semantic role for an offline vector feature, mapped to a color/width at render time so a single
 /// decode serves both light and dark appearance.
 enum OfflineFeatureRole {
-	case water, park, green, land
+	case water, park, green, land, river
 	case majorRoad, mediumRoad, minorRoad, path, rail, boundary
 }
 
@@ -35,6 +35,9 @@ struct OfflineMapPolygon: Identifiable {
 	let id: String
 	let role: OfflineFeatureRole
 	let coordinates: [CLLocationCoordinate2D]
+	/// Interior rings (holes) — islands in a lake, clearings in a park. Rendered
+	/// via MKPolygon(interiorPolygons:); dropping them floods islands solid.
+	var interiorRings: [[CLLocationCoordinate2D]] = []
 }
 
 struct OfflineMapPolyline: Identifiable {
@@ -231,7 +234,7 @@ final class OfflineVectorTileProvider: ObservableObject {
 	}
 
 	/// Painter's order for stitched road layers (earlier = underneath).
-	nonisolated private static let roadDrawOrder: [OfflineFeatureRole] = [.path, .minorRoad, .mediumRoad, .majorRoad, .rail, .boundary]
+	nonisolated private static let roadDrawOrder: [OfflineFeatureRole] = [.river, .path, .minorRoad, .mediumRoad, .majorRoad, .rail, .boundary]
 
 	/// Drop fills whose bounding box is smaller than this (meters) — invisible slivers/clutter.
 	nonisolated static let defaultMinFillMeters: Double = 40
@@ -479,6 +482,13 @@ extension OfflineVectorTileProvider {
 		for feature in vector.features(for: "water") {
 			appendPolygons(feature.geometry, role: .water, bounds: bounds, into: &polys, id: nextID)
 		}
+		// Rivers and streams as centerlines — narrower waterways have no polygon
+		// in the water layer and vanished entirely without these.
+		for feature in vector.features(for: "physical_line") {
+			let kind = (feature.properties["kind"] as? String) ?? (feature.properties["pmap:kind"] as? String)
+			guard kind == "river" || kind == "stream" || kind == "canal" else { continue }
+			appendPolylines(feature.geometry, role: .river, bounds: bounds, into: &lines, id: nextID)
+		}
 		// All roads (incl. the residential/neighborhood street grid); footpaths are still skipped.
 		for feature in vector.features(for: "roads") {
 			let kind = (feature.properties["kind"] as? String) ?? (feature.properties["pmap:kind"] as? String)
@@ -512,19 +522,25 @@ extension OfflineVectorTileProvider {
 	nonisolated private static let simplifyEpsilon = 0.00008
 
 	nonisolated private static func appendPolygons(_ geometry: GISTools.GeoJsonGeometry, role: OfflineFeatureRole, bounds: GeoBounds?, into polys: inout [OfflineMapPolygon], id: () -> String) {
-		func add(_ ring: [GISTools.Coordinate3D]) {
+		func prepared(_ ring: [GISTools.Coordinate3D]) -> [CLLocationCoordinate2D]? {
 			var coords = ring.map(coord)
 			if let bounds { coords = clipPolygon(coords, to: bounds) }
 			coords = simplify(coords, epsilon: simplifyEpsilon)
-			guard coords.count >= 3 else { return }
-			polys.append(OfflineMapPolygon(id: id(), role: role, coordinates: coords))
+			return coords.count >= 3 ? coords : nil
+		}
+		func add(_ rings: [[GISTools.Coordinate3D]]) {
+			guard let outerRing = rings.first, let outer = prepared(outerRing) else { return }
+			// Interior rings are holes (islands in water, clearings in parks) —
+			// dropping them painted islands solid blue.
+			let interiors = rings.dropFirst().compactMap(prepared)
+			polys.append(OfflineMapPolygon(id: id(), role: role, coordinates: outer, interiorRings: interiors))
 		}
 		switch geometry {
 		case let polygon as GISTools.Polygon:
-			if let outer = polygon.rings.first?.coordinates { add(outer) }
+			add(polygon.rings.map(\.coordinates))
 		case let multi as GISTools.MultiPolygon:
 			for polygon in multi.polygons {
-				if let outer = polygon.rings.first?.coordinates { add(outer) }
+				add(polygon.rings.map(\.coordinates))
 			}
 		default:
 			break
@@ -720,6 +736,11 @@ enum OfflineMapPalette {
 		case .land: return earth(dark: dark)
 		default: return nil
 		}
+	}
+
+	/// River/stream centerline stroke — the water fill color, fully opaque.
+	static func riverStroke(dark: Bool) -> UIColor {
+		fill(.water, dark: dark) ?? .systemBlue
 	}
 
 	/// Road fill: white centerline (light) or a lighter-than-land gray (dark).

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -1537,7 +1537,13 @@ struct MeshMapMK: View {
 			let shapes = polys.compactMap { poly -> MKPolygon? in
 				guard poly.coordinates.count >= 3 else { return nil }
 				var coords = poly.coordinates
-				return MKPolygon(coordinates: &coords, count: coords.count)
+				// Interior rings punch holes (islands in water, clearings in parks).
+				let holes = poly.interiorRings.compactMap { ring -> MKPolygon? in
+					guard ring.count >= 3 else { return nil }
+					var holeCoords = ring
+					return MKPolygon(coordinates: &holeCoords, count: holeCoords.count)
+				}
+				return MKPolygon(coordinates: &coords, count: coords.count, interiorPolygons: holes.isEmpty ? nil : holes)
 			}
 			guard !shapes.isEmpty else { continue }
 			result.append(ClusterMapOverlay(
@@ -1547,8 +1553,25 @@ struct MeshMapMK: View {
 			))
 		}
 
+		// 2b) Rivers/streams as centerlines, under the road network.
+		let linesByRole = Dictionary(grouping: offlineVectors.roads, by: { $0.role })
+		if let rivers = linesByRole[.river] {
+			let shapes = rivers.compactMap { line -> MKPolyline? in
+				guard line.coordinates.count >= 2 else { return nil }
+				var coords = line.coordinates
+				return MKPolyline(coordinates: &coords, count: coords.count)
+			}
+			if !shapes.isEmpty {
+				result.append(ClusterMapOverlay(
+					id: "offline-rivers",
+					overlay: MKMultiPolyline(shapes),
+					style: ClusterMapOverlayStyle(strokeUIColor: OfflineMapPalette.riverStroke(dark: dark), fillUIColor: nil, lineWidth: 1.4, level: .aboveRoads)
+				))
+			}
+		}
+
 		// 3) Roads, batched per role into MKMultiPolylines (keeps the dense grid to a few overlays).
-		let roadsByRole = Dictionary(grouping: offlineVectors.roads, by: { $0.role })
+		let roadsByRole = linesByRole
 		func roadMultiPolyline(_ role: OfflineFeatureRole) -> MKMultiPolyline? {
 			guard let lines = roadsByRole[role] else { return nil }
 			let shapes = lines.compactMap { line -> MKPolyline? in


### PR DESCRIPTION
## Summary

Reported as strange water on the offline basemap: islands inside water polygons rendered flooded, and narrower rivers were missing entirely.

## What changed

- Polygon decoding kept only the outer ring; interior rings (islands in lakes, clearings in parks) now carry through clipping and simplification and render as MKPolygon holes.
- Rivers, streams, and canals render as water-colored centerlines under the road network. They come from the water layer's LineString features — current Protomaps builds have no physical_line layer, which is why the first attempt rendered nothing.
- tvOS map is unaffected for now (explicit role lists); wiring rivers there is a follow-up.

## Testing

iOS and tvOS schemes build. Probed live daily-build tiles to confirm the water layer carries river/stream/canal LineStrings and no physical_line layer exists. Verified visually on device with the offline basemap.