### PR TITLE
Stop tvOS node rows reading as "in 0 sec."

### DIFF
--- a/Meshtastic TV/App/MapScreen.swift
+++ b/Meshtastic TV/App/MapScreen.swift
@@ -209,9 +209,9 @@ private struct NodeRow: View {
 				HStack(spacing: 14) {
 					if let lastHeard = node.lastHeard {
 						Label {
-								// Abbreviated: the full "10 minutes ago" crowds out the role
-							// and position labels beside it on a 520pt list.
-							Text(lastHeard.formatted(.relative(presentation: .numeric, unitsStyle: .abbreviated)))
+								// Compact so the role and position labels fit beside it on a
+							// 520pt list, and never future-tense for a just-heard node.
+							Text(RelativeAge.text(since: lastHeard))
 						} icon: {
 							Image(systemName: node.isOnline ? "checkmark.circle.fill" : "moon.circle.fill")
 								.foregroundStyle(node.isOnline ? Color("MeshtasticSuccess") : Color("MeshtasticWarning"))

--- a/Meshtastic TV/Models/RelativeAge.swift
+++ b/Meshtastic TV/Models/RelativeAge.swift
@@ -1,0 +1,27 @@
+//
+//  RelativeAge.swift
+//  Meshtastic TV
+//
+//  Copyright(c) Garth Vander Houwen 8/19/26.
+//
+//  Compact "how long ago" text for the wall display.
+//
+
+import Foundation
+
+enum RelativeAge {
+
+	/// "0s ago", "12s ago", "4m ago", "3h ago".
+	///
+	/// Sub-minute is formatted by hand because `.relative` rounds a just-arrived
+	/// sample to zero and then picks future tense — a node heard a moment ago read
+	/// as "in 0 sec.", which looks like a countdown. Above a minute the system
+	/// formatter is used so the units stay localized.
+	static func text(since date: Date, now: Date = Date()) -> String {
+		let elapsed = max(0, now.timeIntervalSince(date))
+		if elapsed < 60 {
+			return "\(Int(elapsed))s ago"
+		}
+		return date.formatted(.relative(presentation: .numeric, unitsStyle: .narrow))
+	}
+}

--- a/Meshtastic TV/Views/MeshStatsStrip.swift
+++ b/Meshtastic TV/Views/MeshStatsStrip.swift
@@ -210,13 +210,7 @@ struct MeshStatsStrip: View {
 	}
 
 	private func metadataText(_ stats: MeshClient.ConnectedNodeStats) -> String {
-		// Narrow units ("4m ago") keep the line short. Sub-minute is formatted by hand
-		// because .relative renders a just-arrived sample as "in 0 sec." — it rounds to
-		// zero and then picks future tense, which reads like a countdown.
-		let elapsed = max(0, Date().timeIntervalSince(stats.receivedAt))
-		let updated = elapsed < 60
-			? "\(Int(elapsed))s ago"
-			: stats.receivedAt.formatted(.relative(presentation: .numeric, unitsStyle: .narrow))
+		let updated = RelativeAge.text(since: stats.receivedAt)
 		guard let dupes = stats.packetsRxDupe else { return "Updated \(updated)" }
 		return "\(packetText(dupes, fractionDigits: 0)) dupes · Updated \(updated)"
 	}

--- a/MeshtasticTests/RelativeAgeTests.swift
+++ b/MeshtasticTests/RelativeAgeTests.swift
@@ -1,0 +1,48 @@
+//
+//  RelativeAgeTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/19/26.
+//
+
+import Testing
+import Foundation
+
+/// `RelativeAge` is in the tvOS target, which has no test target of its own, so the
+/// rule is duplicated here to pin the behaviour that matters: a just-arrived sample
+/// must never read as future tense.
+@Suite("Relative age")
+struct RelativeAgeTests {
+
+	private func text(since date: Date, now: Date) -> String {
+		let elapsed = max(0, now.timeIntervalSince(date))
+		if elapsed < 60 { return "\(Int(elapsed))s ago" }
+		return date.formatted(.relative(presentation: .numeric, unitsStyle: .narrow))
+	}
+
+	@Test func justArrivedReadsAsPast() {
+		let now = Date(timeIntervalSince1970: 1_000_000)
+		// The bug: Foundation renders this as "in 0 sec.".
+		#expect(text(since: now, now: now) == "0s ago")
+		#expect(text(since: now.addingTimeInterval(-0.4), now: now) == "0s ago")
+	}
+
+	@Test func subMinuteCountsSeconds() {
+		let now = Date(timeIntervalSince1970: 2_000_000)
+		#expect(text(since: now.addingTimeInterval(-12), now: now) == "12s ago")
+		#expect(text(since: now.addingTimeInterval(-59), now: now) == "59s ago")
+	}
+
+	@Test func aFutureStampNeverGoesNegative() {
+		let now = Date(timeIntervalSince1970: 3_000_000)
+		// Clock skew between radio and phone must not produce "-5s ago".
+		#expect(text(since: now.addingTimeInterval(5), now: now) == "0s ago")
+	}
+
+	@Test func pastAMinuteHandsOffToTheFormatter() {
+		let now = Date(timeIntervalSince1970: 4_000_000)
+		let result = text(since: now.addingTimeInterval(-600), now: now)
+		#expect(!result.hasSuffix("s ago") || result.contains("min"))
+		#expect(!result.contains("in "), "must not be future tense, got \(result)")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #2320. The stats bar's sub-minute age fix shipped there; the node rows' did not, because the shared helper it depended on never got committed. Rows still render "in 0 sec." for a node heard a moment ago.

## What changed

- New `RelativeAge` helper holding the rule in one place.
- `NodeRow` uses it instead of calling `.relative` directly — this is the actual bug fix.
- `MeshStatsStrip` drops its inline copy of the same logic in favour of the helper.

The rule: under a minute, format the seconds by hand, because `.relative` rounds a just-arrived sample to zero and then chooses future tense. Above a minute, hand off to the system formatter so units stay localized. A stamp slightly in the future — radio/phone clock skew — clamps to "0s ago" instead of going negative.

## Testing

tvOS builds. 4 new tests in `RelativeAgeTests`, all passing: the just-arrived case that was the bug, sub-minute seconds, the future-stamp clamp, and that past a minute the output is never future tense.

The helper lives in the tvOS target, which has no test target, so the tests pin the rule rather than importing the type — noted in the test file so nobody mistakes it for real coverage of the shipped symbol.

Verified on an Apple TV 4K simulator against the DEF CON replay: rows now read "1s ago", "2s ago", "3s ago" where they previously read "in 0 sec.".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative timestamps for recently seen nodes and mesh statistics.
  * Very recent activity now displays clear seconds-ago text instead of incorrectly showing future-tense wording.
  * Timestamp formatting remains compact and localized for older activity.

* **Tests**
  * Added coverage for recent, future-dated, and minute-plus timestamp scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->