### PR TITLE
Remove unused tvOS map Menu handler

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -48,7 +48,6 @@ struct MapScreen: View {
 				nodes: locatedNodes,
 				selectedNodeNum: $selectedNodeNum,
 				recenterToken: recenterToken,
-				onMenuExit: escapeMap,
 				offlineVectors: offlineVectors
 			)
 			.ignoresSafeArea()
@@ -92,13 +91,6 @@ struct MapScreen: View {
 			.sorted { ($0.lastHeard ?? .distantPast) > ($1.lastHeard ?? .distantPast) }
 		if newSorted.map(\.num) != sortedNodes.map(\.num) { sortedNodes = newSorted }
 		if newLocated.map(\.num) != locatedNodes.map(\.num) { locatedNodes = newLocated }
-	}
-
-	/// Menu pressed while the map held focus: pop any open node detail and hand
-	/// focus back to the node list — without this, MKMapView is a focus trap.
-	private func escapeMap() {
-		navPath = []
-		focusedNodeNum = selectedNodeNum ?? sortedNodes.first?.num
 	}
 
 	private var nodeList: some View {
@@ -183,15 +175,6 @@ struct MapScreen: View {
 				)
 				.ignoresSafeArea(edges: [.top, .leading])
 		}
-	}
-
-	private var disconnectButton: some View {
-		Button(role: .destructive) {
-			client.disconnect()
-		} label: {
-			Label("Disconnect", systemImage: "xmark.circle.fill")
-		}
-		.buttonStyle(.bordered)
 	}
 }
 

--- a/Meshtastic TV/Map/MeshTVMapView.swift
+++ b/Meshtastic TV/Map/MeshTVMapView.swift
@@ -280,12 +280,6 @@ struct MeshTVMapView: UIViewRepresentable {
 	@Binding var selectedNodeNum: UInt32?
 	/// Increment to re-frame the camera on the whole mesh (see MapScreen's button).
 	var recenterToken: Int = 0
-	/// Called on a Menu press while the map has focus. MKMapView captures the
-	/// directional input for panning and never releases focus on its own, so
-	/// without this the map is a focus trap (and an unhandled Menu press can
-	/// suspend the app instead of going back). MapScreen uses it to hand focus
-	/// back to the node list.
-	var onMenuExit: (() -> Void)?
 
 	/// Standard / Hybrid / Satellite, chosen in Settings. Shared via the same
 	/// @AppStorage key so changing it there updates the map live.
@@ -355,10 +349,6 @@ struct MeshTVMapView: UIViewRepresentable {
 
 		init(_ parent: MeshTVMapView) {
 			self.parent = parent
-		}
-
-		@objc func menuPressed() {
-			parent.onMenuExit?()
 		}
 
 		/// Diff the annotation set against `nodes` (add / update coordinate / remove),


### PR DESCRIPTION
## What changed?

- Removed the unreachable tvOS map Menu callback path.
- Removed an unused duplicate Disconnect button view.
- Kept the visible Disconnect row and native tvOS Back/Menu handling unchanged.

## Why did it change?

This is a follow-up to closed PR #2313. Review there confirmed that the map callback could not run because the map is non-interactive and no press recognizer calls it. Removing the path avoids implying that the map handles Menu presses while preserving the system behavior at the map root.

## How is this tested?

- Built the `Meshtastic TV` scheme for a generic tvOS simulator.
- Ran SwiftLint on both changed files. It reported one existing `large_tuple` warning outside this diff and no serious violations.
- Ran `git diff --check`.
- Ran `/ponytail-review`: `Lean already. Ship.`

## Screenshots/Videos (when applicable)

Not included. This removes unreachable code and does not change the visible UI.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.

No documentation update is needed because this is a deletion-only cleanup with no user-visible behavior change.
