### PR TITLE
fix(tak): update TAKPacket SDK to 0.9.1

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -1951,7 +1951,7 @@
 			repositoryURL = "https://github.com/meshtastic/TAKPacket-SDK.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.5.1;
+				minimumVersion = 0.9.1;
 			};
 		};
 		EF8B64957FF0A454C2EE0FBB /* XCRemoteSwiftPackageReference "CocoaMQTT" */ = {

--- a/Meshtastic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Meshtastic.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
-        "version" : "1.38.0"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/meshtastic/TAKPacket-SDK.git",
       "state" : {
-        "revision" : "25658b6b16b20500f8561c7acbf86349e77e5db8",
-        "version" : "0.5.1"
+        "revision" : "1e91b47c493d130a10ce77ac569b3ca9e5d3bb4a",
+        "version" : "0.9.1"
       }
     },
     {

--- a/Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Meshtastic.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
-        "version" : "1.38.0"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/meshtastic/TAKPacket-SDK.git",
       "state" : {
-        "revision" : "25658b6b16b20500f8561c7acbf86349e77e5db8",
-        "version" : "0.5.1"
+        "revision" : "1e91b47c493d130a10ce77ac569b3ca9e5d3bb4a",
+        "version" : "0.9.1"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -24,7 +24,7 @@ packages:
     majorVersion: 4.16.0
   TAKPacket-SDK:
     url: https://github.com/meshtastic/TAKPacket-SDK.git
-    minorVersion: 0.5.1
+    minorVersion: 0.9.1
   CocoaMQTT:
     url: https://github.com/emqx/CocoaMQTT
     majorVersion: 2.0.0


### PR DESCRIPTION
## What changed?

- Update TAKPacket-SDK from 0.5.1 to 0.9.1.
- Regenerate the Xcode project and refresh both app package lockfiles.
- Resolve SwiftProtobuf 1.38.1, required by the updated SDK.

## Why did it change?

Android 2.8.1 sends TAK V2 packets with TAKPacket-SDK 0.9.1. Version 0.9.0 introduced a new zstd dictionary that is wire-incompatible with the older dictionary used by the Apple app, so iOS received port 78 packets but could not decompress them.

Fixes #2348.

## How is this tested?

- Full iOS simulator app build succeeded.
- Full non-snapshot unit suite passed: 2,774 tests across 469 suites.
- TAKPacket-SDK 0.9.1 Swift tests passed.
- A compile smoke test passed for every SDK API used by the Apple TAK bridge.
- Workspace and project package resolution, XcodeGen idempotence, and `git diff --check` passed.

Not run: the physical two-radio Android to iOS/iTAK reproduction.

## Screenshots/Videos (when applicable)

N/A. Dependency-only change.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TAKPacket-SDK package to version 0.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->