### PR TITLE
Use the tvOS Back button to disconnect

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -13,6 +13,11 @@
 import SwiftUI
 import SwiftData
 
+private enum MapNavigationDestination: Hashable {
+	case settings
+	case node(UInt32)
+}
+
 struct MapScreen: View {
 	@Bindable var client: MeshClient
 	@State private var selectedNodeNum: UInt32?
@@ -22,7 +27,8 @@ struct MapScreen: View {
 	// focus for NavigationLink rows, so track it explicitly and mirror it into
 	// the map selection (debounced map-side).
 	@FocusState private var focusedNodeNum: UInt32?
-	@State private var navPath: [UInt32] = []
+	@State private var navPath: [MapNavigationDestination] = []
+	@State private var showingDisconnectConfirmation = false
 
 	/// The persisted node store — the map and list read from here, not the client.
 	@Query private var allNodes: [MeshNode]
@@ -81,6 +87,21 @@ struct MapScreen: View {
 				pollTick += 1
 			}
 		}
+		.onExitCommand {
+			if navPath.isEmpty {
+				showingDisconnectConfirmation = true
+			} else {
+				navPath.removeLast()
+			}
+		}
+		.alert("Disconnect from this node?", isPresented: $showingDisconnectConfirmation) {
+			Button("Disconnect", role: .destructive) {
+				client.disconnect()
+			}
+			Button("Cancel", role: .cancel) {}
+		} message: {
+			Text("You will return to the connection screen.")
+		}
 	}
 
 	private func recomputeNodeLists(from nodes: [MeshNode]) {
@@ -113,21 +134,14 @@ struct MapScreen: View {
 					} label: {
 						Label("Re-center Map", systemImage: "scope")
 					}
-					NavigationLink {
-						SettingsView()
-					} label: {
+					NavigationLink(value: MapNavigationDestination.settings) {
 						Label("Settings", systemImage: "gearshape")
-					}
-					Button(role: .destructive) {
-						client.disconnect()
-					} label: {
-						Label("Disconnect", systemImage: "xmark.circle.fill")
 					}
 				}
 
 				Section {
 					ForEach(sortedNodes) { node in
-						NavigationLink(value: node.num) {
+						NavigationLink(value: MapNavigationDestination.node(node.num)) {
 							NodeRow(node: node)
 						}
 						.focused($focusedNodeNum, equals: node.num)
@@ -139,9 +153,14 @@ struct MapScreen: View {
 			.onChange(of: focusedNodeNum) { _, newValue in
 				if let newValue { selectedNodeNum = newValue }
 			}
-			.navigationDestination(for: UInt32.self) { num in
-				if let node = allNodes.first(where: { $0.num == num }) {
-					NodeDetailView(node: node)
+			.navigationDestination(for: MapNavigationDestination.self) { destination in
+				switch destination {
+				case .settings:
+					SettingsView()
+				case .node(let num):
+					if let node = allNodes.first(where: { $0.num == num }) {
+						NodeDetailView(node: node)
+					}
 				}
 			}
 			.safeAreaInset(edge: .top) {
@@ -183,15 +202,6 @@ struct MapScreen: View {
 				)
 				.ignoresSafeArea(edges: [.top, .leading])
 		}
-	}
-
-	private var disconnectButton: some View {
-		Button(role: .destructive) {
-			client.disconnect()
-		} label: {
-			Label("Disconnect", systemImage: "xmark.circle.fill")
-		}
-		.buttonStyle(.bordered)
 	}
 }
 


### PR DESCRIPTION
## What changed?

- Handle the tvOS Back/Menu command on the connected map screen.
- Pop Settings or node details when they are open, and ask for confirmation before disconnecting at the map root.
- Remove the on-screen Disconnect button. Confirming the alert disconnects and returns to the connection screen.

## Why did it change?

Pressing Back from the connected map root exited to the tvOS Home Screen. Disconnect was also a separate list action. The remote button should keep the user in the app and provide the disconnect path with confirmation.

## How is this tested?

- Built the `Meshtastic TV` scheme for the tvOS simulator.
- Ran an isolated tvOS UI test that used `XCUIRemote.shared.press(.menu)`, confirmed the alert, selected Disconnect, and verified the connection screen. 1 test passed with 0 failures.
- Captured the connected map, confirmation alert, and returned connection screen on an Apple TV 4K 1080p simulator against a replay node.
- Ran SwiftLint on `Meshtastic TV/App/MapScreen.swift` with 0 violations.
- Ran `git diff --check`.

## Screenshots/Videos (when applicable)

Captured on an Apple TV 4K 1080p simulator against a replay node:

- Connected map with the Disconnect button removed.
- Back-button disconnect confirmation.
- Connection screen after confirming Disconnect.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.

There is no in-app documentation page mapped to the Meshtastic TV target. The `skip-docs-check` label is applied.
