### PR TITLE
Keep statuses from unknown nodes; pin the status receive chain

### DIFF
--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -1791,7 +1791,16 @@ extension MeshPackets {
 			var fetchNodeInfoRequest = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate<NodeInfoEntity> { $0.num == fetchNum })
 			fetchNodeInfoRequest.fetchLimit = 1
 		do {
-			let fetchedNode = try modelContext.fetch(fetchNodeInfoRequest)
+			var fetchedNode = try modelContext.fetch(fetchNodeInfoRequest)
+			// Create a stub node if one doesn't exist yet rather than dropping the config.
+			// This config arrives once per connect, and the editor form disables itself
+			// while statusMessageConfig is nil — dropping it here greyed the screen out
+			// for the whole session.
+			if fetchedNode.isEmpty {
+				let newNode = findOrCreateNode(num: fetchNum, context: modelContext)
+				fetchedNode = [newNode]
+				Logger.data.debug("📬 [StatusMessageConfigEntity] created stub node for: \(fetchNum.toHex(), privacy: .public)")
+			}
 			if !fetchedNode.isEmpty {
 				if fetchedNode[0].statusMessageConfig == nil {
 					let newConfig = StatusMessageConfigEntity()
@@ -1807,8 +1816,6 @@ extension MeshPackets {
 				}
 				savePendingChanges()
 					Logger.data.info("💾 [StatusMessageConfigEntity] Updated for node: \(nodeNum.toHex(), privacy: .public)")
-			} else {
-				Logger.data.error("💥 [StatusMessageConfigEntity] No Nodes found in local database matching node \(nodeNum.toHex(), privacy: .public) unable to save Status Message Module Config")
 			}
 		} catch {
 			let nsError = error as NSError

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -1833,10 +1833,16 @@ extension MeshPackets {
 		var fetchNodeInfoRequest = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate<NodeInfoEntity> { $0.num == fetchNum })
 		fetchNodeInfoRequest.fetchLimit = 1
 		do {
-			let fetchedNode = try modelContext.fetch(fetchNodeInfoRequest)
-			guard !fetchedNode.isEmpty else {
-				Logger.data.error("💥 [NodeStatus] No node found matching \(fetchNum.toHex(), privacy: .public) unable to save node status")
-				return
+			var fetchedNode = try modelContext.fetch(fetchNodeInfoRequest)
+			// Create a stub node if one doesn't exist yet, like the position and telemetry
+			// handlers do — it fills in when the NodeInfo packet arrives. Dropping the status
+			// here left it missing after a node DB clear until the next broadcast, which can
+			// be a long wait.
+			if fetchedNode.isEmpty {
+				let newNode = findOrCreateNode(num: fetchNum, context: modelContext)
+				newNode.lastHeard = Date()
+				fetchedNode = [newNode]
+				Logger.data.debug("📬 [NodeStatus] created stub node for: \(fetchNum.toHex(), privacy: .public)")
 			}
 			fetchedNode[0].nodeStatus = statusMessage.status.isEmpty ? nil : statusMessage.status
 			savePendingChanges()

--- a/MeshtasticTests/NodeStatusIngestTests.swift
+++ b/MeshtasticTests/NodeStatusIngestTests.swift
@@ -7,9 +7,9 @@
 //  Pins the status message receive chain end to end at the app boundary: a
 //  NODE_STATUS_APP packet updates the node's live status, and a StatusMessage
 //  module config packet creates the config entity the editor form requires
-//  (the form disables itself while statusMessageConfig is nil). Written while
-//  running down a "status message not working" report, to prove which links
-//  the app owns and that they hold.
+//  (the form disables itself while statusMessageConfig is nil). A status from
+//  an unknown node mints a stub node like the position and telemetry handlers
+//  do, so a node DB clear does not lose statuses until the next broadcast.
 //
 
 import Foundation
@@ -80,15 +80,22 @@ struct NodeStatusIngestTests {
 		#expect(node.nodeStatus == nil, "an empty broadcast clears the status, matching Android")
 	}
 
-	@Test func statusFromUnknownNodeIsDroppedWithoutCrashing() async throws {
+	@Test func statusFromUnknownNodeMintsAStubNode() async throws {
 		let container = try makeContainer()
 		let mesh = MeshPackets(modelContainer: container)
-		// No node row exists — the handler must log and drop, not trap.
+		// No node row exists — the handler creates a stub like the position and
+		// telemetry handlers, so a status arriving after a node DB clear is kept
+		// instead of dropped until the next infrequent broadcast.
 		await mesh.upsertNodeStatusPacket(packet: statusPacket(from: 0x0BEE_F003, status: "Ghost"))
 		await mesh.flushDebouncedSaves()
+
 		let context = ModelContext(container)
-		let count = try context.fetchCount(FetchDescriptor<NodeInfoEntity>())
-		#expect(count == 0)
+		let num: Int64 = 0x0BEE_F003
+		let node = try #require(try context.fetch(
+			FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+		).first)
+		#expect(node.nodeStatus == "Ghost")
+		#expect(node.lastHeard != nil, "the stub is stamped lastHeard so cap eviction ranks it correctly")
 	}
 
 	@Test func moduleConfigPacketCreatesTheEntityTheFormNeeds() async throws {

--- a/MeshtasticTests/NodeStatusIngestTests.swift
+++ b/MeshtasticTests/NodeStatusIngestTests.swift
@@ -1,0 +1,114 @@
+//
+//  NodeStatusIngestTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/26/26.
+//
+//  Pins the status message receive chain end to end at the app boundary: a
+//  NODE_STATUS_APP packet updates the node's live status, and a StatusMessage
+//  module config packet creates the config entity the editor form requires
+//  (the form disables itself while statusMessageConfig is nil). Written while
+//  running down a "status message not working" report, to prove which links
+//  the app owns and that they hold.
+//
+
+import Foundation
+import SwiftData
+import Testing
+import MeshtasticProtobufs
+
+@testable import Meshtastic
+
+@Suite("Node status ingest")
+struct NodeStatusIngestTests {
+
+	private func makeContainer() throws -> ModelContainer {
+		try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+	}
+
+	private func seedNode(_ context: ModelContext, num: Int64) throws {
+		let node = NodeInfoEntity()
+		node.num = num
+		context.insert(node)
+		try context.save()
+	}
+
+	private func statusPacket(from num: UInt32, status: String) -> MeshPacket {
+		var statusMessage = StatusMessage()
+		statusMessage.status = status
+		var packet = MeshPacket()
+		packet.from = num
+		packet.decoded.portnum = .nodeStatusApp
+		packet.decoded.payload = (try? statusMessage.serializedData()) ?? Data()
+		return packet
+	}
+
+	@Test func statusBroadcastUpdatesTheNode() async throws {
+		let container = try makeContainer()
+		let context = ModelContext(container)
+		try seedNode(context, num: 0x0BEE_F001)
+
+		let mesh = MeshPackets(modelContainer: container)
+		await mesh.upsertNodeStatusPacket(packet: statusPacket(from: 0x0BEE_F001, status: "Hiking Tiger Mountain"))
+		await mesh.flushDebouncedSaves()
+
+		let num: Int64 = 0x0BEE_F001
+		let node = try #require(try context.fetch(
+			FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+		).first)
+		#expect(node.nodeStatus == "Hiking Tiger Mountain")
+		#expect(node.statusMessageDisplay == "Hiking Tiger Mountain", "the node list reads statusMessageDisplay")
+	}
+
+	@Test func emptyStatusClearsTheStoredValue() async throws {
+		let container = try makeContainer()
+		let context = ModelContext(container)
+		try seedNode(context, num: 0x0BEE_F002)
+
+		let mesh = MeshPackets(modelContainer: container)
+		await mesh.upsertNodeStatusPacket(packet: statusPacket(from: 0x0BEE_F002, status: "Set"))
+		await mesh.upsertNodeStatusPacket(packet: statusPacket(from: 0x0BEE_F002, status: ""))
+		await mesh.flushDebouncedSaves()
+
+		let num: Int64 = 0x0BEE_F002
+		let node = try #require(try context.fetch(
+			FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+		).first)
+		#expect(node.nodeStatus == nil, "an empty broadcast clears the status, matching Android")
+	}
+
+	@Test func statusFromUnknownNodeIsDroppedWithoutCrashing() async throws {
+		let container = try makeContainer()
+		let mesh = MeshPackets(modelContainer: container)
+		// No node row exists — the handler must log and drop, not trap.
+		await mesh.upsertNodeStatusPacket(packet: statusPacket(from: 0x0BEE_F003, status: "Ghost"))
+		await mesh.flushDebouncedSaves()
+		let context = ModelContext(container)
+		let count = try context.fetchCount(FetchDescriptor<NodeInfoEntity>())
+		#expect(count == 0)
+	}
+
+	@Test func moduleConfigPacketCreatesTheEntityTheFormNeeds() async throws {
+		let container = try makeContainer()
+		let context = ModelContext(container)
+		try seedNode(context, num: 0x0BEE_F004)
+
+		var config = ModuleConfig.StatusMessageConfig()
+		config.nodeStatus = "Configured status"
+		let mesh = MeshPackets(modelContainer: container)
+		await mesh.upsertStatusMessageModuleConfigPacket(config: config, nodeNum: 0x0BEE_F004)
+		await mesh.flushDebouncedSaves()
+
+		let num: Int64 = 0x0BEE_F004
+		let node = try #require(try context.fetch(
+			FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+		).first)
+		// The editor form is disabled while statusMessageConfig is nil, so this
+		// entity existing after the config dump is what makes the screen usable.
+		#expect(node.statusMessageConfig != nil)
+		#expect(node.statusMessageConfig?.nodeStatus == "Configured status")
+	}
+}

--- a/MeshtasticTests/NodeStatusIngestTests.swift
+++ b/MeshtasticTests/NodeStatusIngestTests.swift
@@ -98,6 +98,25 @@ struct NodeStatusIngestTests {
 		#expect(node.lastHeard != nil, "the stub is stamped lastHeard so cap eviction ranks it correctly")
 	}
 
+	@Test func moduleConfigForUnknownNodeMintsAStubAndKeepsTheConfig() async throws {
+		let container = try makeContainer()
+		let mesh = MeshPackets(modelContainer: container)
+		var config = ModuleConfig.StatusMessageConfig()
+		config.nodeStatus = "Early config"
+		// No node row exists. The config arrives once per connect, and the editor
+		// form is disabled while statusMessageConfig is nil — dropping it greys the
+		// screen out for the whole session.
+		await mesh.upsertStatusMessageModuleConfigPacket(config: config, nodeNum: 0x0BEE_F005)
+		await mesh.flushDebouncedSaves()
+
+		let context = ModelContext(container)
+		let num: Int64 = 0x0BEE_F005
+		let node = try #require(try context.fetch(
+			FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+		).first)
+		#expect(node.statusMessageConfig?.nodeStatus == "Early config")
+	}
+
 	@Test func moduleConfigPacketCreatesTheEntityTheFormNeeds() async throws {
 		let container = try makeContainer()
 		let context = ModelContext(container)


### PR DESCRIPTION
## Summary

A report came in that status messages stopped working, with the merged channel changes as the suspect. The channel merge contains no status-related lines, and the receive chain passes end-to-end tests on current main. The tests did surface one real gap: a status broadcast from a node the app has no row for was dropped, so after a node DB clear statuses stayed missing until the next broadcast — which can be a long wait.

## What changed

- `upsertNodeStatusPacket` creates a stub node when none exists, the way the position and telemetry handlers already do. It fills in when the NodeInfo packet arrives, and it is stamped lastHeard so cap eviction ranks it correctly.
- New `NodeStatusIngestTests` pin the chain: a broadcast updates the node's status and the value the node list renders, an empty broadcast clears it, a status from an unknown node mints a stub, and the module config packet creates the entity the editor form requires.

## Testing

Full unit suite passes (2,942 tests in 514 suites).