### PR TITLE
Fix tvOS accessibility (rebased from #2315)

### DIFF
--- a/Meshtastic TV/App/ConnectView.swift
+++ b/Meshtastic TV/App/ConnectView.swift
@@ -11,9 +11,15 @@
 import SwiftUI
 
 struct ConnectView: View {
+	private enum ErrorFocus: Hashable {
+		case connection
+		case discovery
+	}
+
 	@Bindable var client: MeshClient
 	@Environment(\.scenePhase) private var scenePhase
 	@StateObject private var discovery = NodeDiscovery()
+	@AccessibilityFocusState private var errorFocus: ErrorFocus?
 
 	@AppStorage("tv.lastHost") private var host: String = ""
 	@AppStorage("tv.lastPort") private var portText: String = "4403"
@@ -46,6 +52,9 @@ struct ConnectView: View {
 						Section {
 							Label(message, systemImage: "exclamationmark.triangle.fill")
 								.foregroundStyle(Color("MeshtasticError"))
+								.accessibilityLabel("Connection error: \(message)")
+								.accessibilityFocused($errorFocus, equals: .connection)
+								.onAppear { errorFocus = .connection }
 						}
 					}
 
@@ -69,7 +78,7 @@ struct ConnectView: View {
 
 	private var hero: some View {
 		VStack(alignment: .leading, spacing: 28) {
-			Image("meshtastic-wordmark-white")
+			Image(decorative: "meshtastic-wordmark-white")
 				.resizable()
 				.scaledToFit()
 				.frame(width: 620)
@@ -90,6 +99,9 @@ struct ConnectView: View {
 			if let errorMessage = discovery.errorMessage {
 				Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
 					.foregroundStyle(Color("MeshtasticError"))
+					.accessibilityLabel("Discovery error: \(errorMessage)")
+					.accessibilityFocused($errorFocus, equals: .discovery)
+					.onAppear { errorFocus = .discovery }
 				Button("Try Again") { discovery.retry() }
 			} else if discovery.discovered.isEmpty {
 				HStack(spacing: 16) {

--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -22,6 +22,7 @@ struct MapScreen: View {
 	// focus for NavigationLink rows, so track it explicitly and mirror it into
 	// the map selection (debounced map-side).
 	@FocusState private var focusedNodeNum: UInt32?
+	@FocusState private var recenterFocused: Bool
 	@State private var navPath: [UInt32] = []
 
 	/// The persisted node store — the map and list read from here, not the client.
@@ -99,7 +100,14 @@ struct MapScreen: View {
 	/// focus back to the node list — without this, MKMapView is a focus trap.
 	private func escapeMap() {
 		navPath = []
-		focusedNodeNum = selectedNodeNum ?? sortedNodes.first?.num
+		if let selectedNodeNum, sortedNodes.contains(where: { $0.num == selectedNodeNum }) {
+			focusedNodeNum = selectedNodeNum
+		} else if let firstNodeNum = sortedNodes.first?.num {
+			focusedNodeNum = firstNodeNum
+		} else {
+			focusedNodeNum = nil
+			recenterFocused = true
+		}
 	}
 
 	private var nodeList: some View {
@@ -114,6 +122,7 @@ struct MapScreen: View {
 					} label: {
 						Label("Re-center Map", systemImage: "scope")
 					}
+					.focused($recenterFocused)
 					NavigationLink {
 						SettingsView()
 					} label: {
@@ -154,7 +163,7 @@ struct MapScreen: View {
 	private var header: some View {
 		HStack(spacing: 20) {
 			VStack(alignment: .leading, spacing: 6) {
-				Image("meshtastic-wordmark-white")
+				Image(decorative: "meshtastic-wordmark-white")
 					.resizable()
 					.scaledToFit()
 					.frame(height: TVTheme.wordmarkHeight)
@@ -243,5 +252,22 @@ private struct NodeRow: View {
 			// metadata line clipped while the row still had space to its right.
 			.frame(maxWidth: .infinity, alignment: .leading)
 		}
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel(node.displayName)
+		.accessibilityValue(accessibilityValue)
+	}
+
+	private var accessibilityValue: String {
+		var parts = [node.isOnline ? "Online" : "Offline"]
+		if let lastHeard = node.lastHeard {
+			parts.append("Last heard \(lastHeard.formatted(.relative(presentation: .named)))")
+		}
+		if let role = node.nodeRole {
+			parts.append("Role: \(role.name)")
+		}
+		if !node.hasLocation {
+			parts.append("No position")
+		}
+		return parts.joined(separator: ", ")
 	}
 }

--- a/Meshtastic TV/App/RootView.swift
+++ b/Meshtastic TV/App/RootView.swift
@@ -14,14 +14,15 @@ struct RootView: View {
 
 	var body: some View {
 		Group {
-			switch client.state {
-			case .connected:
-				MapScreen(client: client)
-			case .connecting:
-				ConnectingView(host: client.host) { client.disconnect() }
-			case .disconnected, .failed:
-				ConnectView(client: client)
+#if DEBUG
+			if CommandLine.arguments.contains("-tv-show-settings") {
+				NavigationStack { SettingsView() }
+			} else {
+				content
 			}
+#else
+			content
+#endif
 		}
 		// Buttons and icons follow the app AccentColor (Blue 700, matching the iOS
 		// app). The brand green fails WCAG contrast for interactive elements, so it's
@@ -46,6 +47,18 @@ struct RootView: View {
 			UIApplication.shared.isIdleTimerDisabled = (phase == .active)
 		}
 	}
+
+	@ViewBuilder
+	private var content: some View {
+		switch client.state {
+		case .connected:
+			MapScreen(client: client)
+		case .connecting:
+			ConnectingView(host: client.host) { client.disconnect() }
+		case .disconnected, .failed:
+			ConnectView(client: client)
+		}
+	}
 }
 
 private struct ConnectingView: View {
@@ -54,7 +67,7 @@ private struct ConnectingView: View {
 
 	var body: some View {
 		VStack(spacing: 48) {
-			Image("m-logo-white")
+			Image(decorative: "m-logo-white")
 				.resizable()
 				.scaledToFit()
 				.frame(width: 280)

--- a/Meshtastic TV/App/SettingsView.swift
+++ b/Meshtastic TV/App/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView: View {
 	@Environment(\.modelContext) private var context
 	@Query private var nodes: [MeshNode]
 	@State private var confirmClear = false
-	@FocusState private var clearFocused: Bool
+	@FocusState private var mapTypeFocused: Bool
 	/// MKMapType raw value, shared with MeshTVMapView via the same key.
 	@AppStorage("tv.mapType") private var mapTypeRaw: Int = Int(MKMapType.standard.rawValue)
 	@StateObject private var offlineBasemap = TVOfflineBasemap()
@@ -37,6 +37,8 @@ struct SettingsView: View {
 					Text("Satellite").tag(Int(MKMapType.satellite.rawValue))
 				}
 				.pickerStyle(.segmented)
+				.focused($mapTypeFocused)
+				.accessibilityIdentifier("settings.mapType")
 
 				Toggle("Mesh Stats", isOn: $statsBarEnabled)
 				Picker("Stats Position", selection: $statsBarEdge) {
@@ -59,14 +61,14 @@ struct SettingsView: View {
 				} label: {
 					Label("Clear Node Database", systemImage: "trash")
 				}
-				.focused($clearFocused)
+				.accessibilityIdentifier("settings.clearNodeDatabase")
 			} header: {
 				Text("Data")
 			} footer: {
 				Text("Removes all \(nodes.count) saved nodes from this Apple TV. They repopulate from the radio's database on the next connection.")
 			}
 		}
-		.defaultFocus($clearFocused, true)
+		.defaultFocus($mapTypeFocused, true)
 		.navigationTitle("Settings")
 		.alert("Clear Node Database?", isPresented: $confirmClear) {
 			Button("Clear", role: .destructive, action: clearDatabase)

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -43,15 +43,32 @@ struct MeshStatsStrip: View {
 				divider
 			}
 
-			cell(label: "Nodes", value: nodesText)
+			cell(
+				label: "Nodes",
+				value: nodesText,
+				accessibilityLabel: "Nodes online",
+				accessibilityValue: nodesAccessibilityValue
+			)
 				.frame(idealWidth: TVTheme.statsStripNodesWidth, maxWidth: TVTheme.statsStripNodesWidth)
 
 			divider
-			cell(label: "Ch Util", value: percentText(stats?.channelUtilization), color: channelUtilColor)
+			cell(
+				label: "Ch Util",
+				value: percentText(stats?.channelUtilization),
+				color: channelUtilColor,
+				severity: channelUtilSeverity,
+				accessibilityLabel: "Channel utilization"
+			)
 				.frame(idealWidth: TVTheme.statsStripUtilizationWidth, maxWidth: TVTheme.statsStripUtilizationWidth)
 
 			divider
-			cell(label: "Air TX", value: percentText(stats?.airUtilTx), color: airTxColor)
+			cell(
+				label: "Air TX",
+				value: percentText(stats?.airUtilTx),
+				color: airTxColor,
+				severity: airTxSeverity,
+				accessibilityLabel: "Airtime transmit"
+			)
 				.frame(idealWidth: TVTheme.statsStripUtilizationWidth, maxWidth: TVTheme.statsStripUtilizationWidth)
 
 			divider
@@ -96,12 +113,40 @@ struct MeshStatsStrip: View {
 		.accessibilityLabel(Text("Event firmware: \(edition.name)"))
 	}
 
-	private func cell(label: LocalizedStringKey, value: String, color: Color = .primary) -> some View {
+	/// `severity` conveys a warning without relying on colour alone: the glyph rides
+	/// beside the LABEL, where the column has slack, rather than beside the value,
+	/// where it would push these fixed-width columns back into truncation. VoiceOver
+	/// reads it from the accessibility value instead of the glyph.
+	private func cell(
+		label: LocalizedStringKey,
+		value: String,
+		color: Color = .primary,
+		severity: LocalizedStringKey? = nil,
+		accessibilityLabel: LocalizedStringKey? = nil,
+		accessibilityValue: Text? = nil
+	) -> some View {
 		VStack(alignment: .leading, spacing: TVTheme.statsStripMetricSpacing) {
-			metricLabel(label)
+			HStack(spacing: 8) {
+				metricLabel(label)
+				if severity != nil {
+					Image(systemName: "exclamationmark.triangle.fill")
+						.font(.caption.weight(.semibold))
+						.foregroundStyle(color)
+						.accessibilityHidden(true)
+				}
+			}
 			metricValue(value, color: color)
 		}
 		.frame(maxWidth: .infinity, alignment: .leading)
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel(accessibilityLabel ?? label)
+		.accessibilityValue(accessibilityValue ?? severityValue(value, severity))
+	}
+
+	/// "7.5%" on its own, or "7.5%, Congested" when a severity applies.
+	private func severityValue(_ value: String, _ severity: LocalizedStringKey?) -> Text {
+		guard let severity else { return Text(verbatim: value) }
+		return Text(verbatim: value) + Text(verbatim: ", ") + Text(severity)
 	}
 
 	private var packetsCell: some View {
@@ -116,6 +161,9 @@ struct MeshStatsStrip: View {
 				.frame(height: metadataHeight)
 		}
 		.frame(maxWidth: .infinity, alignment: .leading)
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel("Packets")
+		.accessibilityValue(packetsAccessibilityValue)
 	}
 
 	@ViewBuilder
@@ -163,6 +211,7 @@ struct MeshStatsStrip: View {
 			.foregroundStyle(Color.gray)
 			.lineLimit(1)
 			.minimumScaleFactor(0.8)
+			.accessibilityHidden(true)
 	}
 
 	/// Value type steps down when the event badge is present — the badge takes a
@@ -199,6 +248,35 @@ struct MeshStatsStrip: View {
 	private func percentText(_ value: Float?) -> String {
 		guard let value else { return "—" }
 		return String(format: "%.1f%%", value)
+	}
+
+	private var nodesAccessibilityValue: Text {
+		if let online = stats?.onlineNodes, let total = stats?.totalNodes {
+			return Text("\(Int(online)) of \(Int(total)) online")
+		}
+		return Text("\(storeOnlineCount) of \(storeTotalCount) online")
+	}
+
+	private var packetsAccessibilityValue: Text {
+		guard let tx = stats?.packetsTx, let rx = stats?.packetsRx else { return Text("No data") }
+		var value = Text("\(tx.formatted()) transmitted, \(rx.formatted()) received")
+		if let dupes = stats?.packetsRxDupe {
+			value = value + Text(verbatim: ", ") + Text("\(dupes.formatted()) duplicates")
+		}
+		return value
+	}
+
+	private var channelUtilSeverity: LocalizedStringKey? {
+		guard let value = stats?.channelUtilization else { return nil }
+		if value >= 50 { return "Severely congested" }
+		if value >= 25 { return "Congested" }
+		return nil
+	}
+
+	/// 10% is the duty-cycle ceiling in most regions.
+	private var airTxSeverity: LocalizedStringKey? {
+		guard let value = stats?.airUtilTx, value >= 10 else { return nil }
+		return "At duty-cycle limit"
 	}
 
 	/// Firmware treats sustained channel utilization above 25% as a congested mesh.

--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -70,6 +70,13 @@
 			remoteGlobalIDString = A2F1595BC848E48B138C58E1;
 			remoteInfo = WidgetsExtension;
 		};
+		1B5441E6472D077F86C7500B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B1FDE49A580C939ADB9E00CE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 731011765CF28FC65E45163E;
+			remoteInfo = "Meshtastic TV";
+		};
 		7641B817BB20E264D0A5E4E5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B1FDE49A580C939ADB9E00CE /* Project object */;
@@ -214,6 +221,7 @@
 		DD8FE67D6F2C7F041F8E3C8C /* AppIcon_Chirpy.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon_Chirpy.icon; sourceTree = "<group>"; };
 		DD9ED0AFED536B2EE5F32F23 /* AppIcon_Ham.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon_Ham.icon; sourceTree = "<group>"; };
 		E4053FDE501FD7E0A02CEA8D /* WidgetsExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = WidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		E41F76E242AA58583D058626 /* Meshtastic TVUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = "Meshtastic TVUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4B18DB5D1945CE9ABE5A18D /* MeshtasticDataModelV 58.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "MeshtasticDataModelV 58.xcdatamodel"; sourceTree = "<group>"; };
 		E4FC9164DF840C79496963DD /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = ru; path = ru.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
 		E81B359C631E51C6461AAE00 /* MeshtasticDataModelV12.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MeshtasticDataModelV12.xcdatamodel; sourceTree = "<group>"; };
@@ -468,6 +476,15 @@
 			path = AppIntents;
 			sourceTree = "<group>";
 		};
+		9AE441C6AC684B0738ED364A /* MeshtasticTVUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = MeshtasticTVUITests;
+			sourceTree = "<group>";
+		};
 		9F6D2EC582CAA968D897F796 /* Router */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			explicitFileTypes = {
@@ -634,6 +651,7 @@
 			isa = PBXGroup;
 			children = (
 				A127CADA4845100E1C10B022 /* Meshtastic TV.app */,
+				E41F76E242AA58583D058626 /* Meshtastic TVUITests.xctest */,
 				ADF6BAC3992D05079F77B35C /* Meshtastic Watch App.app */,
 				1A740EACFF7FA4000F22EF4E /* Meshtastic.app */,
 				53E4E3191A93EDE5C8C08E1C /* MeshtasticTests.xctest */,
@@ -746,6 +764,7 @@
 				EA229AC7C87CBBD64EC61AA1 /* Meshtastic TV */,
 				F0E2A06151AF30290D808624 /* Meshtastic Watch App */,
 				867FD80926C4A4286D635BAD /* MeshtasticTests */,
+				9AE441C6AC684B0738ED364A /* MeshtasticTVUITests */,
 				8F644F7974EA8B14E77ED53A /* Packages */,
 				F15A1577564640951AD3EA40 /* Settings.bundle */,
 				456E28D41A9B7B1788FEE0CD /* Shared */,
@@ -893,6 +912,28 @@
 			productReference = E4053FDE501FD7E0A02CEA8D /* WidgetsExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		BD5F76AD88798DAA8768A6E5 /* Meshtastic TVUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7C51102928658E793C011B32 /* Build configuration list for PBXNativeTarget "Meshtastic TVUITests" */;
+			buildPhases = (
+				7FEF51F3B1F316789878D34C /* Sources */,
+				971BB3202E0215C375C16856 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0CC301424E6FD9865C42C128 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				9AE441C6AC684B0738ED364A /* MeshtasticTVUITests */,
+			);
+			name = "Meshtastic TVUITests";
+			packageProductDependencies = (
+			);
+			productName = "Meshtastic TVUITests";
+			productReference = E41F76E242AA58583D058626 /* Meshtastic TVUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		C4BC64E061C609D15F5DFAF5 /* Meshtastic Watch App */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF633447B3933E14C9042CFE /* Build configuration list for PBXNativeTarget "Meshtastic Watch App" */;
@@ -993,6 +1034,11 @@
 						DevelopmentTeam = GCH7VS5Y9R;
 						ProvisioningStyle = Automatic;
 					};
+					BD5F76AD88798DAA8768A6E5 = {
+						DevelopmentTeam = GCH7VS5Y9R;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 731011765CF28FC65E45163E;
+					};
 					C4BC64E061C609D15F5DFAF5 = {
 						DevelopmentTeam = GCH7VS5Y9R;
 						ProvisioningStyle = Automatic;
@@ -1050,12 +1096,20 @@
 				55AF3400F316106F54C5485F /* MeshtasticTests */,
 				C4BC64E061C609D15F5DFAF5 /* Meshtastic Watch App */,
 				731011765CF28FC65E45163E /* Meshtastic TV */,
+				BD5F76AD88798DAA8768A6E5 /* Meshtastic TVUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		10D31ADC03EA77B8648E37AA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		971BB3202E0215C375C16856 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1176,6 +1230,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7FEF51F3B1F316789878D34C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9B95112C9BAE16B951830AD3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1196,6 +1257,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0CC301424E6FD9865C42C128 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 731011765CF28FC65E45163E /* Meshtastic TV */;
+			targetProxy = 1B5441E6472D077F86C7500B /* PBXContainerItemProxy */;
+		};
 		3A9A327DE34F907303E13AC7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FEF4168AE260CFE34C972EBB /* Meshtastic */;
@@ -1244,6 +1310,25 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		32D524754999BA9E27FF5ADC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GCH7VS5Y9R;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.TVUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TEST_TARGET_NAME = "Meshtastic TV";
+				TVOS_DEPLOYMENT_TARGET = 17.0;
+			};
+			name = Release;
+		};
 		5554BC660DC627BF91EFBD63 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1582,6 +1667,25 @@
 			};
 			name = Debug;
 		};
+		D88DA2385F85DE1DAAB283C4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GCH7VS5Y9R;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.TVUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TEST_TARGET_NAME = "Meshtastic TV";
+				TVOS_DEPLOYMENT_TARGET = 17.0;
+			};
+			name = Debug;
+		};
 		E2D98709107BDD6820FC226C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1741,6 +1845,15 @@
 			buildConfigurations = (
 				6936E75845F3455F2F8A83BA /* Debug */,
 				67E591654DF7A3F0BC045D06 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7C51102928658E793C011B32 /* Build configuration list for PBXNativeTarget "Meshtastic TVUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D88DA2385F85DE1DAAB283C4 /* Debug */,
+				32D524754999BA9E27FF5ADC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Meshtastic.xcodeproj/xcshareddata/xcschemes/Meshtastic TV.xcscheme
+++ b/Meshtastic.xcodeproj/xcshareddata/xcschemes/Meshtastic TV.xcscheme
@@ -21,6 +21,20 @@
                ReferencedContainer = "container:Meshtastic.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BD5F76AD88798DAA8768A6E5"
+               BuildableName = "Meshtastic TVUITests.xctest"
+               BlueprintName = "Meshtastic TVUITests"
+               ReferencedContainer = "container:Meshtastic.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -39,6 +53,17 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BD5F76AD88798DAA8768A6E5"
+               BuildableName = "Meshtastic TVUITests.xctest"
+               BlueprintName = "Meshtastic TVUITests"
+               ReferencedContainer = "container:Meshtastic.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <CommandLineArguments>
       </CommandLineArguments>

--- a/MeshtasticTVUITests/AccessibilityTests.swift
+++ b/MeshtasticTVUITests/AccessibilityTests.swift
@@ -1,0 +1,39 @@
+//
+//  AccessibilityTests.swift
+//  Meshtastic TVUITests
+//
+
+import XCTest
+
+@MainActor
+final class AccessibilityTests: XCTestCase {
+	override func setUpWithError() throws {
+		continueAfterFailure = false
+	}
+
+	func testConnectionScreenPassesAccessibilityAudit() throws {
+		let app = XCUIApplication()
+		app.launch()
+
+		XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 5))
+		try app.performAccessibilityAudit()
+	}
+
+	func testSettingsStartsWithMapTypeFocused() {
+		let app = XCUIApplication()
+		app.launchArguments = ["-tv-show-settings"]
+		app.launch()
+
+		let mapType = app.descendants(matching: .any)["settings.mapType"]
+		XCTAssertTrue(mapType.waitForExistence(timeout: 5))
+		let mapTypeOptions = ["Standard", "Hybrid", "Satellite"].map { app.buttons[$0] }
+		XCTAssertTrue(waitForFocus(in: mapTypeOptions, timeout: 5))
+		XCTAssertFalse(app.buttons["settings.clearNodeDatabase"].hasFocus)
+	}
+
+	private func waitForFocus(in elements: [XCUIElement], timeout: TimeInterval) -> Bool {
+		let predicate = NSPredicate { _, _ in elements.contains(where: \.hasFocus) }
+		let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+		return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+	}
+}

--- a/project.yml
+++ b/project.yml
@@ -719,6 +719,43 @@ targets:
           TARGETED_DEVICE_FAMILY: "3"
           TVOS_DEPLOYMENT_TARGET: "17.0"
 
+  "Meshtastic TVUITests":
+    type: bundle.ui-testing
+    platform: tvOS
+    sources:
+      - path: "MeshtasticTVUITests"
+        type: syncedFolder
+    dependencies:
+      - target: "Meshtastic TV"
+    settings:
+      configs:
+        Debug:
+          CODE_SIGN_STYLE: "Automatic"
+          CURRENT_PROJECT_VERSION: "1"
+          DEVELOPMENT_TEAM: "GCH7VS5Y9R"
+          GENERATE_INFOPLIST_FILE: "YES"
+          MARKETING_VERSION: "1.0"
+          PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.TVUITests"
+          PRODUCT_NAME: "$(TARGET_NAME)"
+          SDKROOT: "appletvos"
+          SUPPORTED_PLATFORMS: "appletvos appletvsimulator"
+          SWIFT_VERSION: "5.0"
+          TARGETED_DEVICE_FAMILY: "3"
+          TVOS_DEPLOYMENT_TARGET: "17.0"
+        Release:
+          CODE_SIGN_STYLE: "Automatic"
+          CURRENT_PROJECT_VERSION: "1"
+          DEVELOPMENT_TEAM: "GCH7VS5Y9R"
+          GENERATE_INFOPLIST_FILE: "YES"
+          MARKETING_VERSION: "1.0"
+          PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.TVUITests"
+          PRODUCT_NAME: "$(TARGET_NAME)"
+          SDKROOT: "appletvos"
+          SUPPORTED_PLATFORMS: "appletvos appletvsimulator"
+          SWIFT_VERSION: "5.0"
+          TARGETED_DEVICE_FAMILY: "3"
+          TVOS_DEPLOYMENT_TARGET: "17.0"
+
 schemes:
   Meshtastic:
     build:
@@ -773,10 +810,13 @@ schemes:
     build:
       targets:
         "Meshtastic TV": all
+        "Meshtastic TVUITests": [test]
     run:
       config: Debug
     test:
       config: Debug
+      targets:
+        - "Meshtastic TVUITests"
     profile:
       config: Release
     analyze:


### PR DESCRIPTION
## Summary

@bruschill's tvOS accessibility work from #2315, rebased onto current main. The original commit and authorship are preserved; #2315 was branched before the recent stats-strip changes and had drifted into conflict.

## What changed relative to #2315

Only `MeshStatsStrip` needed rework — the rest rebased cleanly.

- The strip was rewritten on main by #2307, #2314 and #2316, so the accessibility semantics were ported onto the current layout instead of the old one. The `cell` helper keeps its `LocalizedStringKey` signature and the packets metadata line stays as one row rather than reverting to separate Dupes and Updated cells.
- The severity glyph now sits beside the column **label** rather than the value. In the value row it would have widened the Ch Util and Air TX columns, which are capped at 140pt, and pushed them back into the truncation #2316 just fixed. It reads identically to VoiceOver, which takes the severity from the accessibility value, not the glyph.
- Accessibility labels and values in the strip use `LocalizedStringKey`/`Text` so they go through the string catalog the TV target picked up in #2307. Composed `String` values would not have been localizable.

Everything else is unchanged from #2315: focus handling for connection and discovery errors, decorative branding images, node row accessibility values, Settings starting on Map Type instead of Clear Node Database, the empty-map focus fallback, and the new tvOS UI test target.

## Testing

tvOS builds. The new `Meshtastic TVUITests` target runs green — 2 tests, 0 failures, including `performAccessibilityAudit()` on the connection screen. `xcodegen generate` produces no diff against the committed project. Verified on an Apple TV 4K simulator against a DEFCON event-firmware replay that the strip still renders without truncation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved VoiceOver labels and announcements for connection errors, map nodes, and mesh statistics.
  * Added clearer severity descriptions for utilization and airtime warnings.
  * Improved focus behavior across connection, map, and settings screens.

* **Testing**
  * Added tvOS UI tests covering accessibility and settings focus behavior.
  * Added support for launching settings directly in debug builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->