### PR TITLE
Stop the node list crashing on nodes deleted behind its snapshot

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
@@ -64,7 +64,9 @@ struct NodeMapSwiftUI: View {
 	@State private var mapRegion = MKCoordinateRegion.init()
 
 	var body: some View {
-		if node.modelContext != nil {
+		// isDeleted too: a deleted-but-unsaved node keeps its modelContext until the save
+		// completes, and reading its persisted properties in that window traps.
+		if node.modelContext != nil && !node.isDeleted {
 			Group {
 				if totalPositionCount > 0 {
 					mapWithNavigation

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -364,7 +364,11 @@ private struct FilteredNodeList: View {
 	// The body of the view
 	var body: some View {
 		List(displayedNodes, selection: $selectedNodeNum) { entry in
-			if entry.node.modelContext != nil {
+			// `!isDeleted` matters as much as the context check: `context.delete()` marks
+			// isDeleted while modelContext stays non-nil until the save completes, and row
+			// bodies re-evaluate mid-save via SwiftData's change notification — reading a
+			// persisted property in that window traps (the NodeListItem SIGTRAP family).
+			if entry.node.modelContext != nil && !entry.node.isDeleted {
 				NavigationLink(value: entry.id) {
 					switch nodeListDensity {
 					case .compact:
@@ -386,6 +390,15 @@ private struct FilteredNodeList: View {
 						connectedNode: connectedNode
 					)
 				}
+			} else {
+				// Keep a row for an entry whose node died since the last snapshot tick (cap
+				// eviction, user delete). A conditional row that silently produces nothing
+				// desyncs the List's item counts from its data and crashes in UICollectionView
+				// batch updates ("attempt to delete item N from section 0..."). The purge pass
+				// in the cadence task removes the entry through a real, consistent diff.
+				Color.clear
+					.frame(height: 1)
+					.accessibilityHidden(true)
 			}
 		}
 		.navigationTitle(String.localizedStringWithFormat("Nodes (%@)".localized, String(displayedNodes.count)))
@@ -393,15 +406,21 @@ private struct FilteredNodeList: View {
 			// Recompute the displayed list on a gentle cadence instead of inside `body`.
 			// During live ingestion every packet writes to SwiftData; running displayNodes
 			// (a scan over the whole node set) per write pegged the main thread on reconnect
-			// with a large DB. ~3/sec is imperceptible and keeps CPU sane. The scan only runs
-			// while the Nodes tab is frontmost — TabView keeps this view alive on other tabs
-			// (and this task re-fires on every tab switch), so the guard comes first; entering
-			// the tab re-fires the task and refreshes immediately.
-			guard router.selectedTab == .nodes else { return }
+			// with a large DB. ~3/sec is imperceptible and keeps CPU sane. The full scan only
+			// runs while the Nodes tab is frontmost — TabView keeps this view alive on other
+			// tabs (and this task re-fires on every tab switch), so entering the tab refreshes
+			// immediately. While parked on another tab the loop still ticks, but only to drop
+			// entries whose nodes have been deleted (cap evictions keep running during
+			// ingestion): the stale snapshot otherwise holds dead nodes for as long as the
+			// user stays away, and any row re-evaluation in that window hits them.
 			refreshDisplayedNodes()
 			while !Task.isCancelled {
 				try? await Task.sleep(for: .milliseconds(350))
-				refreshDisplayedNodes()
+				if router.selectedTab == .nodes {
+					refreshDisplayedNodes()
+				} else {
+					purgeDeadDisplayedNodes()
+				}
 			}
 		}
 	}
@@ -409,9 +428,21 @@ private struct FilteredNodeList: View {
 	private func refreshDisplayedNodes() {
 		// Accessing any property on a ModelContext whose container was replaced can trap in SwiftData.
 		guard boundContainerGeneration == PersistenceController.shared.containerGeneration else { return }
+		guard router.selectedTab == .nodes else { return }
 		let allNodes = (try? context.fetch(makeNodeFetchDescriptor())) ?? []
 		replaceDisplayedNodesIfNeeded(with: displayNodes(from: allNodes, activeNodeNum: accessoryManager.activeDeviceNum))
 		router.updateNodeIndex(from: allNodes)
+	}
+
+	/// Drops entries whose backing node has been deleted, without the full fetch/sort of a
+	/// real refresh — cheap enough to run while the tab is parked in the background.
+	/// `modelContext`/`isDeleted` are safe to read on a dead object; persisted properties are not.
+	private func purgeDeadDisplayedNodes() {
+		guard boundContainerGeneration == PersistenceController.shared.containerGeneration else { return }
+		let live = displayedNodes.filter { $0.node.modelContext != nil && !$0.node.isDeleted }
+		if live.count != displayedNodes.count {
+			displayedNodes = live
+		}
 	}
 
 	@ViewBuilder


### PR DESCRIPTION
## Summary

Two of the app's larger field crashes come from the same window in the node list. The list renders from a throttled snapshot (`displayedNodes`), and the refresh loop only runs while the Nodes tab is frontmost. Node cap evictions keep running during ingestion, so while the user is on another tab or backgrounded, the snapshot holds deleted entities for as long as they stay away.

Both crash signatures fall out of that:

- SIGTRAP in `NodeListItem.swift`: the row guard checked `modelContext != nil` but not `isDeleted`. A deleted-but-unsaved node keeps its context until the save completes, and rows re-evaluate mid-save via SwiftData's change notification, so the row body read persisted properties of a deleted row and trapped. Every other liveness guard in the codebase already includes `isDeleted`; this one was the exception.
- SIGABRT `NSInternalInconsistencyException` ("attempt to delete item N from section 0 which only contains N items"): the row was a bare `if` with no else, so a dead entry rendered zero rows while the data still claimed an item, desyncing the List coordinator's item counts. Symbolicated device crash reports show the abort entirely inside SwiftUI's `UICollectionViewListCoordinatorBase` batch updates with no app frames.

## What changed

`NodeList.swift`:
- Row guard gains `!entry.node.isDeleted`.
- The row gets an inert else branch (1pt clear row) so a node dying between snapshot ticks never changes the row count outside a data update. The next tick removes it through a real diff.
- The cadence task no longer parks entirely on other tabs: the full fetch/sort still runs only on the Nodes tab, but off-tab it ticks a cheap purge pass that drops entries whose node is dead (`modelContext`/`isDeleted` reads only, safe on dead objects).

`NodeMapSwiftUI.swift`: the same `isDeleted` addition to its body guard, the one other site missing it.

## Testing

- Full unit suite: 2,901 tests in 508 suites passing.
- Crash mechanism confirmed from symbolicated on-device reports (SwiftUI List batch-update abort with no app frames; SwiftData trap during save with a Query observer on the stack) rather than from the raw Datadog events, which are unsymbolicated.
- Not reproduced live: triggering it needs deletions to land while the tab is parked, which is timing-dependent. The field signal is the real test — both issues should drop in the next release's numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deleted or unavailable nodes from appearing on the map or in node lists.
  * Improved list refresh behavior to remove stale node entries while preserving list structure.
  * Limited full node refreshes to the Nodes tab for more consistent navigation and display updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->