### PR TITLE
Split the mesh map body so it type-checks reliably

### DIFF
--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -654,67 +654,12 @@ struct MeshMapMK: View {
 				}
 	}
 
+	/// Split across several properties on purpose: as one expression this chain of
+	/// 13 modifiers sat at the type-checker's time limit, so CI flipped between
+	/// passing and "unable to type-check this expression in reasonable time" on
+	/// identical code. Each piece now infers on its own and stays well clear.
 	var body: some View {
-		NavigationStack {
-			ZStack {
-			mapWithSheets
-			}
-			.toolbar {
-				ToolbarItem(placement: .topBarLeading) {
-					MeshtasticLogo()
-				}
-				ToolbarItem(placement: .topBarTrailing) {
-					HStack {
-						if supportsMultipleWindows && showOpenWindowButton && !isMapWindowOpen {
-							Button {
-								if router.selectedTab == .map {
-									router.selectedTab = .nodes
-								}
-								openWindow(id: "meshmap-window")
-								isMapWindowOpen = true
-							} label: {
-								Image(systemName: "macwindow.badge.plus")
-							}
-							.accessibilityLabel(String(localized: "Open map in new window", comment: "VoiceOver label for the open map in a new window button"))
-						}
-						ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
-					}
-				}
-			}
-			.toolbarBackground(.hidden, for: .navigationBar)
-		}
-			.task(id: isMapVisible) {
-				// Throttled position refresh: re-derive the visible positions on a gentle
-				// cadence instead of on every SwiftData write (see `allLatestPositions`).
-				guard isMapVisible else { return }
-				while !Task.isCancelled {
-					refreshPositionState()
-					try? await Task.sleep(for: .seconds(2))
-				}
-			}
-			.onChange(of: offlineMapManager.regions) {
-				reloadOfflineSource()
-				refreshTerrainSources()
-			}
-			.onChange(of: showHillshade) {
-				rebuildHillshadeOverlay()
-			}
-			.onChange(of: showContours) {
-				updateContoursIfNeeded()
-			}
-			.onChange(of: colorScheme) {
-				rebuildHillshadeOverlay()
-			}
-			.onChange(of: offlineMapConnectivity.isNetworkAvailable) {
-				rebuildAllMapContent()
-			}
-			.onChange(of: overlayInputsKey) {
-				rebuildAllMapContent()
-			}
-			.onChange(of: filterRefreshKey) {
-				// Filter/search edits should reflect immediately, not on the next tick.
-				refreshPositionState(force: true)
-			}
+		mapWithStateHooks
 			.onChange(of: regionRefreshKey) {
 				// Pan/zoom settled: re-filter to the new region now; the state key dedupes
 				// the rebuild when the visible set is unchanged.
@@ -802,6 +747,77 @@ struct MeshMapMK: View {
 		}
 		.onReceive(NotificationCenter.default.publisher(for: UIScene.didDisconnectNotification)) { _ in
 			refreshMapWindowOpenState()
+		}
+	}
+
+	private var mapWithStateHooks: some View {
+		mapWithDataHooks
+			.onChange(of: colorScheme) {
+				rebuildHillshadeOverlay()
+			}
+			.onChange(of: offlineMapConnectivity.isNetworkAvailable) {
+				rebuildAllMapContent()
+			}
+			.onChange(of: overlayInputsKey) {
+				rebuildAllMapContent()
+			}
+			.onChange(of: filterRefreshKey) {
+				// Filter/search edits should reflect immediately, not on the next tick.
+				refreshPositionState(force: true)
+			}
+	}
+
+	private var mapWithDataHooks: some View {
+		mapNavigation
+			.task(id: isMapVisible) {
+				// Throttled position refresh: re-derive the visible positions on a gentle
+				// cadence instead of on every SwiftData write (see `allLatestPositions`).
+				guard isMapVisible else { return }
+				while !Task.isCancelled {
+					refreshPositionState()
+					try? await Task.sleep(for: .seconds(2))
+				}
+			}
+			.onChange(of: offlineMapManager.regions) {
+				reloadOfflineSource()
+				refreshTerrainSources()
+			}
+			.onChange(of: showHillshade) {
+				rebuildHillshadeOverlay()
+			}
+			.onChange(of: showContours) {
+				updateContoursIfNeeded()
+			}
+	}
+
+	private var mapNavigation: some View {
+		NavigationStack {
+			ZStack {
+			mapWithSheets
+			}
+			.toolbar {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo()
+				}
+				ToolbarItem(placement: .topBarTrailing) {
+					HStack {
+						if supportsMultipleWindows && showOpenWindowButton && !isMapWindowOpen {
+							Button {
+								if router.selectedTab == .map {
+									router.selectedTab = .nodes
+								}
+								openWindow(id: "meshmap-window")
+								isMapWindowOpen = true
+							} label: {
+								Image(systemName: "macwindow.badge.plus")
+							}
+							.accessibilityLabel(String(localized: "Open map in new window", comment: "VoiceOver label for the open map in a new window button"))
+						}
+						ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")
+					}
+				}
+			}
+			.toolbarBackground(.hidden, for: .navigationBar)
 		}
 	}
 


### PR DESCRIPTION
## Summary

`build-snapshots` has been failing on and off on main with `error: the compiler is unable to type-check this expression in reasonable time` pointing at `MeshMapMK.swift` `var body`, including on commits that don't touch that file.

## What changed

`body` applied 13 modifiers to a single expression — a `.task`, eleven `.onChange`s and an `.onAppear` chained onto the `NavigationStack`. That's enough for the constraint solver to sit near its limit, so a slower or busier machine tips it over while the same code compiles fine elsewhere. The chain is now split across three properties (`mapNavigation` → `mapWithDataHooks` → `mapWithStateHooks` → `body`), each of which infers on its own.

No behaviour change. The modifiers keep their relative order, and `onChange`, `task` and `onAppear` don't interact with each other.

## Testing

iOS builds. With `-warn-long-expression-type-checking=400` nothing in the file exceeds the threshold after the split.

Worth being upfront: I could not reproduce the failure locally — on this machine the original expression type-checks in well under 200ms, which is consistent with it being machine-speed dependent. CI is the real check here, so this is worth watching rather than assuming fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Preserved the existing mesh map experience, including navigation, refresh behavior, toolbar actions, multi-window support, and connected-device details.
  * Improved the internal organization of the map view without changing its visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->