### PR TITLE
fix(ble): pause scanning during pairing without dropping peripheral

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -312,6 +312,12 @@ extension AccessoryManager {
 		do {
 			try await connectionStepper?.run()
 			Logger.transport.debug("🔗 [Connect] ConnectionStepper completed.")
+			// The scan pause covers the whole handshake — pairing happens during the
+			// notify subscription, after the link comes up — so resume only now that
+			// every step finished. Failed attempts resume via connectionDidDisconnect.
+			if let bleTransport = transportForType(.ble) as? BLETransport {
+				await bleTransport.resumeScanningAfterConnectionEstablished()
+			}
 		} catch AccessoryError.tooManyRetries {
 			self.lastConnectionError = AccessoryError.tooManyRetries
 			try await self.closeConnection()

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -333,7 +333,19 @@ actor BLETransport: Transport {
 		centralManager.stopScan()
 	}
 
+	/// The pause exists to keep duplicate-advertisement traffic away from the pairing
+	/// window, which runs through the notify subscription — after the link itself comes
+	/// up. Once the handshake is fully established, resume so the Available Radios list
+	/// stays live for device switching while connected.
+	func resumeScanningAfterConnectionEstablished() {
+		resumeScanningIfPaused()
+	}
+
 	private func resumeScanningAfterFailedConnection() {
+		resumeScanningIfPaused()
+	}
+
+	private func resumeScanningIfPaused() {
 		guard scanningPausedForConnection else { return }
 		scanningPausedForConnection = false
 		guard discoveredDeviceContinuation != nil,

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -55,6 +55,7 @@ actor BLETransport: Transport {
 
 	private var cleanupTask: Task<Void, Never>?
 	private var scanningPausedForConnection = false
+	private let discoverySetupHandler: (@Sendable () async -> Void)?
 	
 	// Transport properties
 	let supportsManualConnection: Bool = false
@@ -67,9 +68,11 @@ actor BLETransport: Transport {
 	///   incidental value lands in `status` at an unpredictable point mid-test.
 	init(
 		createCentralManagerImmediately: Bool = true,
-		centralManager: CBCentralManager? = nil
+		centralManager: CBCentralManager? = nil,
+		discoverySetupHandler: (@Sendable () async -> Void)? = nil
 	) {
 		self.centralManager = centralManager
+		self.discoverySetupHandler = discoverySetupHandler
 		self.discoveredPeripherals = [:]
 		self.discoveredDeviceContinuation = nil
 		self.delegate = BLEDelegate()
@@ -157,6 +160,7 @@ actor BLETransport: Transport {
 				// This gate is opened when the CBCentralManager is in poweredOn state.
 				// Its probably open already, but just to be sure in case we get here too quickly.
 				try await self.setupCompleteGate.wait()
+				await self.discoverySetupHandler?()
 				
 				if await !self.restoreInProgress && !self.scanningPausedForConnection {
 					centralManager.scanForPeripherals(withServices: [meshtasticServiceCBUUID], options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
@@ -256,7 +260,6 @@ actor BLETransport: Transport {
 			if let continuation = connectContinuation {
 				connectContinuation = nil
 				continuation.resume(throwing: AccessoryError.disconnected("Bluetooth powered off"))
-				connectionDidDisconnect(fromPeripheral: connectingPeripheral)
 			}
 			if let connection = activeConnection {
 				Task {
@@ -315,9 +318,10 @@ actor BLETransport: Transport {
 	}
 
 	private func cancelConnectContinuation(for peripheral: CBPeripheral) {
-		self.connectContinuation?.resume(throwing: CancellationError())
+		guard connectingPeripheral?.identifier == peripheral.identifier,
+			  let connectContinuation else { return }
+		connectContinuation.resume(throwing: CancellationError())
 		self.connectContinuation = nil
-		self.connectionDidDisconnect(fromPeripheral: peripheral)
 	}
 
 	/// Stops duplicate-advertisement scanning before CoreBluetooth starts a connection. Keeping the

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -317,7 +317,7 @@ actor BLETransport: Transport {
 		}
 	}
 
-	private func cancelConnectContinuation(for peripheral: CBPeripheral) {
+	func cancelConnectContinuation(for peripheral: CBPeripheral) {
 		guard connectingPeripheral?.identifier == peripheral.identifier,
 			  let connectContinuation else { return }
 		connectContinuation.resume(throwing: CancellationError())

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -54,6 +54,7 @@ actor BLETransport: Transport {
 	static let poweredOffStatusMessage = "Bluetooth is powered off"
 
 	private var cleanupTask: Task<Void, Never>?
+	private var scanningPausedForConnection = false
 	
 	// Transport properties
 	let supportsManualConnection: Bool = false
@@ -64,7 +65,11 @@ actor BLETransport: Transport {
 	///   authorization already does. Tests that drive `handleCentralState` directly need this: a
 	///   real manager reports the host's actual Bluetooth state on its own schedule, and that
 	///   incidental value lands in `status` at an unpredictable point mid-test.
-	init(createCentralManagerImmediately: Bool = true) {
+	init(
+		createCentralManagerImmediately: Bool = true,
+		centralManager: CBCentralManager? = nil
+	) {
+		self.centralManager = centralManager
 		self.discoveredPeripherals = [:]
 		self.discoveredDeviceContinuation = nil
 		self.delegate = BLEDelegate()
@@ -72,10 +77,13 @@ actor BLETransport: Transport {
 		// Only create CBCentralManager immediately if Bluetooth authorization is already
 		// determined. This avoids showing the system permission prompt before the
 		// onboarding Bluetooth screen has a chance to present it in context.
-		if createCentralManagerImmediately, CBCentralManager.authorization != .notDetermined {
-			centralManager = CBCentralManager(delegate: delegate,
-											  queue: centralQueue,
-											  options: Self.centralManagerOptions(restoreIdentifier: kCentralRestoreID)
+		if centralManager == nil,
+		   createCentralManagerImmediately,
+		   CBCentralManager.authorization != .notDetermined {
+			self.centralManager = CBCentralManager(
+				delegate: delegate,
+				queue: centralQueue,
+				options: Self.centralManagerOptions(restoreIdentifier: kCentralRestoreID)
 			)
 		}
 		self.delegate.setTransport(self)
@@ -150,7 +158,7 @@ actor BLETransport: Transport {
 				// Its probably open already, but just to be sure in case we get here too quickly.
 				try await self.setupCompleteGate.wait()
 				
-				if await !self.restoreInProgress {
+				if await !self.restoreInProgress && !self.scanningPausedForConnection {
 					centralManager.scanForPeripherals(withServices: [meshtasticServiceCBUUID], options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
 					
 					let peripherals = await self.discoveredPeripherals.values.map({$0.peripheral})
@@ -197,6 +205,7 @@ actor BLETransport: Transport {
 
 	private func stopScanning() {
 		Logger.transport.debug("🛜 [BLE] Stop Scanning: BLE Discovery has been stopped.")
+		scanningPausedForConnection = false
 		guard centralManager != nil else {
 			discoveredPeripherals.removeAll()
 			discoveredDeviceContinuation = nil
@@ -228,7 +237,9 @@ actor BLETransport: Transport {
 			// Open the gate, so anyone who was waiitng for poweredOn can continue
 			Task { await self.setupCompleteGate.open() }
 			
-			if self.discoveredDeviceContinuation != nil && !restoreInProgress {
+			if self.discoveredDeviceContinuation != nil,
+			   !restoreInProgress,
+			   !scanningPausedForConnection {
 				// We have someone already subscribed to our discovery event stream.
 				// Likely a powerOff event occcurred and need to now restore scanning.
 				central.scanForPeripherals(withServices: [meshtasticServiceCBUUID], options: [CBCentralManagerScanOptionAllowDuplicatesKey: true])
@@ -242,6 +253,11 @@ actor BLETransport: Transport {
 			// the opposite of, so `.error` here also matches this file's own convention for
 			// every other non-powered-on state (.unauthorized, .unsupported, .resetting, etc.).
 			status = .error(Self.poweredOffStatusMessage)
+			if let continuation = connectContinuation {
+				connectContinuation = nil
+				continuation.resume(throwing: AccessoryError.disconnected("Bluetooth powered off"))
+				connectionDidDisconnect(fromPeripheral: connectingPeripheral)
+			}
 			if let connection = activeConnection {
 				Task {
 					Logger.transport.error("🛜 [BLE] Bluetooth has powered off during active connection. Cleaning up.")
@@ -304,17 +320,52 @@ actor BLETransport: Transport {
 		self.connectionDidDisconnect(fromPeripheral: peripheral)
 	}
 
+	/// Stops duplicate-advertisement scanning before CoreBluetooth starts a connection. Keeping the
+	/// discovery stream and cache alive preserves the selected peripheral while the pairing sheet is
+	/// active. A failed attempt restarts the scan so normal discovery and retries can continue.
+	func pauseScanningForConnection() {
+		scanningPausedForConnection = true
+		guard centralManager?.isScanning == true else { return }
+		centralManager.stopScan()
+	}
+
+	private func resumeScanningAfterFailedConnection() {
+		guard scanningPausedForConnection else { return }
+		scanningPausedForConnection = false
+		guard discoveredDeviceContinuation != nil,
+			  centralManager?.state == .poweredOn,
+			  !restoreInProgress else { return }
+		centralManager.scanForPeripherals(
+			withServices: [meshtasticServiceCBUUID],
+			options: [CBCentralManagerScanOptionAllowDuplicatesKey: true]
+		)
+	}
+
+	/// Resolves a peripheral from the live discovery cache or CoreBluetooth's registry. The latter
+	/// keeps connect(to:) valid if discovery teardown cleared the cache before the connect request.
+	private func resolvePeripheral(for device: Device) -> CBPeripheral? {
+		guard let identifier = UUID(uuidString: device.identifier) else {
+			Logger.transport.error("🛜 [BLE] Device identifier is not a UUID: \(device.identifier, privacy: .public)")
+			return nil
+		}
+		if let cachedPeripheral = discoveredPeripherals[identifier]?.peripheral {
+			return cachedPeripheral
+		}
+		return centralManager?.retrievePeripherals(withIdentifiers: [identifier]).first
+	}
+
 	func connect(to device: Device) async throws -> any Connection {
-		guard let peripheral = discoveredPeripherals[UUID(uuidString: device.identifier)!] else {
+		guard activeConnection == nil, connectContinuation == nil else {
+			throw AccessoryError.connectionFailed("BLE transport is busy: already connecting or connected")
+		}
+
+		pauseScanningForConnection()
+		guard let peripheral = resolvePeripheral(for: device) else {
+			resumeScanningAfterFailedConnection()
 			throw AccessoryError.connectionFailed("Peripheral not found")
 		}
 		
 		do {
-			if await self.activeConnection?.peripheral.state == .disconnected {
-				Logger.transport.error("🛜 [BLE] Connect request while an active (but disconnected)")
-				throw AccessoryError.connectionFailed("Connect request while an active connection exists")
-			}
-			
 			let returnConnection = try await withTaskCancellationHandler {
 				let newConnection: BLEConnection = try await withCheckedThrowingContinuation { cont in
 					if self.connectContinuation != nil || self.activeConnection != nil {
@@ -322,24 +373,25 @@ actor BLETransport: Transport {
 						return
 					}
 					self.connectContinuation = cont
-					self.connectingPeripheral = peripheral.peripheral
+					self.connectingPeripheral = peripheral
 					guard centralManager != nil else {
+						self.connectContinuation = nil
 						cont.resume(throwing: AccessoryError.connectionFailed("Bluetooth not initialized"))
 						return
 					}
-					centralManager.connect(peripheral.peripheral)
+					centralManager.connect(peripheral)
 				}
 				self.activeConnection = newConnection
 				return newConnection
 			} onCancel: {
 				Task {
-					await self.cancelConnectContinuation(for: peripheral.peripheral)
+					await self.cancelConnectContinuation(for: peripheral)
 				}
 			}
 			Logger.transport.debug("🛜 [BLE] Connect complete.")
 			return returnConnection
 		} catch {
-			connectionDidDisconnect(fromPeripheral: peripheral.peripheral)
+			connectionDidDisconnect(fromPeripheral: peripheral)
 			throw error
 		}
 	}
@@ -576,6 +628,7 @@ actor BLETransport: Transport {
 		self.activeConnection = nil
 		self.connectingPeripheral = nil
 		restoreInProgress = false
+		resumeScanningAfterFailedConnection()
 	}
 }
 

--- a/MeshtasticTests/BLETransportPeripheralResolutionTests.swift
+++ b/MeshtasticTests/BLETransportPeripheralResolutionTests.swift
@@ -1,0 +1,115 @@
+//
+//  BLETransportPeripheralResolutionTests.swift
+//  MeshtasticTests
+//
+//  Regression coverage for #2200: stopping discovery before pairing cleared
+//  BLETransport's scan cache, so connect(to:) failed before asking CoreBluetooth
+//  to resolve the selected peripheral.
+//
+
+@preconcurrency import CoreBluetooth
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+private final class RecordingCentralManager: CBCentralManager, @unchecked Sendable {
+	enum Call: Equatable {
+		case stopScan
+		case retrievePeripherals([UUID])
+		case startScan
+	}
+
+	private(set) var calls: [Call] = []
+	private var scanning: Bool
+
+	init(scanning: Bool = true) {
+		self.scanning = scanning
+		super.init(delegate: nil, queue: nil, options: nil)
+	}
+
+	override var state: CBManagerState { .poweredOn }
+	override var isScanning: Bool { scanning }
+
+	override func stopScan() {
+		scanning = false
+		calls.append(.stopScan)
+	}
+
+	override func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBPeripheral] {
+		calls.append(.retrievePeripherals(identifiers))
+		return []
+	}
+
+	override func scanForPeripherals(withServices serviceUUIDs: [CBUUID]?, options: [String: Any]? = nil) {
+		scanning = true
+		calls.append(.startScan)
+	}
+}
+
+@Suite("BLETransport peripheral resolution", .timeLimit(.minutes(1)))
+struct BLETransportPeripheralResolutionTests {
+	private func letActorTasksRun() async throws {
+		try await Task.sleep(for: .milliseconds(50))
+	}
+
+	@Test func pairingPausePreservesResolutionWithoutRestartingAbsentDiscovery() async {
+		let centralManager = RecordingCentralManager()
+		let transport = BLETransport(
+			createCentralManagerImmediately: false,
+			centralManager: centralManager
+		)
+		let peripheralID = UUID()
+		let device = Device(
+			id: UUID(),
+			name: "Test Radio",
+			transportType: .ble,
+			identifier: peripheralID.uuidString
+		)
+
+		do {
+			_ = try await transport.connect(to: device)
+			Issue.record("connect(to:) must fail when CoreBluetooth cannot resolve the peripheral")
+		} catch AccessoryError.connectionFailed(let message) {
+			#expect(message == "Peripheral not found")
+		} catch {
+			Issue.record("Expected AccessoryError.connectionFailed, got \(error)")
+		}
+
+		#expect(
+			centralManager.calls == [
+				.stopScan,
+				.retrievePeripherals([peripheralID])
+			],
+			"Pairing must pause scanning and resolve the selected peripheral without starting an unsubscribed discovery scan"
+		)
+	}
+
+	@Test func discoveryStartedDuringConnectionPauseWaitsUntilFailure() async throws {
+		let centralManager = RecordingCentralManager(scanning: false)
+		let transport = BLETransport(
+			createCentralManagerImmediately: false,
+			centralManager: centralManager
+		)
+
+		await transport.handleCentralState(.poweredOn, central: centralManager)
+		try await letActorTasksRun()
+		await transport.pauseScanningForConnection()
+
+		let discovery = await transport.discoverDevices()
+		try await letActorTasksRun()
+
+		#expect(
+			centralManager.calls.isEmpty,
+			"A retry discovery stream must not start scanning while the connection pause is active"
+		)
+
+		await transport.connectionDidDisconnect(fromPeripheral: nil)
+
+		#expect(
+			centralManager.calls == [.startScan],
+			"A failed connection must resume the waiting discovery subscriber exactly once"
+		)
+		withExtendedLifetime(discovery) {}
+	}
+}

--- a/MeshtasticTests/BLETransportPeripheralResolutionTests.swift
+++ b/MeshtasticTests/BLETransportPeripheralResolutionTests.swift
@@ -9,11 +9,12 @@
 
 @preconcurrency import CoreBluetooth
 import Foundation
+import ObjectiveC.runtime
 import Testing
 
 @testable import Meshtastic
 
-private actor DiscoverySetupSignal {
+private actor Signal {
 	private var reached = false
 	private var continuation: CheckedContinuation<Void, Never>?
 
@@ -31,18 +32,40 @@ private actor DiscoverySetupSignal {
 	}
 }
 
+private final class TestPeripheral: CBPeripheral, @unchecked Sendable {
+	static let testIdentifier = UUID()
+
+	override var identifier: UUID { Self.testIdentifier }
+
+	static func make() -> TestPeripheral {
+		// CBPeripheral has no public initializer, so this test-only double has no CoreBluetooth state.
+		guard let peripheral = class_createInstance(TestPeripheral.self, 0) else {
+			fatalError("Unable to allocate test peripheral")
+		}
+		guard let testPeripheral = peripheral as? TestPeripheral else {
+			fatalError("Test peripheral has an unexpected type")
+		}
+		return testPeripheral
+	}
+}
+
 private final class RecordingCentralManager: CBCentralManager, @unchecked Sendable {
 	enum Call: Equatable {
 		case stopScan
 		case retrievePeripherals([UUID])
 		case startScan
+		case connect(UUID)
 	}
 
 	private(set) var calls: [Call] = []
 	private var scanning: Bool
+	private let peripheral: CBPeripheral?
+	private let connectSignal: Signal?
 
-	init(scanning: Bool = true) {
+	init(scanning: Bool = true, peripheral: CBPeripheral? = nil, connectSignal: Signal? = nil) {
 		self.scanning = scanning
+		self.peripheral = peripheral
+		self.connectSignal = connectSignal
 		super.init(delegate: nil, queue: nil, options: nil)
 	}
 
@@ -56,7 +79,13 @@ private final class RecordingCentralManager: CBCentralManager, @unchecked Sendab
 
 	override func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBPeripheral] {
 		calls.append(.retrievePeripherals(identifiers))
-		return []
+		guard let peripheral, identifiers.contains(peripheral.identifier) else { return [] }
+		return [peripheral]
+	}
+
+	override func connect(_ peripheral: CBPeripheral, options: [String: Any]? = nil) {
+		calls.append(.connect(peripheral.identifier))
+		Task { await connectSignal?.markReached() }
 	}
 
 	override func scanForPeripherals(withServices serviceUUIDs: [CBUUID]?, options: [String: Any]? = nil) {
@@ -101,7 +130,7 @@ struct BLETransportPeripheralResolutionTests {
 
 	@Test func discoveryStartedDuringConnectionPauseWaitsUntilFailure() async {
 		let centralManager = RecordingCentralManager(scanning: false)
-		let discoverySetupSignal = DiscoverySetupSignal()
+		let discoverySetupSignal = Signal()
 		let transport = BLETransport(
 			createCentralManagerImmediately: false,
 			centralManager: centralManager,
@@ -126,5 +155,35 @@ struct BLETransportPeripheralResolutionTests {
 			"A failed connection must resume the waiting discovery subscriber exactly once"
 		)
 		withExtendedLifetime(discovery) {}
+	}
+
+	@Test func lateCancellationCleanupAfterConnectKeepsTransportBusy() async throws {
+		let peripheral = TestPeripheral.make()
+		let connectSignal = Signal()
+		let centralManager = RecordingCentralManager(peripheral: peripheral, connectSignal: connectSignal)
+		let transport = BLETransport(
+			createCentralManagerImmediately: false,
+			centralManager: centralManager
+		)
+		let device = Device(
+			id: UUID(),
+			name: "Test Radio",
+			transportType: .ble,
+			identifier: peripheral.identifier.uuidString
+		)
+
+		let connection = Task { try await transport.connect(to: device) }
+		await connectSignal.wait()
+		await transport.handleDidConnect(peripheral: peripheral, central: centralManager)
+		_ = try await connection.value
+
+		await transport.cancelConnectContinuation(for: peripheral)
+
+		do {
+			_ = try await transport.connect(to: device)
+			Issue.record("A late cancellation cleanup must not clear the active connection")
+		} catch AccessoryError.connectionFailed(let message) {
+			#expect(message == "BLE transport is busy: already connecting or connected")
+		}
 	}
 }

--- a/MeshtasticTests/BLETransportPeripheralResolutionTests.swift
+++ b/MeshtasticTests/BLETransportPeripheralResolutionTests.swift
@@ -157,6 +157,31 @@ struct BLETransportPeripheralResolutionTests {
 		withExtendedLifetime(discovery) {}
 	}
 
+	@Test func establishedConnectionResumesScanningForSubscribedDiscovery() async {
+		let centralManager = RecordingCentralManager(scanning: false)
+		let discoverySetupSignal = Signal()
+		let transport = BLETransport(
+			createCentralManagerImmediately: false,
+			centralManager: centralManager,
+			discoverySetupHandler: { await discoverySetupSignal.markReached() }
+		)
+
+		await transport.handleCentralState(.poweredOn, central: centralManager)
+		await transport.pauseScanningForConnection()
+
+		let discovery = await transport.discoverDevices()
+		await discoverySetupSignal.wait()
+		#expect(centralManager.calls.isEmpty, "the pause must hold through the handshake")
+
+		await transport.resumeScanningAfterConnectionEstablished()
+
+		#expect(
+			centralManager.calls == [.startScan],
+			"An established connection must resume the waiting discovery subscriber so Available Radios stays live while connected"
+		)
+		withExtendedLifetime(discovery) {}
+	}
+
 	@Test func lateCancellationCleanupAfterConnectKeepsTransportBusy() async throws {
 		let peripheral = TestPeripheral.make()
 		let connectSignal = Signal()

--- a/MeshtasticTests/BLETransportPeripheralResolutionTests.swift
+++ b/MeshtasticTests/BLETransportPeripheralResolutionTests.swift
@@ -13,6 +13,24 @@ import Testing
 
 @testable import Meshtastic
 
+private actor DiscoverySetupSignal {
+	private var reached = false
+	private var continuation: CheckedContinuation<Void, Never>?
+
+	func markReached() {
+		reached = true
+		continuation?.resume()
+		continuation = nil
+	}
+
+	func wait() async {
+		guard !reached else { return }
+		await withCheckedContinuation { continuation in
+			self.continuation = continuation
+		}
+	}
+}
+
 private final class RecordingCentralManager: CBCentralManager, @unchecked Sendable {
 	enum Call: Equatable {
 		case stopScan
@@ -49,10 +67,6 @@ private final class RecordingCentralManager: CBCentralManager, @unchecked Sendab
 
 @Suite("BLETransport peripheral resolution", .timeLimit(.minutes(1)))
 struct BLETransportPeripheralResolutionTests {
-	private func letActorTasksRun() async throws {
-		try await Task.sleep(for: .milliseconds(50))
-	}
-
 	@Test func pairingPausePreservesResolutionWithoutRestartingAbsentDiscovery() async {
 		let centralManager = RecordingCentralManager()
 		let transport = BLETransport(
@@ -85,19 +99,20 @@ struct BLETransportPeripheralResolutionTests {
 		)
 	}
 
-	@Test func discoveryStartedDuringConnectionPauseWaitsUntilFailure() async throws {
+	@Test func discoveryStartedDuringConnectionPauseWaitsUntilFailure() async {
 		let centralManager = RecordingCentralManager(scanning: false)
+		let discoverySetupSignal = DiscoverySetupSignal()
 		let transport = BLETransport(
 			createCentralManagerImmediately: false,
-			centralManager: centralManager
+			centralManager: centralManager,
+			discoverySetupHandler: { await discoverySetupSignal.markReached() }
 		)
 
 		await transport.handleCentralState(.poweredOn, central: centralManager)
-		try await letActorTasksRun()
 		await transport.pauseScanningForConnection()
 
 		let discovery = await transport.discoverDevices()
-		try await letActorTasksRun()
+		await discoverySetupSignal.wait()
 
 		#expect(
 			centralManager.calls.isEmpty,


### PR DESCRIPTION
## What changed?

- Pause CoreBluetooth scanning before connection and pairing without ending the discovery stream or clearing its peripheral cache.
- Keep deferred discovery and powered-on scan restarts paused for every connection attempt.
- Resolve a selected peripheral from the discovery cache or CoreBluetooth's identifier registry.
- Resume scanning after a failed connection when discovery still has a subscriber.
- Add transport-level regression tests for cache-miss resolution and the retry scan race.

## Why did it change?

BLE discovery remained active while CoreBluetooth subscribed to the encrypted Meshtastic characteristic. On the affected iPad, the PIN sheet appeared and disappeared before entry could complete.

PR #2183 stopped discovery before pairing, but that also cleared `BLETransport.discoveredPeripherals`. PR #2200 reverted it after normal reconnects failed with `Peripheral not found`. This change pauses the scan without dropping the selected peripheral.

Fixes #2212.

## How is this tested?

Automated:

- 15 focused BLE tests passed across 4 suites.
- The retry-race test was mutation-checked. It fails if the logical pause is made conditional on `isScanning` or deferred discovery ignores the pause.
- iOS simulator build passed.
- SourceKit-LSP reported no diagnostics in changed files.
- `git diff --check` passed.

Physical Release validation:

| Device | OS | Fresh pairing | Bonded reconnect |
| --- | --- | --- | --- |
| iPhone 16 Pro Max | iOS 27 beta (`24A5418b`) | Passed | Passed without PIN |
| iPad Pro 13-inch (M4), fresh install 1 | iPadOS 26.6.1 (`23G83`) | Passed | Passed without PIN |
| Same iPad, fresh install 2 | iPadOS 26.6.1 (`23G83`) | Passed | Not repeated |
| Same iPad, fresh install 3 | iPadOS 26.6.1 (`23G83`) | Passed | Not repeated |

Each iPad run used a new app container, no system bond, and no concurrent Meshtastic CoreBluetooth session. The PIN sheet stayed visible, accepted the fixed PIN, and reached `Connected Radio / Subscribed` in every fresh run.

The same iPad, radio, firmware, app sources, and PIN had failed three isolated runs before this change. Exact reporter parity on unsigned iPadOS 26.5.2 was not possible.

## Screenshots/Videos (when applicable)

N/A. No UI changes.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
