### PR TITLE
fix(docs): validate JPEG screenshot references

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -54,7 +54,7 @@ done < <(
     find "$REPO_ROOT/docs" -name '*.md' -print0 | xargs -0 awk '
         /^[[:space:]]*```/ { in_fence = !in_fence; next }
         !in_fence { print }
-    ' | grep -oh 'screenshots/[^")* ]*\.png' | sed 's|screenshots/||' | sort -u
+    ' | grep -ohE 'screenshots/[^")* ]*\.(png|jpe?g)' | sed 's|screenshots/||' | sort -u
 )
 if (( ${#missing_images[@]} > 0 )); then
     echo "error: docs pages reference screenshots that do not exist in docs/assets/screenshots:" >&2

--- a/scripts/copy-snapshots.sh
+++ b/scripts/copy-snapshots.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # scripts/copy-snapshots.sh
-# Copies only doc-referenced snapshot PNGs into the bundled docs output directory.
+# Copies only doc-referenced screenshots into the bundled docs output directory.
 # Usage: bash scripts/copy-snapshots.sh --output Meshtastic/Resources/docs/assets/screenshots
 # See specs/003-app-docs-markdown/contracts/ci-workflow-contract.md for full interface.
 
@@ -26,7 +26,7 @@ SOURCE_DIR="$DOCS_DIR/assets/screenshots"
 mkdir -p "$OUTPUT_DIR"
 
 # Scan markdown files for referenced screenshot filenames
-referenced=$(grep -roh 'screenshots/[^")*]*\.png' "$DOCS_DIR" --include='*.md' \
+referenced=$(grep -rohE 'screenshots/[^")*]*\.(png|jpe?g)' "$DOCS_DIR" --include='*.md' \
 	| sed 's|screenshots/||' \
 	| sort -u)
 


### PR DESCRIPTION
## Summary
- Extend the documentation screenshot guard to validate `.jpg` and `.jpeg` references alongside `.png`.

## Why
The guard promises to catch missing screenshot assets, but it previously ignored JPEG references. This keeps the check aligned with the image formats accepted by the documentation.

## Validation
- `bash scripts/build-docs.sh --output <temporary directory>`
  - Completed successfully: 31 pages built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screenshot references now recognize PNG, JPG, and JPEG images during documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->