### PR TITLE
Explain hidden settings on a managed radio

### DIFF
--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -673,6 +673,15 @@ struct Settings: View {
 				}
 				.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
+				// A managed radio hides the configuration sections; say why instead of
+				// showing nothing (same message as Android).
+				if let node, node.isManaged, accessoryManager.isConnected {
+					Section("Configure") {
+						Label("This radio is managed and can only be changed by a remote admin.", systemImage: "lock.shield")
+							.font(.callout)
+							.foregroundStyle(.orange)
+					}
+				}
 				if let node, !node.isManaged {
 					if accessoryManager.isConnected {
 						Section("Configure") {


### PR DESCRIPTION
## Summary
A managed radio (`is_managed`) hides the whole Configure area in Settings with no explanation, so it looks like the node has no settings.

## What changed
When the connected node is managed, the Configure section shows one row: "This radio is managed and can only be changed by a remote admin." — the same message Android shows. The config sections stay hidden.

Related: meshtastic/design#40

## Testing
Built for the iOS simulator. The row only renders when the connected node's device config reports managed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Configure section to Settings for managed nodes when the accessory is connected.
  * Displays a lock-shield message indicating that radio settings can only be changed by a remote administrator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->