### PR TITLE
Make tvOS Re-center fit the mesh instead of the whole valley

### DIFF
--- a/Meshtastic TV/Map/MeshTVMapView.swift
+++ b/Meshtastic TV/Map/MeshTVMapView.swift
@@ -497,31 +497,83 @@ struct MeshTVMapView: UIViewRepresentable {
 			mapView.setRegion(target, animated: !bigJump)
 		}
 
-		/// Fit the camera to every located node's reported position.
+		/// Fit the camera to every located node's reported position, inside the part
+		/// of the map the user can actually see.
+		///
+		/// The map is full-bleed, so the side list covers its left edge. Fitting the
+		/// mesh to the whole view therefore parked a slice of it behind the list and
+		/// zoomed out further than needed to compensate. `setVisibleMapRect` with edge
+		/// padding fits the visible area instead, and does the padding job the old
+		/// 1.4x span multiplier was doing by hand.
 		@discardableResult
 		private func frameAllNodes(_ mapView: MKMapView, nodes: [MeshNode], animated: Bool) -> Bool {
 			let coords = nodes.compactMap { $0.coordinate }
 			guard !coords.isEmpty else { return false }
 
-			let lats = coords.map(\.latitude)
-			let lons = coords.map(\.longitude)
-			let minLat = lats.min()!, maxLat = lats.max()!
-			let minLon = lons.min()!, maxLon = lons.max()!
-			let center = CLLocationCoordinate2D(
-				latitude: (minLat + maxLat) / 2,
-				longitude: (minLon + maxLon) / 2
+			// Fit where the mesh actually IS, not its extremes. A handful of nodes
+			// parked across town — someone who drove home, a stale position — stretched
+			// the bounding box far past the event and forced the camera way out. Trim to
+			// the middle 90% on each axis so stragglers don't dominate the framing; they
+			// stay on the map, just outside the initial frame.
+			let rect = boundingRect(of: coords, trimming: 0.05)
+			guard !rect.isNull else { return false }
+
+			// A single node (or several on one spot) gives a zero-size rect, which
+			// setVisibleMapRect cannot fit. Give it a small neighbourhood instead.
+			if rect.size.width < 1, rect.size.height < 1 {
+				let region = MKCoordinateRegion(
+					center: coords[0],
+					span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+				)
+				mapView.setRegion(region, animated: animated)
+				return true
+			}
+
+			// How much of the map's left edge the side list hides. Measured rather than
+			// assumed, so it stays right if the layout changes.
+			let originInWindow = mapView.convert(CGPoint.zero, to: nil).x
+			let hiddenLeft = max(0, TVTheme.sideListWidth - originInWindow)
+			let margin: CGFloat = 40
+			let padding = UIEdgeInsets(
+				top: margin,
+				left: hiddenLeft + margin,
+				bottom: margin,
+				right: margin
 			)
-			let span = MKCoordinateSpan(
-				latitudeDelta: max((maxLat - minLat) * 1.4, 0.05),
-				longitudeDelta: max((maxLon - minLon) * 1.4, 0.05)
-			)
-			let region = MKCoordinateRegion(center: center, span: span)
-			if animated {
-				setRegionSmart(mapView, target: region)   // cuts when the jump is big
+
+			if animated, isBigJump(mapView, target: rect) {
+				// Long flights re-evaluate clustering every frame while tiles stream in,
+				// which reads as visual static — cut instead (same rule as setRegionSmart).
+				mapView.setVisibleMapRect(rect, edgePadding: padding, animated: false)
 			} else {
-				mapView.setRegion(region, animated: false)
+				mapView.setVisibleMapRect(rect, edgePadding: padding, animated: animated)
 			}
 			return true
+		}
+
+
+		/// Bounding rect of `coords` after dropping the outermost `fraction` of values
+		/// on each axis (per axis independently, so one distant node cannot widen both).
+		/// `fraction` of 0 gives the full extent.
+		private func boundingRect(of coords: [CLLocationCoordinate2D], trimming fraction: Double) -> MKMapRect {
+			guard !coords.isEmpty else { return .null }
+			let points = coords.map(MKMapPoint.init)
+			let xs = points.map(\.x).sorted()
+			let ys = points.map(\.y).sorted()
+			// Keep at least a handful of points so a small mesh is never trimmed away.
+			let drop = min(Int(Double(points.count) * fraction), max(0, (points.count - 4) / 2))
+			let loX = xs[drop], hiX = xs[xs.count - 1 - drop]
+			let loY = ys[drop], hiY = ys[ys.count - 1 - drop]
+			return MKMapRect(x: loX, y: loY, width: hiX - loX, height: hiY - loY)
+		}
+
+		/// Distance/scale test shared with `setRegionSmart`, in map-rect terms.
+		private func isBigJump(_ mapView: MKMapView, target rect: MKMapRect) -> Bool {
+			let targetCenter = MKMapPoint(x: rect.midX, y: rect.midY)
+			let meters = MKMapPoint(mapView.centerCoordinate).distance(to: targetCenter)
+			let currentWidth = mapView.visibleMapRect.size.width
+			let ratio = currentWidth / max(rect.size.width, 1)
+			return meters > 80_000 || ratio > 4 || ratio < 0.25
 		}
 
 		/// The node number currently selected from the side list, or nil. `sync`


### PR DESCRIPTION
## Summary

Re-center Map zoomed out much further than the mesh needed. It now fits the mesh to the part of the map you can actually see.

## What was wrong

Two things compounded:

- It fitted the node bounding box (padded 1.4x) against the **whole** map view. The map is full-bleed, so a 520pt strip of what it fitted sits behind the side list — the camera had to zoom out to compensate for content it was parking out of sight.
- The box was the extremes of every located node, so one or two far-flung positions — someone who drove home, a stale fix — stretched it across the whole valley.

## What changed

- `setVisibleMapRect` with edge padding, where the left inset is how much of the map the side list actually covers, measured via `convert(_:to: nil)` rather than assumed, so it stays correct if the layout changes. That also replaces the hand-rolled 1.4x span padding.
- The bounding rect trims the outermost 5% of positions per axis, so stragglers don't drive the framing. They stay on the map, just outside the initial frame.
- The old 0.05° minimum span is gone (it prevented a tight mesh from framing tightly); a single node or a coincident group falls back to a small fixed region, since a zero-size rect can't be fitted.
- Big-jump cutting instead of animating is preserved, expressed in map-rect terms.

`applyInitialRegion` shares this code, so launch framing gets the same treatment.

## Testing

Apple TV 4K simulator against a DEF CON replay grown to 1,166 nodes, comparing the same data on `main` and this branch:

- **main**: spans Chinatown to Tropicana to Winchester — the mesh is a small blob left of centre.
- **this branch, sidebar inset + padding only**: Circus Circus to Royal Crest, nodes spread across the visible map.
- **this branch with outlier trimming**: frames the LVCC campus itself, a few hundred metres across.

Trade-off worth knowing: at 5% trim, roughly 58 of those 1,166 nodes start outside the frame and need a pan to reach. The trim fraction and the 40pt margin are both single constants if that balance wants adjusting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map framing so all visible nodes fit more reliably alongside the side list.
  * Removed extreme outlier positions from automatic framing for a more focused map view.
  * Added safeguards for empty or zero-size map regions.
  * Large map repositioning now updates immediately instead of animating through an impractical transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->