### PR TITLE
Take the Watch node snapshot on the MeshPackets actor

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -5,6 +5,7 @@
 //  Created by Garth Vander Houwen on 5/27/22.
 //
 
+import CoreLocation
 import Foundation
 @preconcurrency import SwiftData
 import MeshtasticProtobufs
@@ -153,6 +154,34 @@ actor MeshPackets {
 	func enforceEntityCaps() {
 		evictNodesIfOverCap(Self.maxTotalNodes)
 		evictWaypointsIfOverCap(Self.maxTotalWaypoints)
+	}
+
+	// MARK: - Watch Snapshot
+
+	/// Value-copies every node the Watch cares about, on this actor.
+	///
+	/// The Watch update used to walk main-context entities while this actor's cap
+	/// eviction (`evictNodesIfOverCap`) and near-duplicate position pruning deleted
+	/// rows underneath them. An instance whose row another context deleted keeps
+	/// passing `modelContext != nil` / `isDeleted == false` until the merge lands,
+	/// and the next persisted-property read traps in SwiftData's backing-data
+	/// lookup — the app's largest crash. Running the snapshot here serializes it
+	/// against every delete this actor performs, and only value types cross back.
+	func watchNodeSnapshot(
+		userLatitude: Double,
+		userLongitude: Double,
+		maxDistanceMeters: Double
+	) -> [WatchNode] {
+		// A retired instance's container may already be torn down (see recreateShared()).
+		guard !invalidated else { return [] }
+		let descriptor = FetchDescriptor<NodeInfoEntity>(
+			predicate: #Predicate<NodeInfoEntity> { $0.user != nil }
+		)
+		guard let results = try? modelContext.fetch(descriptor) else { return [] }
+		let userLocation = CLLocation(latitude: userLatitude, longitude: userLongitude)
+		return results.compactMap {
+			WatchNode.make(from: $0, userLocation: userLocation, maxDistanceMeters: maxDistanceMeters)
+		}
 	}
 
 	/// Nodes: cap the total, evicting least-recently-heard first. Never evict favorites — the user

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -177,7 +177,13 @@ actor MeshPackets {
 		let descriptor = FetchDescriptor<NodeInfoEntity>(
 			predicate: #Predicate<NodeInfoEntity> { $0.user != nil }
 		)
-		guard let results = try? modelContext.fetch(descriptor) else { return [] }
+		let results: [NodeInfoEntity]
+		do {
+			results = try modelContext.fetch(descriptor)
+		} catch {
+			Logger.data.error("⌚ Watch snapshot fetch failed: \(error.localizedDescription, privacy: .public)")
+			return []
+		}
 		let userLocation = CLLocation(latitude: userLatitude, longitude: userLongitude)
 		return results.compactMap {
 			WatchNode.make(from: $0, userLocation: userLocation, maxDistanceMeters: maxDistanceMeters)

--- a/Meshtastic/Helpers/WatchSessionManager.swift
+++ b/Meshtastic/Helpers/WatchSessionManager.swift
@@ -85,7 +85,7 @@ final class WatchSessionManager: NSObject, ObservableObject {
 						try? await Task.sleep(for: .seconds(delay))
 					}
 					guard !Task.isCancelled else { return }
-					self.performSendNodesToWatch()
+					await self.performSendNodesToWatch()
 					self.watchUpdateTask = nil
 				}
 			}
@@ -93,15 +93,30 @@ final class WatchSessionManager: NSObject, ObservableObject {
 		}
 
 		Task { @MainActor in
-			self.performSendNodesToWatch()
+			await self.performSendNodesToWatch()
 		}
 	}
 
 	@MainActor
-	private func performSendNodesToWatch() {
+	private func performSendNodesToWatch() async {
 		lastWatchSendTime = Date()
 
-		let nodes = fetchNodesForWatch()
+		guard let userLocation = LocationsHandler.shared.locationsArray.last else {
+			logger.info("No user location available, skipping Watch update")
+			return
+		}
+
+		// Snapshot on the MeshPackets actor, which owns every node/position delete
+		// (cap eviction, near-duplicate position pruning). Walking main-context
+		// entities here raced those deletes: an instance whose row the actor had
+		// deleted passed the liveness guards until its next persisted-property read
+		// trapped in SwiftData's backing-data lookup. Serializing the read against
+		// the deletes removes the race instead of narrowing it.
+		let nodes = await MeshPackets.shared.watchNodeSnapshot(
+			userLatitude: userLocation.coordinate.latitude,
+			userLongitude: userLocation.coordinate.longitude,
+			maxDistanceMeters: Self.maxDistanceMeters
+		)
 		guard !nodes.isEmpty else { return }
 
 		do {
@@ -113,33 +128,8 @@ final class WatchSessionManager: NSObject, ObservableObject {
 		}
 	}
 
-	// MARK: - SwiftData → Watch Node Serialization
-
 	/// Maximum distance in meters to include a node (0.5 miles).
 	private static let maxDistanceMeters: Double = 804.672
-
-	@MainActor
-	private func fetchNodesForWatch() -> [WatchNode] {
-		let context = PersistenceController.shared.context
-		let descriptor = FetchDescriptor<NodeInfoEntity>(
-			predicate: #Predicate<NodeInfoEntity> { $0.user != nil }
-		)
-
-		guard let userLocation = LocationsHandler.shared.locationsArray.last else {
-			logger.info("No user location available, skipping Watch update")
-			return []
-		}
-
-		do {
-			let results = try context.fetch(descriptor)
-			return results.compactMap { nodeInfo -> WatchNode? in
-				WatchNode.make(from: nodeInfo, userLocation: userLocation, maxDistanceMeters: Self.maxDistanceMeters)
-			}
-		} catch {
-			logger.error("Failed to fetch nodes for Watch: \(error.localizedDescription, privacy: .public)")
-			return []
-		}
-	}
 }
 
 // MARK: - WCSessionDelegate
@@ -171,7 +161,7 @@ extension WatchSessionManager: WCSessionDelegate {
 }
 
 // MARK: - WatchNode (mirrors the Watch app's MeshNode, Codable for transfer)
-struct WatchNode: Codable {
+struct WatchNode: Codable, Sendable {
 	let num: UInt32
 	let longName: String
 	let shortName: String
@@ -183,10 +173,13 @@ struct WatchNode: Codable {
 	let snr: Float?
 
 	static func make(from nodeInfo: NodeInfoEntity, userLocation: CLLocation, maxDistanceMeters: Double) -> WatchNode? {
-		// Liveness screens: this walk runs over every node with a user, often while the app is
-		// backgrounded with ingestion still churning — an entity whose row another context
-		// deleted traps in SwiftData's persisted-property accessor the moment it's read
-		// (the 2.7.17 `58e0e820` background crash). Skip anything not verifiably live.
+		// Liveness screens. These are a cheap backstop, not the fix: they only see
+		// deletions made through the entity's own context, which is why the walk kept
+		// crashing (`58e0e820`) when run on the main context against the ingest
+		// actor's deletes. The real protection is that this now runs ON the
+		// MeshPackets actor (see watchNodeSnapshot), serialized with those deletes;
+		// the screens still catch rows removed by main-context writers (admin node
+		// removal, database clear).
 		guard nodeInfo.modelContext != nil, !nodeInfo.isDeleted else { return nil }
 		guard let user = nodeInfo.user, user.modelContext != nil, !user.isDeleted else { return nil }
 		guard let pos = nodeInfo.latestPosition, pos.modelContext != nil, !pos.isDeleted else { return nil }

--- a/MeshtasticTests/WatchNodeSnapshotTests.swift
+++ b/MeshtasticTests/WatchNodeSnapshotTests.swift
@@ -1,0 +1,152 @@
+//
+//  WatchNodeSnapshotTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/23/26.
+//
+//  Pins MeshPackets.watchNodeSnapshot — the Watch update's data source. It runs on
+//  the MeshPackets actor because that actor owns every node/position delete (cap
+//  eviction, near-duplicate pruning); the previous main-context walk raced those
+//  deletes and trapped in SwiftData's backing-data lookup, which was the app's
+//  largest crash. These tests cover the mapping and filtering; the serialization
+//  property is by construction (same actor), not something a unit test can race.
+//
+
+import CoreLocation
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Watch node snapshot")
+struct WatchNodeSnapshotTests {
+
+	private static let userLat = 48.0
+	private static let userLon = -122.0
+	private static let halfMile = 804.672
+
+	private func makeContainer() throws -> ModelContainer {
+		try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+	}
+
+	@discardableResult
+	private func seedNode(
+		_ context: ModelContext,
+		num: Int64,
+		name: String,
+		hasUser: Bool = true,
+		latitude: Double? = nil,
+		longitude: Double? = nil
+	) -> NodeInfoEntity {
+		let node = NodeInfoEntity()
+		node.num = num
+		node.lastHeard = Date()
+		node.snr = 7.5
+		if hasUser {
+			let user = UserEntity()
+			user.num = num
+			user.longName = name
+			user.shortName = String(name.prefix(4))
+			node.user = user
+			context.insert(user)
+		}
+		context.insert(node)
+		if let latitude, let longitude {
+			let position = PositionEntity()
+			position.latitudeI = Int32(latitude * 1e7)
+			position.longitudeI = Int32(longitude * 1e7)
+			position.altitude = 42
+			position.time = Date()
+			position.nodePosition = node
+			context.insert(position)
+			node.latestPositionCache = position
+		}
+		return node
+	}
+
+	@Test func includesOnlyNodesWithUserAndPositionInRange() async throws {
+		let container = try makeContainer()
+		let context = ModelContext(container)
+		// In range: same coordinates as the user.
+		seedNode(context, num: 1, name: "Near Node", latitude: Self.userLat, longitude: Self.userLon)
+		// Out of range: a degree of latitude is ~111 km.
+		seedNode(context, num: 2, name: "Far Node", latitude: Self.userLat + 1.0, longitude: Self.userLon)
+		// No position at all.
+		seedNode(context, num: 3, name: "No Position")
+		// No user: excluded by the fetch predicate.
+		seedNode(context, num: 4, name: "No User", hasUser: false, latitude: Self.userLat, longitude: Self.userLon)
+		try context.save()
+
+		let mesh = MeshPackets(modelContainer: container)
+		let nodes = await mesh.watchNodeSnapshot(
+			userLatitude: Self.userLat,
+			userLongitude: Self.userLon,
+			maxDistanceMeters: Self.halfMile
+		)
+
+		#expect(nodes.count == 1)
+		let node = try #require(nodes.first)
+		#expect(node.num == 1)
+		#expect(node.longName == "Near Node")
+		#expect(node.altitude == 42)
+		#expect(node.snr == 7.5)
+		#expect(node.latitude != nil && abs(node.latitude! - Self.userLat) < 0.0001)
+	}
+
+	@Test func zeroCoordinatePositionIsExcluded() async throws {
+		let container = try makeContainer()
+		let context = ModelContext(container)
+		// 0/0 is the mesh's "no fix" sentinel, not a real position.
+		seedNode(context, num: 5, name: "Null Island", latitude: 0, longitude: 0)
+		try context.save()
+
+		let mesh = MeshPackets(modelContainer: container)
+		let nodes = await mesh.watchNodeSnapshot(
+			userLatitude: 0, userLongitude: 0, maxDistanceMeters: Self.halfMile
+		)
+		#expect(nodes.isEmpty)
+	}
+
+	/// A retired actor's container may be torn down mid-flight (recreateShared);
+	/// the snapshot must refuse rather than read through it.
+	@Test func invalidatedActorReturnsEmpty() async throws {
+		let container = try makeContainer()
+		let context = ModelContext(container)
+		seedNode(context, num: 6, name: "Live Node", latitude: Self.userLat, longitude: Self.userLon)
+		try context.save()
+
+		let mesh = MeshPackets(modelContainer: container)
+		await mesh.invalidate()
+		let nodes = await mesh.watchNodeSnapshot(
+			userLatitude: Self.userLat,
+			userLongitude: Self.userLon,
+			maxDistanceMeters: Self.halfMile
+		)
+		#expect(nodes.isEmpty)
+	}
+
+	/// The exact scenario that crashed in the field: the actor deletes nodes (cap
+	/// eviction) and the snapshot runs against the same store afterward. Deleted
+	/// rows must simply be absent — no invalidated instances reachable.
+	@Test func snapshotAfterActorEvictionSeesOnlySurvivors() async throws {
+		let container = try makeContainer()
+		let context = ModelContext(container)
+		for i in 1...5 {
+			seedNode(context, num: Int64(i), name: "Node \(i)", latitude: Self.userLat, longitude: Self.userLon)
+		}
+		try context.save()
+
+		let mesh = MeshPackets(modelContainer: container)
+		await mesh.evictNodesIfOverCap(2)
+		let nodes = await mesh.watchNodeSnapshot(
+			userLatitude: Self.userLat,
+			userLongitude: Self.userLon,
+			maxDistanceMeters: Self.halfMile
+		)
+		#expect(nodes.count == 2)
+	}
+}

--- a/MeshtasticTests/WatchNodeSnapshotTests.swift
+++ b/MeshtasticTests/WatchNodeSnapshotTests.swift
@@ -40,11 +40,12 @@ struct WatchNodeSnapshotTests {
 		name: String,
 		hasUser: Bool = true,
 		latitude: Double? = nil,
-		longitude: Double? = nil
+		longitude: Double? = nil,
+		lastHeard: Date = Date()
 	) -> NodeInfoEntity {
 		let node = NodeInfoEntity()
 		node.num = num
-		node.lastHeard = Date()
+		node.lastHeard = lastHeard
 		node.snr = 7.5
 		if hasUser {
 			let user = UserEntity()
@@ -135,8 +136,15 @@ struct WatchNodeSnapshotTests {
 	@Test func snapshotAfterActorEvictionSeesOnlySurvivors() async throws {
 		let container = try makeContainer()
 		let context = ModelContext(container)
+		// Distinct lastHeard values make the eviction order deterministic:
+		// least-recently-heard first, so nodes 1-3 go and 4-5 survive.
+		let base = Date(timeIntervalSince1970: 1_700_000_000)
 		for i in 1...5 {
-			seedNode(context, num: Int64(i), name: "Node \(i)", latitude: Self.userLat, longitude: Self.userLon)
+			seedNode(
+				context, num: Int64(i), name: "Node \(i)",
+				latitude: Self.userLat, longitude: Self.userLon,
+				lastHeard: base.addingTimeInterval(Double(i) * 60)
+			)
 		}
 		try context.save()
 
@@ -147,6 +155,6 @@ struct WatchNodeSnapshotTests {
 			userLongitude: Self.userLon,
 			maxDistanceMeters: Self.halfMile
 		)
-		#expect(nodes.count == 2)
+		#expect(Set(nodes.map(\.num)) == [4, 5], "eviction keeps the most recently heard nodes")
 	}
 }


### PR DESCRIPTION
## Summary

The most frequent crash in the app is a SIGTRAP in `WatchNode.make` under `WatchSessionManager.fetchNodesForWatch`, with SwiftData's `_SD_get_faulting_backingdata_tsd` on the stack — SwiftData asserting because a model's backing row no longer exists in the store. A symbolicated TestFlight report from 2.7.19 (2306) pinned it.

The Watch update walks every node with a user on the main context. Meanwhile the `MeshPackets` actor — its own executor, its own `ModelContext` — deletes rows: node cap eviction and near-duplicate position pruning. A main-context instance whose row was deleted by that other context keeps passing the `modelContext != nil` / `isDeleted == false` liveness guards until the merge is processed; the next persisted-property read traps fatally. The guards added in 2.7.17 narrowed the window, which is why the crash shrank but never disappeared. They cannot close it: those checks only see deletions made through the entity's own context.

## What changed

The snapshot now runs on the `MeshPackets` actor itself (`watchNodeSnapshot`), so it is serialized against every delete that actor performs — the race is removed rather than narrowed. Only `Sendable` `WatchNode` value structs cross back to the main actor, which then encodes and sends them to the Watch as before.

- `WatchSessionManager.performSendNodesToWatch()` is async; the user location is read on the main actor and passed in as plain coordinates. `fetchNodesForWatch()` is gone.
- `WatchNode.make` and its liveness guards stay, as a backstop against main-context writers (admin node removal, database clear) — the comment now explains what they can and cannot catch.
- A retired actor instance (after `recreateShared()`) returns an empty snapshot instead of reading through a possibly torn-down container.

## Testing

- New `WatchNodeSnapshotTests`: mapping and range filtering (in range, out of range, no position, no user), the 0/0 no-fix sentinel, the retired-instance refusal, and a snapshot taken after actor-side cap eviction seeing only survivors.
- Full unit suite passes; iOS builds. The crash itself is a cross-actor timing race, so the serialization property is by construction rather than something a unit test can reproduce — worth watching the crash reporter after the next TestFlight build to confirm the family goes quiet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple Watch node updates to avoid crashes while nodes are removed or cleaned up.
  * Watch data now consistently reflects only active, valid nodes.
  * Excludes nodes without location fixes and filters results by distance.

* **Tests**
  * Added coverage for node filtering, invalidated data sources, location validation, and node eviction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->