### PR TITLE
Fix clipped text on the tvOS map screen

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -218,7 +218,9 @@ private struct NodeRow: View {
 				HStack(spacing: 14) {
 					if let lastHeard = node.lastHeard {
 						Label {
-							Text(lastHeard.formatted(.relative(presentation: .named)))
+								// Abbreviated: the full "10 minutes ago" crowds out the role
+							// and position labels beside it on a 520pt list.
+							Text(lastHeard.formatted(.relative(presentation: .numeric, unitsStyle: .abbreviated)))
 						} icon: {
 							Image(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill")
 								.foregroundStyle(node.isOnline ? Color("MeshtasticSuccess") : Color("MeshtasticWarning"))
@@ -234,8 +236,12 @@ private struct NodeRow: View {
 				.font(.caption)
 				.foregroundStyle(.secondary)
 				.lineLimit(1)
+				.minimumScaleFactor(0.75)
 			}
-			Spacer()
+			// Take the row's remaining width outright. A trailing Spacer() competes
+			// with the text for it, and Text yields by truncating — which is why the
+			// metadata line clipped while the row still had space to its right.
+			.frame(maxWidth: .infinity, alignment: .leading)
 		}
 	}
 }

--- a/Meshtastic TV/App/TVTheme.swift
+++ b/Meshtastic TV/App/TVTheme.swift
@@ -44,8 +44,8 @@ enum TVTheme {
 	static let statsStripColumnSpacing: CGFloat = 24
 	static let statsStripMetricSpacing: CGFloat = 6
 	static let statsStripPacketSpacing: CGFloat = 10
-	static let statsStripEventWidth: CGFloat = 300
-	static let statsStripEventLogoSize: CGFloat = 72
+	static let statsStripEventWidth: CGFloat = 250
+	static let statsStripEventLogoSize: CGFloat = 56
 	static let statsStripNodesWidth: CGFloat = 230
 	static let statsStripUtilizationWidth: CGFloat = 180
 	static let statsStripPacketsWidth: CGFloat = 439

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -37,6 +37,9 @@ struct MeshStatsStrip: View {
 			if let edition {
 				eventBadge(edition)
 					.frame(idealWidth: TVTheme.statsStripEventWidth, maxWidth: TVTheme.statsStripEventWidth)
+					// Claim the column before the flexible packets cell does; without
+					// this the badge is what gets compressed, clipping the name.
+					.layoutPriority(1)
 				divider
 			}
 
@@ -84,12 +87,11 @@ struct MeshStatsStrip: View {
 			VStack(alignment: .leading, spacing: TVTheme.statsStripMetricSpacing) {
 				metricLabel("Event")
 				Text(edition.name)
-					.font(.title2.weight(.semibold))
+					.font(.title3.weight(.semibold))
 					.lineLimit(1)
-					.minimumScaleFactor(0.5)
+					.minimumScaleFactor(0.6)
 			}
 		}
-		.frame(maxWidth: .infinity, alignment: .leading)
 		.accessibilityElement(children: .combine)
 		.accessibilityLabel(Text("Event firmware: \(edition.name)"))
 	}
@@ -124,13 +126,13 @@ struct MeshStatsStrip: View {
 				packetCount(rx, arrow: "↓")
 			}
 		} else {
-			metricValue("—", font: .title2)
+			metricValue("—", font: packetFont)
 		}
 	}
 
 	private func packetCount(_ value: UInt32, arrow: String) -> some View {
 		Text("\(value.formatted()) \(arrow)")
-			.font(.title2.weight(.semibold).monospacedDigit())
+			.font(packetFont.weight(.semibold).monospacedDigit())
 			.lineLimit(1)
 			.minimumScaleFactor(0.3)
 			.frame(maxWidth: .infinity, alignment: .leading)
@@ -163,9 +165,15 @@ struct MeshStatsStrip: View {
 			.minimumScaleFactor(0.8)
 	}
 
-	private func metricValue(_ text: String, color: Color = .primary, font: Font = .title) -> some View {
+	/// Value type steps down when the event badge is present — the badge takes a
+	/// column's worth of width, and at `.title` the remaining metrics hit their
+	/// scale floor and truncate ("761 /…") instead of shrinking.
+	private var valueFont: Font { edition == nil ? .title : .title2 }
+	private var packetFont: Font { edition == nil ? .title2 : .title3 }
+
+	private func metricValue(_ text: String, color: Color = .primary, font: Font? = nil) -> some View {
 		Text(text)
-			.font(font.weight(.semibold).monospacedDigit())
+			.font((font ?? valueFont).weight(.semibold).monospacedDigit())
 			.foregroundStyle(color)
 			.lineLimit(1)
 			.minimumScaleFactor(0.5)


### PR DESCRIPTION
## Summary

Text was clipping in three places on the tvOS map screen: the node list rows, the event badge, and the packet counters.

## What changed

- **Node list rows.** The last-heard time and role clipped ("6 minu…", "Client M…") even though the row had empty space to its right — a trailing `Spacer()` competed with the text for width, and Text yields by truncating. The row now takes the remaining width outright, and the relative time is abbreviated ("16 min. ago") so the time, role, and position labels all fit.
- **Event badge.** The name clipped to "DEFC…" because the flexible packets cell was squeezing it. The badge now claims its column first, and with a badge shown the metric values step down one size — at `.title` the remaining columns hit their scale floor and clipped too ("761 /…").
- **Packets.** It asked for a fixed ideal width and then compressed its own text, so the counters clipped to "1,2… 9,8…". It now takes whatever the fixed columns leave, and those columns were trimmed to what their content actually needs. Counters past six figures use compact notation, since a seven-digit pair outgrows the column at any scale. The dupes/updated line is one concatenated Text rather than four — separate Texts each get their own width and the longest clips, so the scale factor never applied to the line as a whole.

A stock (non-event) radio shows no badge and keeps the previous type sizes.

## Testing

tvOS builds. Verified on an Apple TV 4K simulator against a DEFCON event-firmware replay, both with live values (884 / 1118 nodes) and with the counters forced to a worst case (1,234,567 / 9,876,543 tx/rx, 456,789 dupes). Event name, node counts, both utilization figures, the packet counters, the dupes line, and every node row render in full, and the strip stays inside the map column.
