### PR TITLE
Build only the selected tab on iOS 17's legacy TabView

### DIFF
--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -95,6 +95,15 @@ struct ContentView: View {
 
 	/// A custom binding that intercepts tab selection so that tapping the
 	/// already-active tab pops its navigation stack back to root.
+	///
+	/// **iOS 18+ only.** Its setter writes back into the `Router` its getter reads,
+	/// which the modern `Tab(value:)` API handles but iOS 17's legacy `TabView`
+	/// does not: during first layout iOS 17 re-drives the selection, the write
+	/// republishes, the body invalidates, and SwiftUI re-enters the attribute graph
+	/// until it trips `_assertionFailure` — a launch crash seen only on iOS 17
+	/// (Datadog issue bb11da86, 100% iOS 17, all at ApplicationLaunch). Same family
+	/// as the lockdown-gate binding fixed above. iOS 17 binds `Router.selectedTab`
+	/// directly instead and forgoes tap-to-pop.
 	private var tabSelection: Binding<NavigationState.Tab> {
 		Binding(
 			get: { appState.router.selectedTab },
@@ -232,46 +241,72 @@ struct ContentView: View {
 				}
 			}
 		} else {
-			TabView(selection: tabSelection) {
-				Messages(
-					router: appState.router,
-					unreadChannelMessages: $appState.unreadChannelMessages,
-					unreadDirectMessages: $appState.unreadDirectMessages
-				)
-				.tabItem {
-					Label("Messages", systemImage: "message")
+			// iOS 17 gets the legacy TabView, which differs from iOS 18's `Tab` in two
+			// ways that matter here. Its selection is bound straight to the stored
+			// @Published value rather than the side-effecting `tabSelection` (so no
+			// tap-to-pop on 17), and each tab's content is built lazily instead of all
+			// five roots — and their @Query subscriptions — being constructed during
+			// first layout. `Tab`'s @ViewBuilder closure gives iOS 18+ that laziness
+			// for free. Datadog issue bb11da86 is an attribute-graph trap at first
+			// layout seen only on iOS 17; shrinking what that pass has to build is the
+			// mitigation, and it also cuts the tab-switch cost on 17.
+			TabView(selection: $router.selectedTab) {
+				ForEach(LegacyTab.allCases) { tab in
+					LegacyTabContent(tab: tab, isActive: router.selectedTab == tab.value) {
+						legacyContent(for: tab)
+					}
+					.tabItem { tab.label }
+					.tag(tab.value)
+					.badge(tab == .messages ? appState.totalUnreadMessages : 0)
 				}
-				.tag(NavigationState.Tab.messages)
-				.badge(appState.totalUnreadMessages)
-
-				NodeList()
-				.tabItem {
-					Label("Nodes", image: "custom.mesh.radio")
-				}
-				.tag(NavigationState.Tab.nodes)
-
-				MeshMapMK(router: appState.router)
-				.tabItem {
-					Label("Map", systemImage: "map")
-				}
-				.tag(NavigationState.Tab.map)
-
-				Settings()
-				.tabItem {
-					Label("Settings", systemImage: "gear")
-				}
-				.tag(NavigationState.Tab.settings)
-
-				Connect(
-					router: appState.router
-				)
-				.tabItem {
-					Label("Connect", systemImage: "link")
-				}
-				.tag(NavigationState.Tab.connect)
 			}
 		}
 	}
+
+	/// Tabs for the iOS 17 legacy `TabView`, mirroring the iOS 18 `Tab` list.
+	private enum LegacyTab: String, CaseIterable, Identifiable {
+		case messages, nodes, map, settings, connect
+
+		var id: String { rawValue }
+
+		var value: NavigationState.Tab {
+			switch self {
+			case .messages: return .messages
+			case .nodes: return .nodes
+			case .map: return .map
+			case .settings: return .settings
+			case .connect: return .connect
+			}
+		}
+
+		@ViewBuilder
+		var label: some View {
+			switch self {
+			case .messages: Label("Messages", systemImage: "message")
+			case .nodes: Label("Nodes", image: "custom.mesh.radio")
+			case .map: Label("Map", systemImage: "map")
+			case .settings: Label("Settings", systemImage: "gear")
+			case .connect: Label("Connect", systemImage: "link")
+			}
+		}
+	}
+
+	@ViewBuilder
+	private func legacyContent(for tab: LegacyTab) -> some View {
+		switch tab {
+		case .messages:
+			Messages(
+				router: appState.router,
+				unreadChannelMessages: $appState.unreadChannelMessages,
+				unreadDirectMessages: $appState.unreadDirectMessages
+			)
+		case .nodes: NodeList()
+		case .map: MeshMapMK(router: appState.router)
+		case .settings: Settings()
+		case .connect: Connect(router: appState.router)
+		}
+	}
+
 }
 
 // MARK: - Reset Placeholder
@@ -294,5 +329,35 @@ struct DatabaseResettingPlaceholder: View {
 				.foregroundColor(.gray)
 		}
 		.frame(maxWidth: .infinity, maxHeight: .infinity)
+	}
+}
+
+/// Defers a legacy-`TabView` tab's content until the tab is first selected, then
+/// keeps it alive so its state survives further tab switches.
+///
+/// The iOS 17 `TabView { A; B; C }` form constructs every tab's root immediately,
+/// which on this app means five view trees and their `@Query` subscriptions all
+/// come up during first layout. iOS 18's `Tab(value:) { }` takes a closure and is
+/// lazy already, so this exists only for the iOS 17 path.
+private struct LegacyTabContent<Content: View>: View {
+	let tab: AnyHashable
+	let isActive: Bool
+	@ViewBuilder let content: () -> Content
+	/// Latched on first activation — never reset, so a tab keeps its navigation
+	/// state once visited, matching the eager behaviour from the second visit on.
+	@State private var hasActivated = false
+
+	var body: some View {
+		Group {
+			if hasActivated {
+				content()
+			} else {
+				Color(.systemBackground)
+			}
+		}
+		.onAppear { if isActive { hasActivated = true } }
+		.onChange(of: isActive) { _, active in
+			if active { hasActivated = true }
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Reduces what iOS 17 builds during first layout, aimed at the iOS-17-only launch crash (Datadog issue `bb11da86`) and at the slow tab switching on 17.

**Read the Testing section before merging — this is a mitigation, not a confirmed fix.**

## What the crash is

One issue, 7,899 crashes in the retained Datadog window, **100% iOS 17 and 0% on iOS 18+**, essentially all at `ApplicationLaunch` 200–900ms in. SIGTRAP with `_assertionFailure` over deep repeating `AttributeGraph` update frames — an attribute-graph cycle during the first layout pass. Crash count ≈ session count across 32 device models. On iOS 17 sessions it was ~15.6% of launches on 2.7.16 and is ~4.1% on 2.7.18; the lockdown-gate fix (#2094, shipped in 2.7.17) removed most of it but not all.

## What changed

`ContentView.tabContent` splits on `#available(iOS 18.0)`, and that `else` branch is the only iOS-17-specific code anywhere in the launch path. Two differences mattered:

- The legacy `TabView { A; B; C }` form constructs **every** tab's root immediately, so all five trees and their `@Query` subscriptions come up during first layout. iOS 18's `Tab(value:) { }` takes a closure and defers that. The iOS 17 path now builds a tab's content when first selected and keeps it alive after, via a small `LegacyTabContent` host.
- Selection binds directly to the stored `@Published` value instead of the computed `tabSelection`, whose setter writes back into the `Router` its getter reads. iOS 17 therefore loses tap-the-active-tab-to-pop-to-root, which is an acceptable trade for an OS this crash is confined to.

iOS 18+ is untouched.

## Testing

Installed the iOS 17.5 simulator runtime and ran both this branch and unfixed main against a DEF CON replay radio with 300 nodes.

Honest status of the verification:

- **17.7 and 17.6 have no simulator runtime** — Apple reports "not available for download". 17.5 is the newest offered.
- **17.5 does not reproduce the crash.** Unfixed main stayed up 5/5 launches with a live radio, 6/6 with the legacy branch forced on a clean store, and 3/3 on a clean store with no radio. So this branch cannot be shown to fix it here; it launches 5/5 as well.
- An earlier theory that `tabSelection`'s setter was cycling at launch was **disproven** by instrumenting the setter: it fires zero times at launch.
- What is left is structural: the only iOS-17-only code at launch is this branch, and it does substantially more work than the iOS 18 path. Confirming the crash is gone needs a real iOS 17.x device, or the crash rate on 17 dropping after release.

Given iOS 17 is effectively unsupported, raising `IPHONEOS_DEPLOYMENT_TARGET` to 18 would remove this crash by construction and is worth weighing against merging this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab navigation behavior on iOS 17.
  * Tabs now load when selected and remain available after being opened.
  * Preserved existing tab-selection behavior on newer iOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->