### PR TITLE
Give the UF2 update sheet room on Mac

### DIFF
--- a/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/UF2MassStorageView.swift
+++ b/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/UF2MassStorageView.swift
@@ -94,6 +94,13 @@ struct UF2MassStorageView: View {
 				}
 			}
 		}
+		#if targetEnvironment(macCatalyst)
+		// Mac Catalyst gives a sheet a fixed 620x680 window, about 20pt shorter than this
+		// content needs, so the Important Notes section sits below the bottom edge. Ask for a
+		// taller sheet; Catalyst clamps the request to the app window, and the ScrollView
+		// still handles whatever is left over.
+		.frame(minHeight: 740)
+		#endif
 		.fileExporter(
 			isPresented: $isExporting,
 			document: document,

--- a/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/UF2MassStorageView.swift
+++ b/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/UF2MassStorageView.swift
@@ -81,6 +81,13 @@ struct UF2MassStorageView: View {
 				}
 				.padding()
 			}
+			// The Mac sheet can still end up shorter than this content — Catalyst clamps the
+			// height requested below to the app window, and translated text is taller again.
+			// Keep the scroll bar showing there so the cut-off edge reads as scrollable rather
+			// than stuck; on iOS the indicator stays out of the way until it's needed.
+			#if targetEnvironment(macCatalyst)
+			.scrollIndicators(.visible)
+			#endif
 			.navigationTitle("UF2 Firmware Update")
 			.navigationBarTitleDisplayMode(.inline)
 			.toolbar {
@@ -95,10 +102,10 @@ struct UF2MassStorageView: View {
 			}
 		}
 		#if targetEnvironment(macCatalyst)
-		// Mac Catalyst gives a sheet a fixed 620x680 window, about 20pt shorter than this
-		// content needs, so the Important Notes section sits below the bottom edge. Ask for a
-		// taller sheet; Catalyst clamps the request to the app window, and the ScrollView
-		// still handles whatever is left over.
+		// Mac Catalyst sizes a sheet from the window, not its content — measured at 620x680,
+		// which is shorter than this content needs, leaving Important Notes below the bottom
+		// edge. Ask for a taller sheet. Catalyst clamps the request to the app window, and
+		// `idealHeight` is ignored here, so this has to be a hard minimum.
 		.frame(minHeight: 740)
 		#endif
 		.fileExporter(


### PR DESCRIPTION
## Summary

The UF2 firmware update sheet looks cut off on Mac — the Important Notes section at the bottom is clipped mid-line, as if the sheet doesn't scroll.

## What changed

It does scroll. The content has always been in a `ScrollView` and nothing was defeating it. The problem is size: Mac Catalyst hands a sheet a fixed 620x680 window no matter how tall the content is, and this content needs about 700pt, so the last section sits below the bottom edge with only ~20pt of scroll to reach it. Catalyst shows no scroll bar at rest, so it reads as stuck rather than scrollable.

On Catalyst the sheet now asks for a 740pt minimum height, which fits the whole thing. iOS and iPadOS are untouched.

Catalyst clamps the request to the app window, so a window too short for 740 still gets the tallest sheet it can and the `ScrollView` covers the remainder — same behavior as today, with less hidden.

## Testing

Measured in a small Catalyst app that copies this sheet's layout, since the sizes are the whole story:

| | sheet window | scroll view | content |
|---|---|---|---|
| before | 620x680 | 681 tall, 64pt top inset | 637.5 tall, so ~20pt hidden |
| after | 620x740 | 741 tall, 64pt top inset | 637.5 tall, nothing hidden |

With the app window too short for a 740pt sheet, the sheet came back 681 tall and the scroll view stayed scrollable.

Builds: iOS Simulator (iPhone 16) and Mac Catalyst.

I could not run the change inside Meshtastic itself on Mac — a second copy of the app won't start while one is already open — so the numbers come from the test app, not the shipping build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the UF2 mass-storage firmware update sheet layout on Mac Catalyst by providing additional vertical space.
  * Preserved scrolling for content that exceeds the available height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->