### PR TITLE
feat(coverage): use offline terrain elevation in the estimate sheet

### DIFF
--- a/Meshtastic/Helpers/Map/TerrainStore.swift
+++ b/Meshtastic/Helpers/Map/TerrainStore.swift
@@ -12,6 +12,7 @@
 //  overzoom), so terrain keeps rendering at street-level zooms.
 //
 
+import CoreLocation
 import Foundation
 import OSLog
 
@@ -163,6 +164,71 @@ actor TerrainStore {
 			}
 		}
 		return ElevationTile(z: z, x: x, y: y, size: size, margin: margin, elevations: elevations)
+	}
+
+	// MARK: - Point queries
+
+	/// Zoom used for single-coordinate elevation lookups: the finest zoom the
+	/// global archive always carries (~30 m data), plenty for a site elevation.
+	static let pointQueryZoom = 12
+
+	/// A coordinate located within a tile grid: the tile indices plus the
+	/// fractional (sample-centered) pixel position inside it.
+	struct TilePixel {
+		let x: Int
+		let y: Int
+		let px: Double
+		let py: Double
+	}
+
+	/// Ground elevation in meters at a coordinate, or nil when no downloaded
+	/// terrain region covers it.
+	func elevation(at coordinate: CLLocationCoordinate2D) -> Double? {
+		let z = Self.pointQueryZoom
+		let pixel = Self.tilePixel(latitude: coordinate.latitude, longitude: coordinate.longitude, z: z, size: Self.tileSize)
+		// Edge tiles are edge-clamped, so also require the coordinate itself to
+		// sit inside the covering region's box — never report a clamped border
+		// value for a point outside the download.
+		guard let box = coverage(z: z, x: pixel.x, y: pixel.y),
+			  coordinate.latitude >= box.minLat, coordinate.latitude <= box.maxLat,
+			  coordinate.longitude >= box.minLon, coordinate.longitude <= box.maxLon,
+			  let tile = elevationTile(z: z, x: pixel.x, y: pixel.y, margin: 1) else { return nil }
+		return Double(Self.sample(tile, px: pixel.px, py: pixel.py))
+	}
+
+	/// The Web-Mercator tile containing a coordinate at zoom `z`, plus the
+	/// coordinate's fractional pixel position (sample-centered) within a
+	/// `size`-sample grid for that tile.
+	static func tilePixel(latitude: Double, longitude: Double, z: Int, size: Int) -> TilePixel {
+		let n = Double(1 << z)
+		// Clamp to the Web-Mercator latitude limit so the y math stays finite.
+		let lat = min(max(latitude, -85.05112878), 85.05112878)
+		let lon = min(max(longitude, -180), 180)
+		let xt = (lon + 180) / 360 * n
+		let latRad = lat * .pi / 180
+		let yt = (1 - log(tan(latRad) + 1 / cos(latRad)) / .pi) / 2 * n
+		let maxIndex = (1 << z) - 1
+		let x = min(max(Int(xt.rounded(.down)), 0), maxIndex)
+		let y = min(max(Int(yt.rounded(.down)), 0), maxIndex)
+		let px = (xt - Double(x)) * Double(size) - 0.5
+		let py = (yt - Double(y)) * Double(size) - 0.5
+		return TilePixel(x: x, y: y, px: px, py: py)
+	}
+
+	/// Bilinear sample of a tile's elevation grid at a fractional pixel position
+	/// (grid coordinates clamp at the margin, matching `gridElevation`).
+	static func sample(_ tile: ElevationTile, px: Double, py: Double) -> Float {
+		let x0 = Int(px.rounded(.down))
+		let y0 = Int(py.rounded(.down))
+		let tx = Float(px - Double(x0))
+		let ty = Float(py - Double(y0))
+		let p00 = tile.gridElevation(x: x0, y: y0)
+		let p10 = tile.gridElevation(x: x0 + 1, y: y0)
+		let p01 = tile.gridElevation(x: x0, y: y0 + 1)
+		let p11 = tile.gridElevation(x: x0 + 1, y: y0 + 1)
+		let top = p00 + (p10 - p00) * tx
+		let bottom = p01 + (p11 - p01) * tx
+		return top + (bottom - top) * ty
 	}
 
 	/// Meters-per-sample for an `ElevationTile` at the given zoom/latitude — the

--- a/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/CoverageEstimateForm.swift
@@ -21,6 +21,9 @@ struct CoverageEstimateSeed: Identifiable {
 	var parameters: SitePlannerParameters
 	/// The selected node's coordinate, when launched from a node.
 	var nodeCoordinate: CLLocationCoordinate2D?
+	/// The node's GPS altitude (meters above sea level), when its position has one.
+	/// Combined with offline terrain elevation to derive antenna height above ground.
+	var nodeAltitude: Double?
 	/// The current map centre, when launched from the map toolbar.
 	var mapCenter: CLLocationCoordinate2D?
 }
@@ -36,6 +39,10 @@ struct CoverageEstimateForm: View {
 	@State private var errorMessage: String?
 	/// In-flight reverse geocode for the chosen coordinate; cancelled when a newer coordinate is picked.
 	@State private var geocodeTask: Task<Void, Never>?
+	/// Reads ground elevation for the chosen coordinate from downloaded offline terrain.
+	@State private var terrainStore = TerrainStore()
+	/// Terrain ground elevation (meters) at the current coordinate, when offline terrain covers it.
+	@State private var groundElevation: Double?
 
 	init(seed: CoverageEstimateSeed, runner: CoverageEstimateRunner) {
 		self.seed = seed
@@ -81,6 +88,9 @@ struct CoverageEstimateForm: View {
 				}
 			}
 			.onAppear(perform: generateInitialNameIfNeeded)
+			.task(id: "\(params.latitude),\(params.longitude)") {
+				await refreshGroundElevation()
+			}
 			.onDisappear {
 				// Tear down a still-running headless run if the sheet is swipe-dismissed. Safe on the
 				// success path too — the import already published its result before `dismiss()`.
@@ -118,6 +128,9 @@ struct CoverageEstimateForm: View {
 
 			DecimalField("Latitude", value: $params.latitude)
 			DecimalField("Longitude", value: $params.longitude)
+			if let groundElevation {
+				groundElevationRow(groundElevation)
+			}
 			labeledNumber("Transmit power (W)", value: $params.txPowerWatts)
 			labeledNumber("Frequency (MHz)", value: $params.txFrequencyMHz)
 			lengthField("Antenna height", canonical: $params.txHeightMeters, storedUnit: .meters, imperialUnit: .feet)
@@ -128,7 +141,24 @@ struct CoverageEstimateForm: View {
 			} icon: {
 				Image("custom.radio.tower")
 			}
+		} footer: {
+			if groundElevation != nil {
+				Text("Ground elevation is read from downloaded offline map terrain.")
+			}
 		}
+	}
+
+	/// Read-only ground elevation at the current coordinate, from offline terrain.
+	private func groundElevationRow(_ elevation: Double) -> some View {
+		let displayUnit: UnitLength = Locale.current.measurementSystem == .metric ? .meters : .feet
+		let measurement = Measurement(value: elevation, unit: UnitLength.meters).converted(to: displayUnit)
+		return HStack {
+			Text("Ground elevation")
+			Spacer()
+			Text(measurement, format: .measurement(width: .abbreviated, usage: .asProvided, numberFormatStyle: .number.precision(.fractionLength(0))))
+				.foregroundStyle(.secondary)
+		}
+		.accessibilityElement(children: .combine)
 	}
 
 	private var receiverSection: some View {
@@ -229,6 +259,49 @@ struct CoverageEstimateForm: View {
 		guard params.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
 			  params.hasValidCoordinate else { return }
 		reverseGeocodeName(for: CLLocationCoordinate2D(latitude: params.latitude, longitude: params.longitude))
+	}
+
+	// MARK: - Offline terrain elevation
+
+	/// Look up the ground elevation at the current coordinate from downloaded
+	/// offline terrain. Runs via `.task(id:)` keyed on the coordinate, so edits
+	/// cancel the previous lookup; the short sleep debounces keystrokes in the
+	/// latitude/longitude fields.
+	private func refreshGroundElevation() async {
+		try? await Task.sleep(nanoseconds: 300_000_000)
+		guard !Task.isCancelled else { return }
+		guard params.hasValidCoordinate else {
+			groundElevation = nil
+			return
+		}
+		let sources = OfflineMapManager.shared.terrainSources()
+		guard !sources.isEmpty else {
+			groundElevation = nil
+			return
+		}
+		await terrainStore.configure(sources: sources)
+		let coordinate = CLLocationCoordinate2D(latitude: params.latitude, longitude: params.longitude)
+		let elevation = await terrainStore.elevation(at: coordinate)
+		guard !Task.isCancelled else { return }
+		groundElevation = elevation
+		applyNodeAntennaHeightIfPossible(groundElevation: elevation)
+	}
+
+	/// When the estimate was launched from a node whose position carries a GPS
+	/// altitude, the node's height above ground is its GPS altitude minus the
+	/// terrain ground elevation — the GPS is physically at the antenna. Fills the
+	/// antenna-height field with that, but only at the node's own coordinate,
+	/// only to raise it above the seeded default, and never over a user edit.
+	private func applyNodeAntennaHeightIfPossible(groundElevation: Double?) {
+		guard let groundElevation,
+			  let nodeAltitude = seed.nodeAltitude,
+			  let node = seed.nodeCoordinate,
+			  params.latitude == node.latitude, params.longitude == node.longitude,
+			  params.txHeightMeters == seed.parameters.txHeightMeters else { return }
+		let height = (nodeAltitude - groundElevation).rounded()
+		// Below the default is GPS noise; above 500 m is a bogus altitude fix.
+		guard height > seed.parameters.txHeightMeters, height <= 500 else { return }
+		params.txHeightMeters = height
 	}
 
 	private func reverseGeocodeName(for coordinate: CLLocationCoordinate2D) {

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -876,7 +876,10 @@ struct MeshMapMK: View {
 	private func presentCoverageEstimate(forNode nodeNum: Int64) {
 		defer { router.mapState = nil }
 		guard let node = getNodeInfo(id: nodeNum, context: context) else { return }
-		let coordinate = node.latestPosition?.nodeCoordinate
+		let position = node.latestPosition
+		let coordinate = position?.nodeCoordinate
+		// 0 is the firmware's "no altitude" sentinel.
+		let altitude = position.flatMap { $0.altitude != 0 ? Double($0.altitude) : nil }
 		let name = node.user?.displayLongName ?? node.user?.shortName ?? ""
 		let params = SitePlannerParameters.prefilled(
 			name: name,
@@ -884,7 +887,7 @@ struct MeshMapMK: View {
 			loRaConfig: connectedLoRaConfig,
 			primaryChannelName: connectedPrimaryChannelName
 		)
-		coverageSeed = CoverageEstimateSeed(parameters: params, nodeCoordinate: coordinate, mapCenter: visibleRegion?.center)
+		coverageSeed = CoverageEstimateSeed(parameters: params, nodeCoordinate: coordinate, nodeAltitude: altitude, mapCenter: visibleRegion?.center)
 		if let coordinate {
 			cameraCommand = ClusterMapCameraCommand(
 				id: UUID(),

--- a/MeshtasticTests/TerrainElevationLookupTests.swift
+++ b/MeshtasticTests/TerrainElevationLookupTests.swift
@@ -1,0 +1,76 @@
+//
+//  TerrainElevationLookupTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/16/26.
+//
+
+import CoreLocation
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Terrain elevation lookup")
+struct TerrainElevationLookupTests {
+
+	// MARK: - tilePixel
+
+	@Test func tilePixelRoundTripsIntoTileBounds() {
+		let coordinates = [
+			CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321),  // Seattle
+			CLLocationCoordinate2D(latitude: 46.6863, longitude: 7.8632),     // Interlaken
+			CLLocationCoordinate2D(latitude: -41.2866, longitude: 174.7756)   // Wellington
+		]
+		for coordinate in coordinates {
+			let pixel = TerrainStore.tilePixel(latitude: coordinate.latitude, longitude: coordinate.longitude, z: 12, size: 256)
+			let bounds = TerrainStore.tileBounds(z: 12, x: pixel.x, y: pixel.y)
+			#expect(coordinate.longitude >= bounds.minLon && coordinate.longitude <= bounds.maxLon)
+			#expect(coordinate.latitude >= bounds.minLat && coordinate.latitude <= bounds.maxLat)
+			// Sample-centered pixel positions stay within the tile's grid span.
+			#expect(pixel.px >= -0.5 && pixel.px <= 255.5)
+			#expect(pixel.py >= -0.5 && pixel.py <= 255.5)
+		}
+	}
+
+	@Test func tilePixelCentersTheTileMidpoint() {
+		// Longitude is linear in Web-Mercator x, so the bounds midpoint must land
+		// exactly mid-grid (sample-centered: size/2 - 0.5).
+		let bounds = TerrainStore.tileBounds(z: 12, x: 655, y: 1428)
+		let midLon = (bounds.minLon + bounds.maxLon) / 2
+		let midLat = (bounds.minLat + bounds.maxLat) / 2
+		let pixel = TerrainStore.tilePixel(latitude: midLat, longitude: midLon, z: 12, size: 256)
+		#expect(pixel.x == 655)
+		#expect(pixel.y == 1428)
+		#expect(abs(pixel.px - 127.5) < 0.001)
+	}
+
+	// MARK: - sample
+
+	private func makeTile(_ elevations: [Float]) -> ElevationTile {
+		ElevationTile(z: 12, x: 0, y: 0, size: 2, margin: 0, elevations: elevations)
+	}
+
+	@Test func sampleInterpolatesBilinearly() {
+		let tile = makeTile([0, 10, 20, 30])
+		#expect(TerrainStore.sample(tile, px: 0, py: 0) == 0)
+		#expect(TerrainStore.sample(tile, px: 1, py: 0) == 10)
+		#expect(TerrainStore.sample(tile, px: 0, py: 1) == 20)
+		#expect(TerrainStore.sample(tile, px: 0.5, py: 0.5) == 15)
+		#expect(TerrainStore.sample(tile, px: 0.5, py: 0) == 5)
+	}
+
+	@Test func sampleClampsOutsideTheGrid() {
+		let tile = makeTile([0, 10, 20, 30])
+		#expect(TerrainStore.sample(tile, px: -3, py: -3) == 0)
+		#expect(TerrainStore.sample(tile, px: 5, py: 5) == 30)
+	}
+
+	// MARK: - elevation(at:)
+
+	@Test func elevationIsNilWithoutSources() async {
+		let store = TerrainStore()
+		let elevation = await store.elevation(at: CLLocationCoordinate2D(latitude: 47.6062, longitude: -122.3321))
+		#expect(elevation == nil)
+	}
+}


### PR DESCRIPTION
Stacked on #2306 (`feat/018-terrain-layer`) — only the last commit is new here.

## Summary
When a downloaded offline map includes terrain, the coverage estimate sheet now uses it for its elevation values.

## What changed
- `TerrainStore.elevation(at:)`: point query that locates the z12 tile for a coordinate and bilinearly samples the decoded elevation grid. Returns nil outside downloaded coverage.
- The Site / Transmitter section shows a read-only Ground elevation row for the current coordinate when offline terrain covers it, updating as the coordinates are edited (meters or feet per locale).
- When the estimate is launched from a node whose position carries a GPS altitude, the antenna height field is prefilled with GPS altitude minus terrain ground elevation — the GPS sits at the antenna, so the difference is its height above ground. Applied only at the node's own coordinate, only to raise the seeded default, and never over a value the user typed.

## Testing
- New `TerrainElevationLookupTests` suite (5 tests, all passing on the iPhone simulator) covering the tile/pixel math, bilinear sampling and clamping, and the no-sources case.
- Debug build for the iOS Simulator succeeds.
- Manual: open Estimate Coverage inside a downloaded region to see the ground elevation row; edit the coordinates and it follows; launch from a node with a GPS altitude to see the antenna height prefill.