### PR TITLE
Give the tvOS packets column the leftover width

### DIFF
--- a/Meshtastic TV/App/TVTheme.swift
+++ b/Meshtastic TV/App/TVTheme.swift
@@ -41,15 +41,14 @@ enum TVTheme {
 	static let statsStripMargin: CGFloat = 24
 
 	/// Mesh stats strip layout.
-	static let statsStripColumnSpacing: CGFloat = 24
+	static let statsStripColumnSpacing: CGFloat = 18
 	static let statsStripMetricSpacing: CGFloat = 6
 	static let statsStripPacketSpacing: CGFloat = 10
-	static let statsStripEventWidth: CGFloat = 250
+	static let statsStripEventWidth: CGFloat = 230
 	static let statsStripEventLogoSize: CGFloat = 56
-	static let statsStripNodesWidth: CGFloat = 230
-	static let statsStripUtilizationWidth: CGFloat = 180
-	static let statsStripPacketsWidth: CGFloat = 439
-	static let statsStripHorizontalPadding: CGFloat = 48
+	static let statsStripNodesWidth: CGFloat = 200
+	static let statsStripUtilizationWidth: CGFloat = 140
+	static let statsStripHorizontalPadding: CGFloat = 36
 	static let statsStripVerticalPadding: CGFloat = 28
 	static let statsStripCornerRadius: CGFloat = 24
 	static let statsStripDividerWidth: CGFloat = 1

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -56,7 +56,7 @@ struct MeshStatsStrip: View {
 
 			divider
 			packetsCell
-				.frame(idealWidth: TVTheme.statsStripPacketsWidth, maxWidth: .infinity)
+				.frame(maxWidth: .infinity, alignment: .leading)
 		}
 		.padding(.horizontal, TVTheme.statsStripHorizontalPadding)
 		.padding(.vertical, TVTheme.statsStripVerticalPadding)
@@ -112,7 +112,7 @@ struct MeshStatsStrip: View {
 				.font(.caption2.weight(.medium).monospacedDigit())
 				.foregroundStyle(.secondary)
 				.lineLimit(1)
-				.minimumScaleFactor(0.75)
+				.minimumScaleFactor(0.6)
 				.frame(height: metadataHeight)
 		}
 		.frame(maxWidth: .infinity, alignment: .leading)
@@ -130,29 +130,38 @@ struct MeshStatsStrip: View {
 		}
 	}
 
+	/// Grouped digits normally; compact ("457K", "1.2M") past six figures, where
+	/// the counters outgrow the column no matter how much they are scaled down.
+	private func packetText(_ value: UInt32, fractionDigits: Int = 1) -> String {
+		value >= 100_000
+			? value.formatted(.number.notation(.compactName).precision(.fractionLength(fractionDigits)))
+			: value.formatted()
+	}
+
 	private func packetCount(_ value: UInt32, arrow: String) -> some View {
-		Text("\(value.formatted()) \(arrow)")
+		Text("\(packetText(value)) \(arrow)")
 			.font(packetFont.weight(.semibold).monospacedDigit())
 			.lineLimit(1)
-			.minimumScaleFactor(0.3)
+			.minimumScaleFactor(0.6)
 			.frame(maxWidth: .infinity, alignment: .leading)
 	}
 
+	/// One concatenated Text, not an HStack of several: separate Texts each get
+	/// their own width and the longest clips, so the scale factor never applies to
+	/// the line as a whole ("457K dup…").
 	@ViewBuilder
 	private var packetMetadata: some View {
 		if let stats {
-			HStack(spacing: TVTheme.statsStripPacketSpacing) {
-				if let dupes = stats.packetsRxDupe {
-					Text("\(dupes.formatted()) dupes")
-					Text("·")
-				}
-				Text("Updated")
-				Text(stats.receivedAt, style: .relative)
-			}
+			dupesText(stats) + Text("Updated ") + Text(stats.receivedAt, style: .relative)
 		} else {
 			Text("Updated —")
 				.hidden()
 		}
+	}
+
+	private func dupesText(_ stats: MeshClient.ConnectedNodeStats) -> Text {
+		guard let dupes = stats.packetsRxDupe else { return Text(verbatim: "") }
+		return Text("\(packetText(dupes, fractionDigits: 0)) dupes") + Text(verbatim: " · ")
 	}
 
 	private func metricLabel(_ text: LocalizedStringKey) -> some View {


### PR DESCRIPTION
## Summary

Follow-up to #2316: this is the packets half of that work, which was pushed after the PR had already been merged and so never reached main.

## What changed

- The packets column asked for a fixed ideal width and then compressed its own text, so with an event badge present the counters clipped to "1,2… 9,8…". It now takes whatever the fixed columns leave, and those columns were trimmed to what their content actually needs.
- Counters past six figures use compact notation ("457K", "1.2M") — a seven-digit pair outgrows the column at any scale factor.
- The dupes/updated line is one concatenated Text rather than four. Separate Texts each get their own width and the longest one clips, so the scale factor never applied to the line as a whole.

## Testing

tvOS builds. Verified on an Apple TV 4K simulator against a DEFCON event-firmware replay, with live values and with the counters forced to a worst case (1,234,567 / 9,876,543 tx/rx and 456,789 dupes). The counters, dupes line, event name, node counts and both utilization figures all render in full, and the strip stays inside the map column.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized the mesh statistics strip layout for better use of available screen space.
  * Packet information now expands responsively and scales metadata more cleanly.
  * Large packet counts use compact notation for improved readability.
  * Packet metadata now includes duplicate counts when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->