### PR TITLE
Gate MQTT proxy receives before decoding packets

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
@@ -33,6 +33,45 @@ actor MqttForwardGate {
 	}
 }
 
+enum MqttForwardAdmissionResult<Work> {
+	case rejected
+	case admitted(Work)
+}
+
+enum MqttForwardAdmission {
+	@MainActor
+	static func admit<Work>(
+		gate: MqttForwardGate,
+		build: () -> Work
+	) async -> MqttForwardAdmissionResult<Work> {
+		guard await gate.tryAcquire() else {
+			return .rejected
+		}
+		return .admitted(build())
+	}
+
+	static func complete<Work>(
+		_ admission: MqttForwardAdmissionResult<Work?>,
+		gate: MqttForwardGate,
+		perform: (Work) async throws -> Void
+	) async throws {
+		switch admission {
+		case .rejected:
+			return
+		case .admitted(nil):
+			await gate.release()
+		case .admitted(let work?):
+			do {
+				try await perform(work)
+				await gate.release()
+			} catch {
+				await gate.release()
+				throw error
+			}
+		}
+	}
+}
+
 extension AccessoryManager {
 
 	// One shared gate — drops concurrent MQTT→BLE writes instead of queuing them.
@@ -94,12 +133,7 @@ extension AccessoryManager {
 		Logger.services.info("📲 MQTT Disconnected")
 	}
 
-	func onMqttMessageReceived(message: CocoaMQTTMessage) {
-		if message.topic.contains("/stat/") {
-			Logger.services.debug("📲 [MQTT] dropping /stat/ message on \(message.topic, privacy: .public)")
-			return
-		}
-
+	private func makeMqttProxyToRadio(message: CocoaMQTTMessage) -> ToRadio? {
 		let rawData = Data(message.payload)
 
 		// Parse the ServiceEnvelope once. Fail open: unparseable bytes are
@@ -115,7 +149,7 @@ extension AccessoryManager {
 			if MqttForwardFilter.decide(envelope: envelope, myNodeHex: myHex) == .dropNoPayload {
 				mqttProxyDroppedNoPayload += 1
 				Logger.services.debug("📲 [MQTT] drop (no payload) topic=\(message.topic, privacy: .public) count=\(self.mqttProxyDroppedNoPayload, privacy: .public)")
-				return
+				return nil
 			}
 		}
 
@@ -142,19 +176,32 @@ extension AccessoryManager {
 
 		var toRadio = ToRadio()
 		toRadio.mqttClientProxyMessage = proxyMessage
+		return toRadio
+	}
+
+	func onMqttMessageReceived(message: CocoaMQTTMessage) {
+		if message.topic.contains("/stat/") {
+			Logger.services.debug("📲 [MQTT] dropping /stat/ message on \(message.topic, privacy: .public)")
+			return
+		}
 
 		// Gate: drop this packet if a previous MQTT→BLE write is still in-flight.
 		// The public broker can deliver global LongFast traffic faster than BLE can
 		// drain it. Queuing every packet would overwhelm the device's radio stack;
 		// dropping excess is preferable to building an unbounded BLE write backlog.
-		Task {
+		Task { @MainActor in
 			let gate = AccessoryManager.mqttForwardGate
-			guard await gate.tryAcquire() else {
-				Logger.services.debug("📲 [MQTT] drop (BLE write in-flight): \(message.topic, privacy: .public)")
-				return
+			let admission = await MqttForwardAdmission.admit(gate: gate) {
+				self.makeMqttProxyToRadio(message: message)
 			}
-			defer { Task { await gate.release() } }
-			try? await self.send(toRadio)
+
+			if case .rejected = admission {
+				Logger.services.debug("📲 [MQTT] drop (BLE write in-flight): \(message.topic, privacy: .public)")
+			}
+
+			try? await MqttForwardAdmission.complete(admission, gate: gate) { toRadio in
+				try await self.send(toRadio)
+			}
 		}
 	}
 

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+MQTT.swift
@@ -199,8 +199,12 @@ extension AccessoryManager {
 				Logger.services.debug("📲 [MQTT] drop (BLE write in-flight): \(message.topic, privacy: .public)")
 			}
 
-			try? await MqttForwardAdmission.complete(admission, gate: gate) { toRadio in
-				try await self.send(toRadio)
+			do {
+				try await MqttForwardAdmission.complete(admission, gate: gate) { toRadio in
+					try await self.send(toRadio)
+				}
+			} catch {
+				Logger.services.error("📲 [MQTT] failed to forward packet to BLE topic=\(message.topic, privacy: .public): \(error.localizedDescription, privacy: .public)")
 			}
 		}
 	}

--- a/MeshtasticTests/MqttForwardFilterTests.swift
+++ b/MeshtasticTests/MqttForwardFilterTests.swift
@@ -16,6 +16,10 @@ import MeshtasticProtobufs
 @Suite("MQTT Forward Filter")
 struct MqttForwardFilterTests {
 
+	private enum MqttForwardAdmissionTestError: Error {
+		case disconnected
+	}
+
 	/// Builds a ServiceEnvelope for the filter under test.
 	/// - `hasPacket == false` leaves the inner packet unset (envelope.hasPacket == false).
 	private func makeEnvelope(
@@ -101,5 +105,133 @@ struct MqttForwardFilterTests {
 	func noPacketForwarded() {
 		let env = makeEnvelope(hasPacket: false)
 		#expect(MqttForwardFilter.decide(envelope: env, myNodeHex: myHex) == .forward)
+	}
+
+	@Test("Busy gate rejects before building forwarded packet")
+	func busyGateRejectsBeforeBuildingForwardedPacket() async {
+		let gate = MqttForwardGate()
+		#expect(await gate.tryAcquire())
+
+		var buildCount = 0
+		let result = await MqttForwardAdmission.admit(gate: gate) {
+			buildCount += 1
+			return Data([0x01])
+		}
+
+		if case .admitted = result {
+			Issue.record("Busy MQTT forward gate admitted queued work")
+		}
+		#expect(buildCount == 0)
+
+		await gate.release()
+	}
+
+	@Test("Nil admitted work releases the gate")
+	func nilAdmittedWorkReleasesGate() async throws {
+		let gate = MqttForwardGate()
+		let admission = await MqttForwardAdmission.admit(gate: gate) {
+			Optional<Int>.none
+		}
+
+		var performedSend = false
+		try await MqttForwardAdmission.complete(admission, gate: gate) { (_: Int) async throws in
+			performedSend = true
+		}
+
+		#expect(!performedSend)
+		let next = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(42)
+		}
+		if case .rejected = next {
+			Issue.record("Gate stayed busy after admitted nil work")
+		}
+		try await MqttForwardAdmission.complete(next, gate: gate) { (_: Int) async throws in }
+	}
+
+	@Test("Successful work keeps the gate busy until completion")
+	func successfulWorkKeepsGateBusyUntilCompletion() async throws {
+		let gate = MqttForwardGate()
+		let admission = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(1)
+		}
+
+		try await MqttForwardAdmission.complete(admission, gate: gate) { (_: Int) async throws in
+			let whilePerforming = await MqttForwardAdmission.admit(gate: gate) {
+				Optional.some(2)
+			}
+			if case .admitted = whilePerforming {
+				Issue.record("Gate released before successful work completed")
+			}
+		}
+
+		let afterCompletion = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(3)
+		}
+		if case .rejected = afterCompletion {
+			Issue.record("Gate stayed busy after successful work completed")
+		}
+		try await MqttForwardAdmission.complete(afterCompletion, gate: gate) { (_: Int) async throws in }
+	}
+
+	@Test("Failed work releases the gate after completion")
+	func failedWorkReleasesGateAfterCompletion() async {
+		let gate = MqttForwardGate()
+		let admission = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(1)
+		}
+
+		await #expect(throws: MqttForwardAdmissionTestError.disconnected) {
+			try await MqttForwardAdmission.complete(admission, gate: gate) { (_: Int) async throws in
+				let whilePerforming = await MqttForwardAdmission.admit(gate: gate) {
+					Optional.some(2)
+				}
+				if case .admitted = whilePerforming {
+					Issue.record("Gate released before failed work completed")
+				}
+				throw MqttForwardAdmissionTestError.disconnected
+			}
+		}
+
+		let afterFailure = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(3)
+		}
+		if case .rejected = afterFailure {
+			Issue.record("Gate stayed busy after failed work completed")
+		}
+		try? await MqttForwardAdmission.complete(afterFailure, gate: gate) { (_: Int) async throws in }
+	}
+
+	@Test("Busy rejection does not prevent a later admission after release")
+	func busyRejectionAllowsLaterAdmissionAfterRelease() async throws {
+		let gate = MqttForwardGate()
+		let first = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(1)
+		}
+
+		let second = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(2)
+		}
+		if case .admitted = second {
+			Issue.record("Busy gate admitted a second packet")
+		}
+
+		try await MqttForwardAdmission.complete(second, gate: gate) { (_: Int) async throws in }
+
+		let stillBusy = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(3)
+		}
+		if case .admitted = stillBusy {
+			Issue.record("Completing a rejected packet released the in-flight packet's gate")
+		}
+
+		try await MqttForwardAdmission.complete(first, gate: gate) { (_: Int) async throws in }
+
+		let third = await MqttForwardAdmission.admit(gate: gate) {
+			Optional.some(4)
+		}
+		if case .rejected = third {
+			Issue.record("Gate rejected a later packet after release")
+		}
+		try await MqttForwardAdmission.complete(third, gate: gate) { (_: Int) async throws in }
 	}
 }

--- a/MeshtasticTests/MqttForwardFilterTests.swift
+++ b/MeshtasticTests/MqttForwardFilterTests.swift
@@ -10,6 +10,7 @@
 
 import Testing
 import Foundation
+import CocoaMQTT
 @testable import Meshtastic
 import MeshtasticProtobufs
 
@@ -18,6 +19,43 @@ struct MqttForwardFilterTests {
 
 	private enum MqttForwardAdmissionTestError: Error {
 		case disconnected
+	}
+
+	private actor MqttForwardTestConnection: Connection {
+		let type: TransportType = .ble
+		var isConnected = true
+		private(set) var sentPackets: [ToRadio] = []
+
+		func send(_ data: ToRadio) async throws {
+			sentPackets.append(data)
+		}
+
+		func connect() async throws -> AsyncStream<ConnectionEvent> {
+			AsyncStream { $0.finish() }
+		}
+
+		func disconnect(withError: Error?, shouldReconnect: Bool) async throws {}
+		func drainPendingPackets() async throws {}
+		func startDrainPendingPackets() throws {}
+		func appDidEnterBackground() {}
+		func appDidBecomeActive() {}
+	}
+
+	@MainActor
+	private func makeManager(connection: MqttForwardTestConnection) -> AccessoryManager {
+		let manager = AccessoryManager(transports: [])
+		let device = Device(
+			id: UUID(),
+			name: "MQTT Test Radio",
+			transportType: .ble,
+			identifier: "mqtt-test-radio",
+			connectionState: .connected,
+			num: 0x433e2700
+		)
+		manager.activeConnection = (device: device, connection: connection)
+		manager.activeDeviceNum = device.num
+		manager.updateState(.subscribed)
+		return manager
 	}
 
 	/// Builds a ServiceEnvelope for the filter under test.
@@ -122,6 +160,30 @@ struct MqttForwardFilterTests {
 			Issue.record("Busy MQTT forward gate admitted queued work")
 		}
 		#expect(buildCount == 0)
+
+		await gate.release()
+	}
+
+	@MainActor
+	@Test("Busy production handler does not send over BLE")
+	func busyProductionHandlerDoesNotSendOverBLE() async throws {
+		let connection = MqttForwardTestConnection()
+		let manager = makeManager(connection: connection)
+		let gate = AccessoryManager.mqttForwardGate
+		#expect(await gate.tryAcquire())
+
+		let payload = try makeEnvelope(gatewayID: "!deadbeef", payload: nil).serializedData()
+		let message = CocoaMQTTMessage(
+			topic: "msh/US/2/e/LongFast/!deadbeef",
+			payload: Array(payload),
+			qos: .qos1,
+			retained: false
+		)
+		manager.onMqttMessageReceived(message: message)
+		await Task.yield()
+
+		#expect(manager.mqttProxyDroppedNoPayload == 0)
+		#expect(await connection.sentPackets.isEmpty)
 
 		await gate.release()
 	}


### PR DESCRIPTION
## Summary

- Acquire the existing MQTT-to-BLE forwarding gate before decoding a service envelope or building a `ToRadio` message.
- Reject MQTT proxy work while a BLE write is in flight.
- Keep the gate held through send completion and release it after successful, empty, or failed work.
- Add deterministic coverage for admission rejection and gate lifecycle behavior.

## Validation

- iOS Simulator: `xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -destination "platform=iOS Simulator,id=D8C8D4AA-2592-4FA5-81B2-EA6208020C93" -only-testing:MeshtasticTests/MqttForwardFilterTests -resultBundlePath /private/tmp/mqtt-admission-clean.xcresult`
- Result: **TEST SUCCEEDED** — 14 tests in 1 suite.
- `git diff --check upstream/main...HEAD` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT-to-radio message forwarding to prevent duplicate or overlapping transmissions.
  * Dropped MQTT packets without usable payloads before forwarding.
  * Ensured forwarding resumes correctly after successful sends, rejected messages, and transmission errors.

* **Tests**
  * Added coverage for busy, successful, empty, and failed forwarding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->