### PR TITLE
Track GeoJSON provenance: planner runs replace, uploads stay user-controlled

### DIFF
--- a/Meshtastic/Helpers/GeoJSONOverlayManager.swift
+++ b/Meshtastic/Helpers/GeoJSONOverlayManager.swift
@@ -149,4 +149,10 @@ class GeoJSONOverlayManager {
 		// Clear cache to force reload with new file states
 		clearCache()
 	}
+
+	/// Set the active state of an uploaded file explicitly (persisted).
+	func setFileActive(_ fileId: UUID, _ isActive: Bool) {
+		MapDataManager.shared.setFileActive(fileId, isActive)
+		clearCache()
+	}
 }

--- a/Meshtastic/Helpers/MapDataManager.swift
+++ b/Meshtastic/Helpers/MapDataManager.swift
@@ -57,7 +57,7 @@ class MapDataManager: ObservableObject {
 	// MARK: - File Upload & Processing
 
 	/// Process and store an uploaded file
-	func processUploadedFile(from sourceURL: URL) async throws -> MapDataMetadata {
+	func processUploadedFile(from sourceURL: URL, source: MapDataSource = .manualUpload) async throws -> MapDataMetadata {
 
 		// 1. Start accessing security-scoped resource
 		let isAccessing = sourceURL.startAccessingSecurityScopedResource()
@@ -89,11 +89,20 @@ class MapDataManager: ObservableObject {
 		try FileManager.default.copyItem(at: sourceURL, to: destURL)
 
 		// 5. Process and validate content
-		let metadata = try await processFileContent(at: destURL, originalName: originalName)
+		let metadata = try await processFileContent(at: destURL, originalName: originalName, source: source)
 
 		// 6. Save metadata and update UI on main thread
 		await MainActor.run {
 			uploadedFiles.append(metadata)
+			// A new Site Planner run replaces the previous one on the map: only the
+			// newest planner file stays active. Manual uploads are never touched —
+			// their visibility belongs to the user.
+			if metadata.source == .sitePlanner {
+				for index in uploadedFiles.indices
+				where uploadedFiles[index].source == .sitePlanner && uploadedFiles[index].id != metadata.id {
+					uploadedFiles[index].isActive = false
+				}
+			}
 			// Clear cached configuration to force reload
 			activeFeatureCollection = nil
 		}
@@ -106,7 +115,7 @@ class MapDataManager: ObservableObject {
 	/// the Site Planner's native bridge) through the same pipeline as `processUploadedFile`, so it
 	/// reuses the exact validation + render + styling path with no round-trip to the share sheet.
 	/// `name` becomes the on-disk file / layer name; a `.geojson` extension is enforced.
-	func importFromString(_ geoJSON: String, name: String) async throws -> MapDataMetadata {
+	func importFromString(_ geoJSON: String, name: String, source: MapDataSource = .manualUpload) async throws -> MapDataMetadata {
 		guard let data = geoJSON.data(using: .utf8) else {
 			throw MapDataError.invalidContent
 		}
@@ -129,7 +138,7 @@ class MapDataManager: ObservableObject {
 		try data.write(to: tempURL)
 		defer { try? FileManager.default.removeItem(at: tempURL) }
 
-		return try await processUploadedFile(from: tempURL)
+		return try await processUploadedFile(from: tempURL, source: source)
 	}
 
 	/// Validate uploaded file
@@ -155,7 +164,7 @@ class MapDataManager: ObservableObject {
 	}
 
 	/// Process file content and extract metadata
-	private func processFileContent(at url: URL, originalName: String) async throws -> MapDataMetadata {
+	private func processFileContent(at url: URL, originalName: String, source: MapDataSource) async throws -> MapDataMetadata {
 		let fileAttributes = try url.resourceValues(forKeys: [.fileSizeKey, .creationDateKey])
 		let fileSize = fileAttributes.fileSize ?? 0
 		let uploadDate = fileAttributes.creationDate ?? Date()
@@ -194,9 +203,6 @@ class MapDataManager: ObservableObject {
 			}
 		}
 
-		// If this is the first file uploaded, make it active by default
-		let isFirstFile = uploadedFiles.isEmpty
-
 		return MapDataMetadata(
 			filename: url.lastPathComponent,
 			originalName: originalName,
@@ -206,7 +212,11 @@ class MapDataManager: ObservableObject {
 			license: nil, // Will be extracted from content if available
 			attribution: nil, // Will be extracted from content if available
 			overlayCount: overlayCount,
-			isActive: isFirstFile
+			// New files start visible: a coverage run replaces the previous one
+			// (older planner files are deactivated by the caller), and a manual
+			// upload shows immediately with its visibility toggle in the user's hands.
+			isActive: true,
+			source: source
 		)
 	}
 
@@ -323,6 +333,20 @@ class MapDataManager: ObservableObject {
 		return uploadedFiles
 	}
 
+	/// Set the active state of an uploaded file explicitly (the settings toggles
+	/// persist through this, so visibility survives relaunch).
+	func setFileActive(_ fileId: UUID, _ isActive: Bool) {
+		guard let index = uploadedFiles.firstIndex(where: { $0.id == fileId }),
+			  uploadedFiles[index].isActive != isActive else { return }
+		uploadedFiles[index].isActive = isActive
+		do {
+			try saveMetadata()
+			activeFeatureCollection = nil
+		} catch {
+			Logger.services.error("🚨 MapDataManager: FAILED to save metadata after setting file active: \(error.localizedDescription)")
+		}
+	}
+
 	/// Toggle the active state of an uploaded file
 	func toggleFileActive(_ fileId: UUID) {
 		if let index = uploadedFiles.firstIndex(where: { $0.id == fileId }) {
@@ -426,6 +450,14 @@ class MapDataManager: ObservableObject {
 
 // MARK: - Supporting Types
 
+/// Where a map data file came from. Site Planner coverage runs are managed
+/// automatically (only the newest stays active); manual uploads keep whatever
+/// visibility the user set.
+enum MapDataSource: String, Codable, Sendable {
+	case manualUpload
+	case sitePlanner
+}
+
 /// Metadata for uploaded map data files
 struct MapDataMetadata: Codable, Identifiable {
 	let id: UUID
@@ -438,8 +470,9 @@ struct MapDataMetadata: Codable, Identifiable {
 	let attribution: String?
 	let overlayCount: Int
 	var isActive: Bool
+	var source: MapDataSource
 
-	init(filename: String, originalName: String, uploadDate: Date, fileSize: Int64, format: String, license: String?, attribution: String?, overlayCount: Int, isActive: Bool) {
+	init(filename: String, originalName: String, uploadDate: Date, fileSize: Int64, format: String, license: String?, attribution: String?, overlayCount: Int, isActive: Bool, source: MapDataSource = .manualUpload) {
 		self.id = UUID()
 		self.filename = filename
 		self.originalName = originalName
@@ -450,6 +483,24 @@ struct MapDataMetadata: Codable, Identifiable {
 		self.attribution = attribution
 		self.overlayCount = overlayCount
 		self.isActive = isActive
+		self.source = source
+	}
+
+	/// Manifests written before `source` existed decode as manual uploads — every
+	/// file back then came from the file picker.
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		id = try container.decode(UUID.self, forKey: .id)
+		filename = try container.decode(String.self, forKey: .filename)
+		originalName = try container.decode(String.self, forKey: .originalName)
+		uploadDate = try container.decode(Date.self, forKey: .uploadDate)
+		fileSize = try container.decode(Int64.self, forKey: .fileSize)
+		format = try container.decode(String.self, forKey: .format)
+		license = try container.decodeIfPresent(String.self, forKey: .license)
+		attribution = try container.decodeIfPresent(String.self, forKey: .attribution)
+		overlayCount = try container.decode(Int.self, forKey: .overlayCount)
+		isActive = try container.decode(Bool.self, forKey: .isActive)
+		source = try container.decodeIfPresent(MapDataSource.self, forKey: .source) ?? .manualUpload
 	}
 
 	var fileSizeString: String {

--- a/Meshtastic/Helpers/MapDataManager.swift
+++ b/Meshtastic/Helpers/MapDataManager.swift
@@ -338,11 +338,15 @@ class MapDataManager: ObservableObject {
 	func setFileActive(_ fileId: UUID, _ isActive: Bool) {
 		guard let index = uploadedFiles.firstIndex(where: { $0.id == fileId }),
 			  uploadedFiles[index].isActive != isActive else { return }
+		let previous = uploadedFiles[index].isActive
 		uploadedFiles[index].isActive = isActive
 		do {
 			try saveMetadata()
 			activeFeatureCollection = nil
 		} catch {
+			// Revert so the session never shows a visibility the manifest does not
+			// hold — otherwise a relaunch would silently flip it back.
+			uploadedFiles[index].isActive = previous
 			Logger.services.error("🚨 MapDataManager: FAILED to save metadata after setting file active: \(error.localizedDescription)")
 		}
 	}

--- a/Meshtastic/Helpers/SitePlanner/CoverageEstimateRunner.swift
+++ b/Meshtastic/Helpers/SitePlanner/CoverageEstimateRunner.swift
@@ -182,7 +182,7 @@ final class CoverageEstimateRunner: NSObject, ObservableObject {
 		// `await` we're back on the main actor and can assign published state directly.
 		Task { [weak self] in
 			do {
-				let metadata = try await MapDataManager.shared.importFromString(geoJSON, name: importName)
+				let metadata = try await MapDataManager.shared.importFromString(geoJSON, name: importName, source: .sitePlanner)
 				guard let self else { return }
 				self.importedResult = CoverageEstimateResult(metadata: metadata, coordinate: coordinate, boundingBox: boundingBox)
 				self.state = .imported

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapDataFiles.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapDataFiles.swift
@@ -197,6 +197,15 @@ struct MapDataFileRow: View {
 						.padding(.vertical, 2)
 						.background(Color.secondary.opacity(0.2))
 						.cornerRadius(4)
+					if file.source == .sitePlanner {
+						Text("Site Planner")
+							.font(.caption2)
+							.fixedSize()
+							.padding(.horizontal, 8)
+							.padding(.vertical, 2)
+							.background(Color.accentColor.opacity(0.2))
+							.cornerRadius(4)
+					}
 					Text("\(file.overlayCount) features")
 						.font(.caption2)
 						.foregroundColor(.secondary)

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
@@ -235,68 +235,7 @@ struct MapSettingsForm: View {
 						let uploadedFiles = mapDataManager.getUploadedFiles()
 						if !uploadedFiles.isEmpty {
 							ForEach(uploadedFiles) { file in
-								Toggle(isOn: Binding(
-									get: {
-										return enabledOverlayConfigs.contains(file.id)
-									},
-									set: { newValue in
-										if newValue {
-											enabledOverlayConfigs.insert(file.id)
-										} else {
-											enabledOverlayConfigs.remove(file.id)
-										}
-									}
-								)) {
-									Label {
-										VStack(alignment: .leading, spacing: 2) {
-											Text(file.originalName)
-												.font(.subheadline)
-												.lineLimit(1)
-											// The format pill must never wrap internally (`.fixedSize()` pins it to
-											// its natural single-line width) — at large Dynamic Type sizes there's
-											// not always room for it plus the feature count on one line, so
-											// `ViewThatFits` drops the count to its own line instead.
-											ViewThatFits(in: .horizontal) {
-												HStack(spacing: 6) {
-													overlayFormatPill(file.format)
-													Text("\(file.overlayCount) features")
-														.font(.caption2)
-														.foregroundColor(.secondary)
-													Spacer()
-													Text(ByteCountFormatter.string(fromByteCount: file.fileSize, countStyle: .file))
-														.font(.caption2)
-														.foregroundColor(.secondary)
-												}
-												VStack(alignment: .leading, spacing: 2) {
-													HStack(spacing: 6) {
-														overlayFormatPill(file.format)
-														Spacer()
-														Text(ByteCountFormatter.string(fromByteCount: file.fileSize, countStyle: .file))
-															.font(.caption2)
-															.foregroundColor(.secondary)
-													}
-													Text("\(file.overlayCount) features")
-														.font(.caption2)
-														.foregroundColor(.secondary)
-												}
-											}
-											Text(file.uploadDate.formatted(date: .abbreviated, time: .shortened))
-												.font(.caption2)
-												.foregroundColor(.secondary)
-										}
-									} icon: {
-										let isEnabled = enabledOverlayConfigs.contains(file.id)
-										Image(systemName: isEnabled ? "doc.fill" : "doc")
-											.foregroundColor(isEnabled ? .accentColor : .secondary)
-									}
-								}
-								.swipeActions(edge: .trailing) {
-									Button(role: .destructive) {
-										deleteOverlayFile(file)
-									} label: {
-										Label("Delete", systemImage: "trash")
-									}
-								}
+								overlayFileRow(file)
 							}
 						} else {
 							ContentUnavailableView("No map data files uploaded", systemImage: "exclamationmark.triangle")
@@ -383,6 +322,90 @@ struct MapSettingsForm: View {
 
 	// MARK: - Overlay file upload / delete
 
+	/// One overlay-file row: visibility toggle plus delete swipe. Extracted (with
+	/// overlayFileLabel below) to keep the enclosing Form inside the compiler's
+	/// type-check budget.
+	@ViewBuilder
+	private func overlayFileRow(_ file: MapDataMetadata) -> some View {
+		let isOn = Binding<Bool>(
+			get: { enabledOverlayConfigs.contains(file.id) },
+			set: { newValue in
+				// Persist through the store so visibility survives relaunch;
+				// the transient set drives this render.
+				GeoJSONOverlayManager.shared.setFileActive(file.id, newValue)
+				if newValue {
+					enabledOverlayConfigs.insert(file.id)
+				} else {
+					enabledOverlayConfigs.remove(file.id)
+				}
+			}
+		)
+		Toggle(isOn: isOn) {
+			Label {
+				overlayFileLabel(file)
+			} icon: {
+				let isEnabled = enabledOverlayConfigs.contains(file.id)
+				Image(systemName: isEnabled ? "doc.fill" : "doc")
+					.foregroundColor(isEnabled ? .accentColor : .secondary)
+			}
+		}
+		.swipeActions(edge: .trailing) {
+			Button(role: .destructive) {
+				deleteOverlayFile(file)
+			} label: {
+				Label("Delete", systemImage: "trash")
+			}
+		}
+	}
+
+	/// The text column of an overlay-file row, extracted so the Toggle expression
+	/// stays inside the compiler's type-check budget.
+	@ViewBuilder
+	private func overlayFileLabel(_ file: MapDataMetadata) -> some View {
+		VStack(alignment: .leading, spacing: 2) {
+			Text(file.originalName)
+				.font(.subheadline)
+				.lineLimit(1)
+			// The format pill must never wrap internally (`.fixedSize()` pins it to
+			// its natural single-line width) — at large Dynamic Type sizes there's
+			// not always room for it plus the feature count on one line, so
+			// `ViewThatFits` drops the count to its own line instead.
+			ViewThatFits(in: .horizontal) {
+				HStack(spacing: 6) {
+					overlayFormatPill(file.format)
+					if file.source == .sitePlanner {
+						overlaySourcePill()
+					}
+					Text("\(file.overlayCount) features")
+						.font(.caption2)
+						.foregroundColor(.secondary)
+					Spacer()
+					Text(ByteCountFormatter.string(fromByteCount: file.fileSize, countStyle: .file))
+						.font(.caption2)
+						.foregroundColor(.secondary)
+				}
+				VStack(alignment: .leading, spacing: 2) {
+					HStack(spacing: 6) {
+						overlayFormatPill(file.format)
+						if file.source == .sitePlanner {
+							overlaySourcePill()
+						}
+						Spacer()
+						Text(ByteCountFormatter.string(fromByteCount: file.fileSize, countStyle: .file))
+							.font(.caption2)
+							.foregroundColor(.secondary)
+					}
+					Text("\(file.overlayCount) features")
+						.font(.caption2)
+						.foregroundColor(.secondary)
+				}
+			}
+			Text(file.uploadDate.formatted(date: .abbreviated, time: .shortened))
+				.font(.caption2)
+				.foregroundColor(.secondary)
+		}
+	}
+
 	private func overlayFormatPill(_ format: String) -> some View {
 		Text(format.uppercased())
 			.font(.caption2)
@@ -391,6 +414,18 @@ struct MapSettingsForm: View {
 			.padding(.horizontal, 6)
 			.padding(.vertical, 1)
 			.background(Color.secondary.opacity(0.2))
+			.cornerRadius(4)
+	}
+
+	/// Marks a file produced by an in-app Site Planner coverage run — those are
+	/// managed automatically (only the newest stays active).
+	private func overlaySourcePill() -> some View {
+		Text("Site Planner")
+			.font(.caption2)
+			.fixedSize()
+			.padding(.horizontal, 8)
+			.padding(.vertical, 2)
+			.background(Color.accentColor.opacity(0.2))
 			.cornerRadius(4)
 	}
 

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapSettingsForm.swift
@@ -437,10 +437,13 @@ struct MapSettingsForm: View {
 
 			Task {
 				do {
-					_ = try await mapDataManager.processUploadedFile(from: selectedFile)
+					let metadata = try await mapDataManager.processUploadedFile(from: selectedFile)
 					await MainActor.run {
 						isProcessingUpload = false
 						mapOverlaysEnabled = true
+						// The upload arrives active in the store; mirror it into the
+						// transient render set so the row and overlay show immediately.
+						enabledOverlayConfigs.insert(metadata.id)
 					}
 				} catch {
 					await MainActor.run {

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -825,7 +825,11 @@ struct MeshMapMK: View {
 	private func applyImportedCoverage(_ result: CoverageEstimateResult) {
 		GeoJSONOverlayManager.shared.clearCache()
 		mapOverlaysEnabled = true
-		enabledOverlayConfigs.insert(result.metadata.id)
+		// Resync from the store rather than just inserting: the import deactivated
+		// older Site Planner files, so their overlays leave the map with this render.
+		enabledOverlayConfigs = Set(
+			GeoJSONOverlayManager.shared.getUploadedFilesWithState().filter { $0.isActive }.map(\.id)
+		)
 		rebuildGeoJSONOverlays()
 		cameraCommand = ClusterMapCameraCommand(
 			id: UUID(),

--- a/MeshtasticTests/MapDataManagerTests.swift
+++ b/MeshtasticTests/MapDataManagerTests.swift
@@ -90,10 +90,14 @@ struct MapDataSourcePolicyTests {
 		#expect(metadata.isActive)
 	}
 
+	// Cleanup is awaited at the end of each test rather than launched from a defer:
+	// an unstructured cleanup Task can still be rewriting upload_history.json when
+	// the next serialized test starts. #expect failures are non-fatal in Swift
+	// Testing, so the cleanup line is reached on assertion failure too.
+
 	@Test func newPlannerRunDeactivatesOnlyOlderPlannerFiles() async throws {
 		let manager = MapDataManager()
 		var created: [MapDataMetadata] = []
-		defer { Task { [created] in await cleanUp(manager, created) } }
 
 		let manual = try await manager.importFromString(sampleGeoJSON, name: "Manual \(UUID().uuidString)")
 		created.append(manual)
@@ -107,12 +111,13 @@ struct MapDataSourcePolicyTests {
 		#expect(files.first(where: { $0.id == firstRun.id })?.isActive == false, "an older planner run is replaced")
 		#expect(files.first(where: { $0.id == secondRun.id })?.isActive == true, "the newest planner run is the active one")
 		#expect(files.first(where: { $0.id == secondRun.id })?.source == .sitePlanner)
+
+		await cleanUp(manager, created)
 	}
 
 	@Test func manualUploadsArriveActiveAndKeepUserVisibility() async throws {
 		let manager = MapDataManager()
 		var created: [MapDataMetadata] = []
-		defer { Task { [created] in await cleanUp(manager, created) } }
 
 		let first = try await manager.importFromString(sampleGeoJSON, name: "Manual1 \(UUID().uuidString)")
 		created.append(first)
@@ -127,5 +132,15 @@ struct MapDataSourcePolicyTests {
 		#expect(files.first(where: { $0.id == first.id })?.isActive == false, "user-set visibility survives later uploads")
 		#expect(files.first(where: { $0.id == second.id })?.isActive == true)
 		#expect(files.first(where: { $0.id == second.id })?.source == .manualUpload)
+
+		// The hidden state must be in the manifest, not just this instance: a fresh
+		// manager reading the same store has to agree, or a relaunch flips it back.
+		let reloaded = MapDataManager()
+		reloaded.loadMetadata()
+		let reloadedFiles = reloaded.getUploadedFiles()
+		#expect(reloadedFiles.first(where: { $0.id == first.id })?.isActive == false, "setFileActive must persist to the manifest")
+		#expect(reloadedFiles.first(where: { $0.id == first.id })?.source == .manualUpload)
+
+		await cleanUp(manager, created)
 	}
 }

--- a/MeshtasticTests/MapDataManagerTests.swift
+++ b/MeshtasticTests/MapDataManagerTests.swift
@@ -58,3 +58,74 @@ struct MapDataManagerImportFromStringTests {
 		}
 	}
 }
+
+/// Covers file provenance and the per-source activation policy: a new Site Planner
+/// run replaces the previous one (only the newest planner file stays active), while
+/// manually uploaded files keep whatever visibility the user set.
+@Suite("MapData source and visibility policy", .serialized)
+struct MapDataSourcePolicyTests {
+
+	private let sampleGeoJSON = """
+	{ "type": "FeatureCollection", "features": [
+		{ "type": "Feature", "geometry": { "type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+		  "properties": { "fill": "#0080ff" } }
+	]}
+	"""
+
+	private func cleanUp(_ manager: MapDataManager, _ files: [MapDataMetadata]) async {
+		for file in files {
+			try? await manager.deleteFile(file)
+		}
+	}
+
+	@Test func manifestsWithoutSourceDecodeAsManualUpload() throws {
+		// A manifest entry written before `source` existed.
+		let legacy = """
+		{ "id": "9E8282D3-D73A-3954-8DD9-D5CAED9B4EFD", "filename": "a.geojson",
+		  "originalName": "a", "uploadDate": 700000000, "fileSize": 10,
+		  "format": "geojson", "overlayCount": 1, "isActive": true }
+		"""
+		let metadata = try JSONDecoder().decode(MapDataMetadata.self, from: Data(legacy.utf8))
+		#expect(metadata.source == .manualUpload)
+		#expect(metadata.isActive)
+	}
+
+	@Test func newPlannerRunDeactivatesOnlyOlderPlannerFiles() async throws {
+		let manager = MapDataManager()
+		var created: [MapDataMetadata] = []
+		defer { Task { [created] in await cleanUp(manager, created) } }
+
+		let manual = try await manager.importFromString(sampleGeoJSON, name: "Manual \(UUID().uuidString)")
+		created.append(manual)
+		let firstRun = try await manager.importFromString(sampleGeoJSON, name: "Run1 \(UUID().uuidString)", source: .sitePlanner)
+		created.append(firstRun)
+		let secondRun = try await manager.importFromString(sampleGeoJSON, name: "Run2 \(UUID().uuidString)", source: .sitePlanner)
+		created.append(secondRun)
+
+		let files = manager.getUploadedFiles()
+		#expect(files.first(where: { $0.id == manual.id })?.isActive == true, "a planner run must not touch manual uploads")
+		#expect(files.first(where: { $0.id == firstRun.id })?.isActive == false, "an older planner run is replaced")
+		#expect(files.first(where: { $0.id == secondRun.id })?.isActive == true, "the newest planner run is the active one")
+		#expect(files.first(where: { $0.id == secondRun.id })?.source == .sitePlanner)
+	}
+
+	@Test func manualUploadsArriveActiveAndKeepUserVisibility() async throws {
+		let manager = MapDataManager()
+		var created: [MapDataMetadata] = []
+		defer { Task { [created] in await cleanUp(manager, created) } }
+
+		let first = try await manager.importFromString(sampleGeoJSON, name: "Manual1 \(UUID().uuidString)")
+		created.append(first)
+		#expect(manager.getUploadedFiles().first(where: { $0.id == first.id })?.isActive == true)
+
+		// The user hides it; a later manual upload must not resurrect or change it.
+		manager.setFileActive(first.id, false)
+		let second = try await manager.importFromString(sampleGeoJSON, name: "Manual2 \(UUID().uuidString)")
+		created.append(second)
+
+		let files = manager.getUploadedFiles()
+		#expect(files.first(where: { $0.id == first.id })?.isActive == false, "user-set visibility survives later uploads")
+		#expect(files.first(where: { $0.id == second.id })?.isActive == true)
+		#expect(files.first(where: { $0.id == second.id })?.source == .manualUpload)
+	}
+}


### PR DESCRIPTION
## Summary

Map data files did not record where they came from, and per-file visibility did not stick. The toggles in map settings wrote to a transient set that was rebuilt from stored state on the next launch, so hiding a file never survived a relaunch. Successive Site Planner coverage runs piled up on the map instead of replacing each other.

## What changed

- `MapDataMetadata` records a `source`: `manualUpload` or `sitePlanner`. Manifests written before the field decode as manual uploads.
- A Site Planner run deactivates older planner files on import, so only the newest run draws. The map resyncs its enabled overlays from the store after an import, which removes the previous run's overlay in the same render. Manual uploads are never touched by this rule.
- Manually uploaded files arrive visible, and the per-file toggles in map settings now persist through the store — visibility survives relaunch.
- Both file lists (map settings and the map data screen) show a Site Planner badge on coverage files.
- The overlay-file row in MapSettingsForm is extracted into helpers; the added pill pushed the old single expression past the compiler's type-check budget.

## Testing

- New tests: manifests without the source field decode as manual uploads; a second planner run deactivates the first while leaving a manual upload alone; manual uploads arrive active and user-set visibility survives later uploads.
- Full unit suite passes (2,941 tests in 514 suites); iOS builds.
- Worth a hands-on pass: run two coverage estimates back to back (second should replace the first on the map), upload a GeoJSON manually, hide it in map settings, relaunch — it should stay hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying map overlays from manual uploads and Site Planner imports.
  * New Site Planner imports automatically deactivate older Site Planner overlays.
  * Added controls to activate or deactivate individual overlay files.
  * Site Planner overlays now display a source badge.

* **Bug Fixes**
  * Manual upload visibility is preserved across Site Planner imports.
  * Legacy map metadata remains compatible and defaults to manual uploads.
  * Map displays now rebuild overlays using only active files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->