### PR TITLE
Hold the event sheet until onboarding finishes

### DIFF
--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -124,7 +124,7 @@ struct ContentView: View {
 		if appState.isDatabaseResetting {
 			DatabaseResettingPlaceholder()
 		} else {
-			ActiveContent(appState: appState, router: router) {
+			ActiveContent(appState: appState, router: router, isOnboarding: isShowingDeviceOnboardingFlow) {
 				tabContent
 			}
 		}
@@ -137,6 +137,10 @@ struct ContentView: View {
 		@ObservedObject var appState: AppState
 		@ObservedObject var router: Router
 		@EnvironmentObject var accessoryManager: AccessoryManager
+		/// True while the first-launch device-onboarding sheet is up. The event sheet
+		/// must not auto-present over it — two sheets presented from different levels
+		/// of the tree fight, and the event sheet ends up covering onboarding.
+		let isOnboarding: Bool
 		@Query private var eventFirmwareEditions: [EventFirmwareEntity]
 		@State private var isShowingEventFirmwareInfo: Bool = false
 		/// The post-event upgrade sheet auto-presents once per connect. ActiveContent is
@@ -145,10 +149,29 @@ struct ContentView: View {
 		@State private var hasAutoPresentedEventEnded: Bool = false
 		private let content: Content
 
-		init(appState: AppState, router: Router, @ViewBuilder content: () -> Content) {
+		init(
+			appState: AppState,
+			router: Router,
+			isOnboarding: Bool,
+			@ViewBuilder content: () -> Content
+		) {
 			self.appState = appState
 			self.router = router
+			self.isOnboarding = isOnboarding
 			self.content = content()
+		}
+
+		/// Once the event's end date has passed, surface the info sheet (with its
+		/// post-event update call to action) automatically on connect — parity with
+		/// Android's post-event upgrade prompt; hasEnded() is false without a valid
+		/// end date, so live/undated editions never nag. Held back while the
+		/// onboarding sheet is up, and retried when it closes.
+		private func autoPresentEndedEventIfNeeded() {
+			guard !isOnboarding, !hasAutoPresentedEventEnded,
+				  let presentation = eventPresentation,
+				  presentation.info.hasEnded() else { return }
+			hasAutoPresentedEventEnded = true
+			isShowingEventFirmwareInfo = true
 		}
 
 		private var eventPresentation: EventFirmwarePresentation? {
@@ -186,16 +209,12 @@ struct ContentView: View {
 						isShowingEventFirmwareInfo = false
 						return
 					}
-					// Once the event's end date has passed, surface the info sheet (with its
-					// post-event update call to action) automatically on connect — parity with
-					// Android's post-event upgrade prompt; hasEnded() is false without a valid
-					// end date, so live/undated editions never nag.
-					if let presentation = eventPresentation,
-					   presentation.info.hasEnded(),
-					   !hasAutoPresentedEventEnded {
-						hasAutoPresentedEventEnded = true
-						isShowingEventFirmwareInfo = true
-					}
+					autoPresentEndedEventIfNeeded()
+				}
+				.onChange(of: isOnboarding) { _, onboarding in
+					// Onboarding just finished — show the sheet we held back. Without this
+					// a first launch that connects during setup never gets the prompt.
+					if !onboarding { autoPresentEndedEventIfNeeded() }
 				}
 		}
 	}


### PR DESCRIPTION
## Summary

On a first launch that connects to a radio during setup, the post-event firmware sheet auto-presented over the device-onboarding sheet.

## What changed

The event sheet is presented from `ActiveContent`, onboarding from `ContentView`. Two sheets presented at different levels of the tree fight each other, and the event sheet won — covering onboarding. The auto-present is now held while onboarding is up, and re-evaluated when onboarding closes so the prompt still appears rather than being dropped for that session.

Only the automatic presentation is gated. Opening the sheet deliberately from the event banner is unchanged.

## Testing

iOS builds. Exercised on an iOS 17.5 simulator against a DEF CON replay: the app launches and connects normally, and the event sheet no longer appears while onboarding is presented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event information no longer interrupts the onboarding experience.
  * Event details are shown automatically after onboarding is completed.
  * Event presentation is limited to once per session.
  * Existing behavior for dismissing events when no edition is available remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->