### PR TITLE
Fix channel cache loss during automatic refresh

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -132,10 +132,7 @@ extension AccessoryManager {
 				// Onboard a new device connection here
 			}
 		}
-		await MeshPackets.shared.beginChannelRefreshStage(
-			for: Int64(myNodeInfo.myNodeNum),
-			requestID: activeConfigRefreshID ?? UInt32(NONCE_ONLY_CONFIG)
-		)
+		await beginAutomaticChannelRefreshStageIfNeeded(for: Int64(myNodeInfo.myNodeNum))
 
 		// Auto-disable new-node notifications for event firmware editions
 		applyEventFirmwareNotificationDefaults(myNodeInfo.firmwareEdition)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -132,7 +132,10 @@ extension AccessoryManager {
 				// Onboard a new device connection here
 			}
 		}
-		await MeshPackets.shared.beginChannelRefreshStage(for: Int64(myNodeInfo.myNodeNum))
+		await MeshPackets.shared.beginChannelRefreshStage(
+			for: Int64(myNodeInfo.myNodeNum),
+			requestID: activeConfigRefreshID ?? UInt32(NONCE_ONLY_CONFIG)
+		)
 
 		// Auto-disable new-node notifications for event firmware editions
 		applyEventFirmwareNotificationDefaults(myNodeInfo.firmwareEdition)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -132,7 +132,7 @@ extension AccessoryManager {
 				// Onboard a new device connection here
 			}
 		}
-		tryClearExistingChannels()
+		await MeshPackets.shared.beginChannelRefreshStage(for: Int64(myNodeInfo.myNodeNum))
 
 		// Auto-disable new-node notifications for event firmware editions
 		applyEventFirmwareNotificationDefaults(myNodeInfo.firmwareEdition)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -565,7 +565,7 @@ extension AccessoryManager {
 		guard Set(incomingChannelNames).count == incomingChannelNames.count else {
 			throw AccessoryError.appError("Channel names must be unique")
 		}
-		var i: Int32 = 0
+		let targetChannelIndexes: [Int32]
 
 		if addChannels {
 			let fetchMyInfoRequest = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == deviceNum })
@@ -575,15 +575,15 @@ extension AccessoryManager {
 				throw AccessoryError.appError("MyInfo not found")
 			}
 
-			i = Int32(fetched.channels.count)
-
-			guard i >= 0 && i < 8 else {
+			let freeIndexes = availableChannelIndexes(from: fetched.channels)
+			guard !freeIndexes.isEmpty else {
 				throw AccessoryError.appError("No free channel slots available")
 			}
 
-			guard fetched.channels.count + channelSet.settings.count <= 8 else {
+			guard channelSet.settings.count <= freeIndexes.count else {
 				throw AccessoryError.appError("Not enough free channel slots")
 			}
+			targetChannelIndexes = Array(freeIndexes.prefix(channelSet.settings.count))
 
 			for cs in channelSet.settings {
 				if fetched.channels.contains(where: { $0.name == cs.name }) {
@@ -596,10 +596,11 @@ extension AccessoryManager {
 			if let txPower = currentLoRaConfig?.txPower {
 				channelSet.loraConfig.txPower = txPower
 			}
+			targetChannelIndexes = channelSet.settings.indices.map { Int32($0) }
 		}
 
 		var deliveredChannels: [Channel] = []
-		for cs in channelSet.settings {
+		for (cs, targetIndex) in zip(channelSet.settings, targetChannelIndexes) {
 			// Stop sending channels if the calling Task was cancelled. The channels already
 			// sent are fine inside a transaction (commit will persist them); skipping the rest
 			// lets the import engine exit promptly. The local-state upserts below are safe to
@@ -607,9 +608,9 @@ extension AccessoryManager {
 			try Task.checkCancellation()
 
 			var chan = Channel()
-			chan.role = (i == 0) ? .primary : .secondary
+			chan.role = (targetIndex == 0) ? .primary : .secondary
 			chan.settings = cs
-			chan.index = i
+			chan.index = targetIndex
 			// Ensure moduleSettings is always explicitly set so the device
 			// stores a defined position_precision value. QR codes typically
 			// omit moduleSettings which causes the firmware to default to 32
@@ -618,8 +619,6 @@ extension AccessoryManager {
 				chan.settings.moduleSettings.positionPrecision = 0
 				chan.settings.moduleSettings.isMuted = false
 			}
-			i += 1
-
 			var adminPacket = AdminMessage()
 			adminPacket.setChannel = chan
 
@@ -682,7 +681,7 @@ extension AccessoryManager {
 			tryClearExistingChannels()
 		}
 		for chan in deliveredChannels {
-			await MeshPackets.shared.channelPacket(channel: chan, fromNum: deviceNum, stageIfRefreshing: false)
+			try applyLocalChannelMutation(chan, fromNum: deviceNum)
 		}
 
 		// Re-sync after the change. When we sent a LoRa config the device reboots
@@ -700,6 +699,54 @@ extension AccessoryManager {
 			Logger.transport.debug("[AccessoryManager] sending wantConfig for saveChannelSet")
 			try await sendWantConfig()
 		}
+	}
+
+	/// Mirrors a user-initiated channel write on the main context. Automatic refresh replacement
+	/// uses this same executor, so a QR/UI mutation cannot land between its baseline check and save.
+	func applyLocalChannelMutation(_ channel: Channel, fromNum: Int64) throws {
+		guard channel.isInitialized && (channel.hasSettings || channel.role == .disabled) else { return }
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == fromNum })
+		let fetchedMyInfo = try context.fetch(descriptor)
+		guard fetchedMyInfo.count == 1, let myInfo = fetchedMyInfo.first else {
+			if channel.role.rawValue > 0 {
+				Logger.data.error("💥Trying to save a local channel mutation to a MyInfo that does not exist: \(fromNum.toHex(), privacy: .public)")
+			}
+			return
+		}
+
+		let channelIndex = Int32(truncatingIfNeeded: channel.index)
+		let existing = myInfo.channels.first { $0.index == channelIndex }
+		if channel.role == .disabled {
+			if let existing {
+				context.delete(existing)
+				try context.save()
+			}
+			return
+		}
+
+		let entity: ChannelEntity
+		if let existing {
+			entity = existing
+		} else {
+			entity = ChannelEntity()
+			context.insert(entity)
+			myInfo.channels.append(entity)
+		}
+		entity.id = channelIndex
+		entity.index = channelIndex
+		entity.uplinkEnabled = channel.settings.uplinkEnabled
+		entity.downlinkEnabled = channel.settings.downlinkEnabled
+		entity.name = channel.settings.name
+		entity.role = Int32(channel.role.rawValue)
+		entity.psk = channel.settings.psk
+		if channel.settings.hasModuleSettings {
+			entity.positionPrecision = Int32(truncatingIfNeeded: channel.settings.moduleSettings.positionPrecision)
+			entity.mute = channel.settings.moduleSettings.isMuted
+		} else {
+			entity.positionPrecision = 0
+			entity.mute = false
+		}
+		try context.save()
 	}
 
 	private func currentLoRaConfig(for deviceNum: Int64) -> Config.LoRaConfig? {
@@ -915,7 +962,7 @@ extension AccessoryManager {
 		_ = try await saveChannel(channel: channel, fromUser: user, toUser: user)
 
 		// Mirror the added channel into local state so it appears immediately (no reboot / re-sync).
-		await MeshPackets.shared.channelPacket(channel: channel, fromNum: deviceNum, stageIfRefreshing: false)
+		try applyLocalChannelMutation(channel, fromNum: deviceNum)
 
 		Logger.mesh.info("➕ [Beacon] Added advertised channel '\(channelName, privacy: .private)' to secondary slot \(targetIndex, privacy: .public) — no reboot")
 	}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -682,7 +682,7 @@ extension AccessoryManager {
 			tryClearExistingChannels()
 		}
 		for chan in deliveredChannels {
-			await MeshPackets.shared.channelPacket(channel: chan, fromNum: deviceNum)
+			await MeshPackets.shared.channelPacket(channel: chan, fromNum: deviceNum, stageIfRefreshing: false)
 		}
 
 		// Re-sync after the change. When we sent a LoRa config the device reboots
@@ -915,7 +915,7 @@ extension AccessoryManager {
 		_ = try await saveChannel(channel: channel, fromUser: user, toUser: user)
 
 		// Mirror the added channel into local state so it appears immediately (no reboot / re-sync).
-		await MeshPackets.shared.channelPacket(channel: channel, fromNum: deviceNum)
+		await MeshPackets.shared.channelPacket(channel: channel, fromNum: deviceNum, stageIfRefreshing: false)
 
 		Logger.mesh.info("➕ [Beacon] Added advertised channel '\(channelName, privacy: .private)' to secondary slot \(targetIndex, privacy: .public) — no reboot")
 	}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -575,7 +575,10 @@ extension AccessoryManager {
 				throw AccessoryError.appError("MyInfo not found")
 			}
 
-			let freeIndexes = availableChannelIndexes(from: fetched.channels)
+			// Appended channels are always secondaries. An unoccupied index 0 here means
+			// the local cache is empty or partial — never a license to hand an imported
+			// channel the primary slot (the role assignment below keys on index 0).
+			let freeIndexes = availableChannelIndexes(from: fetched.channels).filter { $0 > 0 }
 			guard !freeIndexes.isEmpty else {
 				throw AccessoryError.appError("No free channel slots available")
 			}
@@ -681,7 +684,14 @@ extension AccessoryManager {
 			tryClearExistingChannels()
 		}
 		for chan in deliveredChannels {
-			try applyLocalChannelMutation(chan, fromNum: deviceNum)
+			do {
+				try applyLocalChannelMutation(chan, fromNum: deviceNum)
+			} catch {
+				// The radio already accepted this channel; the wantConfig re-sync below is
+				// the recovery path for local state. Failing the import here would report
+				// an error for a change the device applied.
+				Logger.data.error("💥 Failed to mirror channel \(chan.index, privacy: .public) locally: \(error.localizedDescription, privacy: .public)")
+			}
 		}
 
 		// Re-sync after the change. When we sent a LoRa config the device reboots

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -715,7 +715,7 @@ extension AccessoryManager {
 		}
 
 		let channelIndex = Int32(truncatingIfNeeded: channel.index)
-		let existing = myInfo.channels.first { $0.index == channelIndex }
+		let existing = canonicalValidUniqueChannels(from: myInfo.channels).first { $0.index == channelIndex }
 		if channel.role == .disabled {
 			if let existing {
 				context.delete(existing)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -440,7 +440,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			}
 		} onCancel: {
 			Task { @MainActor in
-				await self.cancelAutomaticConfigRefreshWaiter(id: waiterID, owner: owner)
+				self.cancelAutomaticConfigRefreshWaiter(id: waiterID, owner: owner)
 			}
 		}
 	}
@@ -460,15 +460,12 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		activeAutomaticConfigRefresh = refresh
 	}
 
-	private func cancelAutomaticConfigRefreshWaiter(id: UUID, owner: AutomaticChannelRefreshOwner) async {
+	private func cancelAutomaticConfigRefreshWaiter(id: UUID, owner: AutomaticChannelRefreshOwner) {
 		guard var refresh = activeAutomaticConfigRefresh,
 			  refresh.owner == owner,
 			  let continuation = refresh.waiters.removeValue(forKey: id) else { return }
 		activeAutomaticConfigRefresh = refresh
 		continuation.resume(throwing: CancellationError())
-		if refresh.waiters.isEmpty {
-			await finishAutomaticConfigRefresh(owner: owner, error: CancellationError())
-		}
 	}
 
 	private func finishAutomaticConfigRefresh(owner: AutomaticChannelRefreshOwner, error: Error?) async {
@@ -494,7 +491,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			  refresh.sessionID == activeConnection?.device.id else { return }
 		refresh.nodeNum = nodeNum
 		activeAutomaticConfigRefresh = refresh
-		await MeshPackets.shared.beginChannelRefreshStage(for: nodeNum, owner: refresh.owner)
+		let stageLease = MeshPackets.acquireSharedChannelRefreshStageLease()
+		_ = await stageLease.begin(for: nodeNum, owner: refresh.owner)
 	}
 
 	func sendWantDatabase() async throws {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -303,6 +303,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	
 	// Continuations
 	var wantConfigContinuation: CheckedContinuation<Void, Error>?
+	var activeConfigRefreshID: UInt32?
+	var nextConfigRefreshID: UInt32 = 69422
 	var firstDatabaseNodeInfoContinuation: CheckedContinuation<Void, Error>?
 	var wantDatabaseGate: AsyncGate = AsyncGate()
 
@@ -398,32 +400,50 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		// connects). It now runs after the connection completes — see connect() Step 8 — where it
 		// also prunes against post-dump lastHeard values instead of pre-dump ones.
 		let configRefreshNodeNum = activeConnection?.device.num ?? activeDeviceNum
+		let configRefreshID = nextAutomaticConfigRefreshID()
+		activeConfigRefreshID = configRefreshID
 
 		do {
 			try await withTaskCancellationHandler {
 				var toRadio: ToRadio = ToRadio()
-				toRadio.wantConfigID = UInt32(NONCE_ONLY_CONFIG)
+				toRadio.wantConfigID = configRefreshID
 				try await self.send(toRadio)
 				try await connection.startDrainPendingPackets()
 				try await withCheckedThrowingContinuation { cont in
 					self.wantConfigContinuation = cont
 				}
 				self.wantConfigContinuation = nil
+				if self.activeConfigRefreshID == configRefreshID {
+					self.activeConfigRefreshID = nil
+				}
 				Logger.transport.info("✅ [Accessory] NONCE_ONLY_CONFIG Done")
 			} onCancel: {
 				Task { @MainActor in
-					if let continuation = wantConfigContinuation {
+					if activeConfigRefreshID == configRefreshID, let continuation = wantConfigContinuation {
 						wantConfigContinuation = nil
+						activeConfigRefreshID = nil
 						continuation.resume(throwing: CancellationError())
 					}
 				}
 			}
 		} catch {
-			if let configRefreshNodeNum {
-				await MeshPackets.shared.discardChannelRefreshStage(for: configRefreshNodeNum)
+			if activeConfigRefreshID == configRefreshID {
+				activeConfigRefreshID = nil
+				if let configRefreshNodeNum {
+					await MeshPackets.shared.discardChannelRefreshStage(for: configRefreshNodeNum, requestID: configRefreshID)
+				}
 			}
 			throw error
 		}
+	}
+
+	private func nextAutomaticConfigRefreshID() -> UInt32 {
+		defer {
+			repeat {
+				nextConfigRefreshID = nextConfigRefreshID == UInt32.max ? 1 : nextConfigRefreshID + 1
+			} while nextConfigRefreshID == UInt32(NONCE_ONLY_CONFIG) || nextConfigRefreshID == UInt32(NONCE_ONLY_DB)
+		}
+		return nextConfigRefreshID
 	}
 
 	func sendWantDatabase() async throws {
@@ -485,6 +505,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		if let closingNodeNum {
 			await MeshPackets.shared.discardChannelRefreshStage(for: closingNodeNum)
 		}
+		activeConfigRefreshID = nil
 
 		// Lockdown: clear per-connection state. If a Lock Now was in flight, the
 		// disconnect resolves the coordinator to `.lockNowAcknowledged`.
@@ -514,6 +535,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		// Clean up continuations — nil before resume to prevent double-resume races
 		if let continuation = wantConfigContinuation {
 			wantConfigContinuation = nil
+			activeConfigRefreshID = nil
 			continuation.resume(throwing: CancellationError())
 		}
 		if let continuation = firstDatabaseNodeInfoContinuation {
@@ -1055,12 +1077,13 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 			Logger.transport.info("✅ [Accessory] Notifying completions that have completed for configCompleteID: \(configCompleteID)")
 			switch configCompleteID {
-			case UInt32(NONCE_ONLY_CONFIG):
+			case let id where id == activeConfigRefreshID || id == UInt32(NONCE_ONLY_CONFIG):
 				if let completedNodeNum = activeConnection?.device.num ?? activeDeviceNum {
-					await MeshPackets.shared.commitChannelRefreshStage(for: completedNodeNum)
+					await MeshPackets.shared.commitChannelRefreshStage(for: completedNodeNum, requestID: configCompleteID)
 				}
-				if let continuation = wantConfigContinuation {
+				if activeConfigRefreshID == configCompleteID, let continuation = wantConfigContinuation {
 					wantConfigContinuation = nil
+					activeConfigRefreshID = nil
 					continuation.resume()
 				}
 				

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -497,16 +497,15 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			  refresh.sessionID == activeConnection?.device.id else { return }
 		refresh.nodeNum = nodeNum
 		activeAutomaticConfigRefresh = refresh
-		let stageLease = MeshPackets.acquireSharedChannelRefreshStageLease()
 		let owner = refresh.owner
-		let didBegin = await stageLease.begin(
+		let didBegin = await MeshPackets.shared.beginChannelRefreshStage(
 			for: nodeNum,
 			owner: owner,
 			baseline: refresh.channelRefreshBaselineByNode[nodeNum] ?? []
 		)
 		guard didBegin, activeAutomaticConfigRefresh?.owner == owner else {
 			if didBegin {
-				await stageLease.packets.discardChannelRefreshStage(for: nodeNum, owner: owner)
+				await MeshPackets.shared.discardChannelRefreshStage(for: nodeNum, owner: owner)
 			}
 			return
 		}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -498,11 +498,18 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		refresh.nodeNum = nodeNum
 		activeAutomaticConfigRefresh = refresh
 		let stageLease = MeshPackets.acquireSharedChannelRefreshStageLease()
-		_ = await stageLease.begin(
+		let owner = refresh.owner
+		let didBegin = await stageLease.begin(
 			for: nodeNum,
-			owner: refresh.owner,
+			owner: owner,
 			baseline: refresh.channelRefreshBaselineByNode[nodeNum] ?? []
 		)
+		guard didBegin, activeAutomaticConfigRefresh?.owner == owner else {
+			if didBegin {
+				await stageLease.packets.discardChannelRefreshStage(for: nodeNum, owner: owner)
+			}
+			return
+		}
 	}
 
 	func sendWantDatabase() async throws {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -397,24 +397,32 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		// ingestion actor ahead of the config handshake and node-DB dump (one cause of slow/hung
 		// connects). It now runs after the connection completes — see connect() Step 8 — where it
 		// also prunes against post-dump lastHeard values instead of pre-dump ones.
+		let configRefreshNodeNum = activeConnection?.device.num ?? activeDeviceNum
 
-		try await withTaskCancellationHandler {
-			var toRadio: ToRadio = ToRadio()
-			toRadio.wantConfigID = UInt32(NONCE_ONLY_CONFIG)
-			try await self.send(toRadio)
-			try await connection.startDrainPendingPackets()
-			try await withCheckedThrowingContinuation { cont in
-				self.wantConfigContinuation = cont
-			}
-			self.wantConfigContinuation = nil
-			Logger.transport.info("✅ [Accessory] NONCE_ONLY_CONFIG Done")
-		} onCancel: {
-			Task { @MainActor in
-				if let continuation = wantConfigContinuation {
-					wantConfigContinuation = nil
-					continuation.resume(throwing: CancellationError())
+		do {
+			try await withTaskCancellationHandler {
+				var toRadio: ToRadio = ToRadio()
+				toRadio.wantConfigID = UInt32(NONCE_ONLY_CONFIG)
+				try await self.send(toRadio)
+				try await connection.startDrainPendingPackets()
+				try await withCheckedThrowingContinuation { cont in
+					self.wantConfigContinuation = cont
+				}
+				self.wantConfigContinuation = nil
+				Logger.transport.info("✅ [Accessory] NONCE_ONLY_CONFIG Done")
+			} onCancel: {
+				Task { @MainActor in
+					if let continuation = wantConfigContinuation {
+						wantConfigContinuation = nil
+						continuation.resume(throwing: CancellationError())
+					}
 				}
 			}
+		} catch {
+			if let configRefreshNodeNum {
+				await MeshPackets.shared.discardChannelRefreshStage(for: configRefreshNodeNum)
+			}
+			throw error
 		}
 	}
 
@@ -467,11 +475,16 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 		Logger.transport.debug("[AccessoryManager] received disconnect request")
 
+		let closingNodeNum = activeConnection?.device.num ?? activeDeviceNum
+
 		if let activeConnection {
 			updateDevice(deviceId: activeConnection.device.id, key: \.connectionState, value: .disconnected)
 			self.activeConnection = nil
 		}
 		self.activeDeviceNum = nil
+		if let closingNodeNum {
+			await MeshPackets.shared.discardChannelRefreshStage(for: closingNodeNum)
+		}
 
 		// Lockdown: clear per-connection state. If a Lock Now was in flight, the
 		// disconnect resolves the coordinator to `.lockNowAcknowledged`.
@@ -1043,6 +1056,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			Logger.transport.info("✅ [Accessory] Notifying completions that have completed for configCompleteID: \(configCompleteID)")
 			switch configCompleteID {
 			case UInt32(NONCE_ONLY_CONFIG):
+				if let completedNodeNum = activeConnection?.device.num ?? activeDeviceNum {
+					await MeshPackets.shared.commitChannelRefreshStage(for: completedNodeNum)
+				}
 				if let continuation = wantConfigContinuation {
 					wantConfigContinuation = nil
 					continuation.resume()

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -108,6 +108,7 @@ enum AccessoryManagerState: Equatable {
 private struct AutomaticConfigRefresh {
 	let owner: AutomaticChannelRefreshOwner
 	let sessionID: UUID
+	let channelRefreshBaselineByNode: [Int64: [ChannelRefreshSnapshot]]
 	var nodeNum: Int64?
 	var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
 }
@@ -409,9 +410,11 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			sessionID: activeConnection?.device.id ?? UUID(),
 			generation: nextAutomaticConfigRefreshGeneration
 		)
+		let channelRefreshBaselineByNode = MeshPackets.captureChannelRefreshBaselines(in: context)
 		activeAutomaticConfigRefresh = AutomaticConfigRefresh(
 			owner: owner,
 			sessionID: owner.sessionID,
+			channelRefreshBaselineByNode: channelRefreshBaselineByNode,
 			nodeNum: activeConnection?.device.num ?? activeDeviceNum
 		)
 		automaticConfigRefreshTask = Task { @MainActor [weak self] in
@@ -421,12 +424,15 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	}
 
 	private func runAutomaticConfigRefresh(owner: AutomaticChannelRefreshOwner, connection: Connection) async {
-		guard activeAutomaticConfigRefresh?.owner == owner else { return }
+		guard !Task.isCancelled, activeAutomaticConfigRefresh?.owner == owner else { return }
 		do {
+			try Task.checkCancellation()
 			var toRadio: ToRadio = ToRadio()
 			toRadio.wantConfigID = UInt32(NONCE_ONLY_CONFIG)
 			try await send(toRadio)
+			try Task.checkCancellation()
 			try await connection.startDrainPendingPackets()
+			try Task.checkCancellation()
 		} catch {
 			await finishAutomaticConfigRefresh(owner: owner, error: error)
 		}
@@ -492,7 +498,11 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		refresh.nodeNum = nodeNum
 		activeAutomaticConfigRefresh = refresh
 		let stageLease = MeshPackets.acquireSharedChannelRefreshStageLease()
-		_ = await stageLease.begin(for: nodeNum, owner: refresh.owner)
+		_ = await stageLease.begin(
+			for: nodeNum,
+			owner: refresh.owner,
+			baseline: refresh.channelRefreshBaselineByNode[nodeNum] ?? []
+		)
 	}
 
 	func sendWantDatabase() async throws {
@@ -552,6 +562,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 		self.activeDeviceNum = nil
 		if let refresh = activeAutomaticConfigRefresh {
+			automaticConfigRefreshTask?.cancel()
 			await finishAutomaticConfigRefresh(owner: refresh.owner, error: CancellationError())
 		} else if let closingNodeNum {
 			await MeshPackets.shared.discardChannelRefreshStage(for: closingNodeNum)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -105,6 +105,13 @@ enum AccessoryManagerState: Equatable {
 	}
 }
 
+private struct AutomaticConfigRefresh {
+	let owner: AutomaticChannelRefreshOwner
+	let sessionID: UUID
+	var nodeNum: Int64?
+	var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+}
+
 @MainActor
 class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	// Singleton Access.  Conditionally compiled
@@ -302,9 +309,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	var mqttProxyDroppedNoPayload: Int = 0
 	
 	// Continuations
-	var wantConfigContinuation: CheckedContinuation<Void, Error>?
-	var activeConfigRefreshID: UInt32?
-	var nextConfigRefreshID: UInt32 = 69422
+	private var activeAutomaticConfigRefresh: AutomaticConfigRefresh?
+	private var automaticConfigRefreshTask: Task<Void, Never>?
+	private var nextAutomaticConfigRefreshGeneration: UInt64 = 0
 	var firstDatabaseNodeInfoContinuation: CheckedContinuation<Void, Error>?
 	var wantDatabaseGate: AsyncGate = AsyncGate()
 
@@ -385,10 +392,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	}
 
 	func sendWantConfig() async throws {
-		if let inProgressWantConfigContinuation = wantConfigContinuation {
-			Logger.transport.info("[Accessory] Existing continuation for wantConfig(Config). Cancelling.")
-			wantConfigContinuation = nil
-			inProgressWantConfigContinuation.resume(throwing: CancellationError())
+		if let activeAutomaticConfigRefresh {
+			return try await waitForAutomaticConfigRefresh(activeAutomaticConfigRefresh.owner)
 		}
 		guard let connection = activeConnection?.connection else {
 			Logger.transport.error("Unable to send wantConfig (config): No device connected")
@@ -399,51 +404,97 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		// ingestion actor ahead of the config handshake and node-DB dump (one cause of slow/hung
 		// connects). It now runs after the connection completes — see connect() Step 8 — where it
 		// also prunes against post-dump lastHeard values instead of pre-dump ones.
-		let configRefreshNodeNum = activeConnection?.device.num ?? activeDeviceNum
-		let configRefreshID = nextAutomaticConfigRefreshID()
-		activeConfigRefreshID = configRefreshID
+		nextAutomaticConfigRefreshGeneration &+= 1
+		let owner = AutomaticChannelRefreshOwner(
+			sessionID: activeConnection?.device.id ?? UUID(),
+			generation: nextAutomaticConfigRefreshGeneration
+		)
+		activeAutomaticConfigRefresh = AutomaticConfigRefresh(
+			owner: owner,
+			sessionID: owner.sessionID,
+			nodeNum: activeConnection?.device.num ?? activeDeviceNum
+		)
+		automaticConfigRefreshTask = Task { @MainActor [weak self] in
+			await self?.runAutomaticConfigRefresh(owner: owner, connection: connection)
+		}
+		try await waitForAutomaticConfigRefresh(owner)
+	}
 
+	private func runAutomaticConfigRefresh(owner: AutomaticChannelRefreshOwner, connection: Connection) async {
+		guard activeAutomaticConfigRefresh?.owner == owner else { return }
 		do {
-			try await withTaskCancellationHandler {
-				var toRadio: ToRadio = ToRadio()
-				toRadio.wantConfigID = configRefreshID
-				try await self.send(toRadio)
-				try await connection.startDrainPendingPackets()
-				try await withCheckedThrowingContinuation { cont in
-					self.wantConfigContinuation = cont
-				}
-				self.wantConfigContinuation = nil
-				if self.activeConfigRefreshID == configRefreshID {
-					self.activeConfigRefreshID = nil
-				}
-				Logger.transport.info("✅ [Accessory] NONCE_ONLY_CONFIG Done")
-			} onCancel: {
-				Task { @MainActor in
-					if activeConfigRefreshID == configRefreshID, let continuation = wantConfigContinuation {
-						wantConfigContinuation = nil
-						activeConfigRefreshID = nil
-						continuation.resume(throwing: CancellationError())
-					}
-				}
-			}
+			var toRadio: ToRadio = ToRadio()
+			toRadio.wantConfigID = UInt32(NONCE_ONLY_CONFIG)
+			try await send(toRadio)
+			try await connection.startDrainPendingPackets()
 		} catch {
-			if activeConfigRefreshID == configRefreshID {
-				activeConfigRefreshID = nil
-				if let configRefreshNodeNum {
-					await MeshPackets.shared.discardChannelRefreshStage(for: configRefreshNodeNum, requestID: configRefreshID)
-				}
-			}
-			throw error
+			await finishAutomaticConfigRefresh(owner: owner, error: error)
 		}
 	}
 
-	private func nextAutomaticConfigRefreshID() -> UInt32 {
-		defer {
-			repeat {
-				nextConfigRefreshID = nextConfigRefreshID == UInt32.max ? 1 : nextConfigRefreshID + 1
-			} while nextConfigRefreshID == UInt32(NONCE_ONLY_CONFIG) || nextConfigRefreshID == UInt32(NONCE_ONLY_DB)
+	private func waitForAutomaticConfigRefresh(_ owner: AutomaticChannelRefreshOwner) async throws {
+		let waiterID = UUID()
+		try await withTaskCancellationHandler {
+			try await withCheckedThrowingContinuation { continuation in
+				registerAutomaticConfigRefreshWaiter(continuation, id: waiterID, owner: owner)
+			}
+		} onCancel: {
+			Task { @MainActor in
+				await self.cancelAutomaticConfigRefreshWaiter(id: waiterID, owner: owner)
+			}
 		}
-		return nextConfigRefreshID
+	}
+
+	private func registerAutomaticConfigRefreshWaiter(
+		_ continuation: CheckedContinuation<Void, Error>,
+		id: UUID,
+		owner: AutomaticChannelRefreshOwner
+	) {
+		guard !Task.isCancelled,
+			  var refresh = activeAutomaticConfigRefresh,
+			  refresh.owner == owner else {
+			continuation.resume(throwing: CancellationError())
+			return
+		}
+		refresh.waiters[id] = continuation
+		activeAutomaticConfigRefresh = refresh
+	}
+
+	private func cancelAutomaticConfigRefreshWaiter(id: UUID, owner: AutomaticChannelRefreshOwner) async {
+		guard var refresh = activeAutomaticConfigRefresh,
+			  refresh.owner == owner,
+			  let continuation = refresh.waiters.removeValue(forKey: id) else { return }
+		activeAutomaticConfigRefresh = refresh
+		continuation.resume(throwing: CancellationError())
+		if refresh.waiters.isEmpty {
+			await finishAutomaticConfigRefresh(owner: owner, error: CancellationError())
+		}
+	}
+
+	private func finishAutomaticConfigRefresh(owner: AutomaticChannelRefreshOwner, error: Error?) async {
+		guard let refresh = activeAutomaticConfigRefresh, refresh.owner == owner else { return }
+		activeAutomaticConfigRefresh = nil
+		automaticConfigRefreshTask = nil
+		if let error {
+			if let nodeNum = refresh.nodeNum {
+				await MeshPackets.shared.discardChannelRefreshStage(for: nodeNum, owner: owner)
+			}
+			for continuation in refresh.waiters.values {
+				continuation.resume(throwing: error)
+			}
+		} else {
+			for continuation in refresh.waiters.values {
+				continuation.resume()
+			}
+		}
+	}
+
+	func beginAutomaticChannelRefreshStageIfNeeded(for nodeNum: Int64) async {
+		guard var refresh = activeAutomaticConfigRefresh,
+			  refresh.sessionID == activeConnection?.device.id else { return }
+		refresh.nodeNum = nodeNum
+		activeAutomaticConfigRefresh = refresh
+		await MeshPackets.shared.beginChannelRefreshStage(for: nodeNum, owner: refresh.owner)
 	}
 
 	func sendWantDatabase() async throws {
@@ -502,10 +553,11 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			self.activeConnection = nil
 		}
 		self.activeDeviceNum = nil
-		if let closingNodeNum {
+		if let refresh = activeAutomaticConfigRefresh {
+			await finishAutomaticConfigRefresh(owner: refresh.owner, error: CancellationError())
+		} else if let closingNodeNum {
 			await MeshPackets.shared.discardChannelRefreshStage(for: closingNodeNum)
 		}
-		activeConfigRefreshID = nil
 
 		// Lockdown: clear per-connection state. If a Lock Now was in flight, the
 		// disconnect resolves the coordinator to `.lockNowAcknowledged`.
@@ -533,11 +585,6 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		heartbeatResponseTimer = nil
 		
 		// Clean up continuations — nil before resume to prevent double-resume races
-		if let continuation = wantConfigContinuation {
-			wantConfigContinuation = nil
-			activeConfigRefreshID = nil
-			continuation.resume(throwing: CancellationError())
-		}
 		if let continuation = firstDatabaseNodeInfoContinuation {
 			firstDatabaseNodeInfoContinuation = nil
 			continuation.resume(throwing: CancellationError())
@@ -1077,15 +1124,16 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 			Logger.transport.info("✅ [Accessory] Notifying completions that have completed for configCompleteID: \(configCompleteID)")
 			switch configCompleteID {
-			case let id where id == activeConfigRefreshID || id == UInt32(NONCE_ONLY_CONFIG):
-				if let completedNodeNum = activeConnection?.device.num ?? activeDeviceNum {
-					await MeshPackets.shared.commitChannelRefreshStage(for: completedNodeNum, requestID: configCompleteID)
+			case UInt32(NONCE_ONLY_CONFIG):
+				guard let refresh = activeAutomaticConfigRefresh,
+					  refresh.sessionID == activeConnection?.device.id else {
+					Logger.transport.warning("[Accessory] Ignoring config completion without its active refresh owner")
+					break
 				}
-				if activeConfigRefreshID == configCompleteID, let continuation = wantConfigContinuation {
-					wantConfigContinuation = nil
-					activeConfigRefreshID = nil
-					continuation.resume()
+				if let completedNodeNum = refresh.nodeNum {
+					await MeshPackets.shared.commitChannelRefreshStage(for: completedNodeNum, owner: refresh.owner)
 				}
+				await finishAutomaticConfigRefresh(owner: refresh.owner, error: nil)
 				
 			case UInt32(NONCE_ONLY_DB):
 				// Open the gate for the wantDatabaseContinuation

--- a/Meshtastic/Export/DeviceProfileExport.swift
+++ b/Meshtastic/Export/DeviceProfileExport.swift
@@ -450,7 +450,7 @@ extension NodeInfoEntity {
 		var channelSet = ChannelSet()
 		channelSet.loraConfig = loRaConfig.protoConfig
 
-		for channel in channels.sorted(by: { $0.index < $1.index }) where channel.role > 0 {
+		for channel in canonicalValidUniqueChannels(from: channels) where channel.role > 0 {
 			var settings = ChannelSettings()
 			settings.name = channel.name ?? ""
 			settings.psk = channel.psk ?? Data()

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -179,8 +179,8 @@ actor MeshPackets {
 	/// Periodically recreated to release accumulated ModelContext memory.
 	nonisolated(unsafe) private static var _shared: MeshPackets = MeshPackets(modelContainer: _container)
 	private static let _lock = NSLock()
-	private static var activeChannelRefreshStageCount = 0
-	private static var sharedRecreationDeferredForChannelRefresh = false
+	nonisolated(unsafe) private static var activeChannelRefreshStageCount = 0
+	nonisolated(unsafe) private static var sharedRecreationDeferredForChannelRefresh = false
 	#if DEBUG
 	/// Deterministic concurrency checkpoint used by the refresh boundary regression test. Production
 	/// callers leave this nil, so validation and replacement execute without suspension.
@@ -376,19 +376,7 @@ actor MeshPackets {
 
 	@MainActor
 	private static func channelSnapshot(from myInfo: MyInfoEntity) -> [ChannelRefreshSnapshot] {
-		myInfo.channels.map { channel in
-			ChannelRefreshSnapshot(
-				id: channel.id,
-				index: channel.index,
-				uplinkEnabled: channel.uplinkEnabled,
-				downlinkEnabled: channel.downlinkEnabled,
-				name: channel.name ?? "",
-				role: channel.role,
-				psk: channel.psk ?? Data(),
-				positionPrecision: channel.positionPrecision,
-				mute: channel.mute
-			)
-		}.sorted(by: channelSnapshotIsOrderedBefore)
+		myInfo.channels.map(Self.channelRefreshSnapshot).sorted(by: channelSnapshotIsOrderedBefore)
 	}
 
 	@MainActor
@@ -416,6 +404,24 @@ actor MeshPackets {
 
 	@MainActor
 	private static func apply(stagedChannel: StagedChannel, to channel: ChannelEntity) {
+		applyChannelRefresh(stagedChannel, to: channel)
+	}
+
+	nonisolated private static func channelRefreshSnapshot(from channel: ChannelEntity) -> ChannelRefreshSnapshot {
+		ChannelRefreshSnapshot(
+			id: channel.id,
+			index: channel.index,
+			uplinkEnabled: channel.uplinkEnabled,
+			downlinkEnabled: channel.downlinkEnabled,
+			name: channel.name ?? "",
+			role: channel.role,
+			psk: channel.psk ?? Data(),
+			positionPrecision: channel.positionPrecision,
+			mute: channel.mute
+		)
+	}
+
+	nonisolated private static func applyChannelRefresh(_ stagedChannel: StagedChannel, to channel: ChannelEntity) {
 		channel.id = stagedChannel.id
 		channel.index = stagedChannel.index
 		channel.uplinkEnabled = stagedChannel.uplinkEnabled
@@ -769,19 +775,7 @@ actor MeshPackets {
 	}
 
 	private func currentChannelSnapshot(from myInfo: MyInfoEntity) -> [ChannelRefreshSnapshot] {
-		myInfo.channels.map { channel in
-			ChannelRefreshSnapshot(
-				id: channel.id,
-				index: channel.index,
-				uplinkEnabled: channel.uplinkEnabled,
-				downlinkEnabled: channel.downlinkEnabled,
-				name: channel.name ?? "",
-				role: channel.role,
-				psk: channel.psk ?? Data(),
-				positionPrecision: channel.positionPrecision,
-				mute: channel.mute
-			)
-		}.sorted(by: Self.channelSnapshotIsOrderedBefore)
+		myInfo.channels.map(Self.channelRefreshSnapshot).sorted(by: Self.channelSnapshotIsOrderedBefore)
 	}
 
 	private func isCompleteChannelRefresh(_ stagedChannels: [Int32: StagedChannel]) -> Bool {
@@ -879,15 +873,7 @@ actor MeshPackets {
 	}
 
 	private func apply(stagedChannel: StagedChannel, to channel: ChannelEntity) {
-		channel.id = stagedChannel.id
-		channel.index = stagedChannel.index
-		channel.uplinkEnabled = stagedChannel.uplinkEnabled
-		channel.downlinkEnabled = stagedChannel.downlinkEnabled
-		channel.name = stagedChannel.name
-		channel.role = stagedChannel.role
-		channel.psk = stagedChannel.psk
-		channel.positionPrecision = stagedChannel.positionPrecision
-		channel.mute = stagedChannel.mute
+		Self.applyChannelRefresh(stagedChannel, to: channel)
 	}
 
 	func deviceMetadataPacket (metadata: DeviceMetadata, fromNum: Int64, sessionPasskey: Data? = Data()) {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -80,6 +80,23 @@ actor MeshPackets {
 		let mute: Bool
 	}
 
+	private struct ChannelSnapshot: Equatable {
+		let index: Int32
+		let uplinkEnabled: Bool
+		let downlinkEnabled: Bool
+		let name: String
+		let role: Int32
+		let psk: Data
+		let positionPrecision: Int32
+		let mute: Bool
+	}
+
+	private struct ChannelRefreshStage {
+		let requestID: UInt32?
+		let baseline: [Int32: ChannelSnapshot]
+		var channels: [Int32: StagedChannel] = [:]
+	}
+
 	private struct TelemetryPruneKey: Hashable {
 		let nodeNum: Int64
 		let metricsType: Int32
@@ -109,7 +126,8 @@ actor MeshPackets {
 	static func recreateShared() {
 		_lock.lock()
 		let previous = _shared
-		_shared = MeshPackets(modelContainer: _container)
+		let replacement = MeshPackets(modelContainer: _container)
+		_shared = replacement
 		_lock.unlock()
 		// Invalidate the retired instance. In-flight tasks that captured `MeshPackets.shared`
 		// before the swap (a debounced save, a late packet for the previous radio) still hold
@@ -117,7 +135,11 @@ actor MeshPackets {
 		// on-disk store as the new one. Letting those writes land after a device-switch
 		// clearDatabase resurrects the previous radio's rows (nodes bleeding across devices)
 		// and can trip reused-rowid "destroyed by ModelContext.reset" traps.
-		Task { await previous.invalidate() }
+		Task {
+			let stages = await previous.drainChannelRefreshStagesForRecreation()
+			await replacement.restoreChannelRefreshStages(stages)
+			await previous.invalidate()
+		}
 		Logger.data.info("♻️ [MeshPackets] Recreated shared instance to release ModelContext memory")
 	}
 
@@ -126,25 +148,41 @@ actor MeshPackets {
 	/// Set when this instance has been replaced by `recreateShared()`. A retired instance must
 	/// never persist again — see `recreateShared()`.
 	private var invalidated = false
-	private var channelRefreshStages: [Int64: [Int32: StagedChannel]] = [:]
+	private var channelRefreshStages: [Int64: ChannelRefreshStage] = [:]
 
 	func invalidate() {
 		invalidated = true
 		debounceSaveTask?.cancel()
 		debounceSaveTask = nil
+	}
+
+	private func drainChannelRefreshStagesForRecreation() -> [Int64: ChannelRefreshStage] {
+		let stages = channelRefreshStages
 		channelRefreshStages.removeAll()
+		return stages
 	}
 
-	func beginChannelRefreshStage(for nodeNum: Int64) {
-		channelRefreshStages[nodeNum] = [:]
+	private func restoreChannelRefreshStages(_ stages: [Int64: ChannelRefreshStage]) {
+		for (nodeNum, stage) in stages where channelRefreshStages[nodeNum] == nil {
+			channelRefreshStages[nodeNum] = stage
+		}
 	}
 
-	func discardChannelRefreshStage(for nodeNum: Int64) {
+	func beginChannelRefreshStage(for nodeNum: Int64, requestID: UInt32? = nil) {
+		channelRefreshStages[nodeNum] = ChannelRefreshStage(
+			requestID: requestID,
+			baseline: currentChannelSnapshot(for: nodeNum)
+		)
+	}
+
+	func discardChannelRefreshStage(for nodeNum: Int64, requestID: UInt32? = nil) {
+		guard stageMatches(nodeNum: nodeNum, requestID: requestID) else { return }
 		channelRefreshStages[nodeNum] = nil
 	}
 
-	func commitChannelRefreshStage(for nodeNum: Int64) {
-		guard let stagedChannels = channelRefreshStages.removeValue(forKey: nodeNum) else { return }
+	func commitChannelRefreshStage(for nodeNum: Int64, requestID: UInt32? = nil) {
+		guard stageMatches(nodeNum: nodeNum, requestID: requestID),
+			  let stage = channelRefreshStages[nodeNum] else { return }
 		let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == nodeNum })
 		do {
 			let fetchedMyInfo = try modelContext.fetch(fetchDescriptor)
@@ -153,19 +191,33 @@ actor MeshPackets {
 				return
 			}
 			let myInfo = fetchedMyInfo[0]
+			guard isCompleteChannelRefresh(stage.channels, baseline: stage.baseline) else {
+				Logger.data.error("💥 Refusing incomplete staged channel refresh for: \(nodeNum.toHex(), privacy: .public)")
+				return
+			}
+			guard currentChannelSnapshot(from: myInfo) == stage.baseline else {
+				channelRefreshStages[nodeNum] = nil
+				Logger.data.info("💾 Discarded staged channel refresh after local channel changes for: \(nodeNum.toHex(), privacy: .public)")
+				return
+			}
 			for channel in myInfo.channels {
 				modelContext.delete(channel)
 			}
 			myInfo.channels.removeAll()
-			for staged in stagedChannels.values.sorted(by: { $0.index < $1.index }) {
+			let enabledChannels = stage.channels.values
+				.filter { $0.role != Int32(Channel.Role.disabled.rawValue) }
+				.sorted(by: { $0.index < $1.index })
+			for staged in enabledChannels {
 				let channel = ChannelEntity()
 				modelContext.insert(channel)
 				apply(stagedChannel: staged, to: channel)
 				myInfo.channels.append(channel)
 			}
-			savePendingChanges()
-			Logger.data.info("💾 Committed \(stagedChannels.count, privacy: .public) staged channel(s) for: \(nodeNum, privacy: .public)")
+			try modelContext.save()
+			channelRefreshStages[nodeNum] = nil
+			Logger.data.info("💾 Committed \(enabledChannels.count, privacy: .public) staged channel(s) for: \(nodeNum, privacy: .public)")
 		} catch {
+			modelContext.rollback()
 			let nsError = error as NSError
 			Logger.data.error("💥 Error committing staged channels from ADMIN_APP \(nsError, privacy: .public)")
 		}
@@ -492,13 +544,51 @@ actor MeshPackets {
 		return nil
 	}
 
-	func channelPacket (channel: Channel, fromNum: Int64) {
-		if channel.isInitialized && channel.hasSettings && channel.role != Channel.Role.disabled {
+	private func stageMatches(nodeNum: Int64, requestID: UInt32?) -> Bool {
+		guard let stage = channelRefreshStages[nodeNum] else { return false }
+		return requestID == nil || stage.requestID == requestID
+	}
+
+	private func currentChannelSnapshot(for nodeNum: Int64) -> [Int32: ChannelSnapshot] {
+		let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == nodeNum })
+		guard let myInfo = try? modelContext.fetch(fetchDescriptor).first else { return [:] }
+		return currentChannelSnapshot(from: myInfo)
+	}
+
+	private func currentChannelSnapshot(from myInfo: MyInfoEntity) -> [Int32: ChannelSnapshot] {
+		myInfo.channels.reduce(into: [:]) { snapshot, channel in
+			snapshot[channel.index] = ChannelSnapshot(
+				index: channel.index,
+				uplinkEnabled: channel.uplinkEnabled,
+				downlinkEnabled: channel.downlinkEnabled,
+				name: channel.name ?? "",
+				role: channel.role,
+				psk: channel.psk ?? Data(),
+				positionPrecision: channel.positionPrecision,
+				mute: channel.mute
+			)
+		}
+	}
+
+	private func isCompleteChannelRefresh(_ stagedChannels: [Int32: StagedChannel], baseline: [Int32: ChannelSnapshot]) -> Bool {
+		guard let primary = stagedChannels[0],
+			  primary.role == Int32(Channel.Role.primary.rawValue) else { return false }
+		for index in baseline.keys where stagedChannels[index] == nil {
+			return false
+		}
+		return stagedChannels.values.allSatisfy { staged in
+			staged.index >= 0 && staged.index < 8 &&
+			(staged.index == 0 || staged.role != Int32(Channel.Role.primary.rawValue))
+		}
+	}
+
+	func channelPacket(channel: Channel, fromNum: Int64, stageIfRefreshing: Bool = true) {
+		if channel.isInitialized && (channel.hasSettings || channel.role == Channel.Role.disabled) {
 			let logString = String.localizedStringWithFormat("Channel received: %d %@".localized, channel.index, String(fromNum))
 			Logger.admin.info("🎛️ \(logString, privacy: .public)")
 
-			if channelRefreshStages[fromNum] != nil {
-				channelRefreshStages[fromNum]?[Int32(truncatingIfNeeded: channel.index)] = stagedChannel(from: channel)
+			if stageIfRefreshing, channelRefreshStages[fromNum] != nil {
+				channelRefreshStages[fromNum]?.channels[Int32(truncatingIfNeeded: channel.index)] = stagedChannel(from: channel)
 				return
 			}
 
@@ -508,6 +598,14 @@ actor MeshPackets {
 				let fetchedMyInfo = try modelContext.fetch(fetchDescriptor)
 				if fetchedMyInfo.count == 1 {
 					let existing = fetchedMyInfo[0].channels.first(where: { $0.index == Int32(truncatingIfNeeded: channel.index) })
+					if channel.role == Channel.Role.disabled {
+						if let existing {
+							modelContext.delete(existing)
+							savePendingChanges()
+							Logger.data.info("💾 Deleted MyInfo channel \(channel.index, privacy: .public) from Channel App Packet For: \(fetchedMyInfo[0].myNodeNum, privacy: .public)")
+						}
+						return
+					}
 					let newChannel: ChannelEntity
 					if let existing {
 						newChannel = existing
@@ -530,6 +628,19 @@ actor MeshPackets {
 	}
 
 	private func stagedChannel(from channel: Channel) -> StagedChannel {
+		if channel.role == Channel.Role.disabled {
+			return StagedChannel(
+				id: Int32(truncatingIfNeeded: channel.index),
+				index: Int32(truncatingIfNeeded: channel.index),
+				uplinkEnabled: false,
+				downlinkEnabled: false,
+				name: "",
+				role: Int32(Channel.Role.disabled.rawValue),
+				psk: Data(),
+				positionPrecision: 0,
+				mute: false
+			)
+		}
 		let positionPrecision: Int32
 		let mute: Bool
 		if channel.settings.hasModuleSettings {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -66,6 +66,13 @@ func generateMessageMarkdown(message: String) -> String {
 	return messageWithMarkdown
 }
 
+/// Identifies one locally initiated automatic config refresh. The radio protocol reserves a
+/// single config nonce, so this ownership stays local rather than appearing on the wire.
+struct AutomaticChannelRefreshOwner: Equatable, Sendable {
+	let sessionID: UUID
+	let generation: UInt64
+}
+
 @ModelActor
 actor MeshPackets {
 	private struct StagedChannel {
@@ -92,7 +99,7 @@ actor MeshPackets {
 	}
 
 	private struct ChannelRefreshStage {
-		let requestID: UInt32?
+		let owner: AutomaticChannelRefreshOwner?
 		let baseline: [Int32: ChannelSnapshot]
 		var channels: [Int32: StagedChannel] = [:]
 	}
@@ -114,6 +121,8 @@ actor MeshPackets {
 	/// Periodically recreated to release accumulated ModelContext memory.
 	nonisolated(unsafe) private static var _shared: MeshPackets = MeshPackets(modelContainer: _container)
 	private static let _lock = NSLock()
+	private static var activeChannelRefreshStageCount = 0
+	private static var sharedRecreationDeferredForChannelRefresh = false
 
 	static var shared: MeshPackets {
 		_lock.lock()
@@ -125,9 +134,14 @@ actor MeshPackets {
 	/// Call after DB retrieval completes or periodically to release accumulated memory.
 	static func recreateShared() {
 		_lock.lock()
+		guard activeChannelRefreshStageCount == 0 else {
+			sharedRecreationDeferredForChannelRefresh = true
+			_lock.unlock()
+			Logger.data.info("♻️ [MeshPackets] Deferred actor recreation until channel refresh finishes")
+			return
+		}
 		let previous = _shared
-		let replacement = MeshPackets(modelContainer: _container)
-		_shared = replacement
+		_shared = MeshPackets(modelContainer: _container)
 		_lock.unlock()
 		// Invalidate the retired instance. In-flight tasks that captured `MeshPackets.shared`
 		// before the swap (a debounced save, a late packet for the previous radio) still hold
@@ -135,12 +149,29 @@ actor MeshPackets {
 		// on-disk store as the new one. Letting those writes land after a device-switch
 		// clearDatabase resurrects the previous radio's rows (nodes bleeding across devices)
 		// and can trip reused-rowid "destroyed by ModelContext.reset" traps.
-		Task {
-			let stages = await previous.drainChannelRefreshStagesForRecreation()
-			await replacement.restoreChannelRefreshStages(stages)
-			await previous.invalidate()
-		}
+		Task { await previous.invalidate() }
 		Logger.data.info("♻️ [MeshPackets] Recreated shared instance to release ModelContext memory")
+	}
+
+	private static func channelRefreshStageDidBegin() {
+		_lock.lock()
+		activeChannelRefreshStageCount += 1
+		_lock.unlock()
+	}
+
+	private static func channelRefreshStageDidEnd() {
+		_lock.lock()
+		activeChannelRefreshStageCount -= 1
+		let shouldRecreate = activeChannelRefreshStageCount == 0 && sharedRecreationDeferredForChannelRefresh
+		if shouldRecreate {
+			sharedRecreationDeferredForChannelRefresh = false
+		}
+		_lock.unlock()
+		if shouldRecreate {
+			Task { @MainActor in
+				MeshPackets.recreateShared()
+			}
+		}
 	}
 
 	// MARK: - Save Helpers
@@ -156,33 +187,24 @@ actor MeshPackets {
 		debounceSaveTask = nil
 	}
 
-	private func drainChannelRefreshStagesForRecreation() -> [Int64: ChannelRefreshStage] {
-		let stages = channelRefreshStages
-		channelRefreshStages.removeAll()
-		return stages
-	}
-
-	private func restoreChannelRefreshStages(_ stages: [Int64: ChannelRefreshStage]) {
-		for (nodeNum, stage) in stages where channelRefreshStages[nodeNum] == nil {
-			channelRefreshStages[nodeNum] = stage
-		}
-	}
-
-	func beginChannelRefreshStage(for nodeNum: Int64, requestID: UInt32? = nil) {
+	func beginChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {
+		guard channelRefreshStages[nodeNum] == nil else { return }
+		MeshPackets.channelRefreshStageDidBegin()
 		channelRefreshStages[nodeNum] = ChannelRefreshStage(
-			requestID: requestID,
+			owner: owner,
 			baseline: currentChannelSnapshot(for: nodeNum)
 		)
 	}
 
-	func discardChannelRefreshStage(for nodeNum: Int64, requestID: UInt32? = nil) {
-		guard stageMatches(nodeNum: nodeNum, requestID: requestID) else { return }
-		channelRefreshStages[nodeNum] = nil
+	func discardChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {
+		guard stageMatches(nodeNum: nodeNum, owner: owner) else { return }
+		endChannelRefreshStage(for: nodeNum)
 	}
 
-	func commitChannelRefreshStage(for nodeNum: Int64, requestID: UInt32? = nil) {
-		guard stageMatches(nodeNum: nodeNum, requestID: requestID),
+	func commitChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {
+		guard stageMatches(nodeNum: nodeNum, owner: owner),
 			  let stage = channelRefreshStages[nodeNum] else { return }
+		defer { endChannelRefreshStage(for: nodeNum) }
 		let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == nodeNum })
 		do {
 			let fetchedMyInfo = try modelContext.fetch(fetchDescriptor)
@@ -191,12 +213,11 @@ actor MeshPackets {
 				return
 			}
 			let myInfo = fetchedMyInfo[0]
-			guard isCompleteChannelRefresh(stage.channels, baseline: stage.baseline) else {
+			guard isCompleteChannelRefresh(stage.channels) else {
 				Logger.data.error("💥 Refusing incomplete staged channel refresh for: \(nodeNum.toHex(), privacy: .public)")
 				return
 			}
 			guard currentChannelSnapshot(from: myInfo) == stage.baseline else {
-				channelRefreshStages[nodeNum] = nil
 				Logger.data.info("💾 Discarded staged channel refresh after local channel changes for: \(nodeNum.toHex(), privacy: .public)")
 				return
 			}
@@ -214,7 +235,6 @@ actor MeshPackets {
 				myInfo.channels.append(channel)
 			}
 			try modelContext.save()
-			channelRefreshStages[nodeNum] = nil
 			Logger.data.info("💾 Committed \(enabledChannels.count, privacy: .public) staged channel(s) for: \(nodeNum, privacy: .public)")
 		} catch {
 			modelContext.rollback()
@@ -544,9 +564,14 @@ actor MeshPackets {
 		return nil
 	}
 
-	private func stageMatches(nodeNum: Int64, requestID: UInt32?) -> Bool {
+	private func endChannelRefreshStage(for nodeNum: Int64) {
+		guard channelRefreshStages.removeValue(forKey: nodeNum) != nil else { return }
+		MeshPackets.channelRefreshStageDidEnd()
+	}
+
+	private func stageMatches(nodeNum: Int64, owner: AutomaticChannelRefreshOwner?) -> Bool {
 		guard let stage = channelRefreshStages[nodeNum] else { return false }
-		return requestID == nil || stage.requestID == requestID
+		return owner == nil || stage.owner == owner
 	}
 
 	private func currentChannelSnapshot(for nodeNum: Int64) -> [Int32: ChannelSnapshot] {
@@ -570,12 +595,10 @@ actor MeshPackets {
 		}
 	}
 
-	private func isCompleteChannelRefresh(_ stagedChannels: [Int32: StagedChannel], baseline: [Int32: ChannelSnapshot]) -> Bool {
+	private func isCompleteChannelRefresh(_ stagedChannels: [Int32: StagedChannel]) -> Bool {
 		guard let primary = stagedChannels[0],
 			  primary.role == Int32(Channel.Role.primary.rawValue) else { return false }
-		for index in baseline.keys where stagedChannels[index] == nil {
-			return false
-		}
+		guard Set(stagedChannels.keys) == Set(Int32(0)...Int32(7)) else { return false }
 		return stagedChannels.values.allSatisfy { staged in
 			staged.index >= 0 && staged.index < 8 &&
 			(staged.index == 0 || staged.role != Int32(Channel.Role.primary.rawValue))

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -75,7 +75,49 @@ struct AutomaticChannelRefreshOwner: Equatable, Sendable {
 
 @ModelActor
 actor MeshPackets {
-	private struct StagedChannel {
+	/// Holds the shared-actor recreation guard from the instant the actor is captured until the
+	/// refresh stage accepts ownership of that guard. This closes the capture/actor-hop window where
+	/// a periodic recycle could previously retire the actor before its stage became visible.
+	final class SharedChannelRefreshStageLease: @unchecked Sendable {
+		let packets: MeshPackets
+		private let resolutionLock = NSLock()
+		private var beginWasClaimed = false
+
+		init(packets: MeshPackets) {
+			self.packets = packets
+		}
+
+		func begin(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) async -> Bool {
+			guard claimBegin() else { return false }
+			let didBegin = await packets.beginLeasedChannelRefreshStage(for: nodeNum, owner: owner)
+			if !didBegin {
+				MeshPackets.releaseSharedChannelRefreshStageLease()
+			}
+			return didBegin
+		}
+
+		deinit {
+			if releaseNeededOnDeinit() {
+				MeshPackets.releaseSharedChannelRefreshStageLease()
+			}
+		}
+
+		private func claimBegin() -> Bool {
+			resolutionLock.lock()
+			defer { resolutionLock.unlock() }
+			guard !beginWasClaimed else { return false }
+			beginWasClaimed = true
+			return true
+		}
+
+		private func releaseNeededOnDeinit() -> Bool {
+			resolutionLock.lock()
+			defer { resolutionLock.unlock() }
+			return !beginWasClaimed
+		}
+	}
+
+	private struct StagedChannel: Sendable {
 		let id: Int32
 		let index: Int32
 		let uplinkEnabled: Bool
@@ -87,7 +129,7 @@ actor MeshPackets {
 		let mute: Bool
 	}
 
-	private struct ChannelSnapshot: Equatable {
+	private struct ChannelSnapshot: Equatable, Sendable {
 		let index: Int32
 		let uplinkEnabled: Bool
 		let downlinkEnabled: Bool
@@ -101,6 +143,7 @@ actor MeshPackets {
 	private struct ChannelRefreshStage {
 		let owner: AutomaticChannelRefreshOwner?
 		let baseline: [Int32: ChannelSnapshot]
+		let holdsSharedRecreationLease: Bool
 		var channels: [Int32: StagedChannel] = [:]
 	}
 
@@ -123,11 +166,26 @@ actor MeshPackets {
 	private static let _lock = NSLock()
 	private static var activeChannelRefreshStageCount = 0
 	private static var sharedRecreationDeferredForChannelRefresh = false
+	#if DEBUG
+	/// Deterministic concurrency checkpoint used by the refresh boundary regression test. Production
+	/// callers leave this nil, so validation and replacement execute without suspension.
+	@MainActor static var channelRefreshCommitValidationHook: (@MainActor @Sendable () async -> Void)?
+	#endif
 
 	static var shared: MeshPackets {
 		_lock.lock()
 		defer { _lock.unlock() }
 		return _shared
+	}
+
+	/// Captures the current shared actor and activates its no-recycle guarantee under the same
+	/// lock. The returned lease transfers that guarantee to a successfully created stage.
+	static func acquireSharedChannelRefreshStageLease() -> SharedChannelRefreshStageLease {
+		_lock.lock()
+		activeChannelRefreshStageCount += 1
+		let packets = _shared
+		_lock.unlock()
+		return SharedChannelRefreshStageLease(packets: packets)
 	}
 
 	/// Discards the current actor and creates a fresh one with a new ModelContext.
@@ -153,14 +211,12 @@ actor MeshPackets {
 		Logger.data.info("♻️ [MeshPackets] Recreated shared instance to release ModelContext memory")
 	}
 
-	private static func channelRefreshStageDidBegin() {
+	private static func releaseSharedChannelRefreshStageLease() {
 		_lock.lock()
-		activeChannelRefreshStageCount += 1
-		_lock.unlock()
-	}
-
-	private static func channelRefreshStageDidEnd() {
-		_lock.lock()
+		guard activeChannelRefreshStageCount > 0 else {
+			_lock.unlock()
+			return
+		}
 		activeChannelRefreshStageCount -= 1
 		let shouldRecreate = activeChannelRefreshStageCount == 0 && sharedRecreationDeferredForChannelRefresh
 		if shouldRecreate {
@@ -189,11 +245,24 @@ actor MeshPackets {
 
 	func beginChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {
 		guard channelRefreshStages[nodeNum] == nil else { return }
-		MeshPackets.channelRefreshStageDidBegin()
 		channelRefreshStages[nodeNum] = ChannelRefreshStage(
 			owner: owner,
-			baseline: currentChannelSnapshot(for: nodeNum)
+			baseline: currentChannelSnapshot(for: nodeNum),
+			holdsSharedRecreationLease: false
 		)
+	}
+
+	private func beginLeasedChannelRefreshStage(
+		for nodeNum: Int64,
+		owner: AutomaticChannelRefreshOwner?
+	) -> Bool {
+		guard channelRefreshStages[nodeNum] == nil else { return false }
+		channelRefreshStages[nodeNum] = ChannelRefreshStage(
+			owner: owner,
+			baseline: currentChannelSnapshot(for: nodeNum),
+			holdsSharedRecreationLease: true
+		)
+		return true
 	}
 
 	func discardChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {
@@ -201,46 +270,103 @@ actor MeshPackets {
 		endChannelRefreshStage(for: nodeNum)
 	}
 
-	func commitChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {
+	func commitChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) async {
 		guard stageMatches(nodeNum: nodeNum, owner: owner),
 			  let stage = channelRefreshStages[nodeNum] else { return }
 		defer { endChannelRefreshStage(for: nodeNum) }
+		guard isCompleteChannelRefresh(stage.channels) else {
+			Logger.data.error("💥 Refusing incomplete staged channel refresh for: \(nodeNum.toHex(), privacy: .public)")
+			return
+		}
+		let container = modelContext.container
+		await Self.commitChannelRefreshStageOnMainActor(
+			for: nodeNum,
+			baseline: stage.baseline,
+			stagedChannels: stage.channels,
+			container: container
+		)
+	}
+
+	/// UI channel edits are main-context mutations. Running both baseline validation and the
+	/// destructive replacement on that same executor makes them one non-reentrant critical section.
+	@MainActor
+	private static func commitChannelRefreshStageOnMainActor(
+		for nodeNum: Int64,
+		baseline: [Int32: ChannelSnapshot],
+		stagedChannels: [Int32: StagedChannel],
+		container: ModelContainer
+	) async {
+		let context = container.mainContext
 		let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == nodeNum })
 		do {
-			let fetchedMyInfo = try modelContext.fetch(fetchDescriptor)
+			let fetchedMyInfo = try context.fetch(fetchDescriptor)
 			guard fetchedMyInfo.count == 1 else {
 				Logger.data.error("💥Trying to commit staged channels to a MyInfo that does not exist: \(nodeNum.toHex(), privacy: .public)")
 				return
 			}
 			let myInfo = fetchedMyInfo[0]
-			guard isCompleteChannelRefresh(stage.channels) else {
-				Logger.data.error("💥 Refusing incomplete staged channel refresh for: \(nodeNum.toHex(), privacy: .public)")
-				return
-			}
-			guard currentChannelSnapshot(from: myInfo) == stage.baseline else {
+			guard channelSnapshot(from: myInfo) == baseline else {
 				Logger.data.info("💾 Discarded staged channel refresh after local channel changes for: \(nodeNum.toHex(), privacy: .public)")
 				return
 			}
+			#if DEBUG
+			if let hook = channelRefreshCommitValidationHook {
+				await hook()
+			}
+			#endif
+			guard channelSnapshot(from: myInfo) == baseline else {
+				Logger.data.info("💾 Discarded staged channel refresh after a serialized local channel change for: \(nodeNum.toHex(), privacy: .public)")
+				return
+			}
 			for channel in myInfo.channels {
-				modelContext.delete(channel)
+				context.delete(channel)
 			}
 			myInfo.channels.removeAll()
-			let enabledChannels = stage.channels.values
+			let enabledChannels = stagedChannels.values
 				.filter { $0.role != Int32(Channel.Role.disabled.rawValue) }
 				.sorted(by: { $0.index < $1.index })
 			for staged in enabledChannels {
 				let channel = ChannelEntity()
-				modelContext.insert(channel)
+				context.insert(channel)
 				apply(stagedChannel: staged, to: channel)
 				myInfo.channels.append(channel)
 			}
-			try modelContext.save()
+			try context.save()
 			Logger.data.info("💾 Committed \(enabledChannels.count, privacy: .public) staged channel(s) for: \(nodeNum, privacy: .public)")
 		} catch {
-			modelContext.rollback()
+			context.rollback()
 			let nsError = error as NSError
 			Logger.data.error("💥 Error committing staged channels from ADMIN_APP \(nsError, privacy: .public)")
 		}
+	}
+
+	@MainActor
+	private static func channelSnapshot(from myInfo: MyInfoEntity) -> [Int32: ChannelSnapshot] {
+		myInfo.channels.reduce(into: [:]) { snapshot, channel in
+			snapshot[channel.index] = ChannelSnapshot(
+				index: channel.index,
+				uplinkEnabled: channel.uplinkEnabled,
+				downlinkEnabled: channel.downlinkEnabled,
+				name: channel.name ?? "",
+				role: channel.role,
+				psk: channel.psk ?? Data(),
+				positionPrecision: channel.positionPrecision,
+				mute: channel.mute
+			)
+		}
+	}
+
+	@MainActor
+	private static func apply(stagedChannel: StagedChannel, to channel: ChannelEntity) {
+		channel.id = stagedChannel.id
+		channel.index = stagedChannel.index
+		channel.uplinkEnabled = stagedChannel.uplinkEnabled
+		channel.downlinkEnabled = stagedChannel.downlinkEnabled
+		channel.name = stagedChannel.name
+		channel.role = stagedChannel.role
+		channel.psk = stagedChannel.psk
+		channel.positionPrecision = stagedChannel.positionPrecision
+		channel.mute = stagedChannel.mute
 	}
 
 	/// Saves any pending changes in the model context. Call once at the end of each
@@ -565,8 +691,10 @@ actor MeshPackets {
 	}
 
 	private func endChannelRefreshStage(for nodeNum: Int64) {
-		guard channelRefreshStages.removeValue(forKey: nodeNum) != nil else { return }
-		MeshPackets.channelRefreshStageDidEnd()
+		guard let stage = channelRefreshStages.removeValue(forKey: nodeNum) else { return }
+		if stage.holdsSharedRecreationLease {
+			MeshPackets.releaseSharedChannelRefreshStageLease()
+		}
 	}
 
 	private func stageMatches(nodeNum: Int64, owner: AutomaticChannelRefreshOwner?) -> Bool {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -155,6 +155,7 @@ actor MeshPackets {
 	}
 
 	private struct ChannelRefreshStage {
+		let id = UUID()
 		let owner: AutomaticChannelRefreshOwner?
 		let baseline: [ChannelRefreshSnapshot]
 		let holdsSharedRecreationLease: Bool
@@ -306,7 +307,7 @@ actor MeshPackets {
 	func commitChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) async {
 		guard stageMatches(nodeNum: nodeNum, owner: owner),
 			  let stage = channelRefreshStages[nodeNum] else { return }
-		defer { endChannelRefreshStage(for: nodeNum) }
+		defer { endChannelRefreshStage(for: nodeNum, stageID: stage.id) }
 		guard isCompleteChannelRefresh(stage.channels) else {
 			Logger.data.error("💥 Refusing incomplete staged channel refresh for: \(nodeNum.toHex(), privacy: .public)")
 			return
@@ -747,8 +748,10 @@ actor MeshPackets {
 		return nil
 	}
 
-	private func endChannelRefreshStage(for nodeNum: Int64) {
-		guard let stage = channelRefreshStages.removeValue(forKey: nodeNum) else { return }
+	private func endChannelRefreshStage(for nodeNum: Int64, stageID: UUID? = nil) {
+		guard let stage = channelRefreshStages[nodeNum],
+			  stageID == nil || stage.id == stageID else { return }
+		channelRefreshStages.removeValue(forKey: nodeNum)
 		if stage.holdsSharedRecreationLease {
 			MeshPackets.releaseSharedChannelRefreshStageLease()
 		}

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -73,6 +73,18 @@ struct AutomaticChannelRefreshOwner: Equatable, Sendable {
 	let generation: UInt64
 }
 
+struct ChannelRefreshSnapshot: Equatable, Sendable {
+	let id: Int32
+	let index: Int32
+	let uplinkEnabled: Bool
+	let downlinkEnabled: Bool
+	let name: String
+	let role: Int32
+	let psk: Data
+	let positionPrecision: Int32
+	let mute: Bool
+}
+
 @ModelActor
 actor MeshPackets {
 	/// Holds the shared-actor recreation guard from the instant the actor is captured until the
@@ -87,9 +99,17 @@ actor MeshPackets {
 			self.packets = packets
 		}
 
-		func begin(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) async -> Bool {
+		func begin(
+			for nodeNum: Int64,
+			owner: AutomaticChannelRefreshOwner? = nil,
+			baseline: [ChannelRefreshSnapshot]? = nil
+		) async -> Bool {
 			guard claimBegin() else { return false }
-			let didBegin = await packets.beginLeasedChannelRefreshStage(for: nodeNum, owner: owner)
+			let didBegin = await packets.beginLeasedChannelRefreshStage(
+				for: nodeNum,
+				owner: owner,
+				baseline: baseline
+			)
 			if !didBegin {
 				MeshPackets.releaseSharedChannelRefreshStageLease()
 			}
@@ -129,20 +149,9 @@ actor MeshPackets {
 		let mute: Bool
 	}
 
-	private struct ChannelSnapshot: Equatable, Sendable {
-		let index: Int32
-		let uplinkEnabled: Bool
-		let downlinkEnabled: Bool
-		let name: String
-		let role: Int32
-		let psk: Data
-		let positionPrecision: Int32
-		let mute: Bool
-	}
-
 	private struct ChannelRefreshStage {
 		let owner: AutomaticChannelRefreshOwner?
-		let baseline: [Int32: ChannelSnapshot]
+		let baseline: [ChannelRefreshSnapshot]
 		let holdsSharedRecreationLease: Bool
 		var channels: [Int32: StagedChannel] = [:]
 	}
@@ -254,12 +263,13 @@ actor MeshPackets {
 
 	private func beginLeasedChannelRefreshStage(
 		for nodeNum: Int64,
-		owner: AutomaticChannelRefreshOwner?
+		owner: AutomaticChannelRefreshOwner?,
+		baseline: [ChannelRefreshSnapshot]?
 	) -> Bool {
 		guard channelRefreshStages[nodeNum] == nil else { return false }
 		channelRefreshStages[nodeNum] = ChannelRefreshStage(
 			owner: owner,
-			baseline: currentChannelSnapshot(for: nodeNum),
+			baseline: baseline ?? currentChannelSnapshot(for: nodeNum),
 			holdsSharedRecreationLease: true
 		)
 		return true
@@ -292,7 +302,7 @@ actor MeshPackets {
 	@MainActor
 	private static func commitChannelRefreshStageOnMainActor(
 		for nodeNum: Int64,
-		baseline: [Int32: ChannelSnapshot],
+		baseline: [ChannelRefreshSnapshot],
 		stagedChannels: [Int32: StagedChannel],
 		container: ModelContainer
 	) async {
@@ -341,9 +351,10 @@ actor MeshPackets {
 	}
 
 	@MainActor
-	private static func channelSnapshot(from myInfo: MyInfoEntity) -> [Int32: ChannelSnapshot] {
-		myInfo.channels.reduce(into: [:]) { snapshot, channel in
-			snapshot[channel.index] = ChannelSnapshot(
+	private static func channelSnapshot(from myInfo: MyInfoEntity) -> [ChannelRefreshSnapshot] {
+		myInfo.channels.map { channel in
+			ChannelRefreshSnapshot(
+				id: channel.id,
 				index: channel.index,
 				uplinkEnabled: channel.uplinkEnabled,
 				downlinkEnabled: channel.downlinkEnabled,
@@ -353,7 +364,30 @@ actor MeshPackets {
 				positionPrecision: channel.positionPrecision,
 				mute: channel.mute
 			)
+		}.sorted(by: channelSnapshotIsOrderedBefore)
+	}
+
+	@MainActor
+	static func captureChannelRefreshBaselines(in context: ModelContext) -> [Int64: [ChannelRefreshSnapshot]] {
+		let myInfos = (try? context.fetch(FetchDescriptor<MyInfoEntity>())) ?? []
+		return myInfos.reduce(into: [:]) { baselines, myInfo in
+			baselines[myInfo.myNodeNum] = channelSnapshot(from: myInfo)
 		}
+	}
+
+	private static func channelSnapshotIsOrderedBefore(
+		_ lhs: ChannelRefreshSnapshot,
+		_ rhs: ChannelRefreshSnapshot
+	) -> Bool {
+		if lhs.index != rhs.index { return lhs.index < rhs.index }
+		if lhs.id != rhs.id { return lhs.id < rhs.id }
+		if lhs.role != rhs.role { return lhs.role < rhs.role }
+		if lhs.name != rhs.name { return lhs.name < rhs.name }
+		if lhs.psk != rhs.psk { return lhs.psk.lexicographicallyPrecedes(rhs.psk) }
+		if lhs.uplinkEnabled != rhs.uplinkEnabled { return !lhs.uplinkEnabled }
+		if lhs.downlinkEnabled != rhs.downlinkEnabled { return !lhs.downlinkEnabled }
+		if lhs.positionPrecision != rhs.positionPrecision { return lhs.positionPrecision < rhs.positionPrecision }
+		return !lhs.mute && rhs.mute
 	}
 
 	@MainActor
@@ -702,15 +736,16 @@ actor MeshPackets {
 		return owner == nil || stage.owner == owner
 	}
 
-	private func currentChannelSnapshot(for nodeNum: Int64) -> [Int32: ChannelSnapshot] {
+	private func currentChannelSnapshot(for nodeNum: Int64) -> [ChannelRefreshSnapshot] {
 		let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == nodeNum })
-		guard let myInfo = try? modelContext.fetch(fetchDescriptor).first else { return [:] }
+		guard let myInfo = try? modelContext.fetch(fetchDescriptor).first else { return [] }
 		return currentChannelSnapshot(from: myInfo)
 	}
 
-	private func currentChannelSnapshot(from myInfo: MyInfoEntity) -> [Int32: ChannelSnapshot] {
-		myInfo.channels.reduce(into: [:]) { snapshot, channel in
-			snapshot[channel.index] = ChannelSnapshot(
+	private func currentChannelSnapshot(from myInfo: MyInfoEntity) -> [ChannelRefreshSnapshot] {
+		myInfo.channels.map { channel in
+			ChannelRefreshSnapshot(
+				id: channel.id,
 				index: channel.index,
 				uplinkEnabled: channel.uplinkEnabled,
 				downlinkEnabled: channel.downlinkEnabled,
@@ -720,7 +755,7 @@ actor MeshPackets {
 				positionPrecision: channel.positionPrecision,
 				mute: channel.mute
 			)
-		}
+		}.sorted(by: Self.channelSnapshotIsOrderedBefore)
 	}
 
 	private func isCompleteChannelRefresh(_ stagedChannels: [Int32: StagedChannel]) -> Bool {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -87,61 +87,6 @@ struct ChannelRefreshSnapshot: Equatable, Sendable {
 
 @ModelActor
 actor MeshPackets {
-	/// Holds the shared-actor recreation guard from the instant the actor is captured until the
-	/// refresh stage accepts ownership of that guard. This closes the capture/actor-hop window where
-	/// a periodic recycle could previously retire the actor before its stage became visible.
-	final class SharedChannelRefreshStageLease: @unchecked Sendable {
-		let packets: MeshPackets
-		private let resolutionLock = NSLock()
-		private var beginWasClaimed = false
-
-		init(packets: MeshPackets) {
-			self.packets = packets
-		}
-
-		func begin(
-			for nodeNum: Int64,
-			owner: AutomaticChannelRefreshOwner? = nil,
-			baseline: [ChannelRefreshSnapshot]? = nil
-		) async -> Bool {
-			guard claimBegin() else { return false }
-			#if DEBUG
-			if let hook = await MeshPackets.channelRefreshStageBeginHook {
-				await hook()
-			}
-			#endif
-			let didBegin = await packets.beginLeasedChannelRefreshStage(
-				for: nodeNum,
-				owner: owner,
-				baseline: baseline
-			)
-			if !didBegin {
-				MeshPackets.releaseSharedChannelRefreshStageLease()
-			}
-			return didBegin
-		}
-
-		deinit {
-			if releaseNeededOnDeinit() {
-				MeshPackets.releaseSharedChannelRefreshStageLease()
-			}
-		}
-
-		private func claimBegin() -> Bool {
-			resolutionLock.lock()
-			defer { resolutionLock.unlock() }
-			guard !beginWasClaimed else { return false }
-			beginWasClaimed = true
-			return true
-		}
-
-		private func releaseNeededOnDeinit() -> Bool {
-			resolutionLock.lock()
-			defer { resolutionLock.unlock() }
-			return !beginWasClaimed
-		}
-	}
-
 	private struct StagedChannel: Sendable {
 		let id: Int32
 		let index: Int32
@@ -158,7 +103,6 @@ actor MeshPackets {
 		let id = UUID()
 		let owner: AutomaticChannelRefreshOwner?
 		let baseline: [ChannelRefreshSnapshot]
-		let holdsSharedRecreationLease: Bool
 		var channels: [Int32: StagedChannel] = [:]
 	}
 
@@ -179,14 +123,27 @@ actor MeshPackets {
 	/// Periodically recreated to release accumulated ModelContext memory.
 	nonisolated(unsafe) private static var _shared: MeshPackets = MeshPackets(modelContainer: _container)
 	private static let _lock = NSLock()
-	nonisolated(unsafe) private static var activeChannelRefreshStageCount = 0
-	nonisolated(unsafe) private static var sharedRecreationDeferredForChannelRefresh = false
+
+	/// Staged automatic channel refreshes, keyed by node number. Deliberately static rather
+	/// than actor state: `recreateShared()` swaps the shared instance to release memory, and a
+	/// stage tied to the retired instance would silently orphan an in-flight refresh. Static
+	/// storage makes recreation orthogonal — the successor actor stages into and commits from
+	/// the same map. The lock covers the two executors that touch it: this actor (staging
+	/// incoming channel frames) and the main actor (begin/commit/discard from AccessoryManager).
+	nonisolated(unsafe) private static var channelRefreshStages: [Int64: ChannelRefreshStage] = [:]
+	private static let channelRefreshStagesLock = NSLock()
 	#if DEBUG
 	/// Deterministic concurrency checkpoint used by the refresh boundary regression test. Production
 	/// callers leave this nil, so validation and replacement execute without suspension.
 	@MainActor static var channelRefreshCommitValidationHook: (@MainActor @Sendable () async -> Void)?
-	/// Deterministic concurrency checkpoint used by the late stage activation regression test.
-	@MainActor static var channelRefreshStageBeginHook: (@MainActor @Sendable () async -> Void)?
+
+	/// Test-only: the static stage storage outlives any per-test actor, so suites reset it
+	/// alongside `recreateShared()`.
+	static func resetChannelRefreshStagesForTesting() {
+		channelRefreshStagesLock.lock()
+		defer { channelRefreshStagesLock.unlock() }
+		channelRefreshStages.removeAll()
+	}
 	#endif
 
 	static var shared: MeshPackets {
@@ -195,26 +152,10 @@ actor MeshPackets {
 		return _shared
 	}
 
-	/// Captures the current shared actor and activates its no-recycle guarantee under the same
-	/// lock. The returned lease transfers that guarantee to a successfully created stage.
-	static func acquireSharedChannelRefreshStageLease() -> SharedChannelRefreshStageLease {
-		_lock.lock()
-		activeChannelRefreshStageCount += 1
-		let packets = _shared
-		_lock.unlock()
-		return SharedChannelRefreshStageLease(packets: packets)
-	}
-
 	/// Discards the current actor and creates a fresh one with a new ModelContext.
 	/// Call after DB retrieval completes or periodically to release accumulated memory.
 	static func recreateShared() {
 		_lock.lock()
-		guard activeChannelRefreshStageCount == 0 else {
-			sharedRecreationDeferredForChannelRefresh = true
-			_lock.unlock()
-			Logger.data.info("♻️ [MeshPackets] Deferred actor recreation until channel refresh finishes")
-			return
-		}
 		let previous = _shared
 		_shared = MeshPackets(modelContainer: _container)
 		_lock.unlock()
@@ -228,31 +169,11 @@ actor MeshPackets {
 		Logger.data.info("♻️ [MeshPackets] Recreated shared instance to release ModelContext memory")
 	}
 
-	private static func releaseSharedChannelRefreshStageLease() {
-		_lock.lock()
-		guard activeChannelRefreshStageCount > 0 else {
-			_lock.unlock()
-			return
-		}
-		activeChannelRefreshStageCount -= 1
-		let shouldRecreate = activeChannelRefreshStageCount == 0 && sharedRecreationDeferredForChannelRefresh
-		if shouldRecreate {
-			sharedRecreationDeferredForChannelRefresh = false
-		}
-		_lock.unlock()
-		if shouldRecreate {
-			Task { @MainActor in
-				MeshPackets.recreateShared()
-			}
-		}
-	}
-
 	// MARK: - Save Helpers
 
 	/// Set when this instance has been replaced by `recreateShared()`. A retired instance must
 	/// never persist again — see `recreateShared()`.
 	private var invalidated = false
-	private var channelRefreshStages: [Int64: ChannelRefreshStage] = [:]
 
 	func invalidate() {
 		invalidated = true
@@ -260,54 +181,53 @@ actor MeshPackets {
 		debounceSaveTask = nil
 	}
 
-	func beginChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {
-		guard channelRefreshStages[nodeNum] == nil else { return }
-		channelRefreshStages[nodeNum] = ChannelRefreshStage(
-			owner: owner,
-			baseline: currentChannelSnapshot(for: nodeNum),
-			holdsSharedRecreationLease: false
-		)
-	}
-
-	private func beginLeasedChannelRefreshStage(
+	/// Begins a staged refresh for `nodeNum`, capturing the baseline the commit will later
+	/// validate against. Returns false when a stage already exists — unless `owner` is a newer
+	/// generation of the same refresh session, which supersedes the older stage atomically
+	/// (stale-owner cleanup stays owner-scoped, so it cannot discard the successor).
+	@discardableResult
+	func beginChannelRefreshStage(
 		for nodeNum: Int64,
-		owner: AutomaticChannelRefreshOwner?,
-		baseline: [ChannelRefreshSnapshot]?
+		owner: AutomaticChannelRefreshOwner? = nil,
+		baseline: [ChannelRefreshSnapshot]? = nil
 	) -> Bool {
-		if let existingStage = channelRefreshStages[nodeNum] {
-			guard canReplaceLeasedChannelRefreshStage(existingStage, with: owner) else { return false }
-			endChannelRefreshStage(for: nodeNum)
+		let resolvedBaseline = baseline ?? currentChannelSnapshot(for: nodeNum)
+		Self.channelRefreshStagesLock.lock()
+		defer { Self.channelRefreshStagesLock.unlock() }
+		if let existingStage = Self.channelRefreshStages[nodeNum] {
+			guard Self.canReplaceChannelRefreshStage(existingStage, with: owner) else { return false }
 		}
-		channelRefreshStages[nodeNum] = ChannelRefreshStage(
-			owner: owner,
-			baseline: baseline ?? currentChannelSnapshot(for: nodeNum),
-			holdsSharedRecreationLease: true
-		)
+		Self.channelRefreshStages[nodeNum] = ChannelRefreshStage(owner: owner, baseline: resolvedBaseline)
 		return true
 	}
 
-	/// A later automatic refresh for the same connection supersedes an older stage atomically.
-	/// The replacement keeps stale-owner cleanup owner-scoped, so it cannot discard the successor.
-	private func canReplaceLeasedChannelRefreshStage(
+	private static func canReplaceChannelRefreshStage(
 		_ existingStage: ChannelRefreshStage,
 		with owner: AutomaticChannelRefreshOwner?
 	) -> Bool {
-		guard existingStage.holdsSharedRecreationLease,
-			  let existingOwner = existingStage.owner,
+		guard let existingOwner = existingStage.owner,
 			  let owner,
 			  existingOwner.sessionID == owner.sessionID else { return false }
 		return existingOwner.generation < owner.generation
 	}
 
 	func discardChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {
-		guard stageMatches(nodeNum: nodeNum, owner: owner) else { return }
-		endChannelRefreshStage(for: nodeNum)
+		Self.channelRefreshStagesLock.lock()
+		defer { Self.channelRefreshStagesLock.unlock() }
+		guard let stage = Self.channelRefreshStages[nodeNum],
+			  owner == nil || stage.owner == owner else { return }
+		Self.channelRefreshStages.removeValue(forKey: nodeNum)
 	}
 
 	func commitChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) async {
-		guard stageMatches(nodeNum: nodeNum, owner: owner),
-			  let stage = channelRefreshStages[nodeNum] else { return }
-		defer { endChannelRefreshStage(for: nodeNum, stageID: stage.id) }
+		Self.channelRefreshStagesLock.lock()
+		guard let stage = Self.channelRefreshStages[nodeNum],
+			  owner == nil || stage.owner == owner else {
+			Self.channelRefreshStagesLock.unlock()
+			return
+		}
+		Self.channelRefreshStagesLock.unlock()
+		defer { Self.endChannelRefreshStage(for: nodeNum, stageID: stage.id) }
 		guard isCompleteChannelRefresh(stage.channels) else {
 			Logger.data.error("💥 Refusing incomplete staged channel refresh for: \(nodeNum.toHex(), privacy: .public)")
 			return
@@ -754,18 +674,13 @@ actor MeshPackets {
 		return nil
 	}
 
-	private func endChannelRefreshStage(for nodeNum: Int64, stageID: UUID? = nil) {
-		guard let stage = channelRefreshStages[nodeNum],
-			  stageID == nil || stage.id == stageID else { return }
+	/// Removes the stage only when it is still the one the caller worked with — stale async
+	/// work ending late cannot remove a successor's stage.
+	private static func endChannelRefreshStage(for nodeNum: Int64, stageID: UUID) {
+		channelRefreshStagesLock.lock()
+		defer { channelRefreshStagesLock.unlock() }
+		guard let stage = channelRefreshStages[nodeNum], stage.id == stageID else { return }
 		channelRefreshStages.removeValue(forKey: nodeNum)
-		if stage.holdsSharedRecreationLease {
-			MeshPackets.releaseSharedChannelRefreshStageLease()
-		}
-	}
-
-	private func stageMatches(nodeNum: Int64, owner: AutomaticChannelRefreshOwner?) -> Bool {
-		guard let stage = channelRefreshStages[nodeNum] else { return false }
-		return owner == nil || stage.owner == owner
 	}
 
 	private func currentChannelSnapshot(for nodeNum: Int64) -> [ChannelRefreshSnapshot] {
@@ -793,9 +708,14 @@ actor MeshPackets {
 			let logString = String.localizedStringWithFormat("Channel received: %d %@".localized, channel.index, String(fromNum))
 			Logger.admin.info("🎛️ \(logString, privacy: .public)")
 
-			if stageIfRefreshing, channelRefreshStages[fromNum] != nil {
-				channelRefreshStages[fromNum]?.channels[Int32(truncatingIfNeeded: channel.index)] = stagedChannel(from: channel)
-				return
+			if stageIfRefreshing {
+				Self.channelRefreshStagesLock.lock()
+				let isStaging = Self.channelRefreshStages[fromNum] != nil
+				if isStaging {
+					Self.channelRefreshStages[fromNum]?.channels[Int32(truncatingIfNeeded: channel.index)] = stagedChannel(from: channel)
+				}
+				Self.channelRefreshStagesLock.unlock()
+				if isStaging { return }
 			}
 
 			let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == fromNum })

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -105,6 +105,11 @@ actor MeshPackets {
 			baseline: [ChannelRefreshSnapshot]? = nil
 		) async -> Bool {
 			guard claimBegin() else { return false }
+			#if DEBUG
+			if let hook = await MeshPackets.channelRefreshStageBeginHook {
+				await hook()
+			}
+			#endif
 			let didBegin = await packets.beginLeasedChannelRefreshStage(
 				for: nodeNum,
 				owner: owner,
@@ -179,6 +184,8 @@ actor MeshPackets {
 	/// Deterministic concurrency checkpoint used by the refresh boundary regression test. Production
 	/// callers leave this nil, so validation and replacement execute without suspension.
 	@MainActor static var channelRefreshCommitValidationHook: (@MainActor @Sendable () async -> Void)?
+	/// Deterministic concurrency checkpoint used by the late stage activation regression test.
+	@MainActor static var channelRefreshStageBeginHook: (@MainActor @Sendable () async -> Void)?
 	#endif
 
 	static var shared: MeshPackets {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -68,6 +68,18 @@ func generateMessageMarkdown(message: String) -> String {
 
 @ModelActor
 actor MeshPackets {
+	private struct StagedChannel {
+		let id: Int32
+		let index: Int32
+		let uplinkEnabled: Bool
+		let downlinkEnabled: Bool
+		let name: String
+		let role: Int32
+		let psk: Data
+		let positionPrecision: Int32
+		let mute: Bool
+	}
+
 	private struct TelemetryPruneKey: Hashable {
 		let nodeNum: Int64
 		let metricsType: Int32
@@ -114,11 +126,49 @@ actor MeshPackets {
 	/// Set when this instance has been replaced by `recreateShared()`. A retired instance must
 	/// never persist again — see `recreateShared()`.
 	private var invalidated = false
+	private var channelRefreshStages: [Int64: [Int32: StagedChannel]] = [:]
 
 	func invalidate() {
 		invalidated = true
 		debounceSaveTask?.cancel()
 		debounceSaveTask = nil
+		channelRefreshStages.removeAll()
+	}
+
+	func beginChannelRefreshStage(for nodeNum: Int64) {
+		channelRefreshStages[nodeNum] = [:]
+	}
+
+	func discardChannelRefreshStage(for nodeNum: Int64) {
+		channelRefreshStages[nodeNum] = nil
+	}
+
+	func commitChannelRefreshStage(for nodeNum: Int64) {
+		guard let stagedChannels = channelRefreshStages.removeValue(forKey: nodeNum) else { return }
+		let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == nodeNum })
+		do {
+			let fetchedMyInfo = try modelContext.fetch(fetchDescriptor)
+			guard fetchedMyInfo.count == 1 else {
+				Logger.data.error("💥Trying to commit staged channels to a MyInfo that does not exist: \(nodeNum.toHex(), privacy: .public)")
+				return
+			}
+			let myInfo = fetchedMyInfo[0]
+			for channel in myInfo.channels {
+				modelContext.delete(channel)
+			}
+			myInfo.channels.removeAll()
+			for staged in stagedChannels.values.sorted(by: { $0.index < $1.index }) {
+				let channel = ChannelEntity()
+				modelContext.insert(channel)
+				apply(stagedChannel: staged, to: channel)
+				myInfo.channels.append(channel)
+			}
+			savePendingChanges()
+			Logger.data.info("💾 Committed \(stagedChannels.count, privacy: .public) staged channel(s) for: \(nodeNum, privacy: .public)")
+		} catch {
+			let nsError = error as NSError
+			Logger.data.error("💥 Error committing staged channels from ADMIN_APP \(nsError, privacy: .public)")
+		}
 	}
 
 	/// Saves any pending changes in the model context. Call once at the end of each
@@ -447,6 +497,11 @@ actor MeshPackets {
 			let logString = String.localizedStringWithFormat("Channel received: %d %@".localized, channel.index, String(fromNum))
 			Logger.admin.info("🎛️ \(logString, privacy: .public)")
 
+			if channelRefreshStages[fromNum] != nil {
+				channelRefreshStages[fromNum]?[Int32(truncatingIfNeeded: channel.index)] = stagedChannel(from: channel)
+				return
+			}
+
 			let fetchDescriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == fromNum })
 
 			do {
@@ -461,23 +516,7 @@ actor MeshPackets {
 						modelContext.insert(newChannel)
 						fetchedMyInfo[0].channels.append(newChannel)
 					}
-					newChannel.id = Int32(truncatingIfNeeded: channel.index)
-					newChannel.index = Int32(truncatingIfNeeded: channel.index)
-					newChannel.uplinkEnabled = channel.settings.uplinkEnabled
-					newChannel.downlinkEnabled = channel.settings.downlinkEnabled
-					newChannel.name = channel.settings.name
-					newChannel.role = Int32(channel.role.rawValue)
-					newChannel.psk = channel.settings.psk
-					if channel.settings.hasModuleSettings {
-						newChannel.positionPrecision = Int32(truncatingIfNeeded: channel.settings.moduleSettings.positionPrecision)
-						newChannel.mute = channel.settings.moduleSettings.isMuted
-					} else {
-						// When moduleSettings is absent, use proto3 defaults (0/false)
-						// rather than the entity default of 32, which would incorrectly
-						// enable full-precision position sharing.
-						newChannel.positionPrecision = 0
-						newChannel.mute = false
-					}
+					apply(stagedChannel: stagedChannel(from: channel), to: newChannel)
 					savePendingChanges()
 					Logger.data.info("💾 Updated MyInfo channel \(channel.index, privacy: .public) from Channel App Packet For: \(fetchedMyInfo[0].myNodeNum, privacy: .public)")
 				} else if channel.role.rawValue > 0 {
@@ -488,6 +527,44 @@ actor MeshPackets {
 				Logger.data.error("💥 Error Saving MyInfo Channel from ADMIN_APP \(nsError, privacy: .public)")
 			}
 		}
+	}
+
+	private func stagedChannel(from channel: Channel) -> StagedChannel {
+		let positionPrecision: Int32
+		let mute: Bool
+		if channel.settings.hasModuleSettings {
+			positionPrecision = Int32(truncatingIfNeeded: channel.settings.moduleSettings.positionPrecision)
+			mute = channel.settings.moduleSettings.isMuted
+		} else {
+			// When moduleSettings is absent, use proto3 defaults (0/false)
+			// rather than the entity default of 32, which would incorrectly
+			// enable full-precision position sharing.
+			positionPrecision = 0
+			mute = false
+		}
+		return StagedChannel(
+			id: Int32(truncatingIfNeeded: channel.index),
+			index: Int32(truncatingIfNeeded: channel.index),
+			uplinkEnabled: channel.settings.uplinkEnabled,
+			downlinkEnabled: channel.settings.downlinkEnabled,
+			name: channel.settings.name,
+			role: Int32(channel.role.rawValue),
+			psk: channel.settings.psk,
+			positionPrecision: positionPrecision,
+			mute: mute
+		)
+	}
+
+	private func apply(stagedChannel: StagedChannel, to channel: ChannelEntity) {
+		channel.id = stagedChannel.id
+		channel.index = stagedChannel.index
+		channel.uplinkEnabled = stagedChannel.uplinkEnabled
+		channel.downlinkEnabled = stagedChannel.downlinkEnabled
+		channel.name = stagedChannel.name
+		channel.role = stagedChannel.role
+		channel.psk = stagedChannel.psk
+		channel.positionPrecision = stagedChannel.positionPrecision
+		channel.mute = stagedChannel.mute
 	}
 
 	func deviceMetadataPacket (metadata: DeviceMetadata, fromNum: Int64, sessionPasskey: Data? = Data()) {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -273,13 +273,29 @@ actor MeshPackets {
 		owner: AutomaticChannelRefreshOwner?,
 		baseline: [ChannelRefreshSnapshot]?
 	) -> Bool {
-		guard channelRefreshStages[nodeNum] == nil else { return false }
+		if let existingStage = channelRefreshStages[nodeNum] {
+			guard canReplaceLeasedChannelRefreshStage(existingStage, with: owner) else { return false }
+			endChannelRefreshStage(for: nodeNum)
+		}
 		channelRefreshStages[nodeNum] = ChannelRefreshStage(
 			owner: owner,
 			baseline: baseline ?? currentChannelSnapshot(for: nodeNum),
 			holdsSharedRecreationLease: true
 		)
 		return true
+	}
+
+	/// A later automatic refresh for the same connection supersedes an older stage atomically.
+	/// The replacement keeps stale-owner cleanup owner-scoped, so it cannot discard the successor.
+	private func canReplaceLeasedChannelRefreshStage(
+		_ existingStage: ChannelRefreshStage,
+		with owner: AutomaticChannelRefreshOwner?
+	) -> Bool {
+		guard existingStage.holdsSharedRecreationLease,
+			  let existingOwner = existingStage.owner,
+			  let owner,
+			  existingOwner.sessionID == owner.sessionID else { return false }
+		return existingOwner.generation < owner.generation
 	}
 
 	func discardChannelRefreshStage(for nodeNum: Int64, owner: AutomaticChannelRefreshOwner? = nil) {

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -28,6 +28,19 @@ func projectedDisplayChannels(from channels: [ChannelEntity]) -> [ChannelEntity]
 	return byIndex.values.sorted { $0.index < $1.index }
 }
 
+func validUniqueChannelIndexes(from channels: [ChannelEntity]) -> [Int32] {
+	Set(channels.map(\.index).filter { (Int32(0)...Int32(7)).contains($0) }).sorted()
+}
+
+func availableChannelIndexes(from channels: [ChannelEntity]) -> [Int32] {
+	let occupied = Set(validUniqueChannelIndexes(from: channels))
+	return (Int32(0)...Int32(7)).filter { !occupied.contains($0) }
+}
+
+func nextAvailableSecondaryChannelIndex(from channels: [ChannelEntity]) -> Int32? {
+	availableChannelIndexes(from: channels).first { $0 > 0 }
+}
+
 struct Channels: View {
 
 	@Environment(\.modelContext) private var context
@@ -164,16 +177,12 @@ struct Channels: View {
 						.buttonStyle(.plain)
 					}
 				}
-				if (node.myInfo?.channels.count ?? 0) < 8 {
+				if let nextChannelIndex = nextAvailableSecondaryChannelIndex(from: node.myInfo?.channels ?? []) {
 					Button {
-						let channelIndexes = node.myInfo?.channels.compactMap({ ch -> Int in
-							return Int(ch.index)
-						})
-						let firstChannelIndex = firstMissingChannelIndex(channelIndexes ?? [])
 						channelKeySize = 16
 						let key = generateChannelKey(size: channelKeySize)
 						channelName = ""
-						channelIndex = Int32(firstChannelIndex)
+						channelIndex = nextChannelIndex
 						channelRole = 2
 						channelKey = key
 						positionsEnabled = false
@@ -352,17 +361,6 @@ struct Channels: View {
 			}
 		}
 	}
-}
-
-func firstMissingChannelIndex(_ indexes: [Int]) -> Int {
-	let smallestIndex = 1
-	if indexes.isEmpty { return smallestIndex }
-	if smallestIndex <= indexes.count {
-		for element in smallestIndex...indexes.count where !indexes.contains(element) {
-			return element
-		}
-	}
-	return indexes.count + 1
 }
 
 enum PositionPrecision: Int, CaseIterable, Identifiable {

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -20,6 +20,14 @@ func generateChannelKey(size: Int) -> String {
 	return keyData.base64EncodedString()
 }
 
+func projectedDisplayChannels(from channels: [ChannelEntity]) -> [ChannelEntity] {
+	var byIndex: [Int32: ChannelEntity] = [:]
+	for channel in channels {
+		byIndex[channel.index] = channel
+	}
+	return byIndex.values.sorted { $0.index < $1.index }
+}
+
 struct Channels: View {
 
 	@Environment(\.modelContext) private var context
@@ -52,11 +60,7 @@ struct Channels: View {
 
 	private var displayChannels: [ChannelEntity] {
 		guard let channels = node.myInfo?.channels else { return [] }
-		var byIndex: [Int32: ChannelEntity] = [:]
-		for channel in channels {
-			byIndex[channel.index] = channel
-		}
-		return byIndex.values.sorted { $0.index < $1.index }
+		return projectedDisplayChannels(from: channels)
 	}
 
 	private var locationSharingChannelIndex: Int32? {
@@ -87,23 +91,6 @@ struct Channels: View {
 
 	private var channelFrequencySummary: ChannelFrequencySummary? {
 		ChannelFrequencySummary(loRaConfig: node.loRaConfig, primaryChannelName: primaryChannelName)
-	}
-
-	private func normalizeDuplicateChannelsIfNeeded() {
-		guard let channels = node.myInfo?.channels else { return }
-		var uniqueChannels: [Int32: ChannelEntity] = [:]
-		for channel in channels {
-			uniqueChannels[channel.index] = channel
-		}
-		let deduped = uniqueChannels.values.sorted { $0.index < $1.index }
-		guard deduped.count != channels.count else { return }
-		node.myInfo?.channels = deduped
-		do {
-			try context.save()
-			Logger.data.info("💾 Normalized duplicate channels for node \(self.node.num, privacy: .public)")
-		} catch {
-			Logger.data.error("Failed normalizing duplicate channels: \(error.localizedDescription, privacy: .public)")
-		}
 	}
 
 	var body: some View {
@@ -359,9 +346,6 @@ struct Channels: View {
 		}
 		.padding(.bottom, 5)
 		.navigationTitle("Channels")
-		.onAppear {
-			normalizeDuplicateChannelsIfNeeded()
-		}
 		.toolbar {
 			ToolbarItem(placement: .topBarTrailing) {
 				ConnectedDevice(deviceConnected: accessoryManager.isConnected, name: accessoryManager.activeConnection?.device.shortName ?? "?")

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -21,15 +21,19 @@ func generateChannelKey(size: Int) -> String {
 }
 
 func projectedDisplayChannels(from channels: [ChannelEntity]) -> [ChannelEntity] {
+	canonicalValidUniqueChannels(from: channels)
+}
+
+func canonicalValidUniqueChannels(from channels: [ChannelEntity]) -> [ChannelEntity] {
 	var byIndex: [Int32: ChannelEntity] = [:]
-	for channel in channels {
+	for channel in channels where (Int32(0)...Int32(7)).contains(channel.index) {
 		byIndex[channel.index] = channel
 	}
 	return byIndex.values.sorted { $0.index < $1.index }
 }
 
 func validUniqueChannelIndexes(from channels: [ChannelEntity]) -> [Int32] {
-	Set(channels.map(\.index).filter { (Int32(0)...Int32(7)).contains($0) }).sorted()
+	canonicalValidUniqueChannels(from: channels).map(\.index)
 }
 
 func availableChannelIndexes(from channels: [ChannelEntity]) -> [Int32] {
@@ -39,6 +43,22 @@ func availableChannelIndexes(from channels: [ChannelEntity]) -> [Int32] {
 
 func nextAvailableSecondaryChannelIndex(from channels: [ChannelEntity]) -> Int32? {
 	availableChannelIndexes(from: channels).first { $0 > 0 }
+}
+
+func channelSettingsForSharing(
+	from channels: [ChannelEntity],
+	includedIndexes: Set<Int32>
+) -> [ChannelSettings] {
+	canonicalValidUniqueChannels(from: channels).compactMap { channel in
+		guard channel.role > 0, includedIndexes.contains(channel.index) else { return nil }
+		var settings = ChannelSettings()
+		settings.name = channel.name ?? ""
+		settings.psk = channel.psk ?? Data()
+		settings.id = UInt32(truncatingIfNeeded: channel.id)
+		settings.moduleSettings.positionPrecision = UInt32(truncatingIfNeeded: channel.positionPrecision)
+		settings.moduleSettings.isMuted = channel.mute
+		return settings
+	}
 }
 
 struct Channels: View {

--- a/Meshtastic/Views/Settings/SaveChannelQRCode.swift
+++ b/Meshtastic/Views/Settings/SaveChannelQRCode.swift
@@ -294,7 +294,7 @@ struct SaveChannelQRCode: View {
 			}
 			let channels = node.myInfo?.channels ?? []
 			let names = Set(channels.compactMap { $0.name?.isEmpty == false ? $0.name : nil })
-			return (names, channels.count, node.loRaConfig?.toProto())
+			return (names, validUniqueChannelIndexes(from: channels).count, node.loRaConfig?.toProto())
 		} catch {
 			Logger.data.error("Failed to fetch current channel state: \(error.localizedDescription, privacy: .public)")
 			return ([], 0, nil)

--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -52,13 +52,25 @@ struct ShareChannels: View {
 	@State private var showingHelp = false
 
 	private var shareableChannels: [ChannelEntity] {
-		(node?.myInfo?.channels ?? [])
+		canonicalValidUniqueChannels(from: node?.myInfo?.channels ?? [])
 			.filter { $0.role > 0 }
-			.sorted { $0.index < $1.index }
 	}
 
 	private var channelQRMode: ChannelQRMode {
 		ChannelQRMode(addChannels: !replaceChannels)
+	}
+
+	private var includedChannelIndexes: Set<Int32> {
+		var indexes = Set<Int32>()
+		if includeChannel0 { indexes.insert(0) }
+		if includeChannel1 { indexes.insert(1) }
+		if includeChannel2 { indexes.insert(2) }
+		if includeChannel3 { indexes.insert(3) }
+		if includeChannel4 { indexes.insert(4) }
+		if includeChannel5 { indexes.insert(5) }
+		if includeChannel6 { indexes.insert(6) }
+		if includeChannel7 { indexes.insert(7) }
+		return indexes
 	}
 
 	var body: some View {
@@ -287,55 +299,10 @@ struct ShareChannels: View {
 			return
 		}
 
-		for ch in node?.myInfo?.channels ?? [] where ch.role > 0 {
-			var includeChannel = false
-			switch ch.index {
-			case 0:
-				if includeChannel0 {
-					includeChannel = true
-				}
-			case 1:
-				if includeChannel1 {
-					includeChannel = true
-				}
-			case 2:
-				if includeChannel2 {
-					includeChannel = true
-				}
-			case 3:
-				if includeChannel3 {
-					includeChannel = true
-				}
-			case 4:
-				if includeChannel4 {
-					includeChannel = true
-				}
-			case 5:
-				if includeChannel5 {
-					includeChannel = true
-				}
-			case 6:
-				if includeChannel6 {
-					includeChannel = true
-				}
-			case 7:
-				if includeChannel7 {
-					includeChannel = true
-				}
-			default:
-				includeChannel = false
-			}
-
-			if includeChannel {
-				var channelSettings = ChannelSettings()
-				channelSettings.name = ch.name ?? ""
-				channelSettings.psk = ch.psk ?? Data()
-				channelSettings.id = UInt32(ch.id)
-				channelSettings.moduleSettings.positionPrecision = UInt32(ch.positionPrecision)
-				channelSettings.moduleSettings.isMuted = ch.mute
-				channelSet.settings.append(channelSettings)
-			}
-		}
+		channelSet.settings = channelSettingsForSharing(
+			from: node?.myInfo?.channels ?? [],
+			includedIndexes: includedChannelIndexes
+		)
 
 		guard !channelSet.settings.isEmpty else {
 			channelsUrl = ""

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -63,6 +63,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 	private func resetSharedStore() {
 		PersistenceController.shared.recreateContainer()
 		MeshPackets.recreateShared()
+		MeshPackets.resetChannelRefreshStagesForTesting()
 	}
 
 	private func makeManager(
@@ -617,14 +618,13 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		let sessionID = UUID()
 		let staleOwner = AutomaticChannelRefreshOwner(sessionID: sessionID, generation: 1)
 		let successorOwner = AutomaticChannelRefreshOwner(sessionID: sessionID, generation: 2)
-		let staleLease = MeshPackets.acquireSharedChannelRefreshStageLease()
-		#expect(await staleLease.begin(for: Int64(nodeNum), owner: staleOwner))
+		#expect(await MeshPackets.shared.beginChannelRefreshStage(for: Int64(nodeNum), owner: staleOwner))
 
-		await staleLease.packets.channelPacket(
+		await MeshPackets.shared.channelPacket(
 			channel: channel(index: 0, name: "Stale Primary"),
 			fromNum: Int64(nodeNum)
 		)
-		await stageDisabledSlotsOnMesh(staleLease.packets, nodeNum: Int64(nodeNum))
+		await stageDisabledSlotsOnMesh(MeshPackets.shared, nodeNum: Int64(nodeNum))
 
 		let validationReached = AsyncGate()
 		let allowCommitToContinue = AsyncGate()
@@ -635,22 +635,21 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		defer { MeshPackets.channelRefreshCommitValidationHook = nil }
 
 		let staleCommit = Task {
-			await staleLease.packets.commitChannelRefreshStage(for: Int64(nodeNum), owner: staleOwner)
+			await MeshPackets.shared.commitChannelRefreshStage(for: Int64(nodeNum), owner: staleOwner)
 		}
 		try await validationReached.wait()
 
-		let successorLease = MeshPackets.acquireSharedChannelRefreshStageLease()
-		#expect(await successorLease.begin(for: Int64(nodeNum), owner: successorOwner))
+		#expect(await MeshPackets.shared.beginChannelRefreshStage(for: Int64(nodeNum), owner: successorOwner))
 		await allowCommitToContinue.open()
 		await staleCommit.value
 
 		// An incomplete successor must remain staged. If stale cleanup removed it, this packet
 		// is handled directly and changes the persisted primary channel instead.
-		await successorLease.packets.channelPacket(
+		await MeshPackets.shared.channelPacket(
 			channel: channel(index: 0, name: "Successor Primary"),
 			fromNum: Int64(nodeNum)
 		)
-		await successorLease.packets.commitChannelRefreshStage(for: Int64(nodeNum), owner: successorOwner)
+		await MeshPackets.shared.commitChannelRefreshStage(for: Int64(nodeNum), owner: successorOwner)
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["Stale Primary"])
 	}
@@ -687,21 +686,21 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		#expect(try channelNames(nodeNum: nodeNum) == ["Refreshed Primary"])
 	}
 
-	@Test("A refresh lease prevents recycling after shared capture but before stage activation")
-	func refreshLeaseMakesSharedCaptureAndRecycleGuardAtomic() async throws {
+	@Test("A staged refresh survives shared actor recreation mid-refresh")
+	func stageSurvivesSharedActorRecreationMidRefresh() async throws {
 		resetSharedStore()
 		let nodeNum: UInt32 = 0x001E_A5ED
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
 		let owner = AutomaticChannelRefreshOwner(sessionID: UUID(), generation: 1)
-		let lease = MeshPackets.acquireSharedChannelRefreshStageLease()
-		let capturedMesh = lease.packets
+		#expect(await MeshPackets.shared.beginChannelRefreshStage(for: Int64(nodeNum), owner: owner))
 
+		// The stage is static state, so recycling the shared actor between begin and the
+		// incoming channel frames must not orphan the refresh — the successor instance
+		// continues staging into and committing from the same storage.
 		MeshPackets.recreateShared()
-		#expect(MeshPackets.shared === capturedMesh)
-		#expect(await lease.begin(for: Int64(nodeNum), owner: owner))
 
 		await MeshPackets.shared.channelPacket(
-			channel: channel(index: 0, name: "Leased Primary"),
+			channel: channel(index: 0, name: "Recreated Primary"),
 			fromNum: Int64(nodeNum)
 		)
 		for index in Int32(1)...Int32(7) {
@@ -715,7 +714,7 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		await MeshPackets.shared.commitChannelRefreshStage(for: Int64(nodeNum), owner: owner)
 		await Task.yield()
 
-		#expect(try channelNames(nodeNum: nodeNum) == ["Leased Primary"])
+		#expect(try channelNames(nodeNum: nodeNum) == ["Recreated Primary"])
 	}
 
 	@Test("A successor refresh stage survives stale owner cleanup")
@@ -726,14 +725,12 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		let sessionID = UUID()
 		let staleOwner = AutomaticChannelRefreshOwner(sessionID: sessionID, generation: 1)
 		let successorOwner = AutomaticChannelRefreshOwner(sessionID: sessionID, generation: 2)
-		let staleLease = MeshPackets.acquireSharedChannelRefreshStageLease()
-		#expect(await staleLease.begin(for: Int64(nodeNum), owner: staleOwner))
+		#expect(await MeshPackets.shared.beginChannelRefreshStage(for: Int64(nodeNum), owner: staleOwner))
 
-		let successorLease = MeshPackets.acquireSharedChannelRefreshStageLease()
-		#expect(await successorLease.begin(for: Int64(nodeNum), owner: successorOwner))
-		await staleLease.packets.discardChannelRefreshStage(for: Int64(nodeNum), owner: staleOwner)
+		#expect(await MeshPackets.shared.beginChannelRefreshStage(for: Int64(nodeNum), owner: successorOwner))
+		await MeshPackets.shared.discardChannelRefreshStage(for: Int64(nodeNum), owner: staleOwner)
 
-		await successorLease.packets.channelPacket(
+		await MeshPackets.shared.channelPacket(
 			channel: channel(index: 0, name: "Successor Primary"),
 			fromNum: Int64(nodeNum)
 		)
@@ -741,51 +738,11 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 			var disabled = Channel()
 			disabled.index = index
 			disabled.role = .disabled
-			await successorLease.packets.channelPacket(channel: disabled, fromNum: Int64(nodeNum))
+			await MeshPackets.shared.channelPacket(channel: disabled, fromNum: Int64(nodeNum))
 		}
-		await successorLease.packets.commitChannelRefreshStage(for: Int64(nodeNum), owner: successorOwner)
+		await MeshPackets.shared.commitChannelRefreshStage(for: Int64(nodeNum), owner: successorOwner)
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["Successor Primary"])
-	}
-
-	@Test("Disconnect before delayed stage activation releases the late refresh lease")
-	func disconnectBeforeDelayedStageActivationReleasesLateRefreshLease() async throws {
-		resetSharedStore()
-		let nodeNum: UInt32 = 0x00D1_A17E
-		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
-		let connection = ChannelRefreshLifecycleConnection()
-		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
-		let stageBeginReached = AsyncGate()
-		let allowStageBegin = AsyncGate()
-		let capturedMesh = MeshPackets.shared
-
-		MeshPackets.channelRefreshStageBeginHook = {
-			await stageBeginReached.open()
-			try? await allowStageBegin.wait()
-		}
-		defer { MeshPackets.channelRefreshStageBeginHook = nil }
-
-		let delayedStageBegin = Task {
-			await manager.beginAutomaticChannelRefreshStageIfNeeded(for: Int64(nodeNum))
-		}
-		try await stageBeginReached.wait()
-
-		try await manager.closeConnection()
-		await #expect(throws: CancellationError.self) {
-			try await refresh.value
-		}
-		MeshPackets.recreateShared()
-		#expect(MeshPackets.shared === capturedMesh)
-
-		await allowStageBegin.open()
-		await delayedStageBegin.value
-		for _ in 0..<100 where MeshPackets.shared === capturedMesh {
-			await Task.yield()
-		}
-
-		let didRecreateSharedMesh = MeshPackets.shared !== capturedMesh
-		#expect(didRecreateSharedMesh)
 	}
 
 	@Test("A rejected refresh releases its stage so later radio packets use direct handling")
@@ -815,7 +772,7 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		#expect(try channelNames(nodeNum: nodeNum) == ["Later Radio Primary"])
 	}
 
-	@Test("A drain failure releases its lease and returns later packets to direct handling")
+	@Test("A drain failure discards its stage and returns later packets to direct handling")
 	func failedRefreshReturnsToDirectChannelHandling() async throws {
 		resetSharedStore()
 		let nodeNum: UInt32 = 0x00FA_11ED
@@ -828,17 +785,18 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Failed Refresh Primary"))
-		let stagedMesh = MeshPackets.shared
+		// Stage state is static, so recycling the shared actor mid-refresh is allowed and
+		// must not disturb the in-flight stage: the staged packet stays unpersisted.
 		MeshPackets.recreateShared()
-		#expect(MeshPackets.shared === stagedMesh)
+		#expect(try channelNames(nodeNum: nodeNum) == ["Original Primary"])
 
 		await connection.resumePausedWantConfigSend()
 		await #expect(throws: AccessoryError.self) {
 			try await refresh.value
 		}
-		await Task.yield()
-		#expect(MeshPackets.shared !== stagedMesh)
 
+		// The failed refresh discarded its stage, so a later radio packet is handled
+		// directly instead of accumulating into an orphaned stage.
 		await manager.handleChannel(channel(index: 0, name: "Later Radio Primary"))
 		#expect(try channelNames(nodeNum: nodeNum) == ["Later Radio Primary"])
 	}

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -16,6 +16,7 @@ private actor ChannelRefreshLifecycleConnection: Connection {
 	private(set) var sentWantConfigIDs: [UInt32] = []
 	private var pauseNextConfigSend = false
 	private var pausedConfigSendContinuation: CheckedContinuation<Void, Never>?
+	private var failNextDrain = false
 
 	func pauseNextWantConfigSend() {
 		pauseNextConfigSend = true
@@ -24,6 +25,10 @@ private actor ChannelRefreshLifecycleConnection: Connection {
 	func resumePausedWantConfigSend() {
 		pausedConfigSendContinuation?.resume()
 		pausedConfigSendContinuation = nil
+	}
+
+	func failNextPendingPacketDrain() {
+		failNextDrain = true
 	}
 
 	func send(_ data: ToRadio) async throws {
@@ -40,7 +45,12 @@ private actor ChannelRefreshLifecycleConnection: Connection {
 	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
 	func disconnect(withError: Error?, shouldReconnect: Bool) async throws { isConnected = false }
 	func drainPendingPackets() async throws {}
-	func startDrainPendingPackets() throws {}
+	func startDrainPendingPackets() throws {
+		if failNextDrain {
+			failNextDrain = false
+			throw AccessoryError.ioFailed("Simulated pending-packet drain failure")
+		}
+	}
 	func appDidEnterBackground() {}
 	func appDidBecomeActive() {}
 }
@@ -415,15 +425,14 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		await manager.handleChannel(channel(index: 2, name: "Remote Moved", role: .secondary))
 		await stageDisabledSlots(manager, excluding: [1, 2])
 
-		await MeshPackets.shared.channelPacket(
-			channel: channel(index: 0, name: "User Renamed Primary"),
-			fromNum: Int64(nodeNum),
-			stageIfRefreshing: false
+		try manager.applyLocalChannelMutation(
+			channel(index: 0, name: "User Renamed Primary"),
+			fromNum: Int64(nodeNum)
 		)
 		var deleted = Channel()
 		deleted.index = 1
 		deleted.role = .disabled
-		await MeshPackets.shared.channelPacket(channel: deleted, fromNum: Int64(nodeNum), stageIfRefreshing: false)
+		try manager.applyLocalChannelMutation(deleted, fromNum: Int64(nodeNum))
 		let context = PersistenceController.shared.context
 		let persistedNodeNum = Int64(nodeNum)
 		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
@@ -437,5 +446,164 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try await refresh.value
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["User Renamed Primary", "Move Me"])
+	}
+
+}
+
+extension AccessoryManagerChannelRefreshLifecycleTests {
+	@Test("A main-context edit at the validated refresh boundary survives")
+	func userEditAfterBaselineValidationCausesRefreshDiscard() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00B0_A4D1
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let validationReached = AsyncGate()
+		let allowCommitToContinue = AsyncGate()
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Remote Primary"))
+		await stageDisabledSlots(manager)
+
+		MeshPackets.channelRefreshCommitValidationHook = {
+			await validationReached.open()
+			try? await allowCommitToContinue.wait()
+		}
+		defer { MeshPackets.channelRefreshCommitValidationHook = nil }
+
+		let completion = Task { await completeConfig(manager) }
+		try await validationReached.wait()
+
+		let context = PersistenceController.shared.context
+		let persistedNodeNum = Int64(nodeNum)
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		let myInfo = try #require(context.fetch(descriptor).first)
+		myInfo.channels[0].name = "User Primary"
+		try context.save()
+
+		await allowCommitToContinue.open()
+		await completion.value
+		try await refresh.value
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["User Primary"])
+	}
+
+	@Test("Cancelling the sole waiter keeps the in-flight fixed-nonce refresh alive for a later caller")
+	func cancellingSoleWaiterDoesNotRetireInFlightRefresh() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00CA_11ED
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		await connection.pauseNextWantConfigSend()
+
+		let cancelledWaiter = Task { try await manager.sendWantConfig() }
+		while await connection.sentWantConfigIDs.count < 1 {
+			await Task.yield()
+		}
+		cancelledWaiter.cancel()
+		await #expect(throws: CancellationError.self) {
+			try await cancelledWaiter.value
+		}
+
+		let joinedWaiter = Task { try await manager.sendWantConfig() }
+		await Task.yield()
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Refreshed Primary"))
+		await stageDisabledSlots(manager)
+
+		await connection.resumePausedWantConfigSend()
+		await completeConfig(manager)
+		try await joinedWaiter.value
+
+		#expect(await connection.sentWantConfigIDs == [UInt32(manager.NONCE_ONLY_CONFIG)])
+		#expect(try channelNames(nodeNum: nodeNum) == ["Refreshed Primary"])
+	}
+
+	@Test("A refresh lease prevents recycling after shared capture but before stage activation")
+	func refreshLeaseMakesSharedCaptureAndRecycleGuardAtomic() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x001E_A5ED
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
+		let owner = AutomaticChannelRefreshOwner(sessionID: UUID(), generation: 1)
+		let lease = MeshPackets.acquireSharedChannelRefreshStageLease()
+		let capturedMesh = lease.packets
+
+		MeshPackets.recreateShared()
+		#expect(MeshPackets.shared === capturedMesh)
+		#expect(await lease.begin(for: Int64(nodeNum), owner: owner))
+
+		await MeshPackets.shared.channelPacket(
+			channel: channel(index: 0, name: "Leased Primary"),
+			fromNum: Int64(nodeNum)
+		)
+		for index in Int32(1)...Int32(7) {
+			var disabled = Channel()
+			disabled.index = index
+			disabled.role = .disabled
+			await MeshPackets.shared.channelPacket(channel: disabled, fromNum: Int64(nodeNum))
+		}
+		#expect(try channelNames(nodeNum: nodeNum) == ["Old Primary"])
+
+		await MeshPackets.shared.commitChannelRefreshStage(for: Int64(nodeNum), owner: owner)
+		await Task.yield()
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Leased Primary"])
+	}
+
+	@Test("A rejected refresh releases its stage so later radio packets use direct handling")
+	func rejectedRefreshStageReturnsToDirectChannelHandling() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00AE_1EC7
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Remote Primary"))
+		await stageDisabledSlots(manager)
+
+		let context = PersistenceController.shared.context
+		let persistedNodeNum = Int64(nodeNum)
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		let myInfo = try #require(context.fetch(descriptor).first)
+		myInfo.channels[0].name = "User Primary"
+		try context.save()
+
+		await completeConfig(manager)
+		try await refresh.value
+		await manager.handleChannel(channel(index: 0, name: "Later Radio Primary"))
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Later Radio Primary"])
+	}
+
+	@Test("A drain failure releases its lease and returns later packets to direct handling")
+	func failedRefreshReturnsToDirectChannelHandling() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00FA_11ED
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		await connection.pauseNextWantConfigSend()
+		await connection.failNextPendingPacketDrain()
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Failed Refresh Primary"))
+		let stagedMesh = MeshPackets.shared
+		MeshPackets.recreateShared()
+		#expect(MeshPackets.shared === stagedMesh)
+
+		await connection.resumePausedWantConfigSend()
+		await #expect(throws: AccessoryError.self) {
+			try await refresh.value
+		}
+		await Task.yield()
+		#expect(MeshPackets.shared !== stagedMesh)
+
+		await manager.handleChannel(channel(index: 0, name: "Later Radio Primary"))
+		#expect(try channelNames(nodeNum: nodeNum) == ["Later Radio Primary"])
 	}
 }

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -142,6 +142,15 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		}
 	}
 
+	private func stageDisabledSlotsOnMesh(_ mesh: MeshPackets, nodeNum: Int64) async {
+		for index in Int32(1)...Int32(7) {
+			var disabled = Channel()
+			disabled.index = index
+			disabled.role = .disabled
+			await mesh.channelPacket(channel: disabled, fromNum: nodeNum)
+		}
+	}
+
 	private func startAutomaticConfigRefresh(
 		_ manager: AccessoryManager,
 		connection: ChannelRefreshLifecycleConnection
@@ -540,6 +549,52 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		try await refresh.value
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["User Primary"])
+	}
+
+	@Test("A successor staged refresh survives an older paused commit's cleanup")
+	func successorStageSurvivesPausedOlderCommitCleanup() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00B0_A4D2
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let sessionID = UUID()
+		let staleOwner = AutomaticChannelRefreshOwner(sessionID: sessionID, generation: 1)
+		let successorOwner = AutomaticChannelRefreshOwner(sessionID: sessionID, generation: 2)
+		let staleLease = MeshPackets.acquireSharedChannelRefreshStageLease()
+		#expect(await staleLease.begin(for: Int64(nodeNum), owner: staleOwner))
+
+		await staleLease.packets.channelPacket(
+			channel: channel(index: 0, name: "Stale Primary"),
+			fromNum: Int64(nodeNum)
+		)
+		await stageDisabledSlotsOnMesh(staleLease.packets, nodeNum: Int64(nodeNum))
+
+		let validationReached = AsyncGate()
+		let allowCommitToContinue = AsyncGate()
+		MeshPackets.channelRefreshCommitValidationHook = {
+			await validationReached.open()
+			try? await allowCommitToContinue.wait()
+		}
+		defer { MeshPackets.channelRefreshCommitValidationHook = nil }
+
+		let staleCommit = Task {
+			await staleLease.packets.commitChannelRefreshStage(for: Int64(nodeNum), owner: staleOwner)
+		}
+		try await validationReached.wait()
+
+		let successorLease = MeshPackets.acquireSharedChannelRefreshStageLease()
+		#expect(await successorLease.begin(for: Int64(nodeNum), owner: successorOwner))
+		await allowCommitToContinue.open()
+		await staleCommit.value
+
+		// An incomplete successor must remain staged. If stale cleanup removed it, this packet
+		// is handled directly and changes the persisted primary channel instead.
+		await successorLease.packets.channelPacket(
+			channel: channel(index: 0, name: "Successor Primary"),
+			fromNum: Int64(nodeNum)
+		)
+		await successorLease.packets.commitChannelRefreshStage(for: Int64(nodeNum), owner: successorOwner)
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Stale Primary"])
 	}
 
 	@Test("Cancelling the sole waiter keeps the in-flight fixed-nonce refresh alive for a later caller")

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -605,6 +605,46 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		#expect(try channelNames(nodeNum: nodeNum) == ["Leased Primary"])
 	}
 
+	@Test("Disconnect before delayed stage activation releases the late refresh lease")
+	func disconnectBeforeDelayedStageActivationReleasesLateRefreshLease() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00D1_A17E
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let stageBeginReached = AsyncGate()
+		let allowStageBegin = AsyncGate()
+		let capturedMesh = MeshPackets.shared
+
+		MeshPackets.channelRefreshStageBeginHook = {
+			await stageBeginReached.open()
+			try? await allowStageBegin.wait()
+		}
+		defer { MeshPackets.channelRefreshStageBeginHook = nil }
+
+		let delayedStageBegin = Task {
+			await manager.beginAutomaticChannelRefreshStageIfNeeded(for: Int64(nodeNum))
+		}
+		try await stageBeginReached.wait()
+
+		try await manager.closeConnection()
+		await #expect(throws: CancellationError.self) {
+			try await refresh.value
+		}
+		MeshPackets.recreateShared()
+		#expect(MeshPackets.shared === capturedMesh)
+
+		await allowStageBegin.open()
+		await delayedStageBegin.value
+		for _ in 0..<100 where MeshPackets.shared === capturedMesh {
+			await Task.yield()
+		}
+
+		let didRecreateSharedMesh = MeshPackets.shared !== capturedMesh
+		#expect(didRecreateSharedMesh)
+	}
+
 	@Test("A rejected refresh releases its stage so later radio packets use direct handling")
 	func rejectedRefreshStageReturnsToDirectChannelHandling() async throws {
 		resetSharedStore()

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -13,8 +13,13 @@ import MeshtasticProtobufs
 private actor ChannelRefreshLifecycleConnection: Connection {
 	let type: TransportType = .ble
 	var isConnected = true
+	private(set) var sentWantConfigIDs: [UInt32] = []
 
-	func send(_ data: ToRadio) async throws {}
+	func send(_ data: ToRadio) async throws {
+		if case let .wantConfigID(id) = data.payloadVariant {
+			sentWantConfigIDs.append(id)
+		}
+	}
 	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
 	func disconnect(withError: Error?, shouldReconnect: Bool) async throws { isConnected = false }
 	func drainPendingPackets() async throws {}
@@ -31,38 +36,47 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		MeshPackets.recreateShared()
 	}
 
-	private func makeManager() -> AccessoryManager {
+	private func makeManager(
+		nodeNum: UInt32? = nil,
+		connection: ChannelRefreshLifecycleConnection = ChannelRefreshLifecycleConnection()
+	) -> AccessoryManager {
 		let manager = AccessoryManager(transports: [])
 		let device = Device(
 			id: UUID(),
 			name: "Refresh Test Radio",
 			transportType: .ble,
 			identifier: "refresh-test-radio",
-			connectionState: .connected
+			connectionState: .connected,
+			num: nodeNum.map(Int64.init)
 		)
-		manager.activeConnection = (device: device, connection: ChannelRefreshLifecycleConnection())
+		manager.activeConnection = (device: device, connection: connection)
 		manager.isSwitchingDevices = true
 		manager.context = PersistenceController.shared.context
 		manager.updateState(.connecting)
 		return manager
 	}
 
-	private func seedMyInfo(nodeNum: UInt32, channelName: String) throws {
+	private func seedMyInfo(nodeNum: UInt32, channels: [(index: Int32, name: String, role: Channel.Role)]) throws {
 		let context = PersistenceController.shared.context
 		let myInfo = MyInfoEntity()
 		myInfo.myNodeNum = Int64(nodeNum)
 
-		let channel = ChannelEntity()
-		channel.id = 0
-		channel.index = 0
-		channel.name = channelName
-		channel.role = Int32(Channel.Role.primary.rawValue)
-
 		context.insert(myInfo)
-		context.insert(channel)
-		myInfo.channels.append(channel)
+		for seeded in channels {
+			let channel = ChannelEntity()
+			channel.id = seeded.index
+			channel.index = seeded.index
+			channel.name = seeded.name
+			channel.role = Int32(seeded.role.rawValue)
+			context.insert(channel)
+			myInfo.channels.append(channel)
+		}
 		try context.save()
 		MeshPackets.recreateShared()
+	}
+
+	private func seedMyInfo(nodeNum: UInt32, channelName: String) throws {
+		try seedMyInfo(nodeNum: nodeNum, channels: [(0, channelName, .primary)])
 	}
 
 	private func myInfo(nodeNum: UInt32) -> MyNodeInfo {
@@ -81,8 +95,12 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 	}
 
 	private func completeConfig(_ manager: AccessoryManager) async {
+		await completeConfig(manager, id: UInt32(manager.NONCE_ONLY_CONFIG))
+	}
+
+	private func completeConfig(_ manager: AccessoryManager, id: UInt32) async {
 		var fromRadio = FromRadio()
-		fromRadio.payloadVariant = .configCompleteID(UInt32(manager.NONCE_ONLY_CONFIG))
+		fromRadio.payloadVariant = .configCompleteID(id)
 		await manager.didReceive(.data(fromRadio))
 	}
 
@@ -127,5 +145,115 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		await MeshPackets.shared.commitChannelRefreshStage(for: Int64(nodeNum))
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["Kept Primary"])
+	}
+
+	@Test("Late completion from an older automatic refresh cannot commit a newer stage")
+	func lateOlderConfigCompletionCannotCommitNewerStage() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00A1_10CC
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+
+		let firstRefresh = Task { try await manager.sendWantConfig() }
+		while await connection.sentWantConfigIDs.count < 1 {
+			await Task.yield()
+		}
+		let firstID = await connection.sentWantConfigIDs[0]
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "First Primary"))
+
+		let secondRefresh = Task { try await manager.sendWantConfig() }
+		await #expect(throws: CancellationError.self) {
+			try await firstRefresh.value
+		}
+		while await connection.sentWantConfigIDs.count < 2 {
+			await Task.yield()
+		}
+		let secondID = await connection.sentWantConfigIDs[1]
+		#expect(firstID != secondID)
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Second Primary"))
+
+		await completeConfig(manager, id: firstID)
+		#expect(try channelNames(nodeNum: nodeNum) == ["Original Primary"])
+
+		await completeConfig(manager, id: secondID)
+		try await secondRefresh.value
+		#expect(try channelNames(nodeNum: nodeNum) == ["Second Primary"])
+	}
+
+	@Test("A user deletion during automatic refresh is not resurrected by staged packets")
+	func userDeletionDuringAutomaticRefreshIsNotResurrectedByStage() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00DE_1E7E
+		try seedMyInfo(
+			nodeNum: nodeNum,
+			channels: [
+				(0, "Primary", .primary),
+				(1, "User Deleted", .secondary)
+			]
+		)
+		let manager = makeManager(nodeNum: nodeNum)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Primary"))
+		await manager.handleChannel(channel(index: 1, name: "User Deleted", role: .secondary))
+
+		let context = PersistenceController.shared.context
+		let persistedNodeNum = Int64(nodeNum)
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		let myInfo = try #require(context.fetch(descriptor).first)
+		let deleted = try #require(myInfo.channels.first { $0.index == 1 })
+		context.delete(deleted)
+		try context.save()
+
+		await completeConfig(manager)
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Primary"])
+	}
+
+	@Test("Incomplete automatic refresh snapshot does not replace existing channels")
+	func incompleteAutomaticRefreshSnapshotDoesNotReplaceExistingChannels() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x001C_0C00
+		try seedMyInfo(
+			nodeNum: nodeNum,
+			channels: [
+				(0, "Kept Primary", .primary),
+				(1, "Kept Secondary", .secondary)
+			]
+		)
+		let manager = makeManager(nodeNum: nodeNum)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 1, name: "Lone Secondary", role: .secondary))
+		await completeConfig(manager)
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Kept Primary", "Kept Secondary"])
+	}
+
+	@Test("Disabled channel in an automatic refresh removes the old slot")
+	func disabledChannelInAutomaticRefreshRemovesOldSlot() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00D1_5A81
+		try seedMyInfo(
+			nodeNum: nodeNum,
+			channels: [
+				(0, "Old Primary", .primary),
+				(1, "Old Secondary", .secondary)
+			]
+		)
+		let manager = makeManager(nodeNum: nodeNum)
+		var disabled = Channel()
+		disabled.index = 1
+		disabled.role = .disabled
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "New Primary"))
+		await manager.handleChannel(disabled)
+		await completeConfig(manager)
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["New Primary"])
 	}
 }

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -14,10 +14,27 @@ private actor ChannelRefreshLifecycleConnection: Connection {
 	let type: TransportType = .ble
 	var isConnected = true
 	private(set) var sentWantConfigIDs: [UInt32] = []
+	private var pauseNextConfigSend = false
+	private var pausedConfigSendContinuation: CheckedContinuation<Void, Never>?
+
+	func pauseNextWantConfigSend() {
+		pauseNextConfigSend = true
+	}
+
+	func resumePausedWantConfigSend() {
+		pausedConfigSendContinuation?.resume()
+		pausedConfigSendContinuation = nil
+	}
 
 	func send(_ data: ToRadio) async throws {
 		if case let .wantConfigID(id) = data.payloadVariant {
 			sentWantConfigIDs.append(id)
+			if pauseNextConfigSend {
+				pauseNextConfigSend = false
+				await withCheckedContinuation { continuation in
+					pausedConfigSendContinuation = continuation
+				}
+			}
 		}
 	}
 	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
@@ -104,6 +121,26 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		await manager.didReceive(.data(fromRadio))
 	}
 
+	private func stageDisabledSlots(_ manager: AccessoryManager, excluding: Set<Int32> = []) async {
+		for index in Int32(1)...Int32(7) where !excluding.contains(index) {
+			var disabled = Channel()
+			disabled.index = index
+			disabled.role = .disabled
+			await manager.handleChannel(disabled)
+		}
+	}
+
+	private func startAutomaticConfigRefresh(
+		_ manager: AccessoryManager,
+		connection: ChannelRefreshLifecycleConnection
+	) async -> Task<Void, Error> {
+		let refresh = Task { try await manager.sendWantConfig() }
+		while await connection.sentWantConfigIDs.isEmpty {
+			await Task.yield()
+		}
+		return refresh
+	}
+
 	private func channelNames(nodeNum: UInt32) throws -> [String] {
 		let persistedNodeNum = Int64(nodeNum)
 		let context = ModelContext(PersistenceController.shared.container)
@@ -118,15 +155,19 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		resetSharedStore()
 		let nodeNum: UInt32 = 0x00C0_FFEE
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
-		let manager = makeManager()
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "New Primary"))
 		await manager.handleChannel(channel(index: 1, name: "New Secondary", role: .secondary))
+		await stageDisabledSlots(manager, excluding: [1])
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["Old Primary"])
 
 		await completeConfig(manager)
+		try await refresh.value
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["New Primary", "New Secondary"])
 	}
@@ -136,51 +177,20 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		resetSharedStore()
 		let nodeNum: UInt32 = 0x00D1_5C0
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Kept Primary")
-		let manager = makeManager()
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Discarded Primary"))
 
 		try await manager.closeConnection()
+		await #expect(throws: CancellationError.self) {
+			try await refresh.value
+		}
 		await MeshPackets.shared.commitChannelRefreshStage(for: Int64(nodeNum))
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["Kept Primary"])
-	}
-
-	@Test("Late completion from an older automatic refresh cannot commit a newer stage")
-	func lateOlderConfigCompletionCannotCommitNewerStage() async throws {
-		resetSharedStore()
-		let nodeNum: UInt32 = 0x00A1_10CC
-		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
-		let connection = ChannelRefreshLifecycleConnection()
-		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-
-		let firstRefresh = Task { try await manager.sendWantConfig() }
-		while await connection.sentWantConfigIDs.count < 1 {
-			await Task.yield()
-		}
-		let firstID = await connection.sentWantConfigIDs[0]
-		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
-		await manager.handleChannel(channel(index: 0, name: "First Primary"))
-
-		let secondRefresh = Task { try await manager.sendWantConfig() }
-		await #expect(throws: CancellationError.self) {
-			try await firstRefresh.value
-		}
-		while await connection.sentWantConfigIDs.count < 2 {
-			await Task.yield()
-		}
-		let secondID = await connection.sentWantConfigIDs[1]
-		#expect(firstID != secondID)
-		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
-		await manager.handleChannel(channel(index: 0, name: "Second Primary"))
-
-		await completeConfig(manager, id: firstID)
-		#expect(try channelNames(nodeNum: nodeNum) == ["Original Primary"])
-
-		await completeConfig(manager, id: secondID)
-		try await secondRefresh.value
-		#expect(try channelNames(nodeNum: nodeNum) == ["Second Primary"])
 	}
 
 	@Test("A user deletion during automatic refresh is not resurrected by staged packets")
@@ -194,11 +204,14 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 				(1, "User Deleted", .secondary)
 			]
 		)
-		let manager = makeManager(nodeNum: nodeNum)
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Primary"))
 		await manager.handleChannel(channel(index: 1, name: "User Deleted", role: .secondary))
+		await stageDisabledSlots(manager, excluding: [1])
 
 		let context = PersistenceController.shared.context
 		let persistedNodeNum = Int64(nodeNum)
@@ -209,6 +222,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try context.save()
 
 		await completeConfig(manager)
+		try await refresh.value
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["Primary"])
 	}
@@ -224,11 +238,14 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 				(1, "Kept Secondary", .secondary)
 			]
 		)
-		let manager = makeManager(nodeNum: nodeNum)
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 1, name: "Lone Secondary", role: .secondary))
 		await completeConfig(manager)
+		try await refresh.value
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["Kept Primary", "Kept Secondary"])
 	}
@@ -244,7 +261,9 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 				(1, "Old Secondary", .secondary)
 			]
 		)
-		let manager = makeManager(nodeNum: nodeNum)
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
 		var disabled = Channel()
 		disabled.index = 1
 		disabled.role = .disabled
@@ -252,8 +271,171 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "New Primary"))
 		await manager.handleChannel(disabled)
+		await stageDisabledSlots(manager)
 		await completeConfig(manager)
+		try await refresh.value
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["New Primary"])
+	}
+
+	@Test("Automatic refresh uses the reserved config nonce and coalesces before its waiter is installed")
+	func automaticRefreshUsesReservedNonceAndCoalescesBeforeWaiterInstallation() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00AC_CE55
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		await connection.pauseNextWantConfigSend()
+
+		let firstRefresh = Task { try await manager.sendWantConfig() }
+		while await connection.sentWantConfigIDs.count < 1 {
+			await Task.yield()
+		}
+		let secondRefresh = Task { try await manager.sendWantConfig() }
+		for _ in 0..<100 {
+			if await connection.sentWantConfigIDs.count >= 2 { break }
+			await Task.yield()
+		}
+
+		let sentIDs = await connection.sentWantConfigIDs
+		#expect(sentIDs == [UInt32(manager.NONCE_ONLY_CONFIG)])
+
+		if sentIDs == [UInt32(manager.NONCE_ONLY_CONFIG)] {
+			secondRefresh.cancel()
+			await #expect(throws: CancellationError.self) {
+				try await secondRefresh.value
+			}
+			await connection.resumePausedWantConfigSend()
+			await completeConfig(manager)
+			try await firstRefresh.value
+		} else {
+			firstRefresh.cancel()
+			secondRefresh.cancel()
+			await connection.resumePausedWantConfigSend()
+		}
+	}
+
+	@Test("Duplicate MyInfo retains channels already staged for the active refresh")
+	func duplicateMyInfoRetainsAccumulatedChannelsForActiveRefresh() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00D0_0D00
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "New Primary"))
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 1, name: "New Secondary", role: .secondary))
+		await stageDisabledSlots(manager, excluding: [1])
+		await completeConfig(manager)
+		try await refresh.value
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["New Primary", "New Secondary"])
+	}
+
+	@Test("A missing newly configured secondary slot rejects the complete-looking staged dump")
+	func missingNewSecondarySlotDoesNotReplacePersistedChannels() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00B1_0C00
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Kept Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Replacement Primary"))
+		await stageDisabledSlots(manager, excluding: [1])
+		await completeConfig(manager)
+		try await refresh.value
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Kept Primary"])
+	}
+
+	@Test("An incomplete refresh stage is discarded so later channel packets update the cache")
+	func incompleteRefreshStageIsDiscardedAfterCompletion() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00C1_EA00
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Kept Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 1, name: "Incomplete Secondary", role: .secondary))
+		await completeConfig(manager)
+		try await refresh.value
+		await manager.handleChannel(channel(index: 0, name: "Later Packet"))
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Later Packet"])
+	}
+
+	@Test("Recycling during an active refresh keeps later channel packets in that stage")
+	func recycleDuringActiveRefreshDoesNotBypassStaging() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00EC_1E00
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "New Primary"))
+		MeshPackets.recreateShared()
+		MeshPackets.recreateShared()
+		await manager.handleChannel(channel(index: 1, name: "New Secondary", role: .secondary))
+		#expect(try channelNames(nodeNum: nodeNum) == ["Old Primary"])
+		await stageDisabledSlots(manager, excluding: [1])
+		await completeConfig(manager)
+		try await refresh.value
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["New Primary", "New Secondary"])
+	}
+
+	@Test("Direct user rename deletion and reorder survive an automatic refresh")
+	func directUserChannelChangesAreNotOverwrittenByAutomaticRefresh() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00D1_DEC7
+		try seedMyInfo(
+			nodeNum: nodeNum,
+			channels: [
+				(0, "Original Primary", .primary),
+				(1, "Delete Me", .secondary),
+				(2, "Move Me", .secondary)
+			]
+		)
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Remote Primary"))
+		await manager.handleChannel(channel(index: 1, name: "Remote Secondary", role: .secondary))
+		await manager.handleChannel(channel(index: 2, name: "Remote Moved", role: .secondary))
+		await stageDisabledSlots(manager, excluding: [1, 2])
+
+		await MeshPackets.shared.channelPacket(
+			channel: channel(index: 0, name: "User Renamed Primary"),
+			fromNum: Int64(nodeNum),
+			stageIfRefreshing: false
+		)
+		var deleted = Channel()
+		deleted.index = 1
+		deleted.role = .disabled
+		await MeshPackets.shared.channelPacket(channel: deleted, fromNum: Int64(nodeNum), stageIfRefreshing: false)
+		let context = PersistenceController.shared.context
+		let persistedNodeNum = Int64(nodeNum)
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		let myInfo = try #require(context.fetch(descriptor).first)
+		let moved = try #require(myInfo.channels.first { $0.index == 2 })
+		moved.index = 1
+		moved.id = 1
+		try context.save()
+
+		await completeConfig(manager)
+		try await refresh.value
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["User Renamed Primary", "Move Me"])
 	}
 }

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -605,6 +605,36 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		#expect(try channelNames(nodeNum: nodeNum) == ["Leased Primary"])
 	}
 
+	@Test("A successor refresh stage survives stale owner cleanup")
+	func successorRefreshStageSurvivesStaleOwnerCleanup() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x001E_A5EE
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
+		let sessionID = UUID()
+		let staleOwner = AutomaticChannelRefreshOwner(sessionID: sessionID, generation: 1)
+		let successorOwner = AutomaticChannelRefreshOwner(sessionID: sessionID, generation: 2)
+		let staleLease = MeshPackets.acquireSharedChannelRefreshStageLease()
+		#expect(await staleLease.begin(for: Int64(nodeNum), owner: staleOwner))
+
+		let successorLease = MeshPackets.acquireSharedChannelRefreshStageLease()
+		#expect(await successorLease.begin(for: Int64(nodeNum), owner: successorOwner))
+		await staleLease.packets.discardChannelRefreshStage(for: Int64(nodeNum), owner: staleOwner)
+
+		await successorLease.packets.channelPacket(
+			channel: channel(index: 0, name: "Successor Primary"),
+			fromNum: Int64(nodeNum)
+		)
+		for index in Int32(1)...Int32(7) {
+			var disabled = Channel()
+			disabled.index = index
+			disabled.role = .disabled
+			await successorLease.packets.channelPacket(channel: disabled, fromNum: Int64(nodeNum))
+		}
+		await successorLease.packets.commitChannelRefreshStage(for: Int64(nodeNum), owner: successorOwner)
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Successor Primary"])
+	}
+
 	@Test("Disconnect before delayed stage activation releases the late refresh lease")
 	func disconnectBeforeDelayedStageActivationReleasesLateRefreshLease() async throws {
 		resetSharedStore()

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -486,6 +486,64 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 
 }
 
+private struct ChannelProjectionNames {
+	let displayed: [String]
+	let shared: [String]
+	let exported: [String]
+}
+
+extension AccessoryManagerChannelRefreshLifecycleTests {
+	private func canonicalChannelProjectionNames(nodeNum: UInt32) throws -> ChannelProjectionNames {
+		let persistedNodeNum = Int64(nodeNum)
+		let context = ModelContext(PersistenceController.shared.container)
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		let channels = try context.fetch(descriptor).first?.channels ?? []
+		return ChannelProjectionNames(
+			displayed: projectedDisplayChannels(from: channels).map { $0.name ?? "" },
+			shared: channelSettingsForSharing(from: channels, includedIndexes: Set(Int32(0)...Int32(7))).map(\.name),
+			exported: canonicalValidUniqueChannels(from: channels).filter { $0.role > 0 }.map { $0.name ?? "" }
+		)
+	}
+
+	@Test("Local channel mutation targets the canonical duplicate row")
+	func localChannelMutationTargetsCanonicalDuplicateRow() throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00CA_D001
+		try seedMyInfo(
+			nodeNum: nodeNum,
+			channels: [
+				(0, "Stale Duplicate", .primary),
+				(0, "Displayed Duplicate", .primary),
+				(1, "Secondary", .secondary)
+			]
+		)
+		let manager = makeManager(nodeNum: nodeNum)
+		let initialProjection = try canonicalChannelProjectionNames(nodeNum: nodeNum)
+		let initialCanonicalPrimary = try #require(initialProjection.displayed.first)
+		let fallbackPrimary = initialCanonicalPrimary == "Stale Duplicate" ? "Displayed Duplicate" : "Stale Duplicate"
+
+		try manager.applyLocalChannelMutation(
+			channel(index: 0, name: "User Renamed Primary"),
+			fromNum: Int64(nodeNum)
+		)
+
+		let updatedProjection = try canonicalChannelProjectionNames(nodeNum: nodeNum)
+		#expect(updatedProjection.displayed == ["User Renamed Primary", "Secondary"])
+		#expect(updatedProjection.shared == ["User Renamed Primary", "Secondary"])
+		#expect(updatedProjection.exported == ["User Renamed Primary", "Secondary"])
+
+		var deleted = Channel()
+		deleted.index = 0
+		deleted.role = .disabled
+		try manager.applyLocalChannelMutation(deleted, fromNum: Int64(nodeNum))
+
+		let deletedProjection = try canonicalChannelProjectionNames(nodeNum: nodeNum)
+		#expect(deletedProjection.displayed == [fallbackPrimary, "Secondary"])
+		#expect(deletedProjection.shared == [fallbackPrimary, "Secondary"])
+		#expect(deletedProjection.exported == [fallbackPrimary, "Secondary"])
+	}
+}
+
 extension AccessoryManagerChannelRefreshLifecycleTests {
 	@Test("Disconnect cancels a paused automatic refresh runner before it drains packets")
 	func disconnectCancelsPausedAutomaticRefreshRunner() async throws {

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -1,0 +1,131 @@
+//
+//  AccessoryManagerChannelRefreshLifecycleTests.swift
+//  MeshtasticTests
+//
+
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Meshtastic
+import MeshtasticProtobufs
+
+private actor ChannelRefreshLifecycleConnection: Connection {
+	let type: TransportType = .ble
+	var isConnected = true
+
+	func send(_ data: ToRadio) async throws {}
+	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
+	func disconnect(withError: Error?, shouldReconnect: Bool) async throws { isConnected = false }
+	func drainPendingPackets() async throws {}
+	func startDrainPendingPackets() throws {}
+	func appDidEnterBackground() {}
+	func appDidBecomeActive() {}
+}
+
+@MainActor
+@Suite("Automatic channel refresh lifecycle", .serialized)
+struct AccessoryManagerChannelRefreshLifecycleTests {
+	private func resetSharedStore() {
+		PersistenceController.shared.recreateContainer()
+		MeshPackets.recreateShared()
+	}
+
+	private func makeManager() -> AccessoryManager {
+		let manager = AccessoryManager(transports: [])
+		let device = Device(
+			id: UUID(),
+			name: "Refresh Test Radio",
+			transportType: .ble,
+			identifier: "refresh-test-radio",
+			connectionState: .connected
+		)
+		manager.activeConnection = (device: device, connection: ChannelRefreshLifecycleConnection())
+		manager.isSwitchingDevices = true
+		manager.context = PersistenceController.shared.context
+		manager.updateState(.connecting)
+		return manager
+	}
+
+	private func seedMyInfo(nodeNum: UInt32, channelName: String) throws {
+		let context = PersistenceController.shared.context
+		let myInfo = MyInfoEntity()
+		myInfo.myNodeNum = Int64(nodeNum)
+
+		let channel = ChannelEntity()
+		channel.id = 0
+		channel.index = 0
+		channel.name = channelName
+		channel.role = Int32(Channel.Role.primary.rawValue)
+
+		context.insert(myInfo)
+		context.insert(channel)
+		myInfo.channels.append(channel)
+		try context.save()
+		MeshPackets.recreateShared()
+	}
+
+	private func myInfo(nodeNum: UInt32) -> MyNodeInfo {
+		var myInfo = MyNodeInfo()
+		myInfo.myNodeNum = nodeNum
+		return myInfo
+	}
+
+	private func channel(index: Int32, name: String, role: Channel.Role = .primary) -> Channel {
+		var channel = Channel()
+		channel.index = index
+		channel.role = role
+		channel.settings.name = name
+		channel.settings.psk = Data([UInt8(truncatingIfNeeded: index), 0xAA])
+		return channel
+	}
+
+	private func completeConfig(_ manager: AccessoryManager) async {
+		var fromRadio = FromRadio()
+		fromRadio.payloadVariant = .configCompleteID(UInt32(manager.NONCE_ONLY_CONFIG))
+		await manager.didReceive(.data(fromRadio))
+	}
+
+	private func channelNames(nodeNum: UInt32) throws -> [String] {
+		let persistedNodeNum = Int64(nodeNum)
+		let context = ModelContext(PersistenceController.shared.container)
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		return try context.fetch(descriptor).first?.channels
+			.sorted { $0.index < $1.index }
+			.map { $0.name ?? "" } ?? []
+	}
+
+	@Test("MyInfo refresh stages channels until config completion commits them")
+	func myInfoRefreshStagesChannelsUntilConfigCompletionCommitsThem() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00C0_FFEE
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
+		let manager = makeManager()
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "New Primary"))
+		await manager.handleChannel(channel(index: 1, name: "New Secondary", role: .secondary))
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Old Primary"])
+
+		await completeConfig(manager)
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["New Primary", "New Secondary"])
+	}
+
+	@Test("Disconnect discards an unfinished automatic channel refresh")
+	func disconnectDiscardsUnfinishedAutomaticChannelRefresh() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00D1_5C0
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Kept Primary")
+		let manager = makeManager()
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Discarded Primary"))
+
+		try await manager.closeConnection()
+		await MeshPackets.shared.commitChannelRefreshStage(for: Int64(nodeNum))
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["Kept Primary"])
+	}
+}

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -14,6 +14,7 @@ private actor ChannelRefreshLifecycleConnection: Connection {
 	let type: TransportType = .ble
 	var isConnected = true
 	private(set) var sentWantConfigIDs: [UInt32] = []
+	private(set) var pendingPacketDrainStartCount = 0
 	private var pauseNextConfigSend = false
 	private var pausedConfigSendContinuation: CheckedContinuation<Void, Never>?
 	private var failNextDrain = false
@@ -46,6 +47,7 @@ private actor ChannelRefreshLifecycleConnection: Connection {
 	func disconnect(withError: Error?, shouldReconnect: Bool) async throws { isConnected = false }
 	func drainPendingPackets() async throws {}
 	func startDrainPendingPackets() throws {
+		pendingPacketDrainStartCount += 1
 		if failNextDrain {
 			failNextDrain = false
 			throw AccessoryError.ioFailed("Simulated pending-packet drain failure")
@@ -235,6 +237,31 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try await refresh.value
 
 		#expect(try channelNames(nodeNum: nodeNum) == ["Primary"])
+	}
+
+	@Test("A user edit after wantConfig and before MyInfo discards the staged dump")
+	func userEditBeforeMyInfoIsNotOverwrittenByAutomaticRefresh() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00B4_5E11
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+
+		let context = PersistenceController.shared.context
+		let persistedNodeNum = Int64(nodeNum)
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		let storedMyInfo = try #require(context.fetch(descriptor).first)
+		storedMyInfo.channels[0].name = "User Edited Before MyInfo"
+		try context.save()
+
+		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
+		await manager.handleChannel(channel(index: 0, name: "Remote Primary"))
+		await stageDisabledSlots(manager)
+		await completeConfig(manager)
+		try await refresh.value
+
+		#expect(try channelNames(nodeNum: nodeNum) == ["User Edited Before MyInfo"])
 	}
 
 	@Test("Incomplete automatic refresh snapshot does not replace existing channels")
@@ -451,6 +478,32 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 }
 
 extension AccessoryManagerChannelRefreshLifecycleTests {
+	@Test("Disconnect cancels a paused automatic refresh runner before it drains packets")
+	func disconnectCancelsPausedAutomaticRefreshRunner() async throws {
+		resetSharedStore()
+		let nodeNum: UInt32 = 0x00C1_05E0
+		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
+		let connection = ChannelRefreshLifecycleConnection()
+		let manager = makeManager(nodeNum: nodeNum, connection: connection)
+		await connection.pauseNextWantConfigSend()
+
+		let refresh = Task { try await manager.sendWantConfig() }
+		while await connection.sentWantConfigIDs.isEmpty {
+			await Task.yield()
+		}
+
+		try await manager.closeConnection()
+		await connection.resumePausedWantConfigSend()
+		await #expect(throws: CancellationError.self) {
+			try await refresh.value
+		}
+		for _ in 0..<100 {
+			await Task.yield()
+		}
+
+		#expect(await connection.pendingPacketDrainStartCount == 0)
+	}
+
 	@Test("A main-context edit at the validated refresh boundary survives")
 	func userEditAfterBaselineValidationCausesRefreshDiscard() async throws {
 		resetSharedStore()

--- a/MeshtasticTests/ChannelDisplayProjectionTests.swift
+++ b/MeshtasticTests/ChannelDisplayProjectionTests.swift
@@ -1,5 +1,6 @@
 import Testing
 @testable import Meshtastic
+import MeshtasticProtobufs
 
 @Suite("Channel display projection")
 struct ChannelDisplayProjectionTests {
@@ -33,6 +34,34 @@ struct ChannelDisplayProjectionTests {
 		#expect(channels.count == 8)
 		#expect(validUniqueChannelIndexes(from: channels) == [0, 1, 2, 3, 4, 5, 6])
 		#expect(nextAvailableSecondaryChannelIndex(from: channels) == 7)
+	}
+
+	@Test("Sharing legacy duplicate rows serializes one ordered channel per valid index")
+	@MainActor
+	func sharingDuplicateIndexesSerializesOnlyOnePrimaryAndSevenChannels() throws {
+		let stalePrimary = channel(index: 0, name: "Stale Primary")
+		stalePrimary.role = 1
+		let freshPrimary = channel(index: 0, name: "Fresh Primary")
+		freshPrimary.role = 1
+		let secondaries = (1...6).map { index -> ChannelEntity in
+			let channel = channel(index: Int32(index), name: "Secondary \(index)")
+			channel.role = 2
+			return channel
+		}
+		var channelSet = ChannelSet()
+		channelSet.settings = channelSettingsForSharing(
+			from: [stalePrimary, freshPrimary] + secondaries,
+			includedIndexes: Set(Int32(0)...Int32(7))
+		)
+		let serialized = try channelSet.serializedData()
+		let decoded = try ChannelSet(serializedBytes: serialized)
+
+		#expect(decoded.settings.map(\.name) == [
+			"Fresh Primary", "Secondary 1", "Secondary 2", "Secondary 3",
+			"Secondary 4", "Secondary 5", "Secondary 6"
+		])
+		#expect(decoded.settings.count <= 8)
+		#expect(decoded.settings.filter { $0.name == "Fresh Primary" }.count == 1)
 	}
 
 	private func channel(index: Int32, name: String) -> ChannelEntity {

--- a/MeshtasticTests/ChannelDisplayProjectionTests.swift
+++ b/MeshtasticTests/ChannelDisplayProjectionTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Meshtastic
+
+@Suite("Channel display projection")
+struct ChannelDisplayProjectionTests {
+	@Test("Duplicate-index channels are projected without mutating the source relationship")
+	func duplicateIndexChannelsRemainInSourceRelationship() {
+		let stalePrimary = channel(index: 0, name: "Stale Primary")
+		let freshPrimary = channel(index: 0, name: "Fresh Primary")
+		let secondary = channel(index: 1, name: "Secondary")
+		let myInfo = MyInfoEntity()
+		myInfo.channels = [stalePrimary, freshPrimary, secondary]
+
+		let displayChannels = projectedDisplayChannels(from: myInfo.channels)
+
+		#expect(displayChannels.map(\.name) == ["Fresh Primary", "Secondary"])
+		#expect(myInfo.channels.map(\.name) == ["Stale Primary", "Fresh Primary", "Secondary"])
+	}
+
+	private func channel(index: Int32, name: String) -> ChannelEntity {
+		let channel = ChannelEntity()
+		channel.index = index
+		channel.name = name
+		return channel
+	}
+}

--- a/MeshtasticTests/ChannelDisplayProjectionTests.swift
+++ b/MeshtasticTests/ChannelDisplayProjectionTests.swift
@@ -17,6 +17,24 @@ struct ChannelDisplayProjectionTests {
 		#expect(myInfo.channels.map(\.name) == ["Stale Primary", "Fresh Primary", "Secondary"])
 	}
 
+	@Test("Eight raw rows with a duplicate index still offer the missing secondary slot")
+	func duplicateRawRowsUseValidUniqueIndexesForAddCapacity() {
+		let channels = [
+			channel(index: 0, name: "Legacy Primary"),
+			channel(index: 0, name: "Current Primary"),
+			channel(index: 1, name: "One"),
+			channel(index: 2, name: "Two"),
+			channel(index: 3, name: "Three"),
+			channel(index: 4, name: "Four"),
+			channel(index: 5, name: "Five"),
+			channel(index: 6, name: "Six")
+		]
+
+		#expect(channels.count == 8)
+		#expect(validUniqueChannelIndexes(from: channels) == [0, 1, 2, 3, 4, 5, 6])
+		#expect(nextAvailableSecondaryChannelIndex(from: channels) == 7)
+	}
+
 	private func channel(index: Int32, name: String) -> ChannelEntity {
 		let channel = ChannelEntity()
 		channel.index = index

--- a/MeshtasticTests/ChannelSetSaveTests.swift
+++ b/MeshtasticTests/ChannelSetSaveTests.swift
@@ -331,4 +331,27 @@ struct ChannelSetSaveTests {
 		#expect(indexes.filter { $0 == 0 }.count == 2)
 		#expect(indexes.contains(7))
 	}
+
+	@Test("Append mode never hands an imported channel the primary slot")
+	func appendModeNeverTargetsIndexZero() async throws {
+		// A partial local cache (the #1893 scenario) can leave slot 0 unoccupied.
+		// An appended QR channel must still land on a secondary index — the role
+		// assignment keys on index 0, so targeting it would promote the import
+		// to primary and overwrite the radio's primary channel.
+		let deviceNum: Int64 = 123_456_795
+		try seedMyInfo(deviceNum: deviceNum, channels: [(1, "Only Secondary")])
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection, deviceNum: deviceNum)
+		let link = try makeChannelSetLink(includeLoRaConfig: false, channelNames: ["Appended"])
+
+		// Append mode sends no LoRa config, so the mock's simulated post-wantConfig
+		// disconnect surfaces as an error — after the channel packet and local mirror.
+		await #expect(throws: (any Error).self) {
+			try await manager.saveChannelSet(base64UrlString: link, addChannels: true, okToMQTT: false)
+		}
+
+		let sentIndexes = await connection.sentChannelIndexes
+		#expect(sentIndexes == [2], "the appended channel must take the first free secondary slot, never index 0")
+		#expect(try channelNames(for: deviceNum) == ["Only Secondary", "Appended"])
+	}
 }

--- a/MeshtasticTests/ChannelSetSaveTests.swift
+++ b/MeshtasticTests/ChannelSetSaveTests.swift
@@ -265,4 +265,18 @@ struct ChannelSetSaveTests {
 		#expect(try channelNames(for: connectedDeviceNum) == ["Imported"])
 		#expect(try channelNames(for: staleDeviceNum) == ["Stale"])
 	}
+
+	@Test("Local channel-set save is not diverted into an automatic refresh stage")
+	func testLocalChannelSetSaveIsNotDivertedIntoAutomaticRefreshStage() async throws {
+		let deviceNum: Int64 = 123_456_793
+		try seedMyInfo(deviceNum: deviceNum, channelName: "Existing")
+		await MeshPackets.shared.beginChannelRefreshStage(for: deviceNum)
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection, deviceNum: deviceNum)
+		let channelSet = makeChannelSet(channelNames: ["Imported"])
+
+		try await manager.saveChannelSet(channelSet: channelSet, addChannels: false, okToMQTT: false)
+
+		#expect(try channelNames(for: deviceNum) == ["Imported"])
+	}
 }

--- a/MeshtasticTests/ChannelSetSaveTests.swift
+++ b/MeshtasticTests/ChannelSetSaveTests.swift
@@ -51,6 +51,16 @@ actor MockChannelSetConnection: Connection {
 		}
 	}
 
+	var sentChannelIndexes: [Int32] {
+		sentPackets.compactMap { toRadio in
+			guard case let .packet(meshPacket) = toRadio.payloadVariant,
+				  case let .decoded(dataMessage) = meshPacket.payloadVariant,
+				  let admin = try? AdminMessage(serializedBytes: dataMessage.payload),
+				  case let .setChannel(channel) = admin.payloadVariant else { return nil }
+			return Int32(truncatingIfNeeded: channel.index)
+		}
+	}
+
 	func send(_ data: ToRadio) async throws {
 		sentPackets.append(data)
 		if failureMode == .firstPacket, case .packet = data.payloadVariant {
@@ -128,6 +138,10 @@ struct ChannelSetSaveTests {
 	}
 
 	private func seedMyInfo(deviceNum: Int64, channelName: String) throws {
+		try seedMyInfo(deviceNum: deviceNum, channels: [(0, channelName)])
+	}
+
+	private func seedMyInfo(deviceNum: Int64, channels: [(index: Int32, name: String)]) throws {
 		let context = PersistenceController.shared.context
 		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == deviceNum })
 		for existing in try context.fetch(descriptor) {
@@ -137,14 +151,18 @@ struct ChannelSetSaveTests {
 
 		let myInfo = MyInfoEntity()
 		myInfo.myNodeNum = deviceNum
-		let channel = ChannelEntity()
-		channel.id = 0
-		channel.index = 0
-		channel.name = channelName
-		channel.role = Int32(Channel.Role.primary.rawValue)
 		context.insert(myInfo)
-		context.insert(channel)
-		myInfo.channels.append(channel)
+		for seeded in channels {
+			let channel = ChannelEntity()
+			channel.id = seeded.index
+			channel.index = seeded.index
+			channel.name = seeded.name
+			channel.role = seeded.index == 0
+				? Int32(Channel.Role.primary.rawValue)
+				: Int32(Channel.Role.secondary.rawValue)
+			context.insert(channel)
+			myInfo.channels.append(channel)
+		}
 		try context.save()
 		MeshPackets.recreateShared()
 	}
@@ -278,5 +296,39 @@ struct ChannelSetSaveTests {
 		try await manager.saveChannelSet(channelSet: channelSet, addChannels: false, okToMQTT: false)
 
 		#expect(try channelNames(for: deviceNum) == ["Imported"])
+		await MeshPackets.shared.discardChannelRefreshStage(for: deviceNum)
+	}
+
+	@Test("QR add uses the free valid index when eight raw rows contain a duplicate")
+	func testAddWithDuplicateRawIndexUsesAvailableSlotWithoutDeletingLegacyRows() async throws {
+		let deviceNum: Int64 = 123_456_794
+		try seedMyInfo(
+			deviceNum: deviceNum,
+			channels: [
+				(0, "Legacy Primary"),
+				(0, "Current Primary"),
+				(1, "One"),
+				(2, "Two"),
+				(3, "Three"),
+				(4, "Four"),
+				(5, "Five"),
+				(6, "Six")
+			]
+		)
+		let connection = MockChannelSetConnection(failureMode: .wantConfig)
+		let manager = makeManager(connection: connection, deviceNum: deviceNum)
+		let channelSet = makeChannelSet(channelNames: ["Imported Seven"])
+
+		await #expect(throws: (any Error).self) {
+			try await manager.saveChannelSet(channelSet: channelSet, addChannels: true, okToMQTT: false)
+		}
+
+		#expect(await connection.sentChannelIndexes == [7])
+		let persistedNodeNum = deviceNum
+		let context = ModelContext(PersistenceController.shared.container)
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		let indexes = try #require(context.fetch(descriptor).first).channels.map(\.index)
+		#expect(indexes.filter { $0 == 0 }.count == 2)
+		#expect(indexes.contains(7))
 	}
 }

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -179,6 +179,12 @@ struct AutomaticChannelRefreshStagingTests {
 		disabled.index = 2
 		disabled.role = .disabled
 		await mesh.channelPacket(channel: disabled, fromNum: Int64(nodeNum))
+		for index in Int32(3)...Int32(7) {
+			var disabled = Channel()
+			disabled.index = index
+			disabled.role = .disabled
+			await mesh.channelPacket(channel: disabled, fromNum: Int64(nodeNum))
+		}
 		await mesh.commitChannelRefreshStage(for: Int64(nodeNum))
 
 		let persisted = try persistedChannels(in: container, nodeNum: nodeNum)

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -163,6 +163,7 @@ struct AutomaticChannelRefreshStagingTests {
 		let persisted = try persistedChannels(in: container, nodeNum: nodeNum)
 		#expect(persisted.map(\.index) == [0])
 		#expect(persisted.first?.name == "Existing")
+		await mesh.discardChannelRefreshStage(for: Int64(nodeNum))
 	}
 
 	@Test func committingRefreshStageReplacesPersistedChannelsAtomically() async throws {

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -107,6 +107,98 @@ struct MyInfoIngestionTests {
 	}
 }
 
+// MARK: - Automatic channel refresh staging
+
+@Suite("Automatic channel refresh staging", .serialized)
+@MainActor
+struct AutomaticChannelRefreshStagingTests {
+	private func freshMesh() throws -> (MeshPackets, ModelContainer) {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		return (MeshPackets(modelContainer: container), container)
+	}
+
+	private func seedMyInfo(_ mesh: MeshPackets, nodeNum: UInt32) async {
+		var myInfo = MyNodeInfo()
+		myInfo.myNodeNum = nodeNum
+		_ = await mesh.myInfoPacket(myInfo: myInfo, peripheralId: "test-peripheral")
+	}
+
+	private func channel(index: Int32, name: String, role: Channel.Role = .secondary) -> Channel {
+		var channel = Channel()
+		channel.index = index
+		channel.role = role
+		channel.settings.name = name
+		channel.settings.psk = Data([UInt8(truncatingIfNeeded: index), 0xCA, 0xFE])
+		channel.settings.uplinkEnabled = true
+		channel.settings.downlinkEnabled = false
+		channel.settings.moduleSettings.positionPrecision = 11
+		channel.settings.moduleSettings.isMuted = true
+		return channel
+	}
+
+	private func persistedChannels(in container: ModelContainer, nodeNum: UInt32) throws -> [(index: Int32, name: String?, psk: Data?)] {
+		let persistedNodeNum = Int64(nodeNum)
+		let context = ModelContext(container)
+		let myInfo = try #require(context.fetch(
+			FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == persistedNodeNum })
+		).first)
+		return myInfo.channels
+			.sorted { $0.index < $1.index }
+			.map { ($0.index, $0.name, $0.psk) }
+	}
+
+	@Test func activeRefreshStagePreservesPersistedChannelsBeforeCompletion() async throws {
+		let (mesh, container) = try freshMesh()
+		let nodeNum: UInt32 = 0x0A0B_0C0D
+		await seedMyInfo(mesh, nodeNum: nodeNum)
+		await mesh.channelPacket(channel: channel(index: 0, name: "Existing", role: .primary), fromNum: Int64(nodeNum))
+
+		await mesh.beginChannelRefreshStage(for: Int64(nodeNum))
+		await mesh.channelPacket(channel: channel(index: 0, name: "Staged Replacement", role: .primary), fromNum: Int64(nodeNum))
+		await mesh.channelPacket(channel: channel(index: 1, name: "Staged Secondary"), fromNum: Int64(nodeNum))
+
+		let persisted = try persistedChannels(in: container, nodeNum: nodeNum)
+		#expect(persisted.map(\.index) == [0])
+		#expect(persisted.first?.name == "Existing")
+	}
+
+	@Test func committingRefreshStageReplacesPersistedChannelsAtomically() async throws {
+		let (mesh, container) = try freshMesh()
+		let nodeNum: UInt32 = 0x0102_0304
+		await seedMyInfo(mesh, nodeNum: nodeNum)
+		await mesh.channelPacket(channel: channel(index: 0, name: "Old Primary", role: .primary), fromNum: Int64(nodeNum))
+		await mesh.channelPacket(channel: channel(index: 2, name: "Old Secondary"), fromNum: Int64(nodeNum))
+
+		await mesh.beginChannelRefreshStage(for: Int64(nodeNum))
+		await mesh.channelPacket(channel: channel(index: 1, name: "New Secondary"), fromNum: Int64(nodeNum))
+		await mesh.channelPacket(channel: channel(index: 0, name: "New Primary", role: .primary), fromNum: Int64(nodeNum))
+		await mesh.commitChannelRefreshStage(for: Int64(nodeNum))
+
+		let persisted = try persistedChannels(in: container, nodeNum: nodeNum)
+		#expect(persisted.map(\.index) == [0, 1])
+		#expect(persisted.map(\.name) == ["New Primary", "New Secondary"])
+		#expect(persisted.map(\.psk) == [Data([0, 0xCA, 0xFE]), Data([1, 0xCA, 0xFE])])
+	}
+
+	@Test func discardingRefreshStagePreservesPersistedChannels() async throws {
+		let (mesh, container) = try freshMesh()
+		let nodeNum: UInt32 = 0x0D15_CAFE
+		await seedMyInfo(mesh, nodeNum: nodeNum)
+		await mesh.channelPacket(channel: channel(index: 0, name: "Kept Primary", role: .primary), fromNum: Int64(nodeNum))
+
+		await mesh.beginChannelRefreshStage(for: Int64(nodeNum))
+		await mesh.channelPacket(channel: channel(index: 0, name: "Discarded Primary", role: .primary), fromNum: Int64(nodeNum))
+		await mesh.discardChannelRefreshStage(for: Int64(nodeNum))
+
+		let persisted = try persistedChannels(in: container, nodeNum: nodeNum)
+		#expect(persisted.map(\.index) == [0])
+		#expect(persisted.first?.name == "Kept Primary")
+	}
+}
+
 // MARK: - Local Message Notification Cleanup
 
 @Suite("Local message notification cleanup")

--- a/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
+++ b/MeshtasticTests/MeshPacketsAndTelemetryTests.swift
@@ -175,6 +175,10 @@ struct AutomaticChannelRefreshStagingTests {
 		await mesh.beginChannelRefreshStage(for: Int64(nodeNum))
 		await mesh.channelPacket(channel: channel(index: 1, name: "New Secondary"), fromNum: Int64(nodeNum))
 		await mesh.channelPacket(channel: channel(index: 0, name: "New Primary", role: .primary), fromNum: Int64(nodeNum))
+		var disabled = Channel()
+		disabled.index = 2
+		disabled.role = .disabled
+		await mesh.channelPacket(channel: disabled, fromNum: Int64(nodeNum))
 		await mesh.commitChannelRefreshStage(for: Int64(nodeNum))
 
 		let persisted = try persistedChannels(in: container, nodeNum: nodeNum)


### PR DESCRIPTION
## Summary

An automatic config refresh cleared the channel cache before all channel packets had arrived. If the refresh was interrupted — a BLE drop, a backgrounded app — the channel list came up empty or partial, and the editor could then overwrite an occupied slot (#1893).

## What changed

Channel packets that arrive during an automatic refresh are staged in memory instead of written to the store. The stored channels are replaced only when a complete snapshot has arrived: all eight indices, with a valid primary. An interrupted refresh discards the stage and the old channels stay.

Before replacing anything, the commit checks the stored channels still match what they were when the refresh started. If the user saved, renamed, moved, deleted, or imported a channel in the meantime, the commit refuses and the user's edits win. A newer refresh for the same connection supersedes an older stage; a stale refresh finishing late cannot remove its successor's work.

Stage state is static and lock-guarded rather than tied to the MeshPackets actor instance, so the periodic actor recycle can run mid-refresh without orphaning the stage.

Also fixed along the way: display, add, sharing, and export now agree on which row wins when legacy data holds duplicate channel indexes, and a channel received without module settings gets proto3's position precision default instead of the entity default of 32, which would have silently enabled full-precision position sharing.

## Testing

- 2,930 tests in 511 suites pass.
- Lifecycle regressions cover interrupted and incomplete refreshes, cancellation, disconnect, late completion, duplicate MyInfo, stale-stage cleanup, successor handoff, actor recreation mid-refresh, and user edits during refresh.
- Verified in the simulator: existing channels remain until completion, and an incomplete refresh is refused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic channel refresh reliability during reconnects, cancellations, incomplete updates, and simultaneous requests.
  - Prevented stale or duplicate channel data from overwriting newer changes.
  - Preserved existing channels until refreshes complete successfully.
  - Ensured disabled channels are handled correctly during updates.

- **Improvements**
  - Channel creation and saving now select available indexes more reliably.
  - Channel sharing, QR-code generation, and URL exports use valid, unique, consistently ordered channels.
  - Local channel changes are preserved more reliably during device setting refreshes.
  - Refresh updates now apply channel changes atomically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->