### PR TITLE
Stop the BLE status tests racing real Bluetooth hardware

### DIFF
--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -59,7 +59,12 @@ actor BLETransport: Transport {
 	let supportsManualConnection: Bool = false
 	let requiresPeriodicHeartbeat = false
 			
-	init() {
+	/// - Parameter createCentralManagerImmediately: Pass `false` to skip creating the real
+	///   `CBCentralManager` here, leaving it to `discoverDevices()` exactly as a `.notDetermined`
+	///   authorization already does. Tests that drive `handleCentralState` directly need this: a
+	///   real manager reports the host's actual Bluetooth state on its own schedule, and that
+	///   incidental value lands in `status` at an unpredictable point mid-test.
+	init(createCentralManagerImmediately: Bool = true) {
 		self.discoveredPeripherals = [:]
 		self.discoveredDeviceContinuation = nil
 		self.delegate = BLEDelegate()
@@ -67,7 +72,7 @@ actor BLETransport: Transport {
 		// Only create CBCentralManager immediately if Bluetooth authorization is already
 		// determined. This avoids showing the system permission prompt before the
 		// onboarding Bluetooth screen has a chance to present it in context.
-		if CBCentralManager.authorization != .notDetermined {
+		if createCentralManagerImmediately, CBCentralManager.authorization != .notDetermined {
 			centralManager = CBCentralManager(delegate: delegate,
 											  queue: centralQueue,
 											  options: Self.centralManagerOptions(restoreIdentifier: kCentralRestoreID)

--- a/MeshtasticTests/AccessoryManagerBLEStatusTests.swift
+++ b/MeshtasticTests/AccessoryManagerBLEStatusTests.swift
@@ -29,17 +29,13 @@ struct AccessoryManagerBLEStatusTests {
 	/// `BLETransport.init()` creates a *real* `CBCentralManager` on its own delegate whenever
 	/// `CBCentralManager.authorization` is already determined — true on the simulator, where
 	/// there's no permission prompt to wait on. That manager asynchronously reports genuine
-	/// (simulator) hardware state exactly once, shortly after construction (typically
-	/// `.unsupported`, since simulators have no real radio), completely independently of
-	/// anything a test scripts. If that incidental transition lands *after* a test has already
-	/// driven and observed its own scripted state, it silently clobbers `bleTransportStatus`
-	/// and flakes the very next assertion. Giving it a moment to settle — before constructing the
-	/// `AccessoryManager` under test and before scripting anything — makes the one-time incidental
-	/// transition land (and be reflected in `bleTransport.status`) ahead of
-	/// `observeBLETransportStatus()`'s subscription, so its replay already carries the settled
-	/// value and no further incidental transition remains to race a later scripted one.
-	private func settleIncidentalHardwareStatus(for transport: BLETransport, timeout: Duration = .milliseconds(500)) async {
-		try? await Task.sleep(for: timeout)
+	/// (simulator) hardware state, completely independently of anything a test scripts, and if
+	/// that incidental transition lands after a test has driven its own state it clobbers
+	/// `bleTransportStatus` and flakes the next assertion. These tests script every transition
+	/// through `handleCentralState`, so they opt out of owning a real manager entirely rather
+	/// than sleeping and hoping the incidental value has already landed.
+	private func scriptedTransport() -> BLETransport {
+		BLETransport(createCentralManagerImmediately: false)
 	}
 
 	/// `observeBLETransportStatus()` mirrors status via a background `Task` consuming an
@@ -54,16 +50,14 @@ struct AccessoryManagerBLEStatusTests {
 	}
 
 	@Test func startsFalseBeforeAnyTransition() async {
-		let bleTransport = BLETransport()
-		await settleIncidentalHardwareStatus(for: bleTransport)
+		let bleTransport = scriptedTransport()
 
 		let manager = AccessoryManager(transports: [bleTransport])
 		#expect(manager.isBluetoothPoweredOff == false)
 	}
 
 	@Test func becomesTrueWhenBLEPowersOff() async {
-		let bleTransport = BLETransport()
-		await settleIncidentalHardwareStatus(for: bleTransport)
+		let bleTransport = scriptedTransport()
 
 		let manager = AccessoryManager(transports: [bleTransport])
 		await bleTransport.handleCentralState(.poweredOff, central: unusedCentralManager())
@@ -74,8 +68,7 @@ struct AccessoryManagerBLEStatusTests {
 	}
 
 	@Test func clearsWhenBLEPowersBackOn() async {
-		let bleTransport = BLETransport()
-		await settleIncidentalHardwareStatus(for: bleTransport)
+		let bleTransport = scriptedTransport()
 
 		let manager = AccessoryManager(transports: [bleTransport])
 		let central = unusedCentralManager()

--- a/MeshtasticTests/BLETransportPoweredOffStatusTests.swift
+++ b/MeshtasticTests/BLETransportPoweredOffStatusTests.swift
@@ -29,8 +29,16 @@ struct BLETransportPoweredOffStatusTests {
 		CBCentralManager(delegate: nil, queue: nil)
 	}
 
+	/// These tests script `status` transitions by calling `handleCentralState` directly, so the
+	/// transport must not also own a real `CBCentralManager`: that manager reports the host's
+	/// genuine Bluetooth state on its own schedule, and that incidental value can overwrite
+	/// `status` between the scripted call and the assertion below it.
+	private func scriptedTransport() -> BLETransport {
+		BLETransport(createCentralManagerImmediately: false)
+	}
+
 	@Test func poweredOffSettlesOnError() async {
-		let transport = BLETransport()
+		let transport = scriptedTransport()
 
 		await transport.handleCentralState(.poweredOff, central: unusedCentralManager())
 
@@ -39,7 +47,7 @@ struct BLETransportPoweredOffStatusTests {
 	}
 
 	@Test func poweredOffNeverEndsAtReady() async {
-		let transport = BLETransport()
+		let transport = scriptedTransport()
 
 		await transport.handleCentralState(.poweredOff, central: unusedCentralManager())
 
@@ -50,7 +58,7 @@ struct BLETransportPoweredOffStatusTests {
 	/// A transport that was previously discovering (poweredOn) and then loses power should
 	/// still land on the off-state error, not silently revert to looking "ready".
 	@Test func poweredOffAfterPoweredOnStillSettlesOnError() async {
-		let transport = BLETransport()
+		let transport = scriptedTransport()
 		let manager = unusedCentralManager()
 
 		await transport.handleCentralState(.poweredOn, central: manager)
@@ -63,7 +71,7 @@ struct BLETransportPoweredOffStatusTests {
 	/// A second poweredOff after recovering (poweredOn) and losing power again must still settle
 	/// on the off-state error, not get stuck reflecting the intervening .discovering/.ready state.
 	@Test func poweredOffAfterRecoveryRoundTripStillSettlesOnError() async {
-		let transport = BLETransport()
+		let transport = scriptedTransport()
 		let manager = unusedCentralManager()
 
 		await transport.handleCentralState(.poweredOff, central: manager)

--- a/MeshtasticTests/BLETransportStatusUpdatesTests.swift
+++ b/MeshtasticTests/BLETransportStatusUpdatesTests.swift
@@ -28,53 +28,43 @@ struct BLETransportStatusUpdatesTests {
 		CBCentralManager(delegate: nil, queue: nil)
 	}
 
-	/// `BLETransport()` creates a *real* `CBCentralManager` on its own delegate whenever
-	/// `CBCentralManager.authorization` is already determined — true on the simulator, where
-	/// there's no real permission prompt to wait on. That manager asynchronously reports genuine
-	/// (simulator) hardware state — typically `.unsupported`, since simulators have no real radio
-	/// — independently of anything a test does. Those incidental values can land in the stream
-	/// interleaved with a test's own explicit `handleCentralState` calls, so assertions must drain
-	/// for the expected value rather than assume it's the very next element.
-	private func drainUntil(
-		_ expected: TransportStatus,
-		from iterator: inout AsyncStream<TransportStatus>.AsyncIterator,
-		attempts: Int = 10
-	) async -> Bool {
-		for _ in 0..<attempts {
-			guard let value = await iterator.next() else { return false }
-			if value == expected { return true }
-		}
-		return false
+	/// Every test here scripts `status` transitions by calling `handleCentralState` directly, so
+	/// the transport must not also own a real `CBCentralManager`: that manager reports the host's
+	/// genuine Bluetooth state on its own schedule, and the resulting `handleCentralState` call
+	/// lands in `status` at an arbitrary point between a test's own statements.
+	private func scriptedTransport() -> BLETransport {
+		BLETransport(createCentralManagerImmediately: false)
 	}
 
 	@Test func immediatelyYieldsCurrentStatus() async {
-		let transport = BLETransport()
+		let transport = scriptedTransport()
 		let stream = await transport.statusUpdates()
 		var iterator = stream.makeAsyncIterator()
 
-		// The very first element must be *a* status (the replay), not a hang waiting on a
-		// transition — the real value can legitimately be .uninitialized or the simulator's
-		// own incidental .unsupported depending on timing (see drainUntil above).
+		// A late subscriber must see the current status right away rather than waiting on the
+		// next transition — nothing has been scripted yet, so that's the initial value.
 		let first = await iterator.next()
-		#expect(first != nil, "a late subscriber must see a status right away, not wait for the next transition")
+		#expect(first == .uninitialized, "a late subscriber must see a status right away, not wait for the next transition")
 	}
 
 	@Test func yieldsOnStatusChange() async {
-		let transport = BLETransport()
+		let transport = scriptedTransport()
 		let stream = await transport.statusUpdates()
 		var iterator = stream.makeAsyncIterator()
 
+		#expect(await iterator.next() == .uninitialized) // the subscribe-time replay
+
 		await transport.handleCentralState(.poweredOff, central: unusedCentralManager())
 
-		let sawExpected = await drainUntil(.error(BLETransport.poweredOffStatusMessage), from: &iterator)
-		#expect(sawExpected, "statusUpdates() must eventually carry the .poweredOff transition")
+		let next = await iterator.next()
+		#expect(next == .error(BLETransport.poweredOffStatusMessage), "statusUpdates() must carry the .poweredOff transition")
 	}
 
 	/// The `status` `didSet` guards on an actual change before yielding — repeating the same
 	/// CoreBluetooth state (which can happen; CBCentralManagerDelegate doesn't guarantee distinct
 	/// states) must not enqueue a duplicate value that a late-arriving subscriber would trip over.
 	@Test func doesNotYieldADuplicateForAnUnchangedStatus() async {
-		let transport = BLETransport()
+		let transport = scriptedTransport()
 		let manager = unusedCentralManager()
 
 		await transport.handleCentralState(.poweredOff, central: manager)
@@ -82,47 +72,38 @@ struct BLETransportStatusUpdatesTests {
 		let stream = await transport.statusUpdates()
 		var iterator = stream.makeAsyncIterator()
 
-		// Replay of the current .error status from the subscribe-time yield (possibly preceded
-		// by incidental simulator-hardware values — drain until we see it).
-		let sawReplay = await drainUntil(.error(BLETransport.poweredOffStatusMessage), from: &iterator)
-		#expect(sawReplay)
+		// Replay of the current .error status from the subscribe-time yield.
+		#expect(await iterator.next() == .error(BLETransport.poweredOffStatusMessage))
 
 		// A second, identical .poweredOff must not produce a second queued value.
 		await transport.handleCentralState(.poweredOff, central: manager)
 
-		// A real change afterward proves the duplicate was swallowed: count how many further
-		// .error(poweredOff) values arrive before .discovering shows up. Zero means the repeat
-		// never got queued; any more than zero means it leaked through.
+		// A real change afterward proves the duplicate was swallowed: if the repeat had been
+		// queued it would be sitting ahead of .discovering in the stream.
 		await transport.handleCentralState(.poweredOn, central: manager)
-		var duplicateCount = 0
-		var sawDiscovering = false
-		for _ in 0..<10 {
-			guard let value = await iterator.next() else { break }
-			if value == .discovering { sawDiscovering = true; break }
-			if value == .error(BLETransport.poweredOffStatusMessage) { duplicateCount += 1 }
-		}
-		#expect(sawDiscovering)
-		#expect(duplicateCount == 0, "the repeated .poweredOff must have been swallowed by didSet's equality guard")
+
+		let next = await iterator.next()
+		#expect(next == .discovering, "the repeated .poweredOff must have been swallowed by didSet's equality guard")
 	}
 
 	/// Only `AccessoryManager` is expected to subscribe; a second `statusUpdates()` call replaces
 	/// the stored continuation, so the earlier stream stops receiving new values instead of both
 	/// streams staying live indefinitely.
 	@Test func aSecondSubscriberReplacesTheFirst() async {
-		let transport = BLETransport()
+		let transport = scriptedTransport()
 		let manager = unusedCentralManager()
 
 		let firstStream = await transport.statusUpdates()
 		var firstIterator = firstStream.makeAsyncIterator()
-		_ = await firstIterator.next() // consume the initial replay
+		#expect(await firstIterator.next() == .uninitialized) // consume the initial replay
 
 		let secondStream = await transport.statusUpdates()
 		var secondIterator = secondStream.makeAsyncIterator()
-		_ = await secondIterator.next() // consume the initial replay
+		#expect(await secondIterator.next() == .uninitialized) // consume the initial replay
 
 		await transport.handleCentralState(.poweredOff, central: manager)
 
-		let sawExpected = await drainUntil(.error(BLETransport.poweredOffStatusMessage), from: &secondIterator)
-		#expect(sawExpected)
+		let next = await secondIterator.next()
+		#expect(next == .error(BLETransport.poweredOffStatusMessage))
 	}
 }


### PR DESCRIPTION
## Summary

The unit test job added in #2333 failed on its first run on main. One test failed:
`doesNotYieldADuplicateForAnUnchangedStatus` in `BLETransportStatusUpdatesTests`. It
passed on the PR run and fails only sometimes, because it was racing real Bluetooth
hardware.

`BLETransport()` creates a real `CBCentralManager`. That manager reports the host's
actual Bluetooth state a moment after construction, on its own schedule, and
`handleCentralState` writes it to `status`. On a simulator the value is
`.error("Bluetooth is unsupported on this device")`.

The test scripts `.poweredOff`, subscribes, then repeats `.poweredOff` and checks the
repeat was swallowed by the `didSet` equality guard. If the hardware value lands
between the subscribe and the repeat, `status` is no longer `.poweredOff`, so the
repeat is a genuine change and is correctly yielded — and the test counts it as a
leaked duplicate. Whether it fails comes down to a few milliseconds of timing.

The transport's dedup logic is correct. Only the test was wrong.

## What changed

`BLETransport.init` takes `createCentralManagerImmediately`, defaulting to `true`, so
app code is unchanged. The tests pass `false`. They drive `handleCentralState`
directly and never needed a real manager; skipping it leaves `centralManager` nil
until `discoverDevices()` creates it, which is already what happens when Bluetooth
authorization is `.notDetermined`.

Two workarounds had grown around this race and are now gone:

- `drainUntil`, which read past unexpected values instead of asserting on the next
  one. The assertions are now exact.
- three unconditional 500ms sleeps in `AccessoryManagerBLEStatusTests`, which waited
  for the hardware value to land. That suite went from 1.5s to 0.03s.

`BLETransportPoweredOffStatusTests` had the same race in a narrower window — it reads
`status` right after scripting it — so it uses the flag too.

## Testing

Confirmed the cause rather than guessing, with a throwaway diagnostic (not committed):

- a real `BLETransport()` drifts from `.uninitialized` to
  `.error("Bluetooth is unsupported on this device")` in under 1.5s with no test input
- with the flag off, `status` never changes on its own
- injecting that value at the point it landed on the runner reproduces the CI failure
  exactly, same expectation and same message

Then: the three suites pass 6 runs in a row, and the full unit suite is 2,901 tests in
508 suites passing. The CI job runs 2,774 in 469 — the difference is the 39 snapshot
suites it skips, which the `docs-deploy` job covers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth startup behavior when authorization is still being determined.
  * Prevented unintended Bluetooth hardware callbacks from interfering with status handling.

* **Tests**
  * Improved coverage for Bluetooth status transitions, initial state replay, duplicate updates, and subscriber replacement.
  * Made Bluetooth status tests more deterministic and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->