### PR TITLE
Fit the tvOS stats bar to the space it has

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -64,6 +64,10 @@ struct MapScreen: View {
 						edition: EventEdition(client.firmwareEdition)
 					)
 					.padding(TVTheme.statsStripMargin)
+					// The map is full-bleed but the overlay lands inside the safe
+					// area, so the bar stopped ~80pt short of the screen edge while
+					// its columns were squeezed. Reclaim that width.
+					.ignoresSafeArea(edges: .horizontal)
 				}
 			}
 		}

--- a/Meshtastic TV/App/TVTheme.swift
+++ b/Meshtastic TV/App/TVTheme.swift
@@ -46,8 +46,8 @@ enum TVTheme {
 	static let statsStripPacketSpacing: CGFloat = 10
 	static let statsStripEventWidth: CGFloat = 230
 	static let statsStripEventLogoSize: CGFloat = 56
-	static let statsStripNodesWidth: CGFloat = 200
-	static let statsStripUtilizationWidth: CGFloat = 140
+	static let statsStripNodesWidth: CGFloat = 250
+	static let statsStripUtilizationWidth: CGFloat = 160
 	static let statsStripHorizontalPadding: CGFloat = 36
 	static let statsStripVerticalPadding: CGFloat = 28
 	static let statsStripCornerRadius: CGFloat = 24

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -173,15 +173,17 @@ struct MeshStatsStrip: View {
 				packetCount(tx, arrow: "↑")
 				packetCount(rx, arrow: "↓")
 			}
+			.frame(maxWidth: .infinity, alignment: .leading)
 		} else {
 			metricValue("—", font: packetFont)
 		}
 	}
 
-	/// Grouped digits normally; compact ("457K", "1.2M") past six figures, where
-	/// the counters outgrow the column no matter how much they are scaled down.
+	/// Grouped digits up to five figures, compact ("17.2K", "584.1K", "1.2M") above
+	/// that — the counters outgrow the column at any scale otherwise. VoiceOver still
+	/// gets the exact digits from `packetsAccessibilityValue`.
 	private func packetText(_ value: UInt32, fractionDigits: Int = 1) -> String {
-		value >= 100_000
+		value >= 10_000
 			? value.formatted(.number.notation(.compactName).precision(.fractionLength(fractionDigits)))
 			: value.formatted()
 	}
@@ -191,25 +193,32 @@ struct MeshStatsStrip: View {
 			.font(packetFont.weight(.semibold).monospacedDigit())
 			.lineLimit(1)
 			.minimumScaleFactor(0.6)
-			.frame(maxWidth: .infinity, alignment: .leading)
 	}
 
-	/// One concatenated Text, not an HStack of several: separate Texts each get
-	/// their own width and the longest clips, so the scale factor never applies to
-	/// the line as a whole ("457K dup…").
+	/// One plain string, so `minimumScaleFactor` applies to the whole line. Text
+	/// concatenation does not work here: a `style: .relative` Text stays its own run
+	/// and each run clipped separately ("17,… · Up… 4 m…"). The timestamp is static
+	/// between telemetry updates, and the strip re-renders on each one.
 	@ViewBuilder
 	private var packetMetadata: some View {
 		if let stats {
-			dupesText(stats) + Text("Updated ") + Text(stats.receivedAt, style: .relative)
+			Text(metadataText(stats))
 		} else {
 			Text("Updated —")
 				.hidden()
 		}
 	}
 
-	private func dupesText(_ stats: MeshClient.ConnectedNodeStats) -> Text {
-		guard let dupes = stats.packetsRxDupe else { return Text(verbatim: "") }
-		return Text("\(packetText(dupes, fractionDigits: 0)) dupes") + Text(verbatim: " · ")
+	private func metadataText(_ stats: MeshClient.ConnectedNodeStats) -> String {
+		// Narrow units ("4m ago") keep the line short. Sub-minute is formatted by hand
+		// because .relative renders a just-arrived sample as "in 0 sec." — it rounds to
+		// zero and then picks future tense, which reads like a countdown.
+		let elapsed = max(0, Date().timeIntervalSince(stats.receivedAt))
+		let updated = elapsed < 60
+			? "\(Int(elapsed))s ago"
+			: stats.receivedAt.formatted(.relative(presentation: .numeric, unitsStyle: .narrow))
+		guard let dupes = stats.packetsRxDupe else { return "Updated \(updated)" }
+		return "\(packetText(dupes, fractionDigits: 0)) dupes · Updated \(updated)"
 	}
 
 	private func metricLabel(_ text: LocalizedStringKey) -> some View {


### PR DESCRIPTION
## Summary

The tvOS stats bar was clipping text while leaving space unused, most visibly `NODES 1617 / 16…`.

## What changed

- **Reclaimed the unused width.** The map is full-bleed but its overlay lands inside the trailing title-safe margin, so the bar stopped roughly 80pt short of the screen edge while its columns were squeezed. It now uses that width.
- **Columns sized to real content.** Nodes fits four-and-four digits, and the utilization columns fit a value alongside the severity glyph.
- **Packet counters size to their own text.** Each previously claimed an equal half of the column, so a short tx ("32 ↑") wasted its half while a long rx clipped.
- **Counters compact above five figures** rather than six, so a busy mesh's rx reads "584.1K" instead of clipping. VoiceOver still gets the exact digits from `packetsAccessibilityValue`.
- **The updated line is a single plain string.** Text concatenation didn't work here: a `style: .relative` Text stays its own run, so each run clipped separately ("17,… · Up… 4 m…") and the scale factor never applied to the line. Sub-minute ages are formatted by hand because `.relative` renders a just-arrived sample as "in 0 sec." — it rounds to zero and then picks future tense.

## Testing

tvOS builds and the `Meshtastic TVUITests` suite passes (2 tests, 0 failures). Verified on an Apple TV 4K simulator against a DEFCON event-firmware replay, both with live values and with the worst case from the reported screenshot forced in (1617 / 1617 nodes, 48.8% channel utilization, 584,058 rx, 17,166 dupes): every field renders in full and the bar stays inside the map column.

One trade-off worth noting: the updated line is now a non-localized `String`, as it was before this change. Making it localizable would mean reintroducing the multi-run clipping, so it needs a different approach if we want it translated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded the TV map stats overlay to use the full available width.
  * Increased space for node and utilization statistics.
  * Improved packet count formatting and display of recent packet ages.
  * Packet counts now make better use of available space and switch to compact formatting earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->