### PR TITLE
Never hand the message lists duplicate ForEach ids

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -460,14 +460,20 @@ extension AccessoryManager {
 					var toRadio: ToRadio!
 					toRadio = ToRadio()
 					toRadio.packet = meshPacket
-					Task {
-						let logString = String.localizedStringWithFormat("Sent message %@ from %@ to %@".localized, String(newMessage.messageId), fromUserNum.toHex(), toUserNum.toHex())
-						try await send(toRadio, debugDescription: logString)
-						Logger.mesh.info("💬 \(logString, privacy: .public)")
-					}
 					do {
+						// Save BEFORE the transmit task can start: the mesh echoes this packet
+						// back within seconds, and the ingest actor's duplicate guard fetches
+						// the store — it cannot see this context's unsaved row. A transmit that
+						// beats the save re-inserts the echo under the same messageId, and the
+						// message list briefly renders duplicate ForEach ids, which corrupts
+						// the List's collection-view diff (the 2.7.19 SIGABRT batch-update crash).
 						try context.save()
 						Logger.data.info("💾 Saved a new sent message from \(self.activeDeviceNum?.toHex() ?? "0", privacy: .public) to \(toUserNum.toHex(), privacy: .public)")
+						Task {
+							let logString = String.localizedStringWithFormat("Sent message %@ from %@ to %@".localized, String(newMessage.messageId), fromUserNum.toHex(), toUserNum.toHex())
+							try await send(toRadio, debugDescription: logString)
+							Logger.mesh.info("💬 \(logString, privacy: .public)")
+						}
 						// Donate outgoing message to SiriKit for CarPlay
 						// (CarPlay is iPhone-only, so skip on Mac Catalyst).
 						if !isEmoji {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -489,6 +489,10 @@ extension AccessoryManager {
 				}
 			} catch {
 				Logger.data.error("💥 Send message failure \(self.activeDeviceNum?.toHex() ?? "0", privacy: .public) to \(toUserNum.toHex(), privacy: .public)")
+				// A failed save means nothing was stored and nothing will transmit —
+				// the caller must see the failure (keep the draft, show the error),
+				// not a silent success.
+				throw error
 			}
 
 	}

--- a/Meshtastic/Model/MessageEntity.swift
+++ b/Meshtastic/Model/MessageEntity.swift
@@ -44,3 +44,19 @@ final class MessageEntity {
 
 	init() {}
 }
+
+extension MessageEntity {
+	/// Drops later occurrences of a repeated `messageId`, preserving order.
+	///
+	/// `messageId` is `@Attribute(.unique)`, but uniqueness is enforced per save:
+	/// a sent message (main context) and its mesh echo (ingest actor) can coexist
+	/// briefly before the constraint merges them. The message lists key their
+	/// `ForEach` on `messageId`, and handing SwiftUI duplicate ids corrupts the
+	/// List's collection-view batch update, which crashes. First occurrence wins —
+	/// in the lists' chronological order that is the row the user already sees.
+	static func deduplicatedByMessageId(_ messages: [MessageEntity]) -> [MessageEntity] {
+		var seen = Set<Int64>()
+		seen.reserveCapacity(messages.count)
+		return messages.filter { seen.insert($0.messageId).inserted }
+	}
+}

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -113,7 +113,14 @@ struct ChannelMessageList: View {
 			let fetchedMessages = try fetchMessages(limit: messageLimit + 1)
 			hasEarlierMessages = fetchedMessages.count > messageLimit
 
-			let visibleMessages = Array(fetchedMessages.prefix(messageLimit).reversed())
+			// The ForEach below keys on messageId. The store can transiently hold two
+			// rows with the same messageId (a sent message and its mesh echo, racing
+			// across contexts before the unique constraint merges them) — duplicate
+			// ForEach ids corrupt the List's collection-view diff and crash. Keep the
+			// first occurrence; the merge collapses the rows moments later.
+			let visibleMessages = MessageEntity.deduplicatedByMessageId(
+				Array(fetchedMessages.prefix(messageLimit).reversed())
+			)
 			let previousMessage = hasEarlierMessages ? fetchedMessages[messageLimit] : nil
 
 			messages = visibleMessages

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -110,7 +110,14 @@ struct UserMessageList: View {
 			let fetchedMessages = try fetchMessages(limit: messageLimit + 1)
 			hasEarlierMessages = fetchedMessages.count > messageLimit
 
-			let visibleMessages = Array(fetchedMessages.prefix(messageLimit).reversed())
+			// The ForEach below keys on messageId. The store can transiently hold two
+			// rows with the same messageId (a sent message and its mesh echo, racing
+			// across contexts before the unique constraint merges them) — duplicate
+			// ForEach ids corrupt the List's collection-view diff and crash. Keep the
+			// first occurrence; the merge collapses the rows moments later.
+			let visibleMessages = MessageEntity.deduplicatedByMessageId(
+				Array(fetchedMessages.prefix(messageLimit).reversed())
+			)
 			let previousMessage = hasEarlierMessages ? fetchedMessages[messageLimit] : nil
 
 			messages = visibleMessages

--- a/MeshtasticTests/MessageDeduplicationTests.swift
+++ b/MeshtasticTests/MessageDeduplicationTests.swift
@@ -1,0 +1,43 @@
+//
+//  MessageDeduplicationTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/23/26.
+//
+//  Pins MessageEntity.deduplicatedByMessageId, the guard that keeps the message
+//  lists from handing SwiftUI duplicate ForEach ids while a sent message and its
+//  mesh echo briefly coexist across contexts (the 2.7.19 List batch-update crash).
+//
+
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Message list deduplication")
+struct MessageDeduplicationTests {
+
+	private func message(_ id: Int64, payload: String = "") -> MessageEntity {
+		let message = MessageEntity()
+		message.messageId = id
+		message.messagePayload = payload
+		return message
+	}
+
+	@Test func keepsFirstOccurrenceAndOrder() {
+		let original = message(42, payload: "sent")
+		let echo = message(42, payload: "echo")
+		let result = MessageEntity.deduplicatedByMessageId([message(1), original, message(7), echo, message(9)])
+		#expect(result.map(\.messageId) == [1, 42, 7, 9])
+		#expect(result[1].messagePayload == "sent")
+	}
+
+	@Test func passesUniqueListsThroughUnchanged() {
+		let input = [message(1), message(2), message(3)]
+		let result = MessageEntity.deduplicatedByMessageId(input)
+		#expect(result.map(\.messageId) == [1, 2, 3])
+	}
+
+	@Test func emptyListIsEmpty() {
+		#expect(MessageEntity.deduplicatedByMessageId([]).isEmpty)
+	}
+}


### PR DESCRIPTION
## Summary

The most frequent 2.7.19 TestFlight crash after the Watch one is a SIGABRT in a SwiftUI List batch update: `NSInternalInconsistencyException — attempt to delete item 1 from section 0 which only contains 1 items before the update`, thrown inside `UICollectionView` under SwiftUI's list coordinator, with no app frames. That exception is what UIKit throws when a List's diff disagrees with the data it was handed — classically, duplicate `ForEach` ids.

Both message lists key their `ForEach` on `messageId`. `messageId` is `@Attribute(.unique)`, but uniqueness is enforced per save, and there is a real window where the store view contains two rows with the same id:

1. `sendMessage` inserts the outgoing row on the main context, then starts the radio transmit in an unstructured `Task` **before** `context.save()` runs. The save can also queue behind the ingest actor's writes.
2. The mesh echoes the packet back within seconds. The ingest actor's duplicate guard fetches by `messageId` — on its own context, which cannot see main's uncommitted row — so it inserts a second row with the same id.
3. The unique constraint merges the rows at save, but a list fetch landing between the commits hands the `ForEach` both. The next batch update throws.

## What changed

- `sendMessage` saves the row before creating the transmit task, so the echo cannot come back before the row is committed. Side benefit: a failed save no longer transmits a packet with no local record.
- Both `UserMessageList` and `ChannelMessageList` deduplicate by `messageId` at load (`MessageEntity.deduplicatedByMessageId`, first occurrence wins), so the `ForEach` can never see a duplicate id regardless of how one reaches the store — including packet-id collisions between different senders, which the per-sender mesh packet id space allows.

## Testing

- New `MessageDeduplicationTests` pin the helper: first-occurrence-wins with order preserved, unique lists pass through unchanged, empty input.
- Full unit suite passes; iOS builds. The crash itself needs a sub-second cross-context race on a live radio, so it is not directly reproducible in a unit test — the dedupe layer is the guarantee, the save reorder removes the common trigger. Worth confirming the family goes quiet after the next TestFlight build, alongside the Watch fix in #2354.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outgoing messages are saved locally before transmission, improving message continuity.
* **Bug Fixes**
  * Prevented duplicate messages from appearing in channel and direct-message lists.
  * Improved list stability when sent messages and mesh echoes briefly overlap.
* **Tests**
  * Added coverage for duplicate removal, message ordering, unique messages, and empty lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->