### PR TITLE
fix(watch): declare notification support so Meshtastic gets a Watch notification setting

### DIFF
--- a/Meshtastic Watch App/ContentView.swift
+++ b/Meshtastic Watch App/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
 
 	@StateObject private var phoneManager = PhoneConnectivityManager()
 	@StateObject private var locationManager = WatchLocationManager()
+	@StateObject private var notificationManager = WatchNotificationManager()
 
 	var body: some View {
 		TabView {
@@ -28,6 +29,9 @@ struct ContentView: View {
 		.tabViewStyle(.verticalPage)
 		.onAppear {
 			locationManager.requestAuthorization()
+		}
+		.task {
+			await notificationManager.requestAuthorizationIfNeeded()
 		}
 	}
 }

--- a/Meshtastic Watch App/Managers/WatchNotificationManager.swift
+++ b/Meshtastic Watch App/Managers/WatchNotificationManager.swift
@@ -1,0 +1,84 @@
+//
+//  WatchNotificationManager.swift
+//  Meshtastic Watch App
+//
+//  Copyright(c) Meshtastic 2025.
+//
+
+import Foundation
+import UserNotifications
+import os
+
+/// Declares this target as a notification-capable watchOS app.
+///
+/// The Watch app posts no notifications of its own. Every Meshtastic alert felt on the
+/// wrist is an iPhone notification that watchOS mirrored, and no API opts a notification
+/// out of that mirroring — so the user's only control is the per-app entry under
+/// Watch → Notifications (Custom → Notifications Off).
+///
+/// Earning that entry is the whole point of this type. Watch → Notifications lists apps in
+/// two sections: apps with a watchOS app, and "Mirror iPhone Alerts From" for iPhone-only
+/// apps. Shipping a companion Watch app excludes Meshtastic from the second section, and
+/// while this target requested no notification authorization it earned no place in the
+/// first — leaving alerts arriving on the wrist with no switch in either section to stop
+/// them, and removing the Watch app no help because mirroring does not depend on it.
+///
+/// Deliberately narrow: authorization and foreground presentation only. No
+/// `UNNotificationCategory` is registered here. The categories and actions belong to the
+/// iOS app (`LocalNotificationManager`), which is also what handles a tapback or reply
+/// chosen from a mirrored notification; registering the same identifier on this side
+/// risks shadowing that.
+@MainActor
+final class WatchNotificationManager: NSObject, ObservableObject {
+
+	/// Authorization status surfaced to the UI, mirroring `WatchLocationManager`.
+	@Published private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
+
+	private let logger = Logger(subsystem: "gvh.MeshtasticClient.watchkitapp", category: "🔔 Notifications")
+
+	// MARK: - Lifecycle
+
+	override init() {
+		super.init()
+		UNUserNotificationCenter.current().delegate = self
+	}
+
+	// MARK: - Public API
+
+	/// Ask for notification authorization, but only when the user has not already been
+	/// asked. Same shape as the iOS app's `LocalNotificationManager.schedule()`: read the
+	/// current settings first and prompt only on `.notDetermined`, so an existing decision
+	/// — in either direction — is never re-prompted.
+	func requestAuthorizationIfNeeded() async {
+		let status = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+		authorizationStatus = status
+
+		guard status == .notDetermined else {
+			logger.info("Notification authorization already decided (status=\(status.rawValue))")
+			return
+		}
+
+		do {
+			let granted = try await UNUserNotificationCenter.current()
+				.requestAuthorization(options: [.alert, .badge, .sound])
+			authorizationStatus = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+			logger.info("Notification authorization granted: \(granted)")
+		} catch {
+			logger.error("Error requesting notification authorization: \(error.localizedDescription, privacy: .public)")
+		}
+	}
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+extension WatchNotificationManager: UNUserNotificationCenterDelegate {
+
+	/// Show mirrored alerts while the Watch app itself is frontmost. Without this the
+	/// system suppresses them, so a message arriving while the user is on the foxhunt
+	/// compass would be silently dropped rather than banner-ed.
+	nonisolated func userNotificationCenter(
+		_ center: UNUserNotificationCenter,
+		willPresent notification: UNNotification
+	) async -> UNNotificationPresentationOptions {
+		[.banner, .sound, .list]
+	}
+}

--- a/docs/user/watch.md
+++ b/docs/user/watch.md
@@ -75,3 +75,25 @@ Tap **Refresh** to request an updated node list from the iPhone app. If the phon
 ## Setting Foxhunt Targets
 
 From the iPhone app, mark a node as a foxhunt target from its detail view. Marked nodes are pushed to the Watch and pinned at the top of the Foxhunt list regardless of distance — useful when you know which node you are hunting before you are within ½ mile range.
+
+## Notifications
+
+The Watch app does not create notifications. Every Meshtastic alert on your wrist is a notification from the **iPhone** app that watchOS mirrored across, so it arrives whether or not the Watch app is running.
+
+**Removing the Watch app does not stop them.** Mirroring is a function of the pairing rather than of the Watch app, so deleting Meshtastic from the Watch leaves the alerts exactly as they were. Installing or removing the Watch app and silencing Watch alerts are two separate decisions.
+
+### Silence Meshtastic on the Watch only
+
+On your iPhone, open the **Watch** app → **My Watch** → **Notifications** → **Meshtastic** → **Custom**:
+
+| Option | Effect |
+|--------|--------|
+| Allow Notifications | Alerts appear on the Watch |
+| Send to Notification Center | Delivered silently — no haptic, no screen wake |
+| Notifications Off | No Meshtastic alerts on the Watch at all |
+
+Your iPhone keeps alerting normally under all three.
+
+### Silence a category on both devices
+
+To stop a *kind* of alert everywhere, use **Settings → Meshtastic → Notifications** on the iPhone. Turning a category off there stops the notification being created at all, so nothing reaches the Watch either.

--- a/docs/user/whats-new.md
+++ b/docs/user/whats-new.md
@@ -14,6 +14,8 @@ Recent user-facing changes from roughly the last 12 months. Newest at the top.
 Show roughly the last 12 months of changes; archive entries older than a year by removing them.
 -->
 
+**Aug 2026** — [Apple Watch App](watch.md) — The Watch app now declares notification support, so Meshtastic gets its own entry under Watch → Notifications and alerts on the wrist can be silenced there without touching iPhone notifications. The page also explains that removing the Watch app does not stop mirrored alerts.
+
 **Jul 2026** — [Settings](settings.md) — Packet Authenticity: on firmware that reports XEdDSA support, Security settings gains a Protection Level of Compatible, Balanced, or Strict, controlling whether your radio accepts mesh packets it cannot cryptographically authenticate; Strict asks for confirmation first, and the setting matches the Meshtastic app for Android.
 
 **Jul 2026** — [Bluetooth Device Connection](bluetooth.md) — Connect now shows an inline "Bluetooth is off" row in Available Radios when Bluetooth is disabled, with a tap-to-open-Settings shortcut — previously there was no in-app signal once the system Bluetooth power alert was suppressed.


### PR DESCRIPTION
## What changed?

The `Meshtastic Watch App` target now declares itself a notification-capable watchOS app.

- New `Meshtastic Watch App/Managers/WatchNotificationManager.swift` — sets the `UNUserNotificationCenter` delegate, requests notification authorization, and presents mirrored alerts while the Watch app is frontmost.
- `ContentView.swift` — one `@StateObject` and a `.task` calling it, alongside the existing `WatchLocationManager` authorization request.
- `docs/user/watch.md` — a **Notifications** section, which the page did not have.
- `docs/user/whats-new.md` — one entry.

Deliberately narrow. **No `UNNotificationCategory` is registered on the Watch side.** The categories and actions belong to the iOS app's `LocalNotificationManager`, and that is also what handles a tapback or reply chosen from a mirrored notification — registering the same identifier here risks shadowing it. Authorization is requested only when the status is `.notDetermined`, matching `LocalNotificationManager.schedule()`, so an existing decision is never re-prompted; for anyone who has already allowed notifications on the iPhone this should be a no-op.

Nothing about how notifications are created, scheduled or routed on iOS changes.

## Why did it change?

Fixes #2358.

**Watch → Notifications has exactly two sections.** Apps with a watchOS app get *Mirror my iPhone* / *Custom* (Allow / Send to Notification Center / **Notifications Off**). Below them, "Mirror iPhone Alerts From" lists iPhone-only apps with a single toggle each.

Meshtastic lands in neither:

- It ships a companion watchOS app (`WKRunsIndependentlyOfCompanionApp: "NO"`), which excludes it from *Mirror iPhone Alerts From*.
- The Watch target declared no notification support — zero `UNUserNotificationCenter` usage, no registered category, no `WKNotificationScene`, no delegate — so watchOS gave it no entry in the first section either.

The iPhone app's notifications keep mirroring to the wrist throughout, because mirroring is a function of the pairing and no API opts a notification out of it. So users get alerts on the Watch with **no per-app switch in either section**, and removing the Watch app doesn't help because mirroring never depended on it.

Declaring notification support is what earns the entry in the first section — and that entry is the missing switch: Custom → Notifications Off silences the wrist while the iPhone keeps alerting, independently of whether the Watch app is installed.

## How is this tested?

**Honestly: not locally, and the central claim needs a device.**

I don't have Xcode on this machine, so I could not build the Watch target, run the simulator, or run SwiftLint. `swiftc -parse` is clean on both changed Swift files (syntax only — no type checking, no watchOS SDK). CI is the first real compile.

More importantly, whether declaring notification support actually produces the Watch → Notifications entry is **platform behaviour I cannot verify**. It is the reading I arrived at from the two-section structure of that screen plus the fact that this target declares no notification support at all, and it is consistent with other developers' reports ([Apple forum 773087](https://developer.apple.com/forums/thread/773087), unresolved). It is not something I have observed working.

**So this needs someone with a paired Watch to check before it's worth merging:**

1. With the Watch app installed, open iPhone Watch app → Notifications and confirm **Meshtastic now appears** in the per-app list.
2. Set it to Custom → **Notifications Off**, then send a mesh message. iPhone should alert; Watch should stay silent.
3. Set it back to Allow Notifications and confirm the Watch alerts again.
4. Confirm a tapback and a reply chosen from a mirrored message notification still work — that's the regression this change is shaped to avoid.

If the entry does not appear, the next lever is registering the message category on the Watch plus a `WKNotificationScene`, which I avoided here precisely because of check 4. Happy to take it that way instead if that's the call.

## Screenshots/Videos (when applicable)

Not attached — I can't run the simulator or build for a device here. The user-visible change is an entry appearing in iPhone Watch app → Notifications; there is no new UI inside either app.

## Notes for reviewers

- **Where the authorization request lives.** `ContentView.task`, next to the existing `locationManager.requestAuthorization()` in `.onAppear`, to match how this target already does authorization. Setting the delegate happens earlier, in the manager's `init`, the same shape `PhoneConnectivityManager` uses for `WCSession`.
- **Related gaps, not fixed here.** Four notification categories still have no off switch anywhere — radio client alerts (the #1459 spam), Traceroute Complete, TAK Route Received and firmware-update-available — and `LocalNotificationManager` sets `.timeSensitive` on every notification without the entitlement, so iOS downgrades them all to `.active`. Both are written up in the issue. Kept out of this PR to keep it Watch-scoped, and to stay clear of #2344.
- No `project.yml` change: the Watch target's sources are a `syncedFolder`, so the new file is picked up without touching the project.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly.
- [ ] I have tested the change to ensure that it works as intended — **not done**: no Xcode on this machine, and the settings-pane behaviour needs a paired Watch. See *How is this tested?*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification support to the Watch app.
  * Prompts for notification permission when needed.
  * Displays incoming notifications as banners, with sounds and entries in the notification list, including while the app is in the foreground.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->