### PR TITLE
Fix tvOS Connect section headers

### DIFF
--- a/Meshtastic TV/App/ConnectView.swift
+++ b/Meshtastic TV/App/ConnectView.swift
@@ -58,7 +58,7 @@ struct ConnectView: View {
 					}
 				}
 				// Inset focused controls without hiding native Form section headers.
-				.safeAreaPadding(.horizontal, 16)
+				.safeAreaPadding(.horizontal, TVTheme.connectHorizontalInset)
 			}
 			.padding(.top, TVTheme.screenPadding)
 		}

--- a/Meshtastic TV/App/ConnectView.swift
+++ b/Meshtastic TV/App/ConnectView.swift
@@ -57,8 +57,8 @@ struct ConnectView: View {
 						}
 					}
 				}
-				// Focused tvOS controls grow beyond their rows; keep them inside the Form's clip.
-				.contentMargins(.horizontal, 16, for: .scrollContent)
+				// Inset focused controls without hiding native Form section headers.
+				.safeAreaPadding(.horizontal, 16)
 			}
 			.padding(.top, TVTheme.screenPadding)
 		}

--- a/Meshtastic TV/App/TVTheme.swift
+++ b/Meshtastic TV/App/TVTheme.swift
@@ -23,6 +23,9 @@ enum TVTheme {
 	/// Outer padding for a full detail panel.
 	static let screenPadding: CGFloat = 40
 
+	/// Horizontal inset for controls on the connect screen.
+	static let connectHorizontalInset: CGFloat = 16
+
 	/// Gap between sections in the node detail panel.
 	static let sectionSpacing: CGFloat = 32
 


### PR DESCRIPTION
## What changed?

Use safe-area padding for the tvOS Connect form so native section headers remain visible while focused controls stay inset.

## Why did it change?

Applying horizontal scroll-content margins to the `Form` hides the native “Discovered Nodes” and “Manual Connection” section headers on tvOS. Safe-area padding preserves the 16-point focus inset without suppressing those headers.

No documentation update is needed because this restores existing labels and focus behavior.

## How is this tested?

- Compared the original scroll-content margin, no modifier, and safe-area padding on a tvOS 26.5 simulator.
- Used Vision OCR to confirm both labels are absent with the original margin and present with safe-area padding.
- Built the `Meshtastic TV` scheme for the tvOS simulator.
- Ran SwiftLint on `Meshtastic TV/App/ConnectView.swift`.
- Ran `git diff --check`.
- Built, installed, and launched the change on an Apple TV 4K running tvOS 27.0.
- Confirmed on the physical Apple TV that both labels are visible and focused rows are not clipped on either side.

## Screenshots/Videos (when applicable)

Not included. The layout and focus behavior were verified on a physical Apple TV.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). No documentation update is needed.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal spacing in the connection view to better respect device safe areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->