### PR TITLE
Add an OTAFIX bootloader upgrade flow for nRF52 boards

### DIFF
--- a/Meshtastic/Model/Firmware/MaintenanceUF2.swift
+++ b/Meshtastic/Model/Firmware/MaintenanceUF2.swift
@@ -1,0 +1,174 @@
+//
+//  MaintenanceUF2.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/19/26.
+//
+//  A pinned, content-verified UF2 image used by a maintenance flow (bootloader
+//  upgrade). Unlike release firmware, these images have no versioned upstream
+//  the app can resolve against, so each one is pinned to an exact URL and
+//  SHA-256 digest, and the digest is verified before the image is ever offered
+//  for writing. Mirrors Meshtastic-Android's MaintenanceUf2.kt so both apps
+//  ship the same audited pairings.
+//
+
+import CryptoKit
+import Foundation
+
+struct MaintenanceUF2: Sendable, Equatable {
+	let url: URL
+	let fileName: String
+	/// Lowercase hex SHA-256 of the exact bytes at `url`.
+	let sha256: String
+
+	/// True when `data` hashes to the pinned digest. Any mismatch means the
+	/// upstream bytes changed (or the download was tampered with) and the image
+	/// must not be written.
+	func matches(_ data: Data) -> Bool {
+		let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+		return digest == sha256
+	}
+}
+
+/// OTAFIX bootloader self-update images and the rules for resolving one safely.
+///
+/// The safety contract, unchanged from Android: the **Board-ID the device itself
+/// reports** (in `INFO_UF2.TXT` on its mass-storage volume) is the only input
+/// that selects an image. Product names cannot be correlated between the two
+/// projects (`heltec_t114` vs `heltec-mesh-node-t114`), USB VID/PID collide
+/// across boards, and the XIAO nRF52840 BLE / BLE Sense split differs *only* by
+/// Board-ID — installing the wrong one over UF2 is unrecoverable without SWD.
+/// The connected node's platformio target is a UX gate only: it decides whether
+/// the upgrade is offered, never which image is written.
+enum OTAFIXBootloader {
+
+	/// Release the pinned images below were audited against.
+	static let releaseTag = "0.9.2-OTAFIX2.3-BP1.5"
+
+	private static let releaseBase =
+		"https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/releases/download/\(releaseTag)"
+
+	private static func asset(board: String, sha256: String) -> MaintenanceUF2 {
+		let name = "update-\(board)_bootloader-\(releaseTag)_nosd.uf2"
+		// Force-unwrap is safe: releaseBase and every board string are
+		// compile-time constants that form a valid URL, and the tests cover
+		// every row in the map.
+		return MaintenanceUF2(url: URL(string: "\(releaseBase)/\(name)")!, fileName: name, sha256: sha256)
+	}
+
+	/// Self-update images keyed by the Board-ID the device reports. Rows are
+	/// mirrored verbatim from Meshtastic-Android's `OTAFIX_BY_BOARD_ID`
+	/// (MaintenanceUf2.kt) so both apps ship the same audited pairings.
+	static let imagesByBoardID: [String: MaintenanceUF2] = [
+		"HT-n5262": asset(
+			board: "heltec_t114",
+			sha256: "ae92d3577cb58dd9b43c9b61ffb9bfffda05b0eca4113a0ec42a37cd8be53b19"
+		),
+		"MinewSemi-MX25LE01": asset(
+			board: "minewsemi_mx25le01",
+			sha256: "e09564fd8dd03fc25d76dcb732a0214c79653da3b130240949b783254d3dfc1b"
+		),
+		"TRACKER L1": asset(
+			board: "wio_tracker_l1",
+			sha256: "70fbce0eda9d70d7bd8a4367057badf5ec310838bf3221370d45a56f04956b9e"
+		),
+		"WisBlock-RAK4631-Board": asset(
+			board: "wiscore_rak4631_board",
+			sha256: "8741bc677a3c24f28422c5ffb80761de7d98a127a3b0191ba6585bf57ce9f305"
+		),
+		"WisMesh-Tag": asset(
+			board: "wismesh_tag",
+			sha256: "96d42e1990e17251e8c625e98a1551cac12c6e29111bc2e59ab7c9fe6dec8758"
+		),
+		"nRF52840-SeeedSenseCAPSolarP1-v1": asset(
+			board: "sensecap_solar_p1",
+			sha256: "9b4bce48c1b4830617715c5619457bce6b21f3079803e35e13433de7701290f5"
+		),
+		"nRF52840-SeeedXiao-v1": asset(
+			board: "xiao_nrf52840_ble",
+			sha256: "ff8a0916e98cceb394fd66590bccc17f63612c11ff56b086ef88bd436c8df67f"
+		),
+		"nRF52840-SeeedXiaoSense-v1": asset(
+			board: "xiao_nrf52840_ble_sense",
+			sha256: "fc233d83a1011419625fcb50b49084578460c25bbc0270374ca176757a3c40da"
+		),
+		"nRF52840-T1000-E-v1": asset(
+			board: "t1000_e",
+			sha256: "5c065e11b8acd5b0cefa9295f98bca1512306cfa478856aa76a871124a904cc4"
+		),
+		"nRF52840-TEcho-v1": asset(
+			board: "lilygo_techo",
+			sha256: "2ddb36188ffe521c270bb2ce8441d742d0fe45325c57e4db6475bf63162a59b0"
+		),
+		"nRF52840-ThinkNode-M3-v1": asset(
+			board: "thinknode_m3",
+			sha256: "bf90979f2f6adc96ef6ca09c280b2ab7e66cb8ce2654fc80da9b20407bfb8708"
+		),
+		"nRF52840-ThinkNodeM1-v1": asset(
+			board: "thinknode_m1",
+			sha256: "aa0721b573c60e0b179274d5a5296bac7a8436faf339cfc03116ebe8a4375795"
+		),
+		"nRF52840-ThinkNodeM6-v1": asset(
+			board: "thinknode_m6",
+			sha256: "aaf94953a540a18f3e48f4cdec0c78290ad3c5f8740aea26fa3b3ce3632a8d4a"
+		),
+		"nRF52840-promicro": asset(
+			board: "promicro_nrf52840",
+			sha256: "46ef3440f151d6f2606075bcd1aa83db25a660da7d25b988aeb47ef350c98794"
+		)
+	]
+
+	/// Meshtastic platformio targets whose products OTAFIX lists as supported.
+	///
+	/// A UX gate only — it decides whether the upgrade action is offered, never
+	/// which image is written. Deliberately excludes products that merely share
+	/// a build target with a supported one (WISMESH Hub/Tap, Nomadstar Meteor
+	/// Pro, RAK3401, T-Echo Plus/Lite): OTAFIX ships no bootloader for them, and
+	/// their Board-IDs will refuse at resolution anyway.
+	static let supportedTargets: Set<String> = [
+		"rak4631",
+		"rak_wismeshtag",
+		"t-echo",
+		"heltec-mesh-node-t114",
+		"nrf52_promicro_diy_tcxo",
+		"thinknode_m1",
+		"thinknode_m3",
+		"thinknode_m6",
+		"tracker-t1000-e",
+		"seeed_wio_tracker_L1",
+		"seeed_wio_tracker_L1_eink",
+		"seeed_solar_node",
+		"seeed_xiao_nrf52840_kit"
+	]
+
+	static func supportsTarget(_ platformioTarget: String) -> Bool {
+		supportedTargets.contains(platformioTarget.trimmingCharacters(in: .whitespacesAndNewlines))
+	}
+
+	/// The image matching the Board-ID a device reported, or nil when
+	/// unrecognized. Nil refuses the upgrade: an unrecognized Board-ID means the
+	/// installed bootloader is not one we have a verified pairing for, and
+	/// writing a bootloader built for other hardware is unrecoverable without a
+	/// debug probe.
+	static func image(forBoardID boardID: String) -> MaintenanceUF2? {
+		imagesByBoardID[boardID.trimmingCharacters(in: .whitespaces)]
+	}
+
+	/// The file every Adafruit-family UF2 bootloader exposes on its volume.
+	static let infoFileName = "INFO_UF2.TXT"
+
+	/// Extracts the `Board-ID:` value from `INFO_UF2.TXT` contents. Format is
+	/// fixed by the bootloader's ghostfat.c: CRLF-separated lines of
+	/// `UF2 Bootloader <ver>` / `Model: <name>` / `Board-ID: <id>` / `Date: …`.
+	/// Nil means the volume is not a UF2 bootloader drive — itself a reason to
+	/// refuse the write.
+	static func parseBoardID(fromInfoText text: String) -> String? {
+		for line in text.split(whereSeparator: \.isNewline) {
+			let trimmed = line.trimmingCharacters(in: .whitespaces)
+			guard trimmed.lowercased().hasPrefix("board-id:") else { continue }
+			let value = trimmed.dropFirst("board-id:".count).trimmingCharacters(in: .whitespaces)
+			return value.isEmpty ? nil : value
+		}
+		return nil
+	}
+}

--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -124,36 +124,36 @@
         "keywords": [
             "firmware",
             "update",
-            "event",
-            "app",
             "radio",
+            "app",
+            "event",
             "updates",
             "meshtastic",
             "hardware",
+            "drive",
+            "bootloader",
             "version",
+            "tap",
+            "screen",
+            "connected",
+            "connect",
             "ble",
             "transfer",
             "target",
             "stable",
-            "screen",
+            "radios",
             "progress",
             "notification",
-            "connected",
-            "connect",
+            "install",
+            "board",
             "artwork",
-            "tap",
             "standard",
             "some",
             "shows",
             "settings",
-            "running",
-            "radios",
-            "ota",
-            "node",
-            "keep",
-            "from"
+            "running"
         ],
-        "charCount": 4770
+        "charCount": 5806
     },
     {
         "id": "getting-started",
@@ -426,7 +426,7 @@
             "set",
             "selected"
         ],
-        "charCount": 16929
+        "charCount": 16945
     },
     {
         "id": "signal-meter",

--- a/Meshtastic/Resources/docs/markdown/user/firmware.md
+++ b/Meshtastic/Resources/docs/markdown/user/firmware.md
@@ -38,6 +38,16 @@ For ESP32 BLE updates, the app waits for the radio's final verification response
 
 **Do not close the app or move out of Bluetooth range during a firmware update.**
 
+## Upgrading the Bootloader (nRF52)
+
+Radios with an nRF52 processor can install Meshtastic's OTAFIX bootloader, which makes Bluetooth firmware updates faster and more reliable. When your connected radio supports it, a **Bootloader** section appears on the Firmware Updates screen.
+
+1. Tap **Upgrade Bootloader** and follow the steps: reboot the radio into DFU mode (or double-press its reset button) and connect it to this device with a USB cable. The radio appears as a USB drive.
+2. Choose the radio's drive in the file picker. The app reads the drive's `INFO_UF2.TXT` file to identify the board — the board on the drive decides which image is installed, so the wrong file can never be written to your hardware.
+3. Tap **Install Bootloader Update**. The app downloads the image for your board, verifies it against a pinned checksum, and writes it to the drive. The radio installs the bootloader and reboots itself.
+
+If the drive is not a bootloader drive, the board is not one OTAFIX supports, or the download does not match its checksum, nothing is written.
+
 ## During the Transfer
 
 While a supported OTA transfer is active, the update screen rotates short tips, and you can tap **Play Chirpy Hop** to play without leaving the updater. Firmware progress remains visible above the game, and the back button returns to the normal update screen at any time. Keep the Meshtastic app in the foreground until the update finishes.

--- a/Meshtastic/Resources/docs/user/firmware.html
+++ b/Meshtastic/Resources/docs/user/firmware.html
@@ -58,6 +58,14 @@
 </tbody>
 </table>
 <p><strong>Do not close the app or move out of Bluetooth range during a firmware update.</strong></p>
+<h2>Upgrading the Bootloader (nRF52)</h2>
+<p>Radios with an nRF52 processor can install Meshtastic's OTAFIX bootloader, which makes Bluetooth firmware updates faster and more reliable. When your connected radio supports it, a <strong>Bootloader</strong> section appears on the Firmware Updates screen.</p>
+<ol>
+<li>Tap <strong>Upgrade Bootloader</strong> and follow the steps: reboot the radio into DFU mode (or double-press its reset button) and connect it to this device with a USB cable. The radio appears as a USB drive.</li>
+<li>Choose the radio's drive in the file picker. The app reads the drive's <code>INFO_UF2.TXT</code> file to identify the board — the board on the drive decides which image is installed, so the wrong file can never be written to your hardware.</li>
+<li>Tap <strong>Install Bootloader Update</strong>. The app downloads the image for your board, verifies it against a pinned checksum, and writes it to the drive. The radio installs the bootloader and reboots itself.</li>
+</ol>
+<p>If the drive is not a bootloader drive, the board is not one OTAFIX supports, or the download does not match its checksum, nothing is written.</p>
 <h2>During the Transfer</h2>
 <p>While a supported OTA transfer is active, the update screen rotates short tips, and you can tap <strong>Play Chirpy Hop</strong> to play without leaving the updater. Firmware progress remains visible above the game, and the back button returns to the normal update screen at any time. Keep the Meshtastic app in the foreground until the update finishes.</p>
 <h2>Update Channels</h2>

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -149,6 +149,7 @@ private struct FirmwareContentView: View {
 	@State var locallyChosenFirmwareFile: URL?
 	// For row-level install sheet
 	@State var rowInstallation: RowInstallation?
+	@State var showBootloaderUpgrade = false
 
 	struct RowInstallation: Identifiable {
 		let type: FirmwareFile.FirmwareType
@@ -239,6 +240,23 @@ private struct FirmwareContentView: View {
 				// Extracted switch logic to keep body clean
 				firmwareRows
 			}
+
+			// SECTION 3: BOOTLOADER — nRF52 boards OTAFIX ships a bootloader for.
+			// UX gate only; the sheet identifies the board from the drive's own
+			// INFO_UF2.TXT before anything is offered for writing.
+			if showsBootloaderSection {
+				Section {
+					Button {
+						showBootloaderUpgrade = true
+					} label: {
+						Label("Upgrade Bootloader", systemImage: "memorychip")
+					}
+				} header: {
+					Text("Bootloader")
+				} footer: {
+					Text("OTAFIX is Meshtastic's improved nRF52 bootloader with faster, more reliable Bluetooth firmware updates.")
+				}
+			}
 		}
 		.navigationTitle("Firmware Updates")
 		.navigationBarTitleDisplayMode(.inline)
@@ -246,6 +264,9 @@ private struct FirmwareContentView: View {
 			if !isLoading {
 				firmwareList.refresh()
 			}
+		}
+		.sheet(isPresented: $showBootloaderUpgrade) {
+			BootloaderUpgradeView()
 		}
 		.sheet(item: $rowInstallation) { installation in
 			switch installation.type {
@@ -342,6 +363,14 @@ private struct FirmwareContentView: View {
 			return "firmware-\(platformioTarget)-<version>[-\(nodeRegion.topic)]"
 		}
 		return "firmware-\(platformioTarget)-<version>"
+	}
+
+	/// Whether to offer the OTAFIX bootloader upgrade: nRF52 hardware whose
+	/// product OTAFIX lists as supported. Deciding which image to write happens
+	/// in the sheet, from the Board-ID on the device's own drive.
+	var showsBootloaderSection: Bool {
+		hardware.architecture.flatMap { Architecture(rawValue: $0) } == .nrf52840
+			&& OTAFIXBootloader.supportsTarget(firmwareTarget)
 	}
 
 	var allowedTypes: [UTType] {

--- a/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/BootloaderUpgradeView.swift
+++ b/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/BootloaderUpgradeView.swift
@@ -1,0 +1,316 @@
+//
+//  BootloaderUpgradeView.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/19/26.
+//
+//  Guides an nRF52 user through installing the OTAFIX bootloader (Meshtastic's
+//  fork of the Adafruit nRF52 bootloader with faster, more reliable BLE OTA).
+//
+//  Safety model (mirrors Meshtastic-Android): the image to write is selected
+//  ONLY by the Board-ID the device itself reports in INFO_UF2.TXT on its
+//  mounted drive — never by correlating product names. The user grants the app
+//  access to the drive with the folder picker; the app reads the Board-ID,
+//  downloads the matching release image, verifies its pinned SHA-256, and
+//  writes it onto the drive. An unrecognized Board-ID refuses the upgrade.
+//
+
+import CryptoKit
+import OSLog
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BootloaderUpgradeView: View {
+	@EnvironmentObject var accessoryManager: AccessoryManager
+	@Environment(\.dismiss) var dismiss
+	@Environment(\.modelContext) var context
+
+	enum Phase: Equatable {
+		case idle
+		case resolved(boardID: String, image: MaintenanceUF2)
+		case installing
+		case done(fileName: String)
+		case failed(String)
+	}
+
+	@State private var phase: Phase = .idle
+	@State private var isPickingDrive = false
+	/// The security-scoped drive URL from the folder picker. Access is started
+	/// when granted and stopped when this view goes away or a new pick begins.
+	@State private var driveURL: URL?
+
+	var body: some View {
+		NavigationStack {
+			ScrollView {
+				VStack(spacing: 20) {
+
+					HStack(alignment: .top, spacing: 12) {
+						Image(systemName: "memorychip")
+							.font(.title2)
+							.foregroundStyle(.blue)
+
+						Text("OTAFIX is Meshtastic's improved nRF52 bootloader with faster, more reliable Bluetooth firmware updates. The upgrade is written from the device's own bootloader drive.")
+							.font(.callout)
+					}
+					.padding()
+					.background(Color.secondary.opacity(0.1))
+					.clipShape(RoundedRectangle(cornerRadius: 12))
+
+					Divider()
+
+					VStack(alignment: .leading, spacing: 12) {
+						Label("Step 1: Connect Device", systemImage: "1.circle.fill")
+							.font(.headline)
+
+						Text("Place your device in DFU mode and connect it via USB. It appears as a USB drive.")
+							.fixedSize(horizontal: false, vertical: true)
+
+						Text("If connected, use the button below to reboot into DFU. Otherwise, press your device's reset button twice rapidly.")
+							.font(.caption)
+							.foregroundStyle(.secondary)
+
+						rebootIntoDFUButton()
+					}
+
+					Divider()
+
+					VStack(alignment: .leading, spacing: 12) {
+						Label("Step 2: Choose the Bootloader Drive", systemImage: "2.circle.fill")
+							.font(.headline)
+
+						Text("Select the device's drive in the file picker (for example FTHR840BOOT or RAK4631). The board is identified from the INFO_UF2.TXT file the bootloader publishes there.")
+							.font(.callout)
+							.fixedSize(horizontal: false, vertical: true)
+
+						chooseDriveButton()
+					}
+
+					Divider()
+
+					VStack(alignment: .leading, spacing: 12) {
+						Label("Step 3: Install", systemImage: "3.circle.fill")
+							.font(.headline)
+
+						statusView()
+					}
+
+					Divider()
+
+					VStack(alignment: .leading, spacing: 10) {
+						Label("Important Notes", systemImage: "info.circle")
+							.font(.caption.bold())
+							.foregroundStyle(.secondary)
+
+						Text("• The download is verified against a pinned checksum before anything is written.")
+						Text("• After the file is written the device installs the bootloader and reboots itself; the drive disappears and comes back.")
+						Text("• If the board is not recognized nothing is written — a bootloader for the wrong board cannot be recovered over USB.")
+					}
+					.font(.caption)
+					.foregroundStyle(.secondary)
+				}
+				.padding()
+			}
+			// Catalyst sizes the sheet from the window and hides scroll bars at
+			// rest — same treatment as UF2MassStorageView so the bottom section
+			// never reads as cut off.
+			#if targetEnvironment(macCatalyst)
+			.scrollIndicators(.visible)
+			#endif
+			.navigationTitle("Bootloader Upgrade")
+			.navigationBarTitleDisplayMode(.inline)
+			.toolbar {
+				ToolbarItem(placement: .cancellationAction) {
+					Button {
+						dismiss()
+					} label: {
+						Image(systemName: "xmark")
+					}
+					.accessibilityLabel(String(localized: "Done", comment: "VoiceOver: dismiss the bootloader upgrade sheet"))
+				}
+			}
+		}
+		#if targetEnvironment(macCatalyst)
+		.frame(minHeight: 780)
+		#endif
+		.fileImporter(
+			isPresented: $isPickingDrive,
+			allowedContentTypes: [.folder],
+			allowsMultipleSelection: false
+		) { result in
+			handleDrivePick(result)
+		}
+		.onDisappear {
+			releaseDriveAccess()
+		}
+	}
+
+	// MARK: - Steps
+
+	@ViewBuilder
+	func rebootIntoDFUButton() -> some View {
+		Button {
+			let connectedNode = getNodeInfo(id: accessoryManager.activeDeviceNum ?? 0, context: context)
+			if let connectedNode, let user = connectedNode.user {
+				Task {
+					do {
+						try await accessoryManager.sendEnterDfuMode(fromUser: user, toUser: user)
+					} catch {
+						Logger.mesh.error("Reboot into DFU for bootloader upgrade failed")
+					}
+				}
+			}
+		} label: {
+			Label("Send Reboot into DFU", systemImage: "square.and.arrow.down")
+		}
+		.buttonStyle(.borderedProminent)
+		.controlSize(.large)
+		.frame(maxWidth: .infinity)
+		.disabled(accessoryManager.activeDeviceNum == nil)
+	}
+
+	@ViewBuilder
+	func chooseDriveButton() -> some View {
+		Button {
+			isPickingDrive = true
+		} label: {
+			Label("Choose Bootloader Drive", systemImage: "externaldrive")
+		}
+		.buttonStyle(.borderedProminent)
+		.controlSize(.large)
+		.frame(maxWidth: .infinity)
+		.disabled(phase == .installing)
+	}
+
+	@ViewBuilder
+	func statusView() -> some View {
+		switch phase {
+		case .idle:
+			Text("Choose the drive above to identify the board.")
+				.font(.callout)
+				.foregroundStyle(.secondary)
+
+		case .resolved(let boardID, let image):
+			VStack(alignment: .leading, spacing: 8) {
+				Label {
+					Text("Recognized **\(boardID)**")
+				} icon: {
+					Image(systemName: "checkmark.seal.fill")
+						.foregroundStyle(.green)
+				}
+				Text(image.fileName)
+					.font(.caption.monospaced())
+					.foregroundStyle(.secondary)
+				Button {
+					install()
+				} label: {
+					Label("Install Bootloader Update", systemImage: "arrow.down.circle.fill")
+				}
+				.buttonStyle(.borderedProminent)
+				.controlSize(.large)
+				.frame(maxWidth: .infinity)
+			}
+
+		case .installing:
+			HStack(spacing: 10) {
+				ProgressView()
+				Text("Downloading, verifying and writing…")
+					.font(.callout)
+			}
+
+		case .done(let fileName):
+			Label {
+				Text("Wrote \(fileName). The device is installing the bootloader and will reboot on its own.")
+					.font(.callout)
+			} icon: {
+				Image(systemName: "checkmark.circle.fill")
+					.foregroundStyle(.green)
+			}
+
+		case .failed(let message):
+			Label {
+				Text(message)
+					.font(.callout)
+			} icon: {
+				Image(systemName: "exclamationmark.triangle.fill")
+					.foregroundStyle(.orange)
+			}
+		}
+	}
+
+	// MARK: - Drive handling
+
+	private func handleDrivePick(_ result: Result<[URL], Error>) {
+		releaseDriveAccess()
+		do {
+			guard let url = try result.get().first else { return }
+			guard url.startAccessingSecurityScopedResource() else {
+				phase = .failed(String(localized: "Could not open the selected drive."))
+				return
+			}
+			driveURL = url
+
+			guard let infoText = readInfoFile(in: url) else {
+				phase = .failed(String(localized: "That folder is not a UF2 bootloader drive — no INFO_UF2.TXT found. Select the drive the device mounts in DFU mode."))
+				return
+			}
+			guard let boardID = OTAFIXBootloader.parseBoardID(fromInfoText: infoText) else {
+				phase = .failed(String(localized: "INFO_UF2.TXT has no Board-ID line, so the board cannot be identified safely."))
+				return
+			}
+			guard let image = OTAFIXBootloader.image(forBoardID: boardID) else {
+				phase = .failed(String(localized: "No OTAFIX bootloader is available for board \"\(boardID)\". Nothing was written."))
+				return
+			}
+			phase = .resolved(boardID: boardID, image: image)
+		} catch {
+			phase = .failed(error.localizedDescription)
+		}
+	}
+
+	/// INFO_UF2.TXT read, tolerant of FAT case differences.
+	private func readInfoFile(in drive: URL) -> String? {
+		let fm = FileManager.default
+		let direct = drive.appendingPathComponent(OTAFIXBootloader.infoFileName)
+		if let text = try? String(contentsOf: direct, encoding: .utf8) { return text }
+		guard let names = try? fm.contentsOfDirectory(atPath: drive.path) else { return nil }
+		guard let match = names.first(where: { $0.caseInsensitiveCompare(OTAFIXBootloader.infoFileName) == .orderedSame }) else {
+			return nil
+		}
+		return try? String(contentsOf: drive.appendingPathComponent(match), encoding: .utf8)
+	}
+
+	private func install() {
+		guard case .resolved(_, let image) = phase, let driveURL else { return }
+		phase = .installing
+		Task {
+			do {
+				let (data, response) = try await URLSession.shared.data(from: image.url)
+				if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+					throw URLError(.badServerResponse)
+				}
+				guard image.matches(data) else {
+					Logger.services.error("OTAFIX image failed checksum verification: \(image.fileName, privacy: .public)")
+					phase = .failed(String(localized: "The downloaded image did not match its pinned checksum. Nothing was written — try again later."))
+					return
+				}
+				let destination = driveURL.appendingPathComponent(image.fileName)
+				try data.write(to: destination)
+				Logger.services.info("Wrote OTAFIX bootloader \(image.fileName, privacy: .public) to the device drive")
+				phase = .done(fileName: image.fileName)
+			} catch {
+				Logger.services.error("OTAFIX bootloader install failed: \(error.localizedDescription, privacy: .public)")
+				phase = .failed(String(localized: "Could not install the update: \(error.localizedDescription)"))
+			}
+		}
+	}
+
+	private func releaseDriveAccess() {
+		driveURL?.stopAccessingSecurityScopedResource()
+		driveURL = nil
+	}
+}
+
+#Preview {
+	BootloaderUpgradeView()
+		.environmentObject(AccessoryManager.shared)
+}

--- a/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/BootloaderUpgradeView.swift
+++ b/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/BootloaderUpgradeView.swift
@@ -35,6 +35,9 @@ struct BootloaderUpgradeView: View {
 
 	@State private var phase: Phase = .idle
 	@State private var isPickingDrive = false
+	/// The in-flight download/verify/write. Cancelled before drive access is released so
+	/// the write can never run against a revoked security scope.
+	@State private var installTask: Task<Void, Never>?
 	/// The security-scoped drive URL from the folder picker. Access is started
 	/// when granted and stopped when this view goes away or a new pick begins.
 	@State private var driveURL: URL?
@@ -267,27 +270,40 @@ struct BootloaderUpgradeView: View {
 		}
 	}
 
-	/// INFO_UF2.TXT read, tolerant of FAT case differences.
+	/// INFO_UF2.TXT read, tolerant of FAT case differences. The bootloader emits a few
+	/// hundred bytes; anything large is not the file we expect, so refuse before reading
+	/// it into memory.
+	private static let maxInfoFileBytes = 16 * 1024
+
 	private func readInfoFile(in drive: URL) -> String? {
 		let fm = FileManager.default
 		let direct = drive.appendingPathComponent(OTAFIXBootloader.infoFileName)
-		if let text = try? String(contentsOf: direct, encoding: .utf8) { return text }
+		if let text = boundedInfoText(at: direct) { return text }
 		guard let names = try? fm.contentsOfDirectory(atPath: drive.path) else { return nil }
 		guard let match = names.first(where: { $0.caseInsensitiveCompare(OTAFIXBootloader.infoFileName) == .orderedSame }) else {
 			return nil
 		}
-		return try? String(contentsOf: drive.appendingPathComponent(match), encoding: .utf8)
+		return boundedInfoText(at: drive.appendingPathComponent(match))
+	}
+
+	private func boundedInfoText(at url: URL) -> String? {
+		guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+			  size <= Self.maxInfoFileBytes else { return nil }
+		return try? String(contentsOf: url, encoding: .utf8)
 	}
 
 	private func install() {
 		guard case .resolved(_, let image) = phase, let driveURL else { return }
 		phase = .installing
-		Task {
+		installTask = Task {
 			do {
 				let (data, response) = try await URLSession.shared.data(from: image.url)
 				if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
 					throw URLError(.badServerResponse)
 				}
+				// The sheet may have been dismissed (and drive access released) during
+				// the download — never write against a revoked scope.
+				try Task.checkCancellation()
 				guard image.matches(data) else {
 					Logger.services.error("OTAFIX image failed checksum verification: \(image.fileName, privacy: .public)")
 					phase = .failed(String(localized: "The downloaded image did not match its pinned checksum. Nothing was written — try again later."))
@@ -297,14 +313,19 @@ struct BootloaderUpgradeView: View {
 				try data.write(to: destination)
 				Logger.services.info("Wrote OTAFIX bootloader \(image.fileName, privacy: .public) to the device drive")
 				phase = .done(fileName: image.fileName)
+			} catch is CancellationError {
+				// Dismissed mid-install; nothing was written.
 			} catch {
-				Logger.services.error("OTAFIX bootloader install failed: \(error.localizedDescription, privacy: .public)")
+				// The error can carry the drive path — keep it out of public logs.
+				Logger.services.error("OTAFIX bootloader install failed: \(error.localizedDescription, privacy: .private)")
 				phase = .failed(String(localized: "Could not install the update: \(error.localizedDescription)"))
 			}
 		}
 	}
 
 	private func releaseDriveAccess() {
+		installTask?.cancel()
+		installTask = nil
 		driveURL?.stopAccessingSecurityScopedResource()
 		driveURL = nil
 	}

--- a/MeshtasticTests/MaintenanceUF2Tests.swift
+++ b/MeshtasticTests/MaintenanceUF2Tests.swift
@@ -1,0 +1,131 @@
+//
+//  MaintenanceUF2Tests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/19/26.
+//
+//  Pins the OTAFIX bootloader map and INFO_UF2.TXT parsing (#2336). The map's
+//  correctness is safety-critical — a wrong Board-ID pairing writes a
+//  bootloader built for other hardware, which is unrecoverable without a debug
+//  probe — so the rows are asserted against the audited set mirrored from
+//  Meshtastic-Android rather than merely being internally consistent.
+//
+
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("OTAFIX bootloader resolution")
+struct MaintenanceUF2Tests {
+
+	/// The audited Board-ID set, mirrored from Android's OTAFIX_BY_BOARD_ID.
+	/// A row appearing or vanishing here must be a deliberate change.
+	private static let auditedBoardIDs: Set<String> = [
+		"HT-n5262",
+		"MinewSemi-MX25LE01",
+		"TRACKER L1",
+		"WisBlock-RAK4631-Board",
+		"WisMesh-Tag",
+		"nRF52840-SeeedSenseCAPSolarP1-v1",
+		"nRF52840-SeeedXiao-v1",
+		"nRF52840-SeeedXiaoSense-v1",
+		"nRF52840-T1000-E-v1",
+		"nRF52840-TEcho-v1",
+		"nRF52840-ThinkNode-M3-v1",
+		"nRF52840-ThinkNodeM1-v1",
+		"nRF52840-ThinkNodeM6-v1",
+		"nRF52840-promicro"
+	]
+
+	@Test func mapCarriesExactlyTheAuditedBoards() {
+		#expect(Set(OTAFIXBootloader.imagesByBoardID.keys) == Self.auditedBoardIDs)
+	}
+
+	@Test func everyRowIsInternallyConsistent() throws {
+		for (boardID, image) in OTAFIXBootloader.imagesByBoardID {
+			// Release-pinned URL that ends in its own file name.
+			#expect(image.url.absoluteString.contains(OTAFIXBootloader.releaseTag), "\(boardID) URL is not release-pinned")
+			#expect(image.url.lastPathComponent == image.fileName, "\(boardID) URL/fileName mismatch")
+			#expect(image.fileName.hasPrefix("update-"), "\(boardID) is not a self-update image")
+			#expect(image.fileName.hasSuffix("_nosd.uf2"), "\(boardID) image must not carry a SoftDevice")
+			// Pinned digest is well-formed lowercase hex.
+			#expect(image.sha256.count == 64, "\(boardID) digest length")
+			#expect(image.sha256.allSatisfy { $0.isHexDigit && (!$0.isLetter || $0.isLowercase) }, "\(boardID) digest format")
+			// fileName is interpolated into a path on the drive; keep it inert.
+			#expect(!image.fileName.contains("/") && !image.fileName.contains(".."), "\(boardID) unsafe file name")
+		}
+	}
+
+	/// The split OTAFIX's own README warns about: the two XIAO variants differ
+	/// only by Board-ID, and each must resolve to its own image.
+	@Test func xiaoVariantsResolveToDistinctImages() throws {
+		let ble = try #require(OTAFIXBootloader.image(forBoardID: "nRF52840-SeeedXiao-v1"))
+		let sense = try #require(OTAFIXBootloader.image(forBoardID: "nRF52840-SeeedXiaoSense-v1"))
+		#expect(ble.fileName != sense.fileName)
+		#expect(ble.sha256 != sense.sha256)
+	}
+
+	@Test func unknownBoardIDRefuses() {
+		#expect(OTAFIXBootloader.image(forBoardID: "nRF52840-SomeNewBoard-v1") == nil)
+		#expect(OTAFIXBootloader.image(forBoardID: "") == nil)
+	}
+
+	@Test func boardIDLookupTrimsWhitespace() {
+		#expect(OTAFIXBootloader.image(forBoardID: "  WisBlock-RAK4631-Board ") != nil)
+	}
+
+	// MARK: - INFO_UF2.TXT parsing
+
+	@Test func parsesTheCanonicalInfoFile() {
+		let text = "UF2 Bootloader 0.4.3 lib/nrfx (v2.0.0) lib/tinyusb (0.10.1-293-gaf8e5a90) lib/uf2 (remotes/origin/configupdate-9-gadbb8c7)\r\nModel: WisBlock RAK4631 Board\r\nBoard-ID: WisBlock-RAK4631-Board\r\nDate: Dec 1 2021\r\n"
+		#expect(OTAFIXBootloader.parseBoardID(fromInfoText: text) == "WisBlock-RAK4631-Board")
+	}
+
+	@Test func parsingIsCaseInsensitiveAndTrims() {
+		#expect(OTAFIXBootloader.parseBoardID(fromInfoText: "board-id:   HT-n5262  \n") == "HT-n5262")
+	}
+
+	@Test func missingBoardIDLineIsNil() {
+		#expect(OTAFIXBootloader.parseBoardID(fromInfoText: "Model: Something\r\nDate: Jan 1 2024\r\n") == nil)
+		#expect(OTAFIXBootloader.parseBoardID(fromInfoText: "") == nil)
+	}
+
+	@Test func emptyBoardIDValueIsNil() {
+		#expect(OTAFIXBootloader.parseBoardID(fromInfoText: "Board-ID:\r\n") == nil)
+	}
+
+	// MARK: - UX gate
+
+	@Test func supportedTargetsMatchTheAuditedSet() {
+		// Positive cases from OTAFIX's supported list…
+		#expect(OTAFIXBootloader.supportsTarget("rak4631"))
+		#expect(OTAFIXBootloader.supportsTarget("t-echo"))
+		#expect(OTAFIXBootloader.supportsTarget("tracker-t1000-e"))
+		// …and products that share a build target but have no OTAFIX bootloader
+		// stay excluded (they'd refuse at Board-ID resolution anyway).
+		#expect(!OTAFIXBootloader.supportsTarget("canaryone"))
+		#expect(!OTAFIXBootloader.supportsTarget("tbeam"))
+		#expect(!OTAFIXBootloader.supportsTarget(""))
+	}
+
+	// MARK: - Digest verification
+
+	@Test func checksumMatchGatesTheImage() {
+		let data = Data("meshtastic".utf8)
+		// SHA-256 of "meshtastic"
+		let good = MaintenanceUF2(
+			url: URL(string: "https://example.invalid/a.uf2")!,
+			fileName: "a.uf2",
+			sha256: "eb5cb6dab3bf5bf095a9173a0491a63abb8889dc20f808d5245399017a5ac03d"
+		)
+		let bad = MaintenanceUF2(
+			url: URL(string: "https://example.invalid/a.uf2")!,
+			fileName: "a.uf2",
+			sha256: String(repeating: "0", count: 64)
+		)
+		#expect(good.matches(data))
+		#expect(!bad.matches(data))
+		#expect(!good.matches(Data("meshtastic2".utf8)))
+	}
+}

--- a/MeshtasticTests/MaintenanceUF2Tests.swift
+++ b/MeshtasticTests/MaintenanceUF2Tests.swift
@@ -42,6 +42,57 @@ struct MaintenanceUF2Tests {
 		#expect(Set(OTAFIXBootloader.imagesByBoardID.keys) == Self.auditedBoardIDs)
 	}
 
+	/// The complete audited pairing, Board-ID → (board slug in the file name, digest
+	/// prefix), mirrored from Meshtastic-Android's MaintenanceUf2.kt and re-verified
+	/// against the release assets. A swapped pairing passes every structural check yet
+	/// writes a bootloader built for other hardware — this fixture is what fails then.
+	private static let auditedPairings: [String: (board: String, sha256Prefix: String)] = [
+		"HT-n5262": ("heltec_t114", "ae92d357"),
+		"MinewSemi-MX25LE01": ("minewsemi_mx25le01", "e09564fd"),
+		"TRACKER L1": ("wio_tracker_l1", "70fbce0e"),
+		"WisBlock-RAK4631-Board": ("wiscore_rak4631_board", "8741bc67"),
+		"WisMesh-Tag": ("wismesh_tag", "96d42e19"),
+		"nRF52840-SeeedSenseCAPSolarP1-v1": ("sensecap_solar_p1", "9b4bce48"),
+		"nRF52840-SeeedXiao-v1": ("xiao_nrf52840_ble", "ff8a0916"),
+		"nRF52840-SeeedXiaoSense-v1": ("xiao_nrf52840_ble_sense", "fc233d83"),
+		"nRF52840-T1000-E-v1": ("t1000_e", "5c065e11"),
+		"nRF52840-TEcho-v1": ("lilygo_techo", "2ddb3618"),
+		"nRF52840-ThinkNode-M3-v1": ("thinknode_m3", "bf90979f"),
+		"nRF52840-ThinkNodeM1-v1": ("thinknode_m1", "aa0721b5"),
+		"nRF52840-ThinkNodeM6-v1": ("thinknode_m6", "aaf94953"),
+		"nRF52840-promicro": ("promicro_nrf52840", "46ef3440")
+	]
+
+	@Test func everyPairingMatchesTheAuditedFixture() throws {
+		#expect(OTAFIXBootloader.imagesByBoardID.count == Self.auditedPairings.count)
+		for (boardID, expected) in Self.auditedPairings {
+			let image = try #require(OTAFIXBootloader.image(forBoardID: boardID), "missing \(boardID)")
+			#expect(
+				image.fileName == "update-\(expected.board)_bootloader-\(OTAFIXBootloader.releaseTag)_nosd.uf2",
+				"\(boardID) must map to the \(expected.board) image"
+			)
+			#expect(image.sha256.hasPrefix(expected.sha256Prefix), "\(boardID) digest drifted from the audited pin")
+		}
+	}
+
+	@Test func supportedTargetsMatchTheAuditedSetExactly() {
+		#expect(OTAFIXBootloader.supportedTargets == [
+			"rak4631",
+			"rak_wismeshtag",
+			"t-echo",
+			"heltec-mesh-node-t114",
+			"nrf52_promicro_diy_tcxo",
+			"thinknode_m1",
+			"thinknode_m3",
+			"thinknode_m6",
+			"tracker-t1000-e",
+			"seeed_wio_tracker_L1",
+			"seeed_wio_tracker_L1_eink",
+			"seeed_solar_node",
+			"seeed_xiao_nrf52840_kit"
+		])
+	}
+
 	@Test func everyRowIsInternallyConsistent() throws {
 		for (boardID, image) in OTAFIXBootloader.imagesByBoardID {
 			// Release-pinned URL that ends in its own file name.

--- a/docs/user/firmware.md
+++ b/docs/user/firmware.md
@@ -38,6 +38,16 @@ For ESP32 BLE updates, the app waits for the radio's final verification response
 
 **Do not close the app or move out of Bluetooth range during a firmware update.**
 
+## Upgrading the Bootloader (nRF52)
+
+Radios with an nRF52 processor can install Meshtastic's OTAFIX bootloader, which makes Bluetooth firmware updates faster and more reliable. When your connected radio supports it, a **Bootloader** section appears on the Firmware Updates screen.
+
+1. Tap **Upgrade Bootloader** and follow the steps: reboot the radio into DFU mode (or double-press its reset button) and connect it to this device with a USB cable. The radio appears as a USB drive.
+2. Choose the radio's drive in the file picker. The app reads the drive's `INFO_UF2.TXT` file to identify the board — the board on the drive decides which image is installed, so the wrong file can never be written to your hardware.
+3. Tap **Install Bootloader Update**. The app downloads the image for your board, verifies it against a pinned checksum, and writes it to the drive. The radio installs the bootloader and reboots itself.
+
+If the drive is not a bootloader drive, the board is not one OTAFIX supports, or the download does not match its checksum, nothing is written.
+
 ## During the Transfer
 
 While a supported OTA transfer is active, the update screen rotates short tips, and you can tap **Play Chirpy Hop** to play without leaving the updater. Firmware progress remains visible above the game, and the back button returns to the normal update screen at any time. Keep the Meshtastic app in the foreground until the update finishes.


### PR DESCRIPTION
## Summary

First half of #2336. Android can upgrade a device onto Meshtastic's OTAFIX bootloader (faster, more reliable BLE OTA) in-app; iOS had no path at all short of finding a UF2 on GitHub by hand.

## What changed

The firmware screen gains a Bootloader section for nRF52 boards OTAFIX supports, opening a guided sheet in the style of the existing UF2 mass-storage flow:

1. Reboot the connected device into DFU (or double-tap reset) and connect its USB drive.
2. Pick the mounted drive in the file picker. The app reads `INFO_UF2.TXT` off the drive and identifies the board from its `Board-ID:` line.
3. The matching self-update image is downloaded from the pinned OTAFIX release, verified against its pinned SHA-256, and written onto the drive. The device installs it and reboots itself.

The safety model is Android's, unchanged: the Board-ID the device itself reports is the only input that selects an image — product names can't be correlated between the projects, and the XIAO BLE / BLE Sense split differs only by Board-ID, where writing the wrong image is unrecoverable without a debug probe. The connected node's platformio target only gates whether the action is offered. An unrecognized Board-ID, a missing `INFO_UF2.TXT`, or a checksum mismatch each refuse with nothing written.

The board map (14 boards) is mirrored verbatim from Meshtastic-Android's `MaintenanceUf2.kt`, and every pinned digest was re-verified against the actual release assets before committing.

New files land in synced folders, so no project file changes.

## Testing

- 11 new tests: the audited board set is pinned exactly, per-row URL/filename/digest integrity, the XIAO variant split resolves to distinct images, INFO_UF2.TXT parsing (CRLF, case, trimming, missing/empty lines), unknown-board refusal, and SHA-256 gating.
- Full unit suite: 2,912 tests in 509 suites passing. iOS Simulator and Mac Catalyst builds succeed.
- Not tested end-to-end against hardware: the drive flow needs an nRF52 board in DFU mode on USB-C. The flow mirrors the shipping UF2 firmware flow's mechanics (same picker, same drive), but a RAK4631 walk-through before release would be the real proof.

The erase/recovery half of #2336 is not in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided bootloader upgrade flow for supported nRF52840 devices.
  * Detects compatible hardware, reboots into upgrade mode, identifies the device, and installs the appropriate bootloader image.
  * Verifies downloaded images before installation and reports progress, completion, and errors.

* **Bug Fixes**
  * Prevents upgrades for unsupported devices, invalid drives, unrecognized hardware, and corrupted downloads.

* **Tests**
  * Added coverage for device detection, image selection, metadata parsing, supported targets, and checksum validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->