### PR TITLE
Remove unused tvOS map Menu handler (rebased from #2321)

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -49,7 +49,6 @@ struct MapScreen: View {
 				nodes: locatedNodes,
 				selectedNodeNum: $selectedNodeNum,
 				recenterToken: recenterToken,
-				onMenuExit: escapeMap,
 				offlineVectors: offlineVectors
 			)
 			.ignoresSafeArea()
@@ -94,20 +93,6 @@ struct MapScreen: View {
 			.sorted { ($0.lastHeard ?? .distantPast) > ($1.lastHeard ?? .distantPast) }
 		if newSorted.map(\.num) != sortedNodes.map(\.num) { sortedNodes = newSorted }
 		if newLocated.map(\.num) != locatedNodes.map(\.num) { locatedNodes = newLocated }
-	}
-
-	/// Menu pressed while the map held focus: pop any open node detail and hand
-	/// focus back to the node list — without this, MKMapView is a focus trap.
-	private func escapeMap() {
-		navPath = []
-		if let selectedNodeNum, sortedNodes.contains(where: { $0.num == selectedNodeNum }) {
-			focusedNodeNum = selectedNodeNum
-		} else if let firstNodeNum = sortedNodes.first?.num {
-			focusedNodeNum = firstNodeNum
-		} else {
-			focusedNodeNum = nil
-			recenterFocused = true
-		}
 	}
 
 	private var nodeList: some View {
@@ -195,15 +180,6 @@ struct MapScreen: View {
 				)
 				.ignoresSafeArea(edges: [.top, .leading])
 		}
-	}
-
-	private var disconnectButton: some View {
-		Button(role: .destructive) {
-			client.disconnect()
-		} label: {
-			Label("Disconnect", systemImage: "xmark.circle.fill")
-		}
-		.buttonStyle(.bordered)
 	}
 }
 

--- a/Meshtastic TV/Map/MeshTVMapView.swift
+++ b/Meshtastic TV/Map/MeshTVMapView.swift
@@ -280,12 +280,6 @@ struct MeshTVMapView: UIViewRepresentable {
 	@Binding var selectedNodeNum: UInt32?
 	/// Increment to re-frame the camera on the whole mesh (see MapScreen's button).
 	var recenterToken: Int = 0
-	/// Called on a Menu press while the map has focus. MKMapView captures the
-	/// directional input for panning and never releases focus on its own, so
-	/// without this the map is a focus trap (and an unhandled Menu press can
-	/// suspend the app instead of going back). MapScreen uses it to hand focus
-	/// back to the node list.
-	var onMenuExit: (() -> Void)?
 
 	/// Standard / Hybrid / Satellite, chosen in Settings. Shared via the same
 	/// @AppStorage key so changing it there updates the map live.
@@ -355,10 +349,6 @@ struct MeshTVMapView: UIViewRepresentable {
 
 		init(_ parent: MeshTVMapView) {
 			self.parent = parent
-		}
-
-		@objc func menuPressed() {
-			parent.onMenuExit?()
 		}
 
 		/// Diff the annotation set against `nodes` (add / update coordinate / remove),


### PR DESCRIPTION
## Summary

@bruschill's cleanup from #2321, rebased onto current main. Original commit and authorship preserved; #2321 had gone conflicting after #2326 touched the same file.

Removes the unreachable tvOS map Menu callback path and an unused duplicate Disconnect button. 34 lines, no behaviour change.

## Verification that the path really is dead

Checked on current main before resolving:

- `escapeMap` is only ever *passed* (`onMenuExit: escapeMap`), never called.
- `onMenuExit` is only invoked by `menuPressed`.
- `menuPressed` is attached to **no** gesture recognizer — no `addGestureRecognizer`, no `allowedPressTypes`, no `UIPress` handling anywhere in the file.
- The map is `isUserInteractionEnabled = false` and `canBecomeFocused = false`, so it never holds focus to escape from in the first place.

Menu at the map root continues to be handled by the system (returns to the Home Screen), which is the behaviour #2313 was closed to preserve.

## One thing worth knowing

The conflict was in `escapeMap`, because #2319 had added the empty-map focus fallback (`recenterFocused = true` when no nodes are located) *inside* it. Since `escapeMap` is unreachable, **that accessibility improvement has never executed** — it went in inert. Deleting it here loses nothing that was running, but if that behaviour is still wanted it needs a real trigger, which is a separate change rather than something to preserve in dead code.

## Testing

tvOS scheme builds with no unused-symbol warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Removed the redundant standalone Disconnect button from the map screen.
  * Disconnect remains available directly within the device list.
  * Removed unused map menu and exit navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->