### PR TITLE
Improve Korean translations

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -288,8 +288,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "DFU로 재부팅 보내기"
+            "state": "translated",
+            "value": "DFU 모드로 재부팅"
           }
         },
         "pt-BR": {
@@ -354,8 +354,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Meshtastic에서 연결된 BLE 노드에서 분리합니다."
+            "state": "translated",
+            "value": "“Meshtastic 연결 해제” — 연결된 BLE 노드와의 연결을 해제합니다."
           }
         },
         "pt-BR": {
@@ -426,8 +426,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬틱 직접 메시지를 보내기"
+            "state": "translated",
+            "value": "“Meshtastic 개인 메시지 보내기” — 노드에 개인 메시지를 보냅니다."
           }
         },
         "pt-BR": {
@@ -498,8 +498,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬스트릭 그룹 메시지를 보내세요 - 메시지 체인에 메시지를 보내세요"
+            "state": "translated",
+            "value": "“Meshtastic 그룹 메시지 보내기” — 메시 채널에 메시지를 보냅니다."
           }
         },
         "pt-BR": {
@@ -564,8 +564,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Meshtastic 노드를 종료하거나 재시작하세요."
+            "state": "translated",
+            "value": "“내 Meshtastic 노드 종료” 또는 “내 Meshtastic 노드 재시작”"
           }
         },
         "pt-BR": {
@@ -595,13 +595,37 @@
       }
     },
     "%1$@ reacted %2$@ to \"%3$@\"": {
-      "comment": "Tapback/reaction notification body. %1$@ is the sender name, %2$@ is the reaction emoji, %3$@ is the original message text that was reacted to."
+      "comment": "Tapback/reaction notification body. %1$@ is the sender name, %2$@ is the reaction emoji, %3$@ is the original message text that was reacted to.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@님이 \"%3$@\"에 %2$@로 반응했습니다."
+          }
+        }
+      }
     },
     "%1$@: %2$@": {
-      "comment": "VoiceOver: combined label:value announcement for a Live Activity stat row"
+      "comment": "VoiceOver: combined label:value announcement for a Live Activity stat row",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
+          }
+        }
+      }
     },
     "%1$lld of %2$lld nodes online": {
-      "comment": "VoiceOver: online/total node count in the Dynamic Island expanded trailing region and Live Activity header row"
+      "comment": "VoiceOver: online/total node count in the Dynamic Island expanded trailing region and Live Activity header row",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$lld개 노드 중 %1$lld개 온라인"
+          }
+        }
+      }
     },
     "%@": {
       "localizations": {
@@ -815,8 +839,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%1$@ %2$d"
+            "state": "translated",
+            "value": "%1$@ %2$lld"
           }
         },
         "pt-BR": {
@@ -866,6 +890,12 @@
           "stringUnit": {
             "state": "new",
             "value": "%1$@ %2$llds"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ %2$lld초"
           }
         },
         "uk": {
@@ -1013,8 +1043,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%@ (%d)"
+            "state": "translated",
+            "value": "%1$@ (%2$lld)"
           }
         },
         "pt-BR": {
@@ -1273,8 +1303,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%1$@ - %2$@ 이동하여 %3$@ 돌아오세요"
+            "state": "translated",
+            "value": "%1$@ - 목적지까지 %2$@, 돌아오는 경로 %3$@"
           }
         },
         "pt-BR": {
@@ -1361,7 +1391,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%@ - 응답 없음"
           }
         },
@@ -1449,8 +1479,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%@ - 전송되지 않았습니다"
+            "state": "translated",
+            "value": "%@ - 전송되지 않음"
           }
         },
         "pt-BR": {
@@ -1537,8 +1567,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 수?"
+            "state": "translated",
+            "value": "%@개 채널?"
           }
         },
         "pt-BR": {
@@ -1621,8 +1651,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%@ 잠금 시간"
+            "state": "translated",
+            "value": "%@ 유지 시간"
           }
         },
         "pt-BR": {
@@ -1658,7 +1688,15 @@
       }
     },
     "%@ at %@": {
-      "comment": "VoiceOver label for a data point on a metrics chart. First %@ is the metric name, second %@ is the timestamp."
+      "comment": "VoiceOver label for a data point on a metrics chart. First %@ is the metric name, second %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, %2$@"
+          }
+        }
+      }
     },
     "%@ away": {
       "localizations": {
@@ -1700,8 +1738,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%@ 거리"
+            "state": "translated",
+            "value": "%@ 떨어짐"
           }
         },
         "pt-BR": {
@@ -1788,8 +1826,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%@는 최대 %@바이트까지 가능합니다."
+            "state": "translated",
+            "value": "%1$@의 길이는 최대 %2$@바이트입니다."
           }
         },
         "pt-BR": {
@@ -1870,8 +1908,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "PKC 관리자로부터 config 데이터가 요청되었지만 원격 노드에서 응답이 돌아오지 않았습니다."
+            "state": "translated",
+            "value": "%1$@ 설정 데이터가 PKC 관리자를 통해 요청되었지만 원격 노드가 응답하지 않았습니다."
           }
         },
         "pt-BR": {
@@ -1958,7 +1996,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%@ dB"
           }
         },
@@ -2008,6 +2046,12 @@
     },
     "%@ dBm": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ dBm"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -2023,10 +2067,26 @@
       }
     },
     "%@ degrees": {
-      "comment": "VoiceOver value spoken as a temperature reading in degrees. %@ is the number."
+      "comment": "VoiceOver value spoken as a temperature reading in degrees. %@ is the number.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 도"
+          }
+        }
+      }
     },
     "%@ devices": {
-      "comment": "VoiceOver value spoken as a device count on the PAX counter chart. %@ is the number."
+      "comment": "VoiceOver value spoken as a device count on the PAX counter chart. %@ is the number.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "장치 %@개"
+          }
+        }
+      }
     },
     "%@ documentation page": {
       "comment": "Accessibility label and hint for the web view showing the documentation for a given page. The argument is the name of the page.",
@@ -2064,7 +2124,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%@ 문서 페이지"
           }
         },
@@ -2103,6 +2163,12 @@
     "%@ entered %@": {
       "comment": "Geofence notification body. First %@ is the node name, second %@ is the waypoint name.",
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) %@에 진입했습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -2114,6 +2180,12 @@
     "%@ left %@": {
       "comment": "Geofence notification body. First %@ is the node name, second %@ is the waypoint name.",
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) %@을(를) 벗어났습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -2123,15 +2195,37 @@
       }
     },
     "%@ milliamps": {
-      "comment": "VoiceOver value spoken as a current reading in milliamps. %@ is the number."
+      "comment": "VoiceOver value spoken as a current reading in milliamps. %@ is the number.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 밀리암페어"
+          }
+        }
+      }
     },
     "%@ percent": {
-      "comment": "VoiceOver value spoken as a percentage reading on a chart. %@ is the number."
+      "comment": "VoiceOver value spoken as a percentage reading on a chart. %@ is the number.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 퍼센트"
+          }
+        }
+      }
     },
     "%@ used on this device": {
       "comment": "A footnote that shows the size of the offline map data on the user's device. The argument is the size of the offline map data in bytes.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 기기에서 %@ 사용 중"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -2141,12 +2235,26 @@
       }
     },
     "%@ volts": {
-      "comment": "VoiceOver value spoken as a voltage reading. %@ is the number."
+      "comment": "VoiceOver value spoken as a voltage reading. %@ is the number.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 볼트"
+          }
+        }
+      }
     },
     "%@ will be freed on this device.": {
       "comment": "A message in a confirmation dialog that lets the user remove an offline map. The argument is the size of the map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 기기에서 %@ 공간을 확보합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -2163,6 +2271,12 @@
           "stringUnit": {
             "state": "new",
             "value": "%1$@ · Slot %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ · 슬롯 %2$@"
           }
         },
         "uk": {
@@ -2183,6 +2297,12 @@
             "value": "%1$@ · Updated %2$@"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ · %2$@ 업데이트"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -2201,6 +2321,12 @@
             "value": "%1$@ • %2$@ Towards • %3$@ Back"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ • 목적지까지 %2$@ • 돌아오는 경로 %3$@"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -2216,6 +2342,12 @@
         "en": {
           "stringUnit": {
             "state": "new",
+            "value": "%1$@ → %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
             "value": "%1$@ → %2$@"
           }
         },
@@ -2267,7 +2399,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%@%%"
           }
         },
@@ -2446,8 +2578,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 크기: %1$@ byte"
+            "state": "translated",
+            "value": "%1$@: %2$lld"
           }
         },
         "pt-BR": {
@@ -2522,7 +2654,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%@V"
           }
         },
@@ -2610,7 +2742,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%@mA"
           }
         },
@@ -2698,7 +2830,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%@°C"
           }
         },
@@ -2786,7 +2918,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%d"
           }
         },
@@ -2979,8 +3111,8 @@
             "plural": {
               "other": {
                 "stringUnit": {
-                  "state": "needs_review",
-                  "value": "개수 Hops"
+                  "state": "translated",
+                  "value": "%d 홉"
                 }
               }
             }
@@ -3134,6 +3266,12 @@
     },
     "%d dBm": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d dBm"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -3188,7 +3326,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%lld"
           }
         },
@@ -3238,6 +3376,12 @@
     },
     "%lld Local Stats Readings": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld개 로컬 통계 측정값"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -3286,8 +3430,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld Mesh"
+            "state": "translated",
+            "value": "%lld개 Mesh"
           }
         },
         "pt-BR": {
@@ -3362,8 +3506,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld 총 측정값"
+            "state": "translated",
+            "value": "총 측정값 %lld개"
           }
         },
         "pt-BR": {
@@ -3450,8 +3594,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld개의 감지 이벤트"
+            "state": "translated",
+            "value": "감지 이벤트 %lld개"
           }
         },
         "pt-BR": {
@@ -3518,6 +3662,18 @@
               }
             }
           }
+        },
+        "ko": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 일"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -3527,6 +3683,12 @@
           "stringUnit": {
             "state": "new",
             "value": "%1$lld downloaded · %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld 다운로드됨 · %2$@"
           }
         },
         "uk": {
@@ -3573,8 +3735,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld 번 이상 수신됨"
+            "state": "translated",
+            "value": "%lld개 중복 수신"
           }
         },
         "pt-BR": {
@@ -3736,8 +3898,8 @@
             "plural": {
               "other": {
                 "stringUnit": {
-                  "state": "needs_review",
-                  "value": "%lld 기능"
+                  "state": "translated",
+                  "value": "%lld개 기능"
                 }
               }
             }
@@ -3890,7 +4052,15 @@
       }
     },
     "%lld hops away": {
-      "comment": "VoiceOver: hops-away filter value"
+      "comment": "VoiceOver: hops-away filter value",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 홉 떨어짐"
+          }
+        }
+      }
     },
     "%lld nodes": {
       "localizations": {
@@ -3916,6 +4086,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "%lld ノード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld개 노드"
           }
         },
         "pt-BR": {
@@ -3954,6 +4130,12 @@
       "comment": "A label showing the number of nodes that have been discovered during a scan. The argument is the number of nodes that have been discovered.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 %lld개 발견됨"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -3969,7 +4151,15 @@
       }
     },
     "%lld nodes online": {
-      "comment": "VoiceOver: online node count in the Dynamic Island compact-leading region and minimal presentation"
+      "comment": "VoiceOver: online node count in the Dynamic Island compact-leading region and minimal presentation",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld개 노드 온라인"
+          }
+        }
+      }
     },
     "%lld or less hops away": {
       "localizations": {
@@ -4011,8 +4201,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld hops 이내"
+            "state": "translated",
+            "value": "%lld홉 이내"
           }
         },
         "pt-BR": {
@@ -4060,7 +4250,15 @@
       }
     },
     "%lld percent": {
-      "comment": "VoiceOver value spoken as a percentage — used for both firmware update completion and discovery scan dwell progress"
+      "comment": "VoiceOver value spoken as a percentage — used for both firmware update completion and discovery scan dwell progress",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 퍼센트"
+          }
+        }
+      }
     },
     "%lld received": {
       "comment": "A label that shows the number of packets that were received.",
@@ -4098,8 +4296,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld 수신됨"
+            "state": "translated",
+            "value": "%lld개 수신됨"
           }
         },
         "pt-BR": {
@@ -4170,8 +4368,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld 릴레이가 취소되었습니다."
+            "state": "translated",
+            "value": "%lld회 중계 취소됨"
           }
         },
         "pt-BR": {
@@ -4242,8 +4440,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld 회송"
+            "state": "translated",
+            "value": "%lld회 중계됨"
           }
         },
         "pt-BR": {
@@ -4314,8 +4512,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld 발송"
+            "state": "translated",
+            "value": "%lld개 송신함"
           }
         },
         "pt-BR": {
@@ -4345,7 +4543,15 @@
       }
     },
     "%lld unread": {
-      "comment": "VoiceOver: number of unread messages in a channel"
+      "comment": "VoiceOver: number of unread messages in a channel",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 개 읽지 않음"
+          }
+        }
+      }
     },
     "%lld%%": {
       "localizations": {
@@ -4381,7 +4587,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%lld%%"
           }
         },
@@ -4451,6 +4657,12 @@
             "value": "%1$lld/%2$lld nodi online"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld/%2$lld 노드 온라인"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -4487,6 +4699,12 @@
       "comment": "A label showing the number of bytes used in the status message.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/80 바이트"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -4541,8 +4759,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%llddBm 전송 전력"
+            "state": "translated",
+            "value": "%llddBm 송신 전력"
           }
         },
         "pt-BR": {
@@ -4623,8 +4841,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%llddb 전송 전력"
+            "state": "translated",
+            "value": "%llddb 송신 전력"
           }
         },
         "pt-BR": {
@@ -4711,8 +4929,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "(재)정의 PIN_GPS_EN을 위한 보드"
+            "state": "translated",
+            "value": "보드에 맞게 PIN_GPS_EN을 (재)정의하세요."
           }
         },
         "pt-BR": {
@@ -4761,6 +4979,12 @@
     },
     "0.0.0.0": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0.0.0.0"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -4880,7 +5104,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "1바이트"
           }
         },
@@ -4968,8 +5192,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "1 hop 거리"
+            "state": "translated",
+            "value": "1홉 떨어짐"
           }
         },
         "pt-BR": {
@@ -5056,7 +5280,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "100"
           }
         },
@@ -5138,8 +5362,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "12시간 시계"
+            "state": "translated",
+            "value": "12시간제"
           }
         },
         "pt-BR": {
@@ -5222,7 +5446,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "120분"
           }
         },
@@ -5260,6 +5484,12 @@
     },
     "1200 bps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1200 bps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -5314,7 +5544,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "128비트"
           }
         },
@@ -5364,6 +5594,12 @@
     },
     "1300 bps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1300 bps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -5380,6 +5616,12 @@
     },
     "1400 bps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1400 bps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -5430,7 +5672,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "15분"
           }
         },
@@ -5468,6 +5710,12 @@
     },
     "1600 bps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1600 bps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -5583,7 +5831,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "180분"
           }
         },
@@ -5621,6 +5869,12 @@
     },
     "2400 bps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2400 bps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -5675,7 +5929,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "25"
           }
         },
@@ -5725,6 +5979,12 @@
     },
     "255.255.255.0": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "255.255.255.0"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -5779,7 +6039,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "256비트"
           }
         },
@@ -5863,7 +6123,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "30분"
           }
         },
@@ -5901,6 +6161,12 @@
     },
     "3200 bps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3200 bps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -5951,7 +6217,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "45분"
           }
         },
@@ -6027,7 +6293,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "50"
           }
         },
@@ -6111,7 +6377,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "60분"
           }
         },
@@ -6187,7 +6453,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "7"
           }
         },
@@ -6237,6 +6503,12 @@
     },
     "700 bps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "700 bps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -6253,6 +6525,12 @@
     },
     "700B bps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "700B bps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -6307,7 +6585,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "75"
           }
         },
@@ -6391,7 +6669,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "8089"
           }
         },
@@ -6463,7 +6741,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "90분"
           }
         },
@@ -6681,8 +6959,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "1%"
+            "state": "translated",
+            "value": "< 1%"
           }
         },
         "pt-BR": {
@@ -6765,8 +7043,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "QR코드는 라디오가 통신할 수 있도록 필요한 LoRa 설정과 채널을 포함합니다. 채널을 교체하거나 기존 채널에 추가하려면 채널을 교체하거나 채널을 추가하세요."
+            "state": "translated",
+            "value": "QR 코드는 노드 간 통신에 필요한 LoRa 설정과 채널을 포함합니다. 기존 채널을 덮어쓰려면 **채널 교체**를 사용하고, 기존 채널에 추가하려면 **채널 추가**를 사용하세요."
           }
         },
         "pt-BR": {
@@ -6841,8 +7119,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래스 루트 전송, 응답 없음"
+            "state": "translated",
+            "value": "경로 추적 요청을 전송했지만 응답을 받지 못했습니다."
           }
         },
         "pt-BR": {
@@ -6926,8 +7204,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "0번 채널은 위치 데이터를 전송하는 기본 채널입니다. 2.7 이상 버전을 사용하는 경우, 첫 번째 활성화된 채널에서 위치 데이터를 전송합니다."
+            "state": "translated",
+            "value": "채널 인덱스 0은 브로드캐스트 패킷이 전송되는 기본 채널을 의미합니다. 펌웨어 2.7 이상에서는 위치 기능이 활성화된 첫 번째 채널을 통해 위치 데이터가 브로드캐스트됩니다."
           }
         },
         "pt-BR": {
@@ -6966,6 +7244,12 @@
       "comment": "Description of",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "채널 인덱스 0은 브로드캐스트 패킷이 전송되는 기본 채널을 의미합니다. 펌웨어 2.6.10 이상에서는 위치 데이터가 활성화된 첫 번째 채널에서 브로드캐스트됩니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -7008,8 +7292,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "localhost 연결에는 기본 인증서(self-signed certificate)가 포함되어 있습니다. 필요시 custom .p12를 가져오세요. TAK 클라이언트를 연결할 때 Client CA (.pem)가 검증합니다."
+            "state": "translated",
+            "value": "localhost 연결에는 기본 자체 서명 인증서(self-signed certificate)가 포함되어 있습니다. 필요하면 사용자 지정 .p12 파일을 가져오세요. Client CA (.pem)는 연결하는 TAK 클라이언트를 검증합니다."
           }
         },
         "pt-BR": {
@@ -7048,6 +7332,12 @@
       "comment": "An alert message explaining that a local stats request has been sent to a specific node. The placeholder is replaced with the node name.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에 로컬 통계 요청을 보냈습니다. 응답을 받는 데 시간이 걸릴 수 있습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -7098,8 +7388,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 노드 이전 위치 보고"
+            "state": "translated",
+            "value": "이 노드의 이전 위치 보고"
           }
         },
         "pt-BR": {
@@ -7168,8 +7458,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이전 위치 보고서에 표시된 이동 방향입니다."
+            "state": "translated",
+            "value": "이전 위치 보고에 표시된 이동 방향입니다."
           }
         },
         "pt-BR": {
@@ -7240,8 +7530,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "공유 관심 지점입니다. 지도에서 길게 누르면 만들 수 있습니다."
+            "state": "translated",
+            "value": "공유된 관심 지점입니다. 지도를 길게 눌러 만들 수 있습니다."
           }
         },
         "pt-BR": {
@@ -7280,6 +7570,12 @@
       "comment": "A description of the status message field.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메시 네트워크로 브로드캐스트되는 상태 메시지입니다. 다른 노드는 노드 목록에서 이 상태를 확인할 수 있습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -7340,7 +7636,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "ADC 오버라이드"
           }
         },
@@ -7401,16 +7697,48 @@
       }
     },
     "AQI": {
-      "comment": "Air Quality Index label (acronym) shown on the air quality gauge."
+      "comment": "Air Quality Index label (acronym) shown on the air quality gauge.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AQI"
+          }
+        }
+      }
     },
     "AQI ": {
-      "comment": "Air Quality Index label prefix (acronym) preceding the numeric AQI value."
+      "comment": "Air Quality Index label prefix (acronym) preceding the numeric AQI value.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AQI "
+          }
+        }
+      }
     },
     "AQI %1$lld, %2$@": {
-      "comment": "VoiceOver value for the air quality index gauge; %1$lld is the AQI number, %2$@ is its category description"
+      "comment": "VoiceOver value for the air quality index gauge; %1$lld is the AQI number, %2$@ is its category description",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AQI %1$lld, %2$@"
+          }
+        }
+      }
     },
     "AQI %lld": {
-      "comment": "Air Quality Index label with the numeric AQI value."
+      "comment": "Air Quality Index label with the numeric AQI value.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AQI %lld"
+          }
+        }
+      }
     },
     "About": {
       "localizations": {
@@ -7452,7 +7780,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "소개"
           }
         },
@@ -7540,8 +7868,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬틱에 대해"
+            "state": "translated",
+            "value": "Meshtastic에 대하여"
           }
         },
         "pt-BR": {
@@ -7628,7 +7956,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "정확도 %@"
           }
         },
@@ -7716,7 +8044,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "SNR: %@ dB"
           }
         },
@@ -7804,7 +8132,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "응답 시간: %@"
           }
         },
@@ -7892,8 +8220,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다른 노드에서 확인되었습니다."
+            "state": "translated",
+            "value": "다른 노드에서 수신 확인됨"
           }
         },
         "pt-BR": {
@@ -7980,7 +8308,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "작업"
           }
         },
@@ -8068,7 +8396,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "활성"
           }
         },
@@ -8120,6 +8448,12 @@
       "comment": "A section title for the list of active database files.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성 데이터베이스"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -8170,8 +8504,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "활성화된 설정"
+            "state": "translated",
+            "value": "활성 프리셋"
           }
         },
         "pt-BR": {
@@ -8246,7 +8580,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "활동"
           }
         },
@@ -8328,8 +8662,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "카를라 추가합니다"
+            "state": "translated",
+            "value": "CA 추가"
           }
         },
         "pt-BR": {
@@ -8404,7 +8738,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 추가"
           }
         },
@@ -8492,7 +8826,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 추가"
           }
         },
@@ -8574,7 +8908,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "연락처 추가"
           }
         },
@@ -8650,8 +8984,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬틱 노드 %@를 연락처로 추가하세요."
+            "state": "translated",
+            "value": "Meshtastic 노드 %@를 연락처에 추가"
           }
         },
         "ru": {
@@ -8732,8 +9066,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "좋아요 추가"
+            "state": "translated",
+            "value": "즐겨찾기에 추가"
           }
         },
         "pt-BR": {
@@ -8780,7 +9114,16 @@
         }
       }
     },
-    "Adding a contact saves their name and public key to your connected node so you can message them securely.": {},
+    "Adding a contact saves their name and public key to your connected node so you can message them securely.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연락처를 추가하면 해당 이름과 공개 키가 연결된 노드에 저장되어 안전하게 메시지를 보낼 수 있습니다."
+          }
+        }
+      }
+    },
     "Additional Help": {
       "comment": "A button that opens a link to the Meshtastic FAQ.",
       "isCommentAutoGenerated": true,
@@ -8817,8 +9160,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "추가 도움"
+            "state": "translated",
+            "value": "추가 도움말"
           }
         },
         "pt-BR": {
@@ -8893,7 +9236,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "주소"
           }
         },
@@ -8943,6 +9286,12 @@
     },
     "Address Mode": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "주소 모드"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -8958,10 +9307,26 @@
       }
     },
     "Adjustable. Swipe up to expand, swipe down to shrink the geofence area from this corner": {
-      "comment": "VoiceOver hint for a geofence rectangle corner handle"
+      "comment": "VoiceOver hint for a geofence rectangle corner handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "조절 가능. 위로 쓸어 올리면 확대하고, 아래로 쓸어 내리면 이 모서리에서 지오펜스 영역을 축소합니다."
+          }
+        }
+      }
     },
     "Adjustable. Swipe up to expand, swipe down to shrink the selected area from this corner": {
-      "comment": "VoiceOver hint for a region rectangle corner handle"
+      "comment": "VoiceOver hint for a region rectangle corner handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "조절 가능. 위로 쓸어 올리면 확대하고, 아래로 쓸어 내리면 이 모서리에서 선택한 영역을 축소합니다."
+          }
+        }
+      }
     },
     "Admin Keys": {
       "localizations": {
@@ -8997,7 +9362,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "관리 키"
           }
         },
@@ -9085,7 +9450,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "관리"
           }
         },
@@ -9173,8 +9538,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "관리 기능 활성화"
+            "state": "translated",
+            "value": "관리 기능 활성화됨"
           }
         },
         "pt-BR": {
@@ -9261,7 +9626,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "고급"
           }
         },
@@ -9349,7 +9714,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "고급 장치 GPS"
           }
         },
@@ -9437,7 +9802,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "고급 위치 플래그"
           }
         },
@@ -9519,8 +9884,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "고급 사용자 전용입니다."
+            "state": "translated",
+            "value": "고급 사용자 전용"
           }
         },
         "pt-BR": {
@@ -9682,8 +10047,8 @@
             "plural": {
               "other": {
                 "stringUnit": {
-                  "state": "needs_review",
-                  "value": "%lld일"
+                  "state": "translated",
+                  "value": "%lld일 후"
                 }
               }
             }
@@ -9881,8 +10246,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "설정 값이 저장되면 노드가 재부팅됩니다."
+            "state": "translated",
+            "value": "설정 값을 저장하면 노드가 재부팅됩니다."
           }
         },
         "pl": {
@@ -9945,10 +10310,24 @@
       "comment": "Metric label for airtime used to transmit packets."
     },
     "Air Quality": {
-      "comment": "Node detail section header for particulate-matter air quality readings."
+      "comment": "Node detail section header for particulate-matter air quality readings.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대기질"
+          }
+        }
+      }
     },
     "Air Quality Metrics Enabled": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대기질 측정 활성화"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -9964,10 +10343,24 @@
       }
     },
     "Air Quality Metrics Log": {
-      "comment": "Navigation title and log link for the particulate-matter telemetry log."
+      "comment": "Navigation title and log link for the particulate-matter telemetry log.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대기질 측정 기록"
+          }
+        }
+      }
     },
     "Air Quality Sensor Options": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대기질 센서 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -9983,7 +10376,15 @@
       }
     },
     "Air quality index": {
-      "comment": "VoiceOver: label for the air quality index gauge"
+      "comment": "VoiceOver: label for the air quality index gauge",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대기질 지수"
+          }
+        }
+      }
     },
     "Airtime": {
       "localizations": {
@@ -10031,8 +10432,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "공기 시간"
+            "state": "translated",
+            "value": "송신 시간"
           }
         },
         "pl": {
@@ -10092,7 +10493,15 @@
       }
     },
     "Airtime at %@": {
-      "comment": "VoiceOver label for an airtime point on the device metrics chart. %@ is the timestamp."
+      "comment": "VoiceOver label for an airtime point on the device metrics chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "송신 시간: %@"
+          }
+        }
+      }
     },
     "Alert": {
       "localizations": {
@@ -10134,7 +10543,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "알림"
           }
         },
@@ -10222,8 +10631,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "벨이 울릴 때 GPIO 진동기를 알림합니다."
+            "state": "translated",
+            "value": "벨 수신 시 GPIO 부저 울림"
           }
         },
         "pt-BR": {
@@ -10310,8 +10719,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지를 받을 때 GPIO 벨트를 알림합니다."
+            "state": "translated",
+            "value": "메시지 수신 시 GPIO 부저 울림"
           }
         },
         "pt-BR": {
@@ -10398,8 +10807,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "벨 소리가 들리면 GPIO를 통해 모터를 진동시키세요."
+            "state": "translated",
+            "value": "벨 수신 시 GPIO 진동 모터 진동"
           }
         },
         "pt-BR": {
@@ -10486,8 +10895,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지를 받을 때 GPIO를 통해 모터를 진동시키세요"
+            "state": "translated",
+            "value": "메시지 수신 시 GPIO 진동 모터 진동"
           }
         },
         "pt-BR": {
@@ -10574,8 +10983,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "벨 소리가 들리면 알림 보내기"
+            "state": "translated",
+            "value": "벨 수신 시 알림"
           }
         },
         "pt-BR": {
@@ -10662,8 +11071,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지를 받을 때 알림"
+            "state": "translated",
+            "value": "메시지 수신 시 알림"
           }
         },
         "pt-BR": {
@@ -10750,8 +11159,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든"
+            "state": "translated",
+            "value": "제한 없음"
           }
         },
         "pt-BR": {
@@ -10838,7 +11247,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치 요청 허용"
           }
         },
@@ -10922,8 +11331,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알파"
+            "state": "translated",
+            "value": "Alpha"
           }
         },
         "pt-BR": {
@@ -10998,8 +11407,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Alt"
+            "state": "translated",
+            "value": "고도"
           }
         },
         "pt-BR": {
@@ -11086,7 +11495,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "고도"
           }
         },
@@ -11174,7 +11583,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "고도 %@"
           }
         },
@@ -11262,8 +11671,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "고도 지오디알 분리"
+            "state": "translated",
+            "value": "고도 지오이드 분리"
           }
         },
         "pt-BR": {
@@ -11311,7 +11720,15 @@
       }
     },
     "Altitude at %@": {
-      "comment": "VoiceOver label for an altitude point on the position altitude chart. %@ is the timestamp."
+      "comment": "VoiceOver label for an altitude point on the position altitude chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고도: %@"
+          }
+        }
+      }
     },
     "Altitude is Mean Sea Level": {
       "localizations": {
@@ -11353,8 +11770,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "고도는 평균 해수면입니다"
+            "state": "translated",
+            "value": "고도는 평균 해수면 기준입니다"
           }
         },
         "pt-BR": {
@@ -11441,8 +11858,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "북쪽으로 항상 향하세요"
+            "state": "translated",
+            "value": "항상 북쪽 방향"
           }
         },
         "pt-BR": {
@@ -11535,7 +11952,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "주변 조명"
           }
         },
@@ -11635,7 +12052,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "주변 조명 설정"
           }
         },
@@ -11691,6 +12108,12 @@
     },
     "An admin key must be set before enabling managed mode.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "관리 모드를 활성화하기 전에 관리자 키를 설정해야 합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -11745,8 +12168,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "저렴하고 전력 소모가 적은 라디오를 기반으로 하는 오픈 소스, 오프그리드, 분산된 메시 네트워크입니다."
+            "state": "translated",
+            "value": "저렴하고 저전력인 무선 장치를 기반으로 작동하는 오픈 소스, 오프그리드, 분산형 메시 네트워크입니다."
           }
         },
         "pt-BR": {
@@ -11827,6 +12250,12 @@
             "value": "LoRaノードのメッシュ上の位置を囲む輪郭"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 LoRa 노드 위치를 감싸는 윤곽선입니다."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
@@ -11863,6 +12292,12 @@
       "comment": "A button that analyzes the current preset.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 프리셋 분석"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -11881,6 +12316,12 @@
       "comment": "A footer for the current data report section of the discovery scan view.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 노드의 프리셋만 분석합니다. 이미 수집된 모든 데이터(확인된 모든 노드, 노드별 메시지 및 센서 횟수, 노이즈 플로어를 포함한 RF 상태)를 기반으로 하므로 빈 스캔이 아닌 전체 기록에서 시작합니다. 언제든 중지하여 요약을 확인할 수 있습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -11931,8 +12372,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "분석 중입니다..."
+            "state": "translated",
+            "value": "분석 중..."
           }
         },
         "pt-BR": {
@@ -12007,8 +12448,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "실수로 놓친 메시지는 다시 전달됩니다."
+            "state": "translated",
+            "value": "놓친 메시지는 다시 전달됩니다."
           }
         },
         "pt-BR": {
@@ -12095,7 +12536,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "앱 데이터"
           }
         },
@@ -12183,7 +12624,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "앱 파일"
           }
         },
@@ -12265,7 +12706,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "앱 아이콘"
           }
         },
@@ -12347,7 +12788,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "앱 알림"
           }
         },
@@ -12435,7 +12876,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "앱 설정"
           }
         },
@@ -12523,8 +12964,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "애플 앱"
+            "state": "translated",
+            "value": "Apple 앱"
           }
         },
         "pt-BR": {
@@ -12575,6 +13016,12 @@
       "comment": "A section header for files in the application support directory.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱 지원"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -12629,8 +13076,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "근접 위치 추정"
+            "state": "translated",
+            "value": "대략적인 위치"
           }
         },
         "pt-BR": {
@@ -12678,7 +13125,15 @@
       }
     },
     "Approximate location precision": {
-      "comment": "VoiceOver label for the approximate location precision slider"
+      "comment": "VoiceOver label for the approximate location precision slider",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대략적인 위치 정밀도"
+          }
+        }
+      }
     },
     "Architecture": {
       "comment": "A label displayed under the architecture of a device.",
@@ -12716,8 +13171,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치 아키텍처"
+            "state": "translated",
+            "value": "기기 아키텍처"
           }
         },
         "pt-BR": {
@@ -12792,7 +13247,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "이 메시지를 삭제하시겠습니까?"
           }
         },
@@ -12880,8 +13335,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드를 재설정하시겠습니까?"
+            "state": "translated",
+            "value": "노드를 초기 설정으로 재설정하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -12974,8 +13429,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "확실하시나요?"
+            "state": "translated",
+            "value": "정말 진행하시겠습니까?"
           }
         },
         "pl": {
@@ -13064,8 +13519,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "치르피에게 물어보세요"
+            "state": "translated",
+            "value": "Chirpy에게 묻기"
           }
         },
         "pt-BR": {
@@ -13136,8 +13591,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "치르피 AI 어시스턴트에게 물어보세요"
+            "state": "translated",
+            "value": "Chirpy AI 어시스턴트에게 묻기"
           }
         },
         "pt-BR": {
@@ -13206,8 +13661,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "치르피에게 물어보세요."
+            "state": "translated",
+            "value": "Chirpy에게 묻기…"
           }
         },
         "pt-BR": {
@@ -13276,8 +13731,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬스틱에 대해 무엇이든 물어보세요. 저는 문서를 검색하고 명확한 언어로 답변하겠습니다."
+            "state": "translated",
+            "value": "Meshtastic에 대해 무엇이든 물어보세요.\n문서를 찾아 이해하기 쉽게 답변해 드립니다."
           }
         },
         "pt-BR": {
@@ -13314,6 +13769,12 @@
     },
     "Audio": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -13330,6 +13791,12 @@
     },
     "Audio Config": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -13345,7 +13812,15 @@
       }
     },
     "Authenticate packets when possible, but accept unsigned traffic for maximum compatibility.": {
-      "comment": "Description of the Compatible packet authenticity policy."
+      "comment": "Description of the Compatible packet authenticity policy.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가능한 경우 패킷을 인증하지만, 최대 호환성을 위해 서명되지 않은 트래픽도 허용합니다."
+          }
+        }
+      }
     },
     "Auto-Fix Channel": {
       "comment": "A button label that initiates the process of automatically fixing the TAK server's primary communication channel.",
@@ -13383,8 +13858,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 서버의 기본 통신 채널 자동 수정"
+            "state": "translated",
+            "value": "TAK 채널 자동 수정"
           }
         },
         "pt-BR": {
@@ -13453,7 +13928,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "자동 연결"
           }
         },
@@ -13541,8 +14016,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "설정된 간격에 따라 화면에서 다음 페이지로 자동으로 전환됩니다."
+            "state": "translated",
+            "value": "설정된 간격에 따라 화면 페이지가 자동으로 전환됩니다."
           }
         },
         "pt-BR": {
@@ -13625,7 +14100,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "사용 가능한 Wi-Fi 네트워크"
           }
         },
@@ -13707,8 +14182,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용 가능한 라디오"
+            "state": "translated",
+            "value": "사용 가능한 무선 장치"
           }
         },
         "pl": {
@@ -13807,8 +14282,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용 가능한 모뎀 설정은 기본값은 긴 빠른 것입니다."
+            "state": "translated",
+            "value": "사용 가능한 모뎀 프리셋입니다. 기본값은 Long Fast입니다."
           }
         },
         "pt-BR": {
@@ -13891,8 +14366,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "평균 채널 활용률"
+            "state": "translated",
+            "value": "평균 채널 사용률"
           }
         },
         "pt-BR": {
@@ -13963,8 +14438,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안 파일"
+            "state": "translated",
+            "value": "BIN"
           }
         },
         "pt-BR": {
@@ -14039,8 +14514,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "블루투스"
+            "state": "translated",
+            "value": "BLE"
           }
         },
         "pt-BR": {
@@ -14127,8 +14602,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "블루투스 장치"
+            "state": "translated",
+            "value": "BLE 장치"
           }
         },
         "pt-BR": {
@@ -14197,7 +14672,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "BLE OTA 업데이트"
           }
         },
@@ -14279,8 +14754,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "BLE 핀은 6자리여야 합니다."
+            "state": "translated",
+            "value": "BLE PIN은 6자리 숫자여야 합니다."
           }
         },
         "pl": {
@@ -14341,6 +14816,12 @@
     },
     "BLE Threshold": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLE 임계값"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -14356,10 +14837,26 @@
       }
     },
     "BLE devices at %@": {
-      "comment": "VoiceOver label for a BLE device-count point on the PAX counter chart. %@ is the timestamp."
+      "comment": "VoiceOver label for a BLE device-count point on the PAX counter chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLE 장치: %@"
+          }
+        }
+      }
     },
     "Back to firmware update": {
-      "comment": "VoiceOver label for the close button in the Chirpy game"
+      "comment": "VoiceOver label for the close button in the Chirpy game",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펌웨어 업데이트로 돌아가기"
+          }
+        }
+      }
     },
     "Backup": {
       "localizations": {
@@ -14395,7 +14892,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "백업"
           }
         },
@@ -14451,6 +14948,12 @@
             "value": "Backup Failed"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백업 실패"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -14469,6 +14972,12 @@
       "comment": "A title for a screen that displays a list of node backups.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백업 관리"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -14489,6 +14998,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Backup Now"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지금 백업"
           }
         },
         "uk": {
@@ -14539,8 +15054,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "개인 키를 iCloud 키체인으로 백업하세요."
+            "state": "translated",
+            "value": "개인 키를 iCloud 키체인에 백업하세요."
           }
         },
         "pt-BR": {
@@ -14589,6 +15104,12 @@
     },
     "Bad Rx": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비정상 수신"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -14604,7 +15125,15 @@
       }
     },
     "Balanced — Prefer authenticated": {
-      "comment": "Balanced packet authenticity policy option."
+      "comment": "Balanced packet authenticity policy option.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "균형 — 인증된 패킷 우선"
+          }
+        }
+      }
     },
     "Bandwidth": {
       "localizations": {
@@ -14646,7 +15175,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "대역폭"
           }
         },
@@ -14734,8 +15263,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "바 시리즈"
+            "state": "translated",
+            "value": "막대 그래프 계열"
           }
         },
         "pt-BR": {
@@ -14828,7 +15357,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "배터리"
           }
         },
@@ -14935,8 +15464,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "배터리 레벨"
+            "state": "translated",
+            "value": "배터리 잔량"
           }
         },
         "pl": {
@@ -15042,8 +15571,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "배터리 레벨 %"
+            "state": "translated",
+            "value": "배터리 잔량 %"
           }
         },
         "pl": {
@@ -15143,8 +15672,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "배터리 레벨 %d"
+            "state": "translated",
+            "value": "배터리 잔량 %d"
           }
         },
         "pl": {
@@ -15204,7 +15733,15 @@
       }
     },
     "Battery level at %@": {
-      "comment": "VoiceOver label for a battery-level point on the device metrics chart. %@ is the timestamp."
+      "comment": "VoiceOver label for a battery-level point on the device metrics chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "배터리 잔량: %@"
+          }
+        }
+      }
     },
     "Battery level, voltage, channel utilization, and airtime reported by the node.": {
       "localizations": {
@@ -15240,8 +15777,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드에서 보고된 배터리 수준, 전압, 채널 활용률, 대기 시간"
+            "state": "translated",
+            "value": "노드가 보고한 배터리 잔량, 전압, 채널 사용률 및 송신 시간 데이터입니다."
           }
         },
         "pt-BR": {
@@ -15316,8 +15853,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Baud rate"
+            "state": "translated",
+            "value": "보드레이트"
           }
         },
         "pt-BR": {
@@ -15400,8 +15937,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "디퓨즈 업데이트 시작"
+            "state": "translated",
+            "value": "펌웨어 업데이트 시작"
           }
         },
         "pt-BR": {
@@ -15472,8 +16009,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비트 데이터 (%lld 바이트)"
+            "state": "translated",
+            "value": "바이너리 데이터 (%lld 바이트)"
           }
         },
         "pt-BR": {
@@ -15510,6 +16047,12 @@
     },
     "Bitrate": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비트레이트"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -15570,8 +16113,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "블루투스"
+            "state": "translated",
+            "value": "Bluetooth"
           }
         },
         "pl": {
@@ -15676,8 +16219,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "블루투스 설정"
+            "state": "translated",
+            "value": "Bluetooth 설정"
           }
         },
         "pl": {
@@ -15772,8 +16315,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "블루투스 연결 설정"
+            "state": "translated",
+            "value": "Bluetooth 연결 설정"
           }
         },
         "pt-BR": {
@@ -15821,10 +16364,26 @@
       }
     },
     "Bluetooth is off": {
-      "comment": "Connect tab: title shown in Available Radios when the BLE transport reports Bluetooth is powered off (#2175)"
+      "comment": "Connect tab: title shown in Available Radios when the BLE transport reports Bluetooth is powered off (#2175)",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bluetooth 꺼짐"
+          }
+        }
+      }
     },
     "Bold": {
-      "comment": "VoiceOver: bold formatting toolbar button"
+      "comment": "VoiceOver: bold formatting toolbar button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "굵게"
+          }
+        }
+      }
     },
     "Bold Heading": {
       "localizations": {
@@ -15860,8 +16419,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "강력한 헤드라인"
+            "state": "translated",
+            "value": "굵은 제목"
           }
         },
         "pt-BR": {
@@ -15942,8 +16501,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스크린에 표시되는 제목의 텍스트를 강조 표시합니다."
+            "state": "translated",
+            "value": "화면의 제목 텍스트를 굵게 표시합니다."
           }
         },
         "pt-BR": {
@@ -15991,10 +16550,26 @@
       }
     },
     "Bottom leading corner handle": {
-      "comment": "VoiceOver label for the geofence/region rectangle's bottom leading resize handle"
+      "comment": "VoiceOver label for the geofence/region rectangle's bottom leading resize handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왼쪽 아래 모서리 조절 핸들"
+          }
+        }
+      }
     },
     "Bottom trailing corner handle": {
-      "comment": "VoiceOver label for the geofence/region rectangle's bottom trailing resize handle"
+      "comment": "VoiceOver label for the geofence/region rectangle's bottom trailing resize handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오른쪽 아래 모서리 조절 핸들"
+          }
+        }
+      }
     },
     "Bridge Meshtastic positions, nodes, waypoints, and messages to TAK/CoT format": {
       "comment": "A description of the Mesh to CoT Converter feature.",
@@ -16032,8 +16607,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Mesh to CoT 변환기를 사용하여 TAK/CoT 형식으로 Bridge Meshtastic 위치, 노드, 경로 및 메시지를 변환합니다."
+            "state": "translated",
+            "value": "Meshtastic의 위치, 노드, 웨이포인트 및 메시지를 TAK/CoT 형식으로 연동합니다."
           }
         },
         "pt-BR": {
@@ -16102,8 +16677,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전송기 측량 데이터"
+            "state": "translated",
+            "value": "장치 측정 데이터 브로드캐스트"
           }
         },
         "pt-BR": {
@@ -16146,6 +16721,12 @@
     },
     "Busy Floor (-85 dBm)": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 중 기준값 (-85 dBm)"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -16200,7 +16781,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "GPIO 버튼"
           }
         },
@@ -16288,8 +16869,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "완성형 라디오 구매"
+            "state": "translated",
+            "value": "완제품 노드 구매"
           }
         },
         "pt-BR": {
@@ -16376,8 +16957,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비저 GPIO"
+            "state": "translated",
+            "value": "GPIO 버저"
           }
         },
         "pt-BR": {
@@ -16464,8 +17045,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 기능을 활성화하면, 실시간 지리적 위치를 MQTT 프로토콜을 통해 암호화 없이 전송하는 데 동의하고 명시적으로 동의합니다. 이러한 위치 데이터는 실시간 지도 보고, 장치 추적 및 관련 텔레메트리 기능 등의 목적으로 사용될 수 있습니다."
+            "state": "translated",
+            "value": "이 기능을 활성화하면 MQTT를 통해 실시간 위치 정보가 암호화되지 않은 상태로 전송되는 것에 동의합니다. 위치 정보는 실시간 지도 정보 공유, 장치 추적 및 기타 텔레메트리 기능에 사용될 수 있습니다."
           }
         },
         "pt-BR": {
@@ -16547,8 +17128,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용된 바이트 수"
+            "state": "translated",
+            "value": "사용 바이트 수"
           }
         },
         "pt-BR": {
@@ -16635,8 +17216,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "변경"
+            "state": "translated",
+            "value": "충전 중"
           }
         },
         "pt-BR": {
@@ -16723,8 +17304,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "출발지"
+            "state": "translated",
+            "value": "콜사인"
           }
         },
         "pt-BR": {
@@ -16811,8 +17392,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "출발표는 비어 있을 수 없습니다"
+            "state": "translated",
+            "value": "콜사인은 비워 둘 수 없습니다"
           }
         },
         "pt-BR": {
@@ -16905,7 +17486,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "취소"
           }
         },
@@ -16966,10 +17547,24 @@
       }
     },
     "Cancel reply": {
-      "comment": "VoiceOver: cancel replying to a message"
+      "comment": "VoiceOver: cancel replying to a message",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "응답 취소"
+          }
+        }
+      }
     },
     "Canceled": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소됨"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -16986,6 +17581,12 @@
     },
     "Canceled: %d": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소됨: %d"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -17046,8 +17647,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "캔디 메시지"
+            "state": "translated",
+            "value": "사전 정의 메시지"
           }
         },
         "pl": {
@@ -17152,8 +17753,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "캔디 메시지 설정"
+            "state": "translated",
+            "value": "사전 정의 메시지 설정"
           }
         },
         "pl": {
@@ -17248,8 +17849,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "카플레이 메시징"
+            "state": "translated",
+            "value": "CarPlay 메시지"
           }
         },
         "pt-BR": {
@@ -17324,8 +17925,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "카루셀 간격"
+            "state": "translated",
+            "value": "페이지 전환 간격"
           }
         },
         "pt-BR": {
@@ -17412,7 +18013,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "카테고리"
           }
         },
@@ -17500,7 +18101,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "카테고리"
           }
         },
@@ -17582,8 +18183,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Ch Util"
+            "state": "translated",
+            "value": "채널 사용률"
           }
         },
         "pt-BR": {
@@ -17658,8 +18259,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Ch1 현재"
+            "state": "translated",
+            "value": "Ch1 전류"
           }
         },
         "pt-BR": {
@@ -17746,7 +18347,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Ch1 전압"
           }
         },
@@ -17834,8 +18435,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Ch2 Current"
+            "state": "translated",
+            "value": "Ch2 전류"
           }
         },
         "pt-BR": {
@@ -17922,7 +18523,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Ch2 전압"
           }
         },
@@ -18010,8 +18611,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "현재 전류"
+            "state": "translated",
+            "value": "Ch3 전류"
           }
         },
         "pt-BR": {
@@ -18098,7 +18699,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Ch3 전압"
           }
         },
@@ -18192,7 +18793,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널"
           }
         },
@@ -18292,7 +18893,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 0 포함"
           }
         },
@@ -18380,7 +18981,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 1"
           }
         },
@@ -18468,7 +19069,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 1 포함"
           }
         },
@@ -18556,7 +19157,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 2"
           }
         },
@@ -18644,7 +19245,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 2 포함"
           }
         },
@@ -18732,7 +19333,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 3"
           }
         },
@@ -18820,7 +19421,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 3 포함"
           }
         },
@@ -18908,7 +19509,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 4 포함"
           }
         },
@@ -18996,7 +19597,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 5 포함"
           }
         },
@@ -19084,7 +19685,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 6 포함"
           }
         },
@@ -19172,7 +19773,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 7 포함"
           }
         },
@@ -19254,8 +19855,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널"
+            "state": "translated",
+            "value": "채널 상세 정보"
           }
         },
         "pt-BR": {
@@ -19338,8 +19939,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널이 성공적으로 수정되었습니다."
+            "state": "translated",
+            "value": "채널 수정 완료!"
           }
         },
         "pt-BR": {
@@ -19376,6 +19977,12 @@
     },
     "Channel Icons": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "채널 아이콘"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -19420,7 +20027,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 목록"
           }
         },
@@ -19496,7 +20103,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 이름"
           }
         },
@@ -19584,7 +20191,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 역할"
           }
         },
@@ -19668,7 +20275,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 보안"
           }
         },
@@ -19744,7 +20351,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 URL"
           }
         },
@@ -19838,8 +20445,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 활용"
+            "state": "translated",
+            "value": "채널 사용률"
           }
         },
         "pl": {
@@ -19938,8 +20545,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 이용률 %@%%"
+            "state": "translated",
+            "value": "채널 사용률 %@%%"
           }
         },
         "pt-BR": {
@@ -20026,8 +20633,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 번호는 0에서 7 사이의 값이어야 합니다."
+            "state": "translated",
+            "value": "채널 번호는 0부터 7 사이여야 합니다."
           }
         },
         "pt-BR": {
@@ -20075,7 +20682,15 @@
       }
     },
     "Channel utilization at %@": {
-      "comment": "VoiceOver label for a channel-utilization point on the device metrics chart. %@ is the timestamp."
+      "comment": "VoiceOver label for a channel-utilization point on the device metrics chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 채널 사용률"
+          }
+        }
+      }
     },
     "Channels": {
       "localizations": {
@@ -20123,7 +20738,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널"
           }
         },
@@ -20217,7 +20832,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 도움말"
           }
         },
@@ -20266,7 +20881,15 @@
       }
     },
     "Channels, %lld unread": {
-      "comment": "VoiceOver: Channels section with unread message count"
+      "comment": "VoiceOver: Channels section with unread message count",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "채널, 안 읽은 매시지 %lld개"
+          }
+        }
+      }
     },
     "Chat-dominated: %@": {
       "comment": "A label that indicates which presets had more messages exchanged.",
@@ -20304,8 +20927,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채팅 중심: %@"
+            "state": "translated",
+            "value": "채팅 위주: %@"
           }
         },
         "pt-BR": {
@@ -20341,7 +20964,15 @@
       }
     },
     "Chirpy Hop": {
-      "comment": "VoiceOver label for the Chirpy game play surface"
+      "comment": "VoiceOver label for the Chirpy game play surface",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chirpy Hop"
+          }
+        }
+      }
     },
     "Chirpy is loading an answer": {
       "comment": "A button that displays a loading spinner and a label.",
@@ -20379,8 +21010,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "치르피가 답을 로드 중입니다"
+            "state": "translated",
+            "value": "Chirpy가 답을 로드 중입니다"
           }
         },
         "pt-BR": {
@@ -20419,6 +21050,12 @@
       "comment": "A title for the view that lets the user choose an area to download.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영역 선택"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -20461,8 +21098,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "적절한 장치 역할을 선택하는 방법"
+            "state": "translated",
+            "value": "올바른 장치 역할 선택"
           }
         },
         "pt-BR": {
@@ -20501,6 +21138,12 @@
       "comment": "A prompt for a search bar.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도시, 공원 및 기타"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -20549,8 +21192,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "깨끗합니다"
+            "state": "translated",
+            "value": "지우기"
           }
         },
         "pt-BR": {
@@ -20643,7 +21286,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "앱 데이터 지우기"
           }
         },
@@ -20743,8 +21386,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "클리어 로그"
+            "state": "translated",
+            "value": "로그 지우기"
           }
         },
         "pt-BR": {
@@ -20815,6 +21458,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "古いノードをクリア"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오래된 노드 지우기"
           }
         },
         "pt-BR": {
@@ -20897,8 +21546,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "클리어 번역"
+            "state": "translated",
+            "value": "번역 초기화"
           }
         },
         "pt-BR": {
@@ -20934,12 +21583,26 @@
       }
     },
     "Clear trace route": {
-      "comment": "VoiceOver label for the clear trace route button"
+      "comment": "VoiceOver label for the clear trace route button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 추적 삭제"
+          }
+        }
+      }
     },
     "Clears all active contact filters.": {
       "comment": "A hint for the reset button.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성 연락처 필터를 모두 지웁니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -20958,6 +21621,12 @@
       "comment": "A hint for the reset button.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성 노드 필터를 모두 지웁니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -21004,6 +21673,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "クライアントベースは、自分が管理する他のノードのみをフォロワーに指定してください。不適切な使用は、ローカルメッシュに影響を与える可能性があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Client Base는 자신이 관리하는 노드만 즐겨찾기로 지정해야 합니다. 잘못 사용하면 로컬 메시 네트워크에 문제가 발생할 수 있습니다."
           }
         },
         "ru": {
@@ -21072,7 +21747,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "클라이언트 CA 인증서"
           }
         },
@@ -21142,8 +21817,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "클라이언트 구성"
+            "state": "translated",
+            "value": "클라이언트 설정"
           }
         },
         "pt-BR": {
@@ -21218,7 +21893,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "클라이언트 기록"
           }
         },
@@ -21306,8 +21981,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "클라이언트 역사 요청 전송"
+            "state": "translated",
+            "value": "클라이언트 기록 요청 전송"
           }
         },
         "pt-BR": {
@@ -21394,7 +22069,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "클라이언트 옵션"
           }
         },
@@ -21482,8 +22157,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시계 방향으로 회전 이벤트"
+            "state": "translated",
+            "value": "시계 방향 회전 이벤트"
           }
         },
         "pt-BR": {
@@ -21576,7 +22251,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "닫기"
           }
         },
@@ -21638,6 +22313,12 @@
     },
     "Cluster Nodes": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클러스터 노드"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -21647,10 +22328,24 @@
       }
     },
     "Code": {
-      "comment": "VoiceOver: inline code formatting toolbar button"
+      "comment": "VoiceOver: inline code formatting toolbar button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "코드"
+          }
+        }
+      }
     },
     "Codec2 Enabled": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2 활성화됨"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -21667,6 +22362,12 @@
     },
     "Codec2 Settings": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -21721,8 +22422,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "코딩 속도"
+            "state": "translated",
+            "value": "코딩률"
           }
         },
         "pt-BR": {
@@ -21773,6 +22474,12 @@
       "comment": "A label describing a section that is collapsed.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "접힘"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -21827,7 +22534,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "색상"
           }
         },
@@ -21915,8 +22622,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결"
+            "state": "translated",
+            "value": "통신 중"
           }
         },
         "pt-BR": {
@@ -21965,6 +22672,12 @@
     },
     "Community supported Linux device.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커뮤니티 지원 Linux 장치"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -22013,7 +22726,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "나침반"
           }
         },
@@ -22057,6 +22770,12 @@
     },
     "Compass Orientation": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "나침반 방향"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -22072,7 +22791,15 @@
       }
     },
     "Compatible — Accept unsigned": {
-      "comment": "Compatible packet authenticity policy option."
+      "comment": "Compatible packet authenticity policy option.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "호환 — 서명되지 않은 패킷 허용"
+          }
+        }
+      }
     },
     "Complete Device Setup": {
       "localizations": {
@@ -22108,8 +22835,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "완성된 장치 설정"
+            "state": "translated",
+            "value": "장치 설정 완료"
           }
         },
         "pt-BR": {
@@ -22180,8 +22907,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시틱 지역 탐색 스캔을 완료하여 결과를 확인하세요."
+            "state": "translated",
+            "value": "로컬 메시 탐색 스캔을 완료하여 결과를 확인하세요."
           }
         },
         "pt-BR": {
@@ -22256,7 +22983,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "설정"
           }
         },
@@ -22338,8 +23065,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "구성"
+            "state": "translated",
+            "value": "설정"
           }
         },
         "pt-BR": {
@@ -22414,8 +23141,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "구성 사전"
+            "state": "translated",
+            "value": "설정 프리셋"
           }
         },
         "pt-BR": {
@@ -22502,8 +23229,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Meshtastic 설정: %@"
+            "state": "translated",
+            "value": "%@ 설정"
           }
         },
         "pt-BR": {
@@ -22590,7 +23317,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "설정"
           }
         },
@@ -22678,7 +23405,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "확인"
           }
         },
@@ -22760,7 +23487,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "연결"
           }
         },
@@ -22848,8 +23575,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "MQTT를 프록시를 통해 연결합니다."
+            "state": "translated",
+            "value": "프록시를 통해 MQTT에 연결"
           }
         },
         "pt-BR": {
@@ -22936,8 +23663,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드 연결"
+            "state": "translated",
+            "value": "노드에 연결"
           }
         },
         "pt-BR": {
@@ -23025,8 +23752,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "새로운 라디오에 연결하시겠습니까?"
+            "state": "translated",
+            "value": "새로운 노드에 연결하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -23110,8 +23837,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "네트워크의 로컬 Wi-Fi 노드 연결"
+            "state": "translated",
+            "value": "로컬 Wi-Fi 네트워크의 노드에 연결합니다."
           }
         },
         "pt-BR": {
@@ -23183,8 +23910,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Meshtastic 노드와의 블루투스 저에너지 연결을 통해 최고의 메시징 경험을 즐기세요."
+            "state": "translated",
+            "value": "Meshtastic 노드와의 BLE 연결을 통해 최고의 메시징 경험을 즐기세요."
           }
         },
         "pt-BR": {
@@ -23255,8 +23982,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치를 안정적인 전원 공급원에 연결하세요."
+            "state": "translated",
+            "value": "장치를 안정적인 전원에 연결하세요."
           }
         },
         "pt-BR": {
@@ -23327,8 +24054,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "mPWRD-OS 장치를 Bluetooth를 통해 Wi-Fi 네트워크에 연결하세요."
+            "state": "translated",
+            "value": "Bluetooth를 통해 mPWRD-OS 장치를 Wi-Fi 네트워크에 연결하세요."
           }
         },
         "pt-BR": {
@@ -23409,7 +24136,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "연결됨"
           }
         },
@@ -23507,6 +24234,12 @@
             "value": "接続済みノード %@"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 노드 %@"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -23591,8 +24324,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결된 라디오"
+            "state": "translated",
+            "value": "연결된 노드"
           }
         },
         "pt-BR": {
@@ -23675,8 +24408,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결된 시스템 소프트웨어: **%@**"
+            "state": "translated",
+            "value": "연결된 장치의 펌웨어: **%@**"
           }
         },
         "pt-BR": {
@@ -23712,7 +24445,15 @@
       }
     },
     "Connected to Bluetooth device": {
-      "comment": "VoiceOver label for a connected Bluetooth device"
+      "comment": "VoiceOver label for a connected Bluetooth device",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "블루투스 장치에 연결됨"
+          }
+        }
+      }
     },
     "Connecting . .": {
       "localizations": {
@@ -23760,8 +24501,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결 중입니다."
+            "state": "translated",
+            "value": "연결 중 . ."
           }
         },
         "pl": {
@@ -23861,8 +24602,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "새로운 라디오에 연결하면 전화 앱 데이터가 모두 지워집니다."
+            "state": "translated",
+            "value": "새 라디오에 연결하면 휴대전화의 모든 앱 데이터가 삭제됩니다."
           }
         },
         "pt-BR": {
@@ -23949,8 +24690,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결 시도 %1$lld / %2$lld"
+            "state": "translated",
+            "value": "연결 시도 %1$lld / %2$lld회"
           }
         },
         "pt-BR": {
@@ -24019,7 +24760,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "연결 이름"
           }
         },
@@ -24107,8 +24848,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "MQTT를 통해 암호화되지 않은 노드 데이터를 공유하는 데 동의합니다."
+            "state": "translated",
+            "value": "MQTT를 통한 비암호화 노드 데이터 공유 동의"
           }
         },
         "pt-BR": {
@@ -24189,7 +24930,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "연락처 URL"
           }
         },
@@ -24273,7 +25014,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "연락처"
           }
         },
@@ -24343,8 +25084,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "계속하세요"
+            "state": "translated",
+            "value": "계속하기"
           }
         },
         "pt-BR": {
@@ -24415,8 +25156,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연속 위치 업데이트를 활성화합니다."
+            "state": "translated",
+            "value": "지속적인 위치 업데이트"
           }
         },
         "pt-BR": {
@@ -24491,8 +25232,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "제어 유형"
+            "state": "translated",
+            "value": "제어 방식"
           }
         },
         "pt-BR": {
@@ -24579,8 +25320,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치를 제어하여 장치의 LED를 비추게 합니다. 대부분의 장치에서는 최대 4개의 LED를 제어할 수 있으며, 충전기와 GPS LED는 제어할 수 없습니다."
+            "state": "translated",
+            "value": "장치의 깜박이는 LED를 제어합니다. 대부분의 장치에서는 최대 4개의 LED 중 하나를 제어하며, 충전 및 GPS LED는 제어할 수 없습니다."
           }
         },
         "pt-BR": {
@@ -24667,8 +25408,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "복소한 겉면"
+            "state": "translated",
+            "value": "노드 영역 표시"
           }
         },
         "pt-BR": {
@@ -24755,7 +25496,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "좌표"
           }
         },
@@ -24843,7 +25584,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "좌표 %@, %@"
           }
         },
@@ -24932,7 +25673,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "좌표:"
           }
         },
@@ -25026,8 +25767,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Meshtastic은 LoRa를 사용하여 BLE를 통해 연결된 여러 장치의 데이터를 수집하고 분석합니다."
+            "state": "translated",
+            "value": "복사"
           }
         },
         "pl": {
@@ -25090,6 +25831,12 @@
       "comment": "A context menu item that copies a value to the clipboard. The argument is the name of the value.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사 %@"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -25105,10 +25852,26 @@
       }
     },
     "Copy IP address": {
-      "comment": "VoiceOver label for the copy IP address button"
+      "comment": "VoiceOver label for the copy IP address button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IP 주소 복사"
+          }
+        }
+      }
     },
     "Copy SSH command": {
-      "comment": "VoiceOver label for the copy SSH command button"
+      "comment": "VoiceOver label for the copy SSH command button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 명령 복사"
+          }
+        }
+      }
     },
     "Could not find node": {
       "localizations": {
@@ -25150,8 +25913,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드 찾을 수 없습니다"
+            "state": "translated",
+            "value": "노드를 찾을 수 없습니다"
           }
         },
         "pt-BR": {
@@ -25198,11 +25961,44 @@
         }
       }
     },
-    "Couldn't add this contact. Check that your node is connected and try again.": {},
-    "Couldn't read tag": {},
-    "Couldn't read the channel settings on this tag.": {},
+    "Couldn't add this contact. Check that your node is connected and try again.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 연락처를 추가할 수 없습니다. 노드가 연결되어 있는지 확인한 후 다시 시도하세요."
+          }
+        }
+      }
+    },
+    "Couldn't read tag": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그를 읽을 수 없습니다"
+          }
+        }
+      }
+    },
+    "Couldn't read the channel settings on this tag.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그에 있는 채널 설정을 읽을 수 없습니다."
+          }
+        }
+      }
+    },
     "Count": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개수"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -25257,8 +26053,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시계 반대 방향으로 회전 이벤트"
+            "state": "translated",
+            "value": "시계 반대 방향 회전 이벤트"
           }
         },
         "pt-BR": {
@@ -25341,8 +26137,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "네트워크 연결 가능한 NFC 태그를 생성하세요."
+            "state": "translated",
+            "value": "노드 연락처 NFC 태그 생성"
           }
         },
         "pt-BR": {
@@ -25417,8 +26213,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "경로를 생성합니다."
+            "state": "translated",
+            "value": "경로 생성"
           }
         },
         "pt-BR": {
@@ -25467,6 +26263,12 @@
     },
     "Created by": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작성자"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -25516,7 +26318,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "작성자:"
           }
         },
@@ -25593,7 +26395,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "작성일: %@"
           }
         },
@@ -25675,8 +26477,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위험 알림"
+            "state": "translated",
+            "value": "긴급 알림"
           }
         },
         "pt-BR": {
@@ -25763,8 +26565,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "현재"
+            "state": "translated",
+            "value": "전류"
           }
         },
         "pt-BR": {
@@ -25847,7 +26649,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "현재 소프트웨어 버전"
           }
         },
@@ -25887,6 +26689,12 @@
       "comment": "Name of the map target when the user selects their current location.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 위치"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -25899,6 +26707,12 @@
       "comment": "A label displayed above the current",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 프리셋"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -25914,7 +26728,15 @@
       }
     },
     "Current at %@": {
-      "comment": "VoiceOver label for a current point on the power metrics chart. %@ is the timestamp."
+      "comment": "VoiceOver label for a current point on the power metrics chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 시점의 전류"
+          }
+        }
+      }
     },
     "Current: %lld": {
       "localizations": {
@@ -25956,8 +26778,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld 현재"
+            "state": "translated",
+            "value": "현재: %lld"
           }
         },
         "pt-BR": {
@@ -26040,8 +26862,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "DFU 업데이트"
+            "state": "translated",
+            "value": "DFU 펌웨어 업데이트"
           }
         },
         "pt-BR": {
@@ -26094,6 +26916,12 @@
     },
     "DNS": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DNS"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -26112,6 +26940,12 @@
       "comment": "A description of a dashed line that represents the return path of a trace route.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "발신자로 돌아가는 점선"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -26156,8 +26990,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기록된 경로 경로를 나타내는 점선"
+            "state": "translated",
+            "value": "기록된 경로를 나타내는 점선"
           }
         },
         "pt-BR": {
@@ -26228,7 +27062,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "데이터 브라우저"
           }
         },
@@ -26300,7 +27134,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "데이터베이스 브라우저"
           }
         },
@@ -26376,7 +27210,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "날짜"
           }
         },
@@ -26425,7 +27259,15 @@
       }
     },
     "Days before purging stale nodes": {
-      "comment": "VoiceOver label for the purge stale nodes days slider"
+      "comment": "VoiceOver label for the purge stale nodes days slider",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오래된 노드 정리까지 남은 일수"
+          }
+        }
+      }
     },
     "Debug": {
       "localizations": {
@@ -26467,8 +27309,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "디버깅"
+            "state": "translated",
+            "value": "디버그"
           }
         },
         "pt-BR": {
@@ -26555,8 +27397,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "디버깅 로그"
+            "state": "translated",
+            "value": "디버그 로그"
           }
         },
         "pt-BR": {
@@ -26644,8 +27486,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "디버깅 로그%@"
+            "state": "translated",
+            "value": "디버그 로그%@"
           }
         },
         "pt-BR": {
@@ -26738,7 +27580,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "기본"
           }
         },
@@ -26835,8 +27677,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 키가 필요합니다."
+            "state": "translated",
+            "value": "기본 키 필요"
           }
         },
         "pt-BR": {
@@ -26917,7 +27759,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "삭제"
           }
         },
@@ -27005,8 +27847,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 것을 삭제합니다."
+            "state": "translated",
+            "value": "모두 삭제"
           }
         },
         "pt-BR": {
@@ -27045,6 +27887,12 @@
       "comment": "A confirmation dialog asking the user to confirm the deletion of a backup.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백업을 삭제하시겠습니까?"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -27099,8 +27947,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지를 삭제합니다."
+            "state": "translated",
+            "value": "메시지 삭제"
           }
         },
         "pt-BR": {
@@ -27187,8 +28035,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지를 삭제합니다"
+            "state": "translated",
+            "value": "메시지 삭제"
           }
         },
         "pt-BR": {
@@ -27275,7 +28123,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드 삭제"
           }
         },
@@ -27363,8 +28211,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드 삭제?"
+            "state": "translated",
+            "value": "노드를 삭제하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -27445,8 +28293,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전력 측정을 삭제하시겠습니까?"
+            "state": "translated",
+            "value": "전력 측정 데이터를 삭제하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -27494,7 +28342,15 @@
       }
     },
     "Delete all air quality metrics?": {
-      "comment": "Confirmation button to clear the air quality metrics log."
+      "comment": "Confirmation button to clear the air quality metrics log.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 공기질 측정 데이터를 삭제하시겠습니까?"
+          }
+        }
+      }
     },
     "Delete all config, keys and BLE bonds? ": {
       "localizations": {
@@ -27530,8 +28386,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 설정, 키 및 BLE 연결을 삭제합니다."
+            "state": "translated",
+            "value": "모든 설정, 키 및 BLE 페어링 정보를 삭제하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -27612,8 +28468,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 설정 삭제하시겠습니까?"
+            "state": "translated",
+            "value": "모든 설정을 삭제하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -27700,8 +28556,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 장치 측정을 삭제합니다."
+            "state": "translated",
+            "value": "모든 장치 측정 데이터를 삭제하시겠습니까?"
           }
         },
         "pl": {
@@ -27786,6 +28642,12 @@
             "value": "全ての環境メトリクスを削除しますか？"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 환경 측정 데이터를 삭제하시겠습니까?"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -27832,6 +28694,12 @@
     },
     "Delete all local stats?": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 로컬 통계 데이터를 삭제하시겠습니까?"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -27886,8 +28754,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 패스 데이터 삭제?"
+            "state": "translated",
+            "value": "모든 PAX 데이터를 삭제하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -27974,8 +28842,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 위치를 삭제합니다."
+            "state": "translated",
+            "value": "모든 위치 데이터를 삭제하시겠습니까?"
           }
         },
         "ru": {
@@ -28017,7 +28885,15 @@
       }
     },
     "Delete key backup": {
-      "comment": "VoiceOver label for the delete key backup button"
+      "comment": "VoiceOver label for the delete key backup button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 백업 삭제"
+          }
+        }
+      }
     },
     "Description": {
       "localizations": {
@@ -28059,7 +28935,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "설명"
           }
         },
@@ -28147,7 +29023,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "제품 설명은 100바이트 이하로 작성해주세요."
           }
         },
@@ -28229,7 +29105,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "데스크톱 권장"
           }
         },
@@ -28269,6 +29145,12 @@
       "comment": "A label that describes the zoom range of the map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세부 수준"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -28313,7 +29195,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "상세 정보"
           }
         },
@@ -28383,8 +29265,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "세부 정보..."
+            "state": "translated",
+            "value": "상세 정보..."
           }
         },
         "pt-BR": {
@@ -28432,7 +29314,15 @@
       }
     },
     "Detected": {
-      "comment": "VoiceOver value spoken for a detection-event bar on the detection sensor chart."
+      "comment": "VoiceOver value spoken for a detection-event bar on the detection sensor chart.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "감지됨"
+          }
+        }
+      }
     },
     "Detection": {
       "localizations": {
@@ -28474,7 +29364,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "감지"
           }
         },
@@ -28569,7 +29459,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "감지 센서"
           }
         },
@@ -28675,8 +29565,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "감지 센서 구성"
+            "state": "translated",
+            "value": "감지 센서 설정"
           }
         },
         "pt-BR": {
@@ -28769,7 +29659,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "감지 센서 로그"
           }
         },
@@ -28857,7 +29747,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "감지 이벤트"
           }
         },
@@ -28906,13 +29796,37 @@
       }
     },
     "Detection event at %@": {
-      "comment": "VoiceOver label for a detection-event bar on the detection sensor chart. %@ is the timestamp."
+      "comment": "VoiceOver label for a detection-event bar on the detection sensor chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에 감지 이벤트"
+          }
+        }
+      }
     },
     "Detection events": {
-      "comment": "Legend label for the detection-events series on the detection sensor chart."
+      "comment": "Legend label for the detection-events series on the detection sensor chart.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "감지 이벤트"
+          }
+        }
+      }
     },
     "Detection sensor": {
-      "comment": "VoiceOver label for the detection sensor message badge"
+      "comment": "VoiceOver label for the detection sensor message badge",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "감지 센서"
+          }
+        }
+      }
     },
     "Detection sensor events reported by the node, such as motion or door open/close alerts.": {
       "localizations": {
@@ -28948,8 +29862,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드에서 감지된 센서 이벤트(예: 움직임 또는 문 열림/닫힘 알림 등)를 보고합니다."
+            "state": "translated",
+            "value": "노드에서 보고하는 감지 센서 이벤트입니다. 움직임이나 문 열림/닫힘 알림 등이 포함됩니다."
           }
         },
         "pt-BR": {
@@ -29024,8 +29938,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "감지 센서 메시지는 문자 메시지로 수신됩니다. 알림을 활성화하면 수신된 각 감지 메시지에 대한 알림과 일치하는 비어있는 메시지 배지를 받습니다."
+            "state": "translated",
+            "value": "감지 센서 메시지는 문자 메시지로 수신됩니다. 알림을 활성화하면 감지 메시지를 받을 때마다 알림이 표시되고, 해당 메시지의 읽지 않음 배지가 표시됩니다."
           }
         },
         "pt-BR": {
@@ -29112,7 +30026,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "개발자"
           }
         },
@@ -29206,7 +30120,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치"
           }
         },
@@ -29312,7 +30226,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치 설정"
           }
         },
@@ -29412,7 +30326,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치 설정"
           }
         },
@@ -29500,7 +30414,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치 설정 문서"
           }
         },
@@ -29570,8 +30484,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치가 연결되었습니다."
+            "state": "translated",
+            "value": "장치 연결됨"
           }
         },
         "pt-BR": {
@@ -29646,7 +30560,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치 GPS"
           }
         },
@@ -29698,6 +30612,12 @@
       "comment": "The title of a screen that lists links to other devices.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "장치 링크"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -29752,8 +30672,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치 측정값"
+            "state": "translated",
+            "value": "장치 측정 데이터"
           }
         },
         "pt-BR": {
@@ -29840,8 +30760,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치 측량 로그"
+            "state": "translated",
+            "value": "장치 측정 로그"
           }
         },
         "pt-BR": {
@@ -29922,7 +30842,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치 옵션"
           }
         },
@@ -30004,7 +30924,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치 역할"
           }
         },
@@ -30086,7 +31006,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치 역할"
           }
         },
@@ -30162,7 +31082,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "장치 화면"
           }
         },
@@ -30250,8 +31170,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치는 메쉬 관리자가 관리하며, 사용자는 장치가 설정된 모든 것을 액세스할 수 없습니다."
+            "state": "translated",
+            "value": "장치는 Mesh 관리자가 관리하며, 사용자는 장치의 어떤 설정에도 접근할 수 없습니다."
           }
         },
         "pt-BR": {
@@ -30334,8 +31254,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치 역할은 '%@'입니다. 최적의 작동을 위해 TAK 또는 TAK Tracker로 설정하십시오."
+            "state": "translated",
+            "value": "장치 역할은 '%@'입니다. 최적의 작동을 위해 TAK 또는 TAK Tracker로 설정하는 것이 좋습니다."
           }
         },
         "pt-BR": {
@@ -30410,8 +31330,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본값으로 사용되는 DOP 및 PDOP의 정확도 희석"
+            "state": "translated",
+            "value": "정밀도 희석(DOP) 값 포함 - 기본값은 PDOP"
           }
         },
         "pt-BR": {
@@ -30492,8 +31412,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "직접"
+            "state": "translated",
+            "value": "직접 연결"
           }
         },
         "pt-BR": {
@@ -30574,8 +31494,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Direct Message Key"
+            "state": "translated",
+            "value": "개인 메시지 키"
           }
         },
         "pt-BR": {
@@ -30668,8 +31588,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "직접 메시지"
+            "state": "translated",
+            "value": "개인 메시지"
           }
         },
         "pl": {
@@ -30764,8 +31684,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Direct Message 도움말"
+            "state": "translated",
+            "value": "개인 메시지 도움말"
           }
         },
         "pt-BR": {
@@ -30801,10 +31721,24 @@
       }
     },
     "Direct Messages, %lld unread": {
-      "comment": "VoiceOver: Direct Messages section with unread message count"
+      "comment": "VoiceOver: Direct Messages section with unread message count",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인 메시지, %lld개 읽지 않음"
+          }
+        }
+      }
     },
     "Direct Response": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "직접 응답"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -30855,8 +31789,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "직접 메시지는 공개 키 인프라를 사용하여 암호화됩니다. 2.5 또는 더 높은 버전을 요구합니다."
+            "state": "translated",
+            "value": "개인 메시지는 공개 키 기반 구조(PKI)를 사용하여 암호화됩니다. 펌웨어 버전 2.5 이상이 필요합니다."
           }
         },
         "pt-BR": {
@@ -30931,8 +31865,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널의 공유 키를 사용하여 직접 메시지를 전송합니다."
+            "state": "translated",
+            "value": "개인 메시지는 채널의 공유 암호화 키를 사용합니다."
           }
         },
         "pt-BR": {
@@ -31025,8 +31959,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비활성화"
+            "state": "translated",
+            "value": "비활성화됨"
           }
         },
         "pl": {
@@ -31131,7 +32065,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "연결 해제"
           }
         },
@@ -31225,7 +32159,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드 연결 해제"
           }
         },
@@ -31301,8 +32235,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "현재 연결된 노드를 분리합니다."
+            "state": "translated",
+            "value": "현재 연결된 노드를 연결 해제"
           }
         },
         "pt-BR": {
@@ -31385,8 +32319,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "발견된 노드 지도"
+            "state": "translated",
+            "value": "탐색 지도"
           }
         },
         "pt-BR": {
@@ -31467,8 +32401,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "취소"
+            "state": "translated",
+            "value": "닫기"
           }
         },
         "pl": {
@@ -31573,8 +32507,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "표시"
+            "state": "translated",
+            "value": "디스플레이"
           }
         },
         "pl": {
@@ -31679,8 +32613,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "표시 설정"
+            "state": "translated",
+            "value": "디스플레이 설정"
           }
         },
         "pl": {
@@ -31779,8 +32713,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "섭씨 표시"
+            "state": "translated",
+            "value": "화씨 표시"
           }
         },
         "pt-BR": {
@@ -31867,7 +32801,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "표시 모드"
           }
         },
@@ -31955,7 +32889,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "표시 단위"
           }
         },
@@ -32033,6 +32967,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "あなたのスマートフォンと他のMeshtasticノードとの距離と位置を表示します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 정보가 있는 다른 Meshtastic 노드와 휴대폰 사이의 거리를 표시합니다."
           }
         },
         "ru": {
@@ -32113,7 +33053,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "거리"
           }
         },
@@ -32197,7 +33137,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "거리 및 방향"
           }
         },
@@ -32267,7 +33207,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "거리 필터"
           }
         },
@@ -32349,7 +33289,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "거리 측정"
           }
         },
@@ -32431,7 +33371,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "거리와 방향"
           }
         },
@@ -32503,8 +33443,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "업데이트 중 앱이 종료되지 않습니다."
+            "state": "translated",
+            "value": "업데이트 중 앱을 종료하지 마세요."
           }
         },
         "pt-BR": {
@@ -32579,7 +33519,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "문서"
           }
         },
@@ -32661,7 +33601,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "문서 번역"
           }
         },
@@ -32733,8 +33673,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "문서 파일이 로드되지 않았습니다."
+            "state": "translated",
+            "value": "문서를 불러올 수 없습니다"
           }
         },
         "pt-BR": {
@@ -32770,12 +33710,26 @@
       }
     },
     "Documentation page": {
-      "comment": "VoiceOver label for the documentation web view"
+      "comment": "VoiceOver label for the documentation web view",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문서 페이지"
+          }
+        }
+      }
     },
     "Documents": {
       "comment": "A section header for files in the user's documents directory.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문서"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -32824,8 +33778,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "완료되었습니다."
+            "state": "translated",
+            "value": "완료"
           }
         },
         "pt-BR": {
@@ -32912,8 +33866,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "버튼을 두 번 탭하세요"
+            "state": "translated",
+            "value": "두 번 탭을 버튼으로 사용"
           }
         },
         "pt-BR": {
@@ -32964,6 +33918,12 @@
       "comment": "A hint for the accessibility of a collapsed section.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "두 번 탭하여 접기"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -32982,6 +33942,12 @@
       "comment": "A hint for expanding a section.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "두 번 탭하여 펼치기"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33036,8 +34002,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다운링크 활성화됨"
+            "state": "translated",
+            "value": "다운링크 활성화"
           }
         },
         "pt-BR": {
@@ -33120,8 +34086,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "파일을 다운로드하세요"
+            "state": "translated",
+            "value": "다운로드"
           }
         },
         "pt-BR": {
@@ -33160,6 +34126,12 @@
       "comment": "A title for a screen that lets the user download a new map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 지도 다운로드"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33202,8 +34174,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 서버 데이터 패키지를 다운로드하세요."
+            "state": "translated",
+            "value": "TAK 서버 데이터 패키지 다운로드"
           }
         },
         "pt-BR": {
@@ -33240,6 +34212,12 @@
     },
     "Download map areas to use without a connection.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오프라인에서 사용할 지도 영역을 다운로드합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33252,6 +34230,12 @@
       "comment": "A description of the action of downloading a translation language pack.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 언어 팩을 다운로드하면 해당 언어로 문서를 읽을 수 있습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33302,8 +34286,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다운로드된"
+            "state": "translated",
+            "value": "다운로드됨"
           }
         },
         "pt-BR": {
@@ -33342,6 +34326,12 @@
       "comment": "A description of how to use the map selector.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영역 상자, 모서리 또는 지도를 드래그하여 영역을 선택하세요"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33354,6 +34344,12 @@
       "comment": "A description of how to define a geofence area.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영역 상자, 모서리 또는 지도를 드래그하여 지오펜스 영역을 선택하세요"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33397,8 +34393,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도에서 지점을 드롭하세요."
+            "state": "translated",
+            "value": "지도에 핀 배치"
           }
         },
         "pt-BR": {
@@ -33447,6 +34443,12 @@
     },
     "Drop Unknown": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알 수 없는 항목 제외"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33463,6 +34465,12 @@
     },
     "Drop redundant position broadcasts from the same node.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "같은 노드에서 전송된 중복 위치 브로드캐스트를 삭제합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33479,6 +34487,12 @@
     },
     "Dupes": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중복"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33495,6 +34509,12 @@
     },
     "Dupes: %d": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중복: %d"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33545,8 +34565,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "거주 시간"
+            "state": "translated",
+            "value": "유지 시간"
           }
         },
         "pt-BR": {
@@ -33615,8 +34635,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "각 설정의 대기 시간"
+            "state": "translated",
+            "value": "프리셋별 유지 시간"
           }
         },
         "pt-BR": {
@@ -33685,8 +34705,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "ESP32 BLE 업데이트기"
+            "state": "translated",
+            "value": "ESP32 BLE 업데이트 도구"
           }
         },
         "pt-BR": {
@@ -33755,8 +34775,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "ESP32 OTA 업데이트에는 %@ 또는 최신 버전을 사용하는 것이 필요합니다. Web Flasher를 사용하여 먼저 장치의 소프트웨어 버전을 업데이트하세요."
+            "state": "translated",
+            "value": "ESP32 OTA 업데이트를 사용하려면 펌웨어 %@ 이상이 필요합니다. 먼저 Web Flasher를 사용하여 장치 펌웨어를 업데이트하세요."
           }
         },
         "pt-BR": {
@@ -33825,7 +34845,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "ESP32 업데이트"
           }
         },
@@ -33895,8 +34915,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "ESP32 WiFi 업데이트기"
+            "state": "translated",
+            "value": "ESP32 WiFi 업데이트 도구"
           }
         },
         "pt-BR": {
@@ -33935,6 +34955,12 @@
       "comment": "A description of the signal strength color coding for a trace route.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 구간은 홉 SNR에 따라 색상으로 표시됩니다 — 녹색(좋음), 노란색(보통), 주황색(나쁨), 빨간색(없음)."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -33977,8 +35003,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "각 노드는 짧은 이름(최대 4바이트)을 색상으로 표시된 원 안에 표시하고, 그 옆에 긴 이름을 표시합니다. 원의 색상은 노드 번호에 따라 다릅니다. 짧은 이름은 에모티콘이나 이니셜로 구성될 수 있습니다."
+            "state": "translated",
+            "value": "각 노드는 색상 원 안에 표시되는 짧은 이름(최대 4바이트)과 그 옆에 표시되는 긴 이름을 가집니다. 원의 색상은 노드 번호에 따라 결정됩니다. 짧은 이름에는 이모지 또는 이니셜을 사용할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -34059,7 +35085,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "에코"
           }
         },
@@ -34115,6 +35141,12 @@
     },
     "Edit Bounding Box": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영역 경계 편집"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -34124,7 +35156,15 @@
       }
     },
     "Edit waypoint": {
-      "comment": "VoiceOver label for the edit waypoint button"
+      "comment": "VoiceOver label for the edit waypoint button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 편집"
+          }
+        }
+      }
     },
     "Editing Waypoint": {
       "localizations": {
@@ -34166,7 +35206,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "경로 편집"
           }
         },
@@ -34254,8 +35294,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "높이 증가"
+            "state": "translated",
+            "value": "고도 상승"
           }
         },
         "pt-BR": {
@@ -34342,8 +35382,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "아이콘"
+            "state": "translated",
+            "value": "이모지"
           }
         },
         "pt-BR": {
@@ -34391,7 +35431,15 @@
       }
     },
     "Emoji picker": {
-      "comment": "VoiceOver: open the character/emoji picker"
+      "comment": "VoiceOver: open the character/emoji picker",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이모지 선택기"
+          }
+        }
+      }
     },
     "Empty": {
       "localizations": {
@@ -34433,8 +35481,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "빈"
+            "state": "translated",
+            "value": "비어 있음"
           }
         },
         "pt-BR": {
@@ -34518,8 +35566,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "배경 활동 활성화"
+            "state": "translated",
+            "value": "백그라운드 활동 활성화"
           }
         },
         "pt-BR": {
@@ -34556,6 +35604,12 @@
     },
     "Enable Codec2 audio encoding/decoding for voice communication over the mesh.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mesh 음성 통신을 위한 Codec2 오디오 인코딩/디코딩을 활성화합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -34610,7 +35664,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "알림 활성화"
           }
         },
@@ -34659,10 +35713,26 @@
       }
     },
     "Enable Strict": {
-      "comment": "Confirms enabling the Strict packet authenticity policy."
+      "comment": "Confirms enabling the Strict packet authenticity policy.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "엄격 모드 활성화"
+          }
+        }
+      }
     },
     "Enable Strict authentication?": {
-      "comment": "Strict packet authenticity confirmation title."
+      "comment": "Strict packet authenticity confirmation title.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "엄격 인증을 활성화하시겠습니까?"
+          }
+        }
+      }
     },
     "Enable TAK Server": {
       "localizations": {
@@ -34698,8 +35768,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 서버를 활성화합니다."
+            "state": "translated",
+            "value": "TAK 서버 활성화"
           }
         },
         "pt-BR": {
@@ -34768,8 +35838,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 네트워크에 방송 장치 메트릭스를 활성화합니다. 비활성화 시 메트릭스는 연결된 클라이언트에게만 전송됩니다."
+            "state": "translated",
+            "value": "장치 측정 데이터를 Mesh 네트워크로 브로드캐스트할 수 있습니다. 비활성화하면 측정 데이터는 연결된 클라이언트에만 전송됩니다."
           }
         },
         "pt-BR": {
@@ -34850,8 +35920,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지역 네트워크를 통해 UDP를 통해 방송 패킷을 활성화합니다."
+            "state": "translated",
+            "value": "로컬 네트워크에서 UDP 패킷 브로드캐스트를 활성화합니다."
           }
         },
         "pt-BR": {
@@ -34900,6 +35970,12 @@
     },
     "Enable dropping of unknown/undecryptable packets.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알 수 없거나 복호화할 수 없는 패킷을 버리도록 설정합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -34918,6 +35994,12 @@
       "comment": "A description of the neighbor info broadcasting feature.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이웃 정보 브로드캐스트를 활성화합니다. Mesh 토폴로지 시각화를 위해 직접 수신한 이웃 노드 정보를 주기적으로 전송합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -34934,6 +36016,12 @@
     },
     "Enable per-node rate limiting to throttle chatty nodes.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 노드의 과도한 통신을 제한하기 위한 노드별 전송 빈도 제한을 활성화합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -34988,8 +36076,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 장비를 스토어 앤 포워드 서버로 활성화합니다. ESP32 장치와 PSRAM이 필요합니다."
+            "state": "translated",
+            "value": "이 장치를 Store and Forward 서버로 사용합니다. PSRAM이 탑재된 ESP32 장치가 필요합니다."
           }
         },
         "pt-BR": {
@@ -35082,8 +36170,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "활성화됨"
+            "state": "translated",
+            "value": "사용"
           }
         },
         "pl": {
@@ -35182,8 +36270,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "내장된 I2S 오디오 출력을 지원하는 장치를 RTTTL을 스피커처럼 비벼주는 기능입니다. 예를 들어 T-Watch S3와 T-Deck은 이러한 기능을 갖추고 있습니다."
+            "state": "translated",
+            "value": "내장 I2S 오디오 출력을 지원하는 장치에서 스피커를 버저처럼 사용하여 RTTTL을 재생할 수 있도록 합니다. 예를 들어 T-Watch S3와 T-Deck은 이 기능을 지원합니다."
           }
         },
         "pt-BR": {
@@ -35264,8 +36352,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시틱 지도에서 전화기의 파란색 위치 점을 활성화합니다."
+            "state": "translated",
+            "value": "Mesh 지도에 휴대폰의 파란색 위치 점을 표시합니다."
           }
         },
         "pt-BR": {
@@ -35352,8 +36440,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "센서 모듈을 활성화하려면 센서를 가진 노드와 감지 센서 텍스트 메시지를 수신하거나 감지 센서 로그와 차트를 보기 원하는 모든 노드에서도 활성화해야 합니다."
+            "state": "translated",
+            "value": "감지 센서 모듈을 활성화합니다. 센서가 있는 노드뿐만 아니라 감지 센서 문자 메시지를 수신하거나 로그 및 차트를 확인하려는 모든 노드에서도 활성화해야 합니다."
           }
         },
         "pt-BR": {
@@ -35440,8 +36528,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스토어 및 프론트워드 모듈을 활성화합니다."
+            "state": "translated",
+            "value": "Store and Forward 모듈을 활성화합니다."
           }
         },
         "pt-BR": {
@@ -35528,8 +36616,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Ethernet을 활성화하면 앱의 블루투스 연결이 비활성화됩니다."
+            "state": "translated",
+            "value": "Ethernet을 활성화하면 앱과의 Bluetooth 연결이 비활성화됩니다."
           }
         },
         "pt-BR": {
@@ -35616,8 +36704,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Wi-Fi를 활성화하면 앱의 블루투스 연결이 비활성화됩니다."
+            "state": "translated",
+            "value": "Wi-Fi를 활성화하면 앱과의 Bluetooth 연결이 비활성화됩니다."
           }
         },
         "pt-BR": {
@@ -35704,8 +36792,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "엔코더 프레스 이벤트"
+            "state": "translated",
+            "value": "엔코더 버튼 누름 이벤트"
           }
         },
         "pt-BR": {
@@ -35798,7 +36886,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "암호화됨"
           }
         },
@@ -35859,7 +36947,15 @@
       }
     },
     "Encrypted message": {
-      "comment": "VoiceOver label for the PKI-encrypted direct message badge"
+      "comment": "VoiceOver label for the PKI-encrypted direct message badge",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "암호화된 메시지"
+          }
+        }
+      }
     },
     "Encryption": {
       "comment": "A heading for the encryption information.",
@@ -35897,7 +36993,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "암호화"
           }
         },
@@ -35973,8 +37069,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "암호화 활성화됨"
+            "state": "translated",
+            "value": "암호화 활성화"
           }
         },
         "pt-BR": {
@@ -36057,8 +37153,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치를 충전하세요."
+            "state": "translated",
+            "value": "장치가 충전되어 있는지 확인하세요."
           }
         },
         "pt-BR": {
@@ -36127,7 +37223,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "P12 비밀번호를 입력하세요"
           }
         },
@@ -36199,7 +37295,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Wi-Fi 비밀번호 입력"
           }
         },
@@ -36236,7 +37332,15 @@
       }
     },
     "Enter a passphrase between 1 and 32 bytes.": {
-      "comment": "VoiceOver hint: why the submit button is disabled"
+      "comment": "VoiceOver hint: why the submit button is disabled",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 - 32바이트 사이의 암호 문구를 입력하세요."
+          }
+        }
+      }
     },
     "Enter hostname[:port]": {
       "comment": "A label for a text field where the user can enter a hostname or IP address and optionally a port number.",
@@ -36274,8 +37378,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "주소:포트(포트번호)"
+            "state": "translated",
+            "value": "호스트명[:포트] 입력"
           }
         },
         "pt-BR": {
@@ -36358,8 +37462,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "선택된 텍스트의 URL를 입력하세요"
+            "state": "translated",
+            "value": "선택한 텍스트에 연결할 URL을 입력하세요."
           }
         },
         "pt-BR": {
@@ -36428,7 +37532,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "PKCS#12 파일의 비밀번호를 입력하세요"
           }
         },
@@ -36467,6 +37571,12 @@
     "Entered %@": {
       "comment": "Geofence notification title when a node enters the waypoint area. %@ is the waypoint name.",
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에 진입함"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -36511,8 +37621,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "개체 (%lld)"
+            "state": "translated",
+            "value": "엔티티 (%lld)"
           }
         },
         "pt-BR": {
@@ -36587,8 +37697,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Meshtastic는 LoRa를 기반으로 하는 BLE 기반의 IoT 플랫폼입니다."
+            "state": "translated",
+            "value": "환경"
           }
         },
         "pt-BR": {
@@ -36669,8 +37779,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "환경 측정 기능이 활성화되었습니다."
+            "state": "translated",
+            "value": "환경 측정 데이터 활성화"
           }
         },
         "pt-BR": {
@@ -36751,8 +37861,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "환경 지표 로그"
+            "state": "translated",
+            "value": "환경 측정 데이터 로그"
           }
         },
         "pt-BR": {
@@ -36833,7 +37943,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "환경 센서 옵션"
           }
         },
@@ -36915,8 +38025,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 앱 데이터를 지우시겠습니까?"
+            "state": "translated",
+            "value": "모든 앱 데이터를 삭제하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -37004,8 +38114,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 장치 및 앱 데이터 지우기?"
+            "state": "translated",
+            "value": "모든 장치 및 앱 데이터를 삭제하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -37053,7 +38163,15 @@
       }
     },
     "Error": {
-      "comment": "VoiceOver value when firmware update failed"
+      "comment": "VoiceOver value when firmware update failed",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펌웨어 업데이트 오류"
+          }
+        }
+      }
     },
     "Error: %@": {
       "localizations": {
@@ -37095,7 +38213,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "오류: %@"
           }
         },
@@ -37144,7 +38262,15 @@
       }
     },
     "Estimate coverage": {
-      "comment": "VoiceOver label for the coverage estimate button"
+      "comment": "VoiceOver label for the coverage estimate button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "통신 범위 추정"
+          }
+        }
+      }
     },
     "Ethernet Options": {
       "localizations": {
@@ -37186,7 +38312,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Ethernet 옵션"
           }
         },
@@ -37268,8 +38394,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 교환"
+            "state": "translated",
+            "value": "위치 주고받기"
           }
         },
         "pt-BR": {
@@ -37350,8 +38476,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 정보를 교환합니다."
+            "state": "translated",
+            "value": "사용자 정보 주고받기"
           }
         },
         "pt-BR": {
@@ -37393,10 +38519,24 @@
       }
     },
     "Exit look around": {
-      "comment": "VoiceOver label for the map look-around toggle button when look-around mode is active"
+      "comment": "VoiceOver label for the map look-around toggle button when look-around mode is active",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "둘러보기 종료"
+          }
+        }
+      }
     },
     "Expanded": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펼쳐짐"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -37445,8 +38585,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "유효기간"
+            "state": "translated",
+            "value": "만료일"
           }
         },
         "pt-BR": {
@@ -37533,8 +38673,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "유효기간"
+            "state": "translated",
+            "value": "만료일"
           }
         },
         "pt-BR": {
@@ -37621,8 +38761,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "유효기간"
+            "state": "translated",
+            "value": "유효기간 설정"
           }
         },
         "pt-BR": {
@@ -37710,8 +38850,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "유효기간: %@"
+            "state": "translated",
+            "value": "만료: %@"
           }
         },
         "pt-BR": {
@@ -37798,8 +38938,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "출력"
+            "state": "translated",
+            "value": "내보내기"
           }
         },
         "pt-BR": {
@@ -37847,10 +38987,26 @@
       }
     },
     "Export logs as CSV": {
-      "comment": "VoiceOver label for the export application logs to CSV button"
+      "comment": "VoiceOver label for the export application logs to CSV button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그를 CSV로 내보내기"
+          }
+        }
+      }
     },
     "Export scan summary as PDF": {
-      "comment": "VoiceOver label for the export scan summary to PDF button"
+      "comment": "VoiceOver label for the export scan summary to PDF button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스캔 요약을 PDF로 내보내기"
+          }
+        }
+      }
     },
     "External Notification": {
       "localizations": {
@@ -37898,7 +39054,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "외부 알림"
           }
         },
@@ -38004,7 +39160,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "외부 알림 설정"
           }
         },
@@ -38104,7 +39260,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "공장 초기화"
           }
         },
@@ -38186,8 +39342,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치를 재설정하면 장치와 앱 데이터가 삭제됩니다."
+            "state": "translated",
+            "value": "공장 초기화를 수행하면 장치와 앱 데이터가 삭제됩니다."
           }
         },
         "pt-BR": {
@@ -38234,7 +39390,16 @@
         }
       }
     },
-    "Failed to connect to tag.": {},
+    "Failed to connect to tag.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그에 연결하는 데 실패했습니다."
+          }
+        }
+      }
+    },
     "Failed to exchange user info.": {
       "localizations": {
         "de": {
@@ -38269,8 +39434,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 정보를 교환할 수 없습니다."
+            "state": "translated",
+            "value": "사용자 정보를 교환하는 데 실패했습니다."
           }
         },
         "pt-BR": {
@@ -38351,8 +39516,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 교환에 대한 유효한 위치를 가져오지 못했습니다."
+            "state": "translated",
+            "value": "교환할 유효한 위치를 가져오지 못했습니다."
           }
         },
         "pt-BR": {
@@ -38433,8 +39598,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "교환할 수 있는 유효한 위치를 가져오지 못했습니다."
+            "state": "translated",
+            "value": "교환할 유효한 위치를 가져오지 못했습니다."
           }
         },
         "pt-BR": {
@@ -38481,8 +39646,26 @@
         }
       }
     },
-    "Failed to read tag.": {},
-    "Failed to write tag.": {},
+    "Failed to read tag.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그를 읽는 데 실패했습니다"
+          }
+        }
+      }
+    },
+    "Failed to write tag.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그에 쓰는 데 실패했습니다."
+          }
+        }
+      }
+    },
     "False": {
       "comment": "A label for a boolean value of false.",
       "isCommentAutoGenerated": true,
@@ -38519,8 +39702,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "거짓"
+            "state": "translated",
+            "value": "아니요"
           }
         },
         "pt-BR": {
@@ -38595,8 +39778,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "좋아하는"
+            "state": "translated",
+            "value": "즐겨찾기"
           }
         },
         "pt-BR": {
@@ -38671,8 +39854,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "좋아요와 무시된 노드는 항상 유지됩니다. 다른 노드는 사용자의 설정한 스케줄에 따라 앱 데이터베이스에서 지워집니다. (PKC 키가 있는 노드는 최소 7일 동안 유지됩니다.) 이 기능은 앱에서 장치 노드 데이터베이스에 저장되지 않은 노드를 지우는 데만 사용됩니다."
+            "state": "translated",
+            "value": "즐겨찾기한 노드와 무시된 노드는 항상 유지됩니다. 다른 노드는 사용자가 설정한 일정에 따라 앱 데이터베이스에서 삭제됩니다. (PKC 키가 있는 노드는 항상 최소 7일 동안 유지됩니다.) 이 기능은 장치 노드 데이터베이스에 저장되지 않은 노드만 앱에서 정리합니다."
           }
         },
         "pt-BR": {
@@ -38753,7 +39936,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "즐겨찾기"
           }
         },
@@ -38803,6 +39986,12 @@
     },
     "Favorites Only": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "즐겨찾기만"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -38851,7 +40040,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "최근 메시지가 있는 연락처 목록의 맨 위에 즐겨찾기와 노드가 표시됩니다."
           }
         },
@@ -38933,8 +40122,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "특정 노드의 최신 위치를 가져오세요"
+            "state": "translated",
+            "value": "특정 노드의 최신 위치를 가져옵니다."
           }
         },
         "pt-BR": {
@@ -39015,7 +40204,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "15분"
           }
         },
@@ -39103,8 +40292,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "파일 저장"
+            "state": "translated",
+            "value": "파일 저장소"
           }
         },
         "pt-BR": {
@@ -39180,8 +40369,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "파일 있음"
+            "state": "translated",
+            "value": "사용 가능한 파일"
           }
         },
         "pt-BR": {
@@ -39229,7 +40418,15 @@
       }
     },
     "Fills the transmitter coordinates.": {
-      "comment": "VoiceOver hint for the fill-coordinates button"
+      "comment": "VoiceOver hint for the fill-coordinates button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "송신기 좌표를 입력합니다."
+          }
+        }
+      }
     },
     "Filter the node list and mesh map based on proximity to your phone.": {
       "localizations": {
@@ -39265,8 +40462,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "휴대폰의 근접성에 따라 노드 목록과 맵을 필터링합니다."
+            "state": "translated",
+            "value": "휴대폰과의 거리에 따라 노드 목록과 메시 맵을 필터링합니다."
           }
         },
         "pt-BR": {
@@ -39349,8 +40546,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치를 찾습니다."
+            "state": "translated",
+            "value": "장치 찾기"
           }
         },
         "pt-BR": {
@@ -39425,8 +40622,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연락처를 찾으세요"
+            "state": "translated",
+            "value": "연락처 찾기"
           }
         },
         "pt-BR": {
@@ -39513,8 +40710,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드를 찾으세요"
+            "state": "translated",
+            "value": "노드 찾기"
           }
         },
         "pt-BR": {
@@ -39607,8 +40804,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "끝나네요."
+            "state": "translated",
+            "value": "완료"
           }
         },
         "pl": {
@@ -39702,7 +40899,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "완료"
           }
         },
@@ -39784,8 +40981,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안 파일"
+            "state": "translated",
+            "value": "펌웨어 파일"
           }
         },
         "pt-BR": {
@@ -39856,8 +41053,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "firmware 릴리스"
+            "state": "translated",
+            "value": "펌웨어 릴리즈"
           }
         },
         "pt-BR": {
@@ -39928,8 +41125,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "firmware 업데이트 문서 링크"
+            "state": "translated",
+            "value": "펌웨어 업데이트 문서"
           }
         },
         "pt-BR": {
@@ -40000,8 +41197,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "firmware 업데이트가 필요합니다"
+            "state": "translated",
+            "value": "펌웨어 업데이트가 필요합니다"
           }
         },
         "pt-BR": {
@@ -40076,8 +41273,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "소프트웨어 업데이트"
+            "state": "translated",
+            "value": "펌웨어 업데이트"
           }
         },
         "pt-BR": {
@@ -40170,8 +41367,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안 업데이트 버전"
+            "state": "translated",
+            "value": "펌웨어 버전"
           }
         },
         "pl": {
@@ -40270,8 +41467,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "처음 들었음"
+            "state": "translated",
+            "value": "최초 수신"
           }
         },
         "pt-BR": {
@@ -40358,7 +41555,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "5분"
           }
         },
@@ -40442,7 +41639,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 복구"
           }
         },
@@ -40514,8 +41711,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 채널을 수정하시겠습니까?"
+            "state": "translated",
+            "value": "기본 채널을 복구하시겠습니까?"
           }
         },
         "pt-BR": {
@@ -40596,8 +41793,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "고정 핀"
+            "state": "translated",
+            "value": "고정 PIN"
           }
         },
         "pl": {
@@ -40696,8 +41893,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "정렬된 위치"
+            "state": "translated",
+            "value": "고정 위치"
           }
         },
         "pt-BR": {
@@ -40784,8 +41981,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스크린 회전"
+            "state": "translated",
+            "value": "화면 뒤집기"
           }
         },
         "pt-BR": {
@@ -40872,8 +42069,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스크린을 수직으로 뒤집습니다."
+            "state": "translated",
+            "value": "화면 세로로 뒤집기"
           }
         },
         "pt-BR": {
@@ -40921,12 +42118,26 @@
       }
     },
     "Flyover paused — mesh traffic is high": {
-      "comment": "Shown on the map when the trace-route flyover is paused because live mesh traffic is too high to animate smoothly."
+      "comment": "Shown on the map when the trace-route flyover is paused because live mesh traffic is too high to animate smoothly.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플라이오버 일시 정지 — 메시 트래픽이 높습니다"
+          }
+        }
+      }
     },
     "Flyover speed %@": {
       "comment": "A button that starts or stops a flyover along a trace route. The argument is the string “%g times”.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플라이오버 속도 %@"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -40975,8 +42186,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "MQTT 기능 외의 모든 채널을 MQTT를 통해 브리지할 때 업링크와 다운링크를 설정해야 합니다."
+            "state": "translated",
+            "value": "지도 정보 공유 외의 모든 MQTT 기능에서는 MQTT를 통해 브리지하려는 각 채널에 대해 업링크와 다운링크를 설정해야 합니다."
           }
         },
         "pt-BR": {
@@ -41063,7 +42274,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "모두에게"
           }
         },
@@ -41151,7 +42362,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "나에게"
           }
         },
@@ -41235,8 +42446,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안상의 이유로 iOS는 외부 USB 장치에 직접 쓰지 않습니다. 파일을 수동으로 저장해야 합니다."
+            "state": "translated",
+            "value": "보안상의 이유로 iOS에서는 외부 USB 장치에 직접 파일을 쓸 수 없습니다. 파일을 수동으로 저장해야 합니다."
           }
         },
         "pt-BR": {
@@ -41299,8 +42510,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시계에서 포켓하unts"
+            "state": "translated",
+            "value": "Watch에서 폭스헌트"
           }
         },
         "pt-BR": {
@@ -41375,8 +42586,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "빈도"
+            "state": "translated",
+            "value": "주파수"
           }
         },
         "pt-BR": {
@@ -41463,8 +42674,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "주파수 우회"
+            "state": "translated",
+            "value": "주파수 재정의"
           }
         },
         "pt-BR": {
@@ -41551,7 +42762,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "주파수 슬롯"
           }
         },
@@ -41639,8 +42850,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "친애하는 이름"
+            "state": "translated",
+            "value": "별칭"
           }
         },
         "pt-BR": {
@@ -41727,8 +42938,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지를 전송할 때 메쉬에 사용할 친근한 이름입니다. 예를 들어, '모션'이라는 이름을 사용하면 '모션 감지'라는 메시지가 전송됩니다."
+            "state": "translated",
+            "value": "메시로 전송되는 메시지 형식을 지정하는 이름입니다. 예: 'Motion'을 사용하면 'Motion detected'라는 메시지가 전송됩니다."
           }
         },
         "pt-BR": {
@@ -41809,8 +43020,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "무선(RX): %lld"
+            "state": "translated",
+            "value": "노드에서 수신 (RX): %lld"
           }
         },
         "pt-BR": {
@@ -41887,8 +43098,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최대 노드 거리"
+            "state": "translated",
+            "value": "가장 먼 노드 거리"
           }
         },
         "pt-BR": {
@@ -42013,6 +43224,12 @@
     },
     "GPIO Configuration": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPIO 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -42067,7 +43284,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "GPIO 출력 시간"
           }
         },
@@ -42155,8 +43372,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "GPIO 핀을 모니터링"
+            "state": "translated",
+            "value": "모니터링할 GPIO 핀"
           }
         },
         "pt-BR": {
@@ -42243,8 +43460,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "회전식 엔코더 A 포트의 GPIO 핀"
+            "state": "translated",
+            "value": "로터리 엔코더 A 포트용 GPIO 핀"
           }
         },
         "pt-BR": {
@@ -42331,8 +43548,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "회전 엔코더 B 포트의 GPIO 핀"
+            "state": "translated",
+            "value": "로터리 엔코더 B 포트용 GPIO 핀"
           }
         },
         "pt-BR": {
@@ -42419,8 +43636,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "회전 엔코더를 위한 GPIO 핀을 누르세요."
+            "state": "translated",
+            "value": "로터리 엔코더 누름 버튼용 GPIO 핀"
           }
         },
         "pt-BR": {
@@ -42507,7 +43724,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "GPS EN GPIO"
           }
         },
@@ -42595,8 +43812,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "GPS를 통해 GPIO를 받습니다."
+            "state": "translated",
+            "value": "GPS 수신 GPIO"
           }
         },
         "pt-BR": {
@@ -42683,8 +43900,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "GPS를 통해 GPIO를 전송합니다."
+            "state": "translated",
+            "value": "GPS 송신 GPIO"
           }
         },
         "pt-BR": {
@@ -42765,8 +43982,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드에서 보고된 좌표, 경도, 고도 포함의 GPS 위치 데이터"
+            "state": "translated",
+            "value": "노드가 보고한 GPS 위치 데이터(위도, 경도, 고도 포함)"
           }
         },
         "pt-BR": {
@@ -42803,6 +44020,12 @@
     },
     "Gateway": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "게이트웨이"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -42863,8 +44086,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "QR코드를 생성합니다."
+            "state": "translated",
+            "value": "QR 코드 생성"
           }
         },
         "pl": {
@@ -42957,8 +44180,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 클라이언트를 이 서버에 연결하기 위한 데이터 패키지를 (.zip) 생성합니다."
+            "state": "translated",
+            "value": "TAK 클라이언트 연결 설정용 데이터 패키지(.zip)를 생성합니다."
           }
         },
         "pt-BR": {
@@ -43027,8 +44250,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "현재 사용 중인 개인 키를 대체하기 위해 새로운 개인 키를 생성합니다. 공개 키는 자동으로 개인 키에서 생성됩니다."
+            "state": "translated",
+            "value": "현재 사용 중인 개인 키를 대체할 새 개인 키를 생성합니다. 공개 키는 새 개인 키를 기반으로 자동으로 다시 생성됩니다."
           }
         },
         "pt-BR": {
@@ -43076,7 +44299,15 @@
       }
     },
     "Generate channel key": {
-      "comment": "VoiceOver label for the generate channel key button"
+      "comment": "VoiceOver label for the generate channel key button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "채널 키 생성"
+          }
+        }
+      }
     },
     "Generating local AI recommendation...": {
       "comment": "A message displayed when the local AI recommendation is being generated.",
@@ -43114,8 +44345,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지역 AI 추천이 생성 중입니다..."
+            "state": "translated",
+            "value": "로컬 AI 추천 생성 중…"
           }
         },
         "pt-BR": {
@@ -43152,6 +44383,12 @@
     },
     "Geofence": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지오펜스"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -43164,6 +44401,12 @@
       "comment": "A title for the Geofence Area screen.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지오펜스 영역"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -43202,6 +44445,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ノード位置取得"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 위치 가져오기"
           }
         },
         "ru": {
@@ -43276,8 +44525,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "수분 방수 태양광 및 감지 센서 라우터 노드, 알루미늄 데스크탑 노드 및 견고한 휴대폰을 구입하세요."
+            "state": "translated",
+            "value": "맞춤형 방수 태양광 감지 센서 라우터 노드, 알루미늄 데스크탑 노드, 견고한 휴대용 장치를 만나보세요.\""
           }
         },
         "pt-BR": {
@@ -43359,7 +44608,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시작하기"
           }
         },
@@ -43441,7 +44690,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "GitHub 저장소"
           }
         },
@@ -43493,6 +44742,12 @@
       "comment": "A description of the color-coded endpoints of a trace route.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹색은 발신자를, 빨간색은 대상 노드를 나타냅니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -43537,8 +44792,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "회송 성공: 회색, 재시도 가능: 오렌지, 영구 실패: 빨간색"
+            "state": "translated",
+            "value": "회색은 전달 성공, 주황색은 재시도 가능한 오류, 빨간색은 재시도해도 성공하지 않는 영구 실패를 나타냅니다."
           }
         },
         "pt-BR": {
@@ -43613,7 +44868,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "그룹 메시지"
           }
         },
@@ -43663,6 +44918,12 @@
     },
     "Groups nearby nodes into one numbered pin; tap it to zoom in. Turn off to always show every node.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가까운 노드를 하나의 번호가 표시된 핀으로 그룹화합니다. 핀을 탭하면 확대됩니다. 끄면 항상 모든 노드를 표시합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -43711,8 +44972,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "바람의 속도 %@"
+            "state": "translated",
+            "value": "돌풍 %@"
           }
         },
         "pt-BR": {
@@ -43799,8 +45060,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "높음"
+            "state": "translated",
+            "value": "HIGH"
           }
         },
         "pt-BR": {
@@ -43881,7 +45142,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "하드 리셋"
           }
         },
@@ -43969,8 +45230,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장비"
+            "state": "translated",
+            "value": "하드웨어"
           }
         },
         "pt-BR": {
@@ -44057,8 +45318,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "제목"
+            "state": "translated",
+            "value": "방향"
           }
         },
         "pt-BR": {
@@ -44145,8 +45406,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "제목: %@"
+            "state": "translated",
+            "value": "방향: %@"
           }
         },
         "pt-BR": {
@@ -44230,8 +45491,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지원 및 문서"
+            "state": "translated",
+            "value": "도움말 및 문서"
           }
         },
         "pt-BR": {
@@ -44300,7 +45561,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지원 및 문서"
           }
         },
@@ -44372,8 +45633,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "안녕하세요, 저는 치르피입니다!"
+            "state": "translated",
+            "value": "안녕하세요, 저는 Chirpy입니다!"
           }
         },
         "pt-BR": {
@@ -44448,8 +45709,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알림을 숨기세요"
+            "state": "translated",
+            "value": "알림 숨기기"
           }
         },
         "pt-BR": {
@@ -44537,8 +45798,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알림을 숨기세요"
+            "state": "translated",
+            "value": "알림 숨기기"
           }
         },
         "pt-BR": {
@@ -44586,13 +45847,37 @@
       }
     },
     "Hide altitude chart": {
-      "comment": "VoiceOver label for the altitude chart toggle button when the chart is showing"
+      "comment": "VoiceOver label for the altitude chart toggle button when the chart is showing",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고도 차트 숨기기"
+          }
+        }
+      }
     },
     "Hide contact filters": {
-      "comment": "VoiceOver label for the contact filter toggle button when filters are showing"
+      "comment": "VoiceOver label for the contact filter toggle button when filters are showing",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연락처 필터 숨기기"
+          }
+        }
+      }
     },
     "Hide help": {
-      "comment": "VoiceOver label for the help toggle button when help is showing"
+      "comment": "VoiceOver label for the help toggle button when help is showing",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도움말 숨기기"
+          }
+        }
+      }
     },
     "Hide legend": {
       "comment": "A label for a button that hides the map legend.",
@@ -44630,8 +45915,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "레거시 숨기기"
+            "state": "translated",
+            "value": "범례 숨기기"
           }
         },
         "pt-BR": {
@@ -44700,8 +45985,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 레이블 숨기기"
+            "state": "translated",
+            "value": "지도 범례 숨기기"
           }
         },
         "pt-BR": {
@@ -44737,10 +46022,24 @@
       }
     },
     "Hide map settings": {
-      "comment": "VoiceOver label to hide the map settings panel"
+      "comment": "VoiceOver label to hide the map settings panel",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도 설정 숨기기"
+          }
+        }
+      }
     },
     "Hide node filters": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 필터 숨기기"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -44757,6 +46056,12 @@
     },
     "Hide password": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비밀번호 숨기기"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -44805,8 +46110,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 레이블을 숨깁니다."
+            "state": "translated",
+            "value": "지도 범례를 숨깁니다."
           }
         },
         "pt-BR": {
@@ -44842,10 +46147,24 @@
       }
     },
     "Hides the map settings panel.": {
-      "comment": "VoiceOver hint to hide the map settings panel"
+      "comment": "VoiceOver hint to hide the map settings panel",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도 설정 패널을 숨깁니다."
+          }
+        }
+      }
     },
     "Hides the node filter options.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 필터 옵션을 숨깁니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -44864,6 +46183,12 @@
       "comment": "Label for a higher-detail offline map option.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "높은 상세도"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -44912,8 +46237,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "역사와 최대값을 반환합니다."
+            "state": "translated",
+            "value": "기록 반환 최대 개수"
           }
         },
         "pt-BR": {
@@ -44994,8 +46319,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "역사 리턴 창"
+            "state": "translated",
+            "value": "기록 반환 시간 범위"
           }
         },
         "pt-BR": {
@@ -45036,13 +46361,64 @@
         }
       }
     },
-    "Hold a writable NFC tag near the top of your iPhone to save these channel settings to it.": {},
-    "Hold a writable NFC tag near the top of your iPhone to save your contact to it.": {},
-    "Hold a writable NFC tag near the top of your iPhone to share this contact.": {},
-    "Hold your iPhone near the Meshtastic NFC tag.": {},
-    "Hold your iPhone near the NFC tag.": {},
+    "Hold a writable NFC tag near the top of your iPhone to save these channel settings to it.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쓰기 가능한 NFC 태그를 iPhone 상단에 가까이 대어 이 채널 설정을 저장하세요."
+          }
+        }
+      }
+    },
+    "Hold a writable NFC tag near the top of your iPhone to save your contact to it.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쓰기 가능한 NFC 태그를 iPhone 상단에 가까이 대어 연락처를 저장하세요."
+          }
+        }
+      }
+    },
+    "Hold a writable NFC tag near the top of your iPhone to share this contact.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쓰기 가능한 NFC 태그를 iPhone 상단에 가까이 대어 연락처를 공유하세요."
+          }
+        }
+      }
+    },
+    "Hold your iPhone near the Meshtastic NFC tag.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone을 Meshtastic NFC 태그 가까이에 대세요."
+          }
+        }
+      }
+    },
+    "Hold your iPhone near the NFC tag.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone을 NFC 태그 가까이에 대세요."
+          }
+        }
+      }
+    },
     "Hops": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "홉"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -45097,8 +46473,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "하프웨이"
+            "state": "translated",
+            "value": "홉 수"
           }
         },
         "pt-BR": {
@@ -45185,8 +46561,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "하프웨이 %d"
+            "state": "translated",
+            "value": "홉 수 %d"
           }
         },
         "pt-BR": {
@@ -45273,8 +46649,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "하프웨이: %d"
+            "state": "translated",
+            "value": "홉 수: %d"
           }
         },
         "pt-BR": {
@@ -45361,7 +46737,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시간"
           }
         },
@@ -45449,8 +46825,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시간별 근무 주기"
+            "state": "translated",
+            "value": "시간당 듀티 사이클"
           }
         },
         "pt-BR": {
@@ -45537,8 +46913,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 버튼을 누르거나 메시지를 받으면 화면이 얼마나 오래 켜져 있는지를 나타냅니다."
+            "state": "translated",
+            "value": "사용자 버튼을 누르거나 메시지를 받은 후 화면이 유지되는 시간입니다."
           }
         },
         "pt-BR": {
@@ -45587,6 +46963,12 @@
     },
     "How often air quality metrics are sent out over the mesh. Default is 30 minutes.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공기질 측정값이 메시를 통해 전송되는 주기입니다. 기본값은 30분입니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -45641,8 +47023,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 전송 빈도는 기본 30분입니다."
+            "state": "translated",
+            "value": "장치 측정값이 메시를 통해 전송되는 주기입니다. 기본값은 30분입니다."
           }
         },
         "pt-BR": {
@@ -45729,8 +47111,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "망에서 환경 지표가 얼마나 자주 전송되는지는 기본값으로 30분입니다."
+            "state": "translated",
+            "value": "환경 측정값이 메시를 통해 전송되는 주기입니다. 기본값은 30분입니다."
           }
         },
         "pt-BR": {
@@ -45817,8 +47199,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 전송 빈도는 기본 30분입니다."
+            "state": "translated",
+            "value": "전력 측정값이 메시를 통해 전송되는 주기입니다. 기본값은 30분입니다."
           }
         },
         "pt-BR": {
@@ -45905,8 +47287,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "GPS 위치가 얼마나 자주 가져야 하는지"
+            "state": "translated",
+            "value": "GPS 위치 획득을 시도하는 주기입니다."
           }
         },
         "pt-BR": {
@@ -45957,6 +47339,12 @@
       "comment": "A description of the update interval for neighbor info.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이웃 정보를 브로드캐스트하는 주기입니다. 기본값은 4시간입니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -46011,8 +47399,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "감지 여부와 상관없이 덱스트렉스 네트워크에 감지 센서 상태를 전송하는 빈도를 설정합니다. 기본값은 전송하지 않습니다."
+            "state": "translated",
+            "value": "감지 여부와 관계없이 감지 센서 상태를 메시로 전송하는 주기입니다. 기본값은 전송 안 함입니다."
           }
         },
         "pt-BR": {
@@ -46105,8 +47493,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사람이 감지되었을 때 메시지를 전송할 수 있는 빈도"
+            "state": "translated",
+            "value": "사람이 감지되었을 때 메시를 통해 메시지를 보낼 수 있는 최소 간격입니다."
           }
         },
         "pl": {
@@ -46201,7 +47589,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "업데이트 방법"
           }
         },
@@ -46241,6 +47629,12 @@
       "comment": "A heading for the instructions on how to read the noise floor.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "해석 방법"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -46295,7 +47689,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "습도"
           }
         },
@@ -46377,8 +47771,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "나는 내가 하고 있는 것을 알고 있습니다."
+            "state": "translated",
+            "value": "제가 무엇을 하는지 알고 있습니다"
           }
         },
         "pt-BR": {
@@ -46453,8 +47847,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위 내용을 읽고 이해했습니다. MQTT를 통해 무비밀로 노드 데이터를 전송하는 데 자발적으로 동의합니다."
+            "state": "translated",
+            "value": "위 내용을 읽고 이해했습니다. MQTT를 통해 내 노드 데이터를 암호화되지 않은 상태로 전송하는 것에 자발적으로 동의합니다."
           }
         },
         "pt-BR": {
@@ -46505,6 +47899,12 @@
       "comment": "A button label.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구매하고 싶어요"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -46585,6 +47985,12 @@
     },
     "I2S data in pin.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I2S 데이터 입력 핀"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -46601,6 +48007,12 @@
     },
     "I2S serial clock pin.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I2S 시리얼 클럭 핀"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -46617,6 +48029,12 @@
     },
     "I2S serial data pin.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I2S 시리얼 데이터 핀"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -46633,6 +48051,12 @@
     },
     "I2S word select pin.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I2S 워드 선택 핀"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -46683,12 +48107,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "IAQ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "공기질"
           }
         },
         "pt-BR": {
@@ -46773,12 +48191,6 @@
             "value": "IAQ "
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "공기질"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -46861,12 +48273,6 @@
             "value": "IAQ %lld"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "아큐 %lld"
-          }
-        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -46947,7 +48353,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "ID"
           }
         },
@@ -47033,7 +48439,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "IP 주소"
           }
         },
@@ -47109,7 +48515,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "아이콘"
           }
         },
@@ -47191,7 +48597,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "아이콘"
           }
         },
@@ -47275,8 +48681,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "아이덴티티"
+            "state": "translated",
+            "value": "식별 정보"
           }
         },
         "pt-BR": {
@@ -47347,8 +48753,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "휴대중 / 잠들기"
+            "state": "translated",
+            "value": "대기 / 절전"
           }
         },
         "pt-BR": {
@@ -47423,8 +48829,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "DOP가 설정된 경우 HDOP / VDOP 값을 PDOP 대신 사용하세요."
+            "state": "translated",
+            "value": "PDOP 대신 HDOP / VDOP 사용"
           }
         },
         "pt-BR": {
@@ -47507,8 +48913,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결된 경우 아래 버튼을 사용하여 DFU 모드로 재부팅합니다. 그렇지 않으면, 장치의 재설정 버튼을 두 번 빠르게 누릅니다."
+            "state": "translated",
+            "value": "연결된 경우 아래 버튼을 사용하여 DFU 모드로 진입합니다. 또는 장치의 리셋 버튼을 빠르게 두 번 누르세요."
           }
         },
         "pt-BR": {
@@ -47583,8 +48989,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "출력 핀이 활성화되면 고조전압으로, 비활성화되면 저조전압으로 끌립니다."
+            "state": "translated",
+            "value": "활성화하면 'output' 핀이 액티브 HIGH가 되고, 비활성화하면 액티브 LOW가 됩니다."
           }
         },
         "pt-BR": {
@@ -47671,8 +49077,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "패킷이 설정되면, 전송된 모든 패킷이 장치로 반송됩니다."
+            "state": "translated",
+            "value": "설정하면 전송한 모든 패킷이 장치로 반송됩니다."
           }
         },
         "pt-BR": {
@@ -47759,8 +49165,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 지역 주제가 너무 바쁘다면 더 지역적인 주제를 선택할 수 있습니다."
+            "state": "translated",
+            "value": "기본 지역 토픽이 너무 혼잡하면 더 지역적인 토픽을 선택할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -47841,8 +49247,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "OTA_1 분할에 적절한 업데이트가 로드된 경우 BLE 업데이트 프로세스를 시도할 수 있습니다."
+            "state": "translated",
+            "value": "장치의 OTA_1 파티션에 올바른 업데이터가 로드되어 있는 경우, BLE 업데이트를 시도할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -47911,8 +49317,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "OTA_1 분할에 적절한 업데이트어가 로드된 경우 WiFi 업데이트 프로세스를 시도할 수 있습니다."
+            "state": "translated",
+            "value": "장치의 OTA_1 파티션에 올바른 업데이터가 로드되어 있는 경우, WiFi 업데이트를 시도할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -47951,6 +49357,12 @@
       "comment": "A label for a button that can ignore a node.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "무시"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -48005,8 +49417,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "MQTT를 무시하세요"
+            "state": "translated",
+            "value": "MQTT 무시"
           }
         },
         "pt-BR": {
@@ -48090,6 +49502,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ノードを無視"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 무시"
           }
         },
         "pt-BR": {
@@ -48176,8 +49594,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Ignored"
+            "state": "translated",
+            "value": "무시됨"
           }
         },
         "pt-BR": {
@@ -48258,8 +49676,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "반드시 가져오세요"
+            "state": "translated",
+            "value": "가져오기"
           }
         },
         "pt-BR": {
@@ -48328,8 +49746,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "PEM 파일을 가져옵니다."
+            "state": "translated",
+            "value": ".pem 파일 가져오기"
           }
         },
         "pt-BR": {
@@ -48398,8 +49816,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Custom .p12 파일을 가져오세요"
+            "state": "translated",
+            "value": "사용자 지정 .p12 파일 가져오기"
           }
         },
         "pt-BR": {
@@ -48468,8 +49886,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "인포트 오류"
+            "state": "translated",
+            "value": "가져오기 오류"
           }
         },
         "pt-BR": {
@@ -48544,8 +49962,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "로테이션 경로 가져오기"
+            "state": "translated",
+            "value": "경로 가져오기"
           }
         },
         "pt-BR": {
@@ -48628,8 +50046,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "중요 참고 사항"
+            "state": "translated",
+            "value": "중요 안내 사항"
           }
         },
         "pt-BR": {
@@ -48698,8 +50116,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "설정, 키, BLE 결합도 모두 지워집니다."
+            "state": "translated",
+            "value": "설정뿐만 아니라 키와 BLE 페어링 정보도 모두 삭제됩니다."
           }
         },
         "pt-BR": {
@@ -48747,7 +50165,15 @@
       }
     },
     "In progress": {
-      "comment": "VoiceOver value for indeterminate firmware update state"
+      "comment": "VoiceOver value for indeterminate firmware update state",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "진행 중"
+          }
+        }
+      }
     },
     "Include": {
       "localizations": {
@@ -48795,7 +50221,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "포함"
           }
         },
@@ -48889,8 +50315,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "접수된 메시지"
+            "state": "translated",
+            "value": "받은 메시지"
           }
         },
         "pt-BR": {
@@ -48971,8 +50397,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "불완전한"
+            "state": "translated",
+            "value": "정보 불완전"
           }
         },
         "pt-BR": {
@@ -49021,6 +50447,12 @@
     },
     "Indicates how to rotate or invert the compass output for accurate display.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정확한 표시를 위해 나침반 출력을 회전하거나 반전하는 방법을 지정합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -49065,8 +50497,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "GPS 정확도가 감소했습니다. 노드는 그림자가 있는 영역 내에 있습니다."
+            "state": "translated",
+            "value": "GPS 정확도가 낮음을 나타냅니다. 노드는 음영 처리된 영역 내에 있습니다."
           }
         },
         "pt-BR": {
@@ -49141,8 +50573,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "실내 공기 질 (IAQ)"
+            "state": "translated",
+            "value": "실내 공기질 (IAQ)"
           }
         },
         "pt-BR": {
@@ -49225,8 +50657,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "인프라스트럭처 노드 수"
+            "state": "translated",
+            "value": "인프라 노드 수"
           }
         },
         "pt-BR": {
@@ -49301,8 +50733,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "입력값"
+            "state": "translated",
+            "value": "입력"
           }
         },
         "pt-BR": {
@@ -49385,8 +50817,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 데이터의 정확성을 위해 사용되지만 암호화되지 않은 채널입니다."
+            "state": "translated",
+            "value": "위치 정보(암호화되지 않음)"
           }
         },
         "pt-BR": {
@@ -49457,8 +50889,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "MQTT로 불안정한 상태입니다."
+            "state": "translated",
+            "value": "MQTT(암호화되지 않음)"
           }
         },
         "pt-BR": {
@@ -49529,8 +50961,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "링크를 삽입합니다."
+            "state": "translated",
+            "value": "삽입"
           }
         },
         "pt-BR": {
@@ -49601,7 +51033,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "링크 삽입"
           }
         },
@@ -49673,8 +51105,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "파일을 설치합니다"
+            "state": "translated",
+            "value": "설치"
           }
         },
         "pt-BR": {
@@ -49743,8 +51175,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "유효하지 않은 파일 내용입니다. 파일 형식을 확인해 주세요."
+            "state": "translated",
+            "value": "파일 내용이 올바르지 않습니다. 파일 형식을 확인해 주세요."
           }
         },
         "pt-BR": {
@@ -49791,9 +51223,26 @@
         }
       }
     },
-    "Invalid payload.": {},
+    "Invalid payload.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유효하지 않은 페이로드입니다."
+          }
+        }
+      }
+    },
     "Italic": {
-      "comment": "VoiceOver: italic formatting toolbar button"
+      "comment": "VoiceOver: italic formatting toolbar button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이텔릭"
+          }
+        }
+      }
     },
     "JSON Enabled": {
       "extractionState": "stale",
@@ -49836,8 +51285,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "JSON 지원"
+            "state": "translated",
+            "value": "JSON 활성화됨"
           }
         },
         "pt-BR": {
@@ -49925,8 +51374,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "JSON 모드는 MQTT 출력을 제한적이고 암호화되지 않은 형태로 사용하여 홈Assistant와 원활하게 통합할 수 있습니다."
+            "state": "translated",
+            "value": "JSON 모드는 Home Assistant와 로컬로 연동하기 위한 제한된 비암호화 MQTT 출력입니다."
           }
         },
         "pt-BR": {
@@ -50009,8 +51458,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Wi-Fi 네트워크에 연결"
+            "state": "translated",
+            "value": "연결"
           }
         },
         "pt-BR": {
@@ -50085,7 +51534,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "현재로 이동"
           }
         },
@@ -50169,8 +51618,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "휴대폰과 가까이 유지하세요."
+            "state": "translated",
+            "value": "장치를 휴대폰 가까이 유지하세요."
           }
         },
         "pt-BR": {
@@ -50241,8 +51690,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시드 지도를 최신화하고 다른 앱 사용 중에도 위치 정보를 메시드에 전송합니다."
+            "state": "translated",
+            "value": "메시 맵을 최신 상태로 유지하고 다른 앱을 사용하는 동안에도 위치 정보를 메시 네트워크로 전송합니다."
           }
         },
         "pt-BR": {
@@ -50317,7 +51766,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "키"
           }
         },
@@ -50399,7 +51848,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "키 백업"
           }
         },
@@ -50487,7 +51936,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "키 매핑"
           }
         },
@@ -50575,7 +52024,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "키 크기"
           }
         },
@@ -50663,8 +52112,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "LED 심박수"
+            "state": "translated",
+            "value": "LED 하트비트"
           }
         },
         "pt-BR": {
@@ -50751,7 +52200,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "LED 상태"
           }
         },
@@ -50803,6 +52252,12 @@
       "comment": "A label that indicates a live state",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -50857,8 +52312,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "낮음"
+            "state": "translated",
+            "value": "LOW"
           }
         },
         "pt-BR": {
@@ -50939,8 +52394,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "마지막 들었던 시간"
+            "state": "translated",
+            "value": "마지막 수신 시간"
           }
         },
         "pt-BR": {
@@ -51009,7 +52464,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "최종 업데이트: %@"
           }
         },
@@ -51081,8 +52536,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최종 업데이트: 절대 없음"
+            "state": "translated",
+            "value": "최종 업데이트: 없음"
           }
         },
         "pt-BR": {
@@ -51157,8 +52612,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "마지막 들었던 시간"
+            "state": "translated",
+            "value": "마지막 수신"
           }
         },
         "pt-BR": {
@@ -51241,8 +52696,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "마지막 연결된 장치:"
+            "state": "translated",
+            "value": "마지막으로 확인된 장치:"
           }
         },
         "pt-BR": {
@@ -51317,8 +52772,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "마지막 확인된 기기: %@"
+            "state": "translated",
+            "value": "마지막으로 확인된 장치: %@"
           }
         },
         "pt-BR": {
@@ -51361,6 +52816,12 @@
     },
     "Last updated by": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막 업데이트자"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -51410,8 +52871,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최종 업데이트:"
+            "state": "translated",
+            "value": "마지막 업데이트자:"
           }
         },
         "pt-BR": {
@@ -51482,8 +52943,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "후회합니다"
+            "state": "translated",
+            "value": "나중에"
           }
         },
         "pt-BR": {
@@ -51522,6 +52983,12 @@
       "comment": "A button that resets the chart view to the latest reading.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최신"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -51576,7 +53043,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위도"
           }
         },
@@ -51658,8 +53125,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위도(도) (예: 37.7749)"
+            "state": "translated",
+            "value": "위도(도 단위, 예: 37.7749)"
           }
         },
         "pt-BR": {
@@ -51740,8 +53207,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위도 -90도에서 90도 사이의 범위여야 합니다"
+            "state": "translated",
+            "value": "위도는 -90도와 90도 사이여야 합니다."
           }
         },
         "pt-BR": {
@@ -51830,8 +53297,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최소 혼잡: **%1$@** (%2$@ 사용량)"
+            "state": "translated",
+            "value": "혼잡도가 가장 낮음: **%1$@** (%2$@ 사용률)"
           }
         },
         "pt-BR": {
@@ -51869,6 +53336,12 @@
     "Left %@": {
       "comment": "Geofence notification title when a node leaves the waypoint area. %@ is the waypoint name.",
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 영역을 벗어남"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -51923,7 +53396,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "레벨"
           }
         },
@@ -52023,8 +53496,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "허가된 운영자"
+            "state": "translated",
+            "value": "면허 보유 운용자"
           }
         },
         "pt-BR": {
@@ -52073,6 +53546,12 @@
     },
     "Licensed band": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "허가 대역"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -52127,8 +53606,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "주기적인 방송 간격은 특히 텔레메트리 및 위치에 대해 제한해야 합니다. hop를 늘리려면 가장 바깥쪽 노드에, 중간 노드에 대해서는 하지 마십시오. MQTT는 작업량이 제한된 상황에서 권장되지 않습니다. gateways 노드는 모든 작업을 수행하기 때문입니다."
+            "state": "translated",
+            "value": "모든 주기적 브로드캐스트 간격, 특히 텔레메트리와 위치 정보 전송 간격을 제한하세요. 홉 수를 늘려야 하는 경우 중간 노드가 아닌 네트워크 가장자리의 노드에서 늘리세요. 듀티 사이클 제한이 있는 경우 MQTT 사용은 권장되지 않습니다. 게이트웨이 노드가 모든 작업을 처리하게 되기 때문입니다."
           }
         },
         "pt-BR": {
@@ -52215,8 +53694,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "라인 시리즈"
+            "state": "translated",
+            "value": "선 계열"
           }
         },
         "pt-BR": {
@@ -52264,10 +53743,24 @@
       }
     },
     "Link": {
-      "comment": "VoiceOver: link formatting toolbar button"
+      "comment": "VoiceOver: link formatting toolbar button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "링크"
+          }
+        }
+      }
     },
     "Live": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실시간"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -52284,6 +53777,12 @@
     },
     "Live view of mesh packets crossing the network. Overrides the category and level filters below.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네트워크를 통과하는 메시 패킷을 실시간으로 표시합니다. 아래의 카테고리 및 레벨 필터보다 우선합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -52450,7 +53949,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "LoRa 설정"
           }
         },
@@ -52544,8 +54043,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "LoRa 구성 변경"
+            "state": "translated",
+            "value": "LoRa 설정 변경 사항:"
           }
         },
         "pt-BR": {
@@ -52628,8 +54127,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기존 메시지 로드"
+            "state": "translated",
+            "value": "이전 메시지 불러오기"
           }
         },
         "pt-BR": {
@@ -52700,8 +54199,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "데이터베이스가 API에서 로드되고 있습니다."
+            "state": "translated",
+            "value": "불러오는 중…"
           }
         },
         "pt-BR": {
@@ -52776,8 +54275,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "로그를 로드합니다..."
+            "state": "translated",
+            "value": "로그 불러오는 중…"
           }
         },
         "pt-BR": {
@@ -52858,8 +54357,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드에서 TAK 설정을 로드합니다."
+            "state": "translated",
+            "value": "노드에서 TAK 설정을 불러오는 중..."
           }
         },
         "pt-BR": {
@@ -52930,8 +54429,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장비 정보를 로드 중입니다..."
+            "state": "translated",
+            "value": "하드웨어 정보 로드 중.."
           }
         },
         "pt-BR": {
@@ -53000,8 +54499,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "로드 중..."
+            "state": "translated",
+            "value": "불러오는 중..."
           }
         },
         "pt-BR": {
@@ -53066,8 +54565,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지역망 탐색 설정 및 시작"
+            "state": "translated",
+            "value": "로컬 메시 탐색"
           }
         },
         "pt-BR": {
@@ -53139,8 +54638,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬 디코버리에서 기본 키를 사용하는 데 기본 채널이 필요합니다. 스캔하기 전에 기본 채널 키를 다시 설정하세요."
+            "state": "translated",
+            "value": "로컬 메시 탐색을 사용하려면 기본 채널에서 기본 키를 사용해야 합니다. 스캔하기 전에 기본 채널 키를 기본값으로 재설정하세요."
           }
         },
         "pt-BR": {
@@ -53211,8 +54710,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지역 네트워크 액세스를 위한 옵션"
+            "state": "translated",
+            "value": "로컬 네트워크 접근"
           }
         },
         "pt-BR": {
@@ -53261,6 +54760,12 @@
     },
     "Local Stats": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 통계"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -53277,6 +54782,12 @@
     },
     "Local Stats Log": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 통계 로그"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -53295,6 +54806,12 @@
       "comment": "The title of an alert that appears when a user successfully requests a local stats update.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 통계 요청됨"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -53311,6 +54828,12 @@
     },
     "Location": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -53329,6 +54852,12 @@
       "comment": "Title of a help item that describes the location sharing channel.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 공유"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -53377,7 +54906,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치:"
           }
         },
@@ -53465,8 +54994,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "잠긴"
+            "state": "translated",
+            "value": "잠김"
           }
         },
         "pt-BR": {
@@ -53547,7 +55076,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "로그 아이콘"
           }
         },
@@ -53623,7 +55152,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "로그 레벨"
           }
         },
@@ -53717,8 +55246,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "로그"
+            "state": "translated",
+            "value": "로그 기록"
           }
         },
         "pl": {
@@ -53817,7 +55346,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "로그"
           }
         },
@@ -53905,7 +55434,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "긴 이름"
           }
         },
@@ -53989,8 +55518,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장시간 누르기"
+            "state": "translated",
+            "value": "길게 누르기 동작"
           }
         },
         "pt-BR": {
@@ -54065,8 +55594,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연락처를 좋아하거나 음성으로 비활성화하거나 대화를 삭제하려면 길게 누르세요."
+            "state": "translated",
+            "value": "길게 눌러 연락처를 즐겨찾기에 추가하거나 뮤트, 또는 대화를  삭제할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -54153,8 +55682,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위도"
+            "state": "translated",
+            "value": "경도"
           }
         },
         "pt-BR": {
@@ -54235,8 +55764,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "도수(예: -122.4194)"
+            "state": "translated",
+            "value": "도 단위의 경도(예: -122.4194)"
           }
         },
         "pt-BR": {
@@ -54317,8 +55846,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위도 -180도에서 180도 사이여야 합니다"
+            "state": "translated",
+            "value": "경도는 -180도 이상 180도 이하여야 합니다"
           }
         },
         "pt-BR": {
@@ -54366,7 +55895,15 @@
       }
     },
     "Look around": {
-      "comment": "VoiceOver label for the map look-around toggle button when look-around mode is inactive"
+      "comment": "VoiceOver label for the map look-around toggle button when look-around mode is inactive",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "주변 둘러보기"
+          }
+        }
+      }
     },
     "Low Battery": {
       "localizations": {
@@ -54402,8 +55939,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "배터리 부족"
+            "state": "translated",
+            "value": "배터리 잔량 부족"
           }
         },
         "pt-BR": {
@@ -54454,6 +55991,12 @@
       "comment": "A description of the meaning of a lower noise floor value.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "값이 낮을수록 일반적으로 수신 환경의 잡음이 적음을 의미합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -54602,7 +56145,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "MQTT 클라이언트 프록시"
           }
         },
@@ -54708,7 +56251,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "MQTT 설정"
           }
         },
@@ -54772,6 +56315,12 @@
       "comment": "MQTT downlink channel help text.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MQTT 다운링크"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -54872,6 +56421,12 @@
       "comment": "MQTT uplink channel help text.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MQTT 업링크"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -54969,12 +56524,26 @@
       }
     },
     "MQTT downlink enabled": {
-      "comment": "VoiceOver: this channel downlinks from MQTT"
+      "comment": "VoiceOver: this channel downlinks from MQTT",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MQTT 다운링크 활성화"
+          }
+        }
+      }
     },
     "MQTT packets for this channel can be sent back over LoRa when MQTT is configured.": {
       "comment": "MQTT downlink channel help text.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MQTT가 설정되어 있으면 이 채널의 MQTT 패킷을 LoRa를 통해 다시 전송할 수 있습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -54984,7 +56553,15 @@
       }
     },
     "MQTT uplink enabled": {
-      "comment": "VoiceOver: this channel uplinks to MQTT"
+      "comment": "VoiceOver: this channel uplinks to MQTT",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MQTT 업링크 활성화"
+          }
+        }
+      }
     },
     "Manage Channels": {
       "localizations": {
@@ -55032,7 +56609,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 관리"
           }
         },
@@ -55127,8 +56704,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 지정 지도 오버레이를 관리하세요."
+            "state": "translated",
+            "value": "사용자 지정 지도 오버레이 관리"
           }
         },
         "pt-BR": {
@@ -55210,8 +56787,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 데이터를 관리하세요"
+            "state": "translated",
+            "value": "지도 데이터 관리"
           }
         },
         "pt-BR": {
@@ -55298,8 +56875,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "관리된 장치"
+            "state": "translated",
+            "value": "관리 대상 장치"
           }
         },
         "pt-BR": {
@@ -55380,8 +56957,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용 설명서"
+            "state": "translated",
+            "value": "수동"
           }
         },
         "pt-BR": {
@@ -55462,8 +57039,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "매뉴얼 연결"
+            "state": "translated",
+            "value": "수동 연결"
           }
         },
         "pt-BR": {
@@ -55538,8 +57115,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "마우스 연결 문자열"
+            "state": "translated",
+            "value": "수동 연결 문자열"
           }
         },
         "pt-BR": {
@@ -55622,8 +57199,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "탐색 세션 지도"
+            "state": "translated",
+            "value": "지도"
           }
         },
         "pt-BR": {
@@ -55692,7 +57269,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지도 데이터"
           }
         },
@@ -55776,8 +57353,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 레이어"
+            "state": "translated",
+            "value": "지도 범례"
           }
         },
         "pt-BR": {
@@ -55852,7 +57429,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지도 옵션"
           }
         },
@@ -55940,7 +57517,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지도 오버레이"
           }
         },
@@ -56040,8 +57617,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 보고서"
+            "state": "translated",
+            "value": "지도 정보 공유"
           }
         },
         "pt-BR": {
@@ -56092,6 +57669,12 @@
       "comment": "A copyright notice for OpenStreetMap and Protomaps.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도 데이터 © OpenStreetMap, Protomaps"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56104,6 +57687,12 @@
       "comment": "A label that displays the date and time of the last update to a map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도 업데이트됨"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56116,6 +57705,12 @@
       "comment": "Text displayed in a help item for the location sharing channel.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 위치 정보 전송에 사용되는 채널임을 나타냅니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56126,6 +57721,12 @@
     },
     "Master enable for the traffic management module.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "트래픽 관리 모듈 전체를 활성화하거나 비활성화합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56141,10 +57742,24 @@
       }
     },
     "Match %lld of %lld": {
-      "comment": "VoiceOver: current match position out of the total match count"
+      "comment": "VoiceOver: current match position out of the total match count",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일치 항목 %lld개 중 %lld번째"
+          }
+        }
+      }
     },
     "Max Hops": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최대 홉 수"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56161,6 +57776,12 @@
     },
     "Max Packets": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최대 패킷 수"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56177,6 +57798,12 @@
     },
     "Max Transmit Power": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최대 송신 출력"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56193,6 +57820,12 @@
     },
     "Maximum hop distance from the requestor at which direct NodeInfo responses are served from the local cache.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청자에게 로컬 캐시의 NodeInfo를 직접 응답할 수 있는 최대 홉 거리입니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56209,6 +57842,12 @@
     },
     "Maximum packets allowed per node within the rate limit window.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전송 빈도 제한 기간 동안 노드별로 허용되는 최대 패킷 수입니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56225,6 +57864,12 @@
     },
     "Maximum unknown/undecryptable packets per rate window before the source is dropped.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일정 시간 동안 허용되는 알 수 없거나 복호화할 수 없는 패킷의 최대 수입니다. 이를 초과하면 해당 발신지를 무시합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -56275,8 +57920,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시드 커버리지"
+            "state": "translated",
+            "value": "메시 커버리지"
           }
         },
         "pt-BR": {
@@ -56357,8 +58002,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬 라이브 활동"
+            "state": "translated",
+            "value": "메시 실시간 현황"
           }
         },
         "pl": {
@@ -56463,8 +58108,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 지도"
+            "state": "translated",
+            "value": "메시 맵"
           }
         },
         "pl": {
@@ -56557,8 +58202,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시드 지오매핑 위치"
+            "state": "translated",
+            "value": "메시 맵 취이"
           }
         },
         "pt-BR": {
@@ -56645,8 +58290,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬 활동 업데이트"
+            "state": "translated",
+            "value": "메시 활동 업데이트"
           }
         },
         "pt-BR": {
@@ -56729,8 +58374,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시틱에서 코트 형식으로 변환"
+            "state": "translated",
+            "value": "Meshtastic-CoT 변환기"
           }
         },
         "pt-BR": {
@@ -56795,12 +58440,6 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "メッシュティック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬스틱"
           }
         },
         "pt-BR": {
@@ -56883,8 +58522,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬틱 -> TAK 작동, TAK -> 메쉬틱 차단"
+            "state": "translated",
+            "value": "Meshtastic에서 TAK로의 전송은 허용되지만, TAK에서 Meshtastic으로의 전송은 차단됩니다."
           }
         },
         "pt-BR": {
@@ -56953,8 +58592,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬스티크 노드 %@와 공유된 채널이 있습니다"
+            "state": "translated",
+            "value": "Meshtastic 노드 %@에서 채널을 공유했습니다"
           }
         },
         "pt-BR": {
@@ -57038,8 +58677,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬틱은 개인 정보를 수집하지 않습니다. 사용 및 충돌 데이터를 익명으로 수집하여 앱을 개선합니다."
+            "state": "translated",
+            "value": "Meshtastic은 개인 정보를 수집하지 않습니다. 앱 개선을 위해 사용 현황 및 충돌 데이터를 익명으로 수집합니다."
           }
         },
         "pt-BR": {
@@ -57108,8 +58747,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시틱은 전화기의 위치를 사용하여 여러 기능을 활성화합니다. 설정에서 언제든지 위치 권한을 업데이트할 수 있습니다."
+            "state": "translated",
+            "value": "Meshtastic은 여러 기능을 제공하기 위해 휴대폰의 위치 정보를 사용합니다. 위치 권한은 언제든지 설정에서 변경할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -57194,12 +58833,6 @@
             "value": "Meshtastic® Copyright Meshtastic LLC"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬틱® 저작권 메쉬틱 LLC"
-          }
-        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -57272,7 +58905,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "메시지"
           }
         },
@@ -57366,8 +58999,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 세부 정보"
+            "state": "translated",
+            "value": "메시지 상세 정보"
           }
         },
         "pl": {
@@ -57463,7 +59096,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "메시지 알림"
           }
         },
@@ -57534,7 +59167,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "메시지 크기"
           }
         },
@@ -57618,8 +59251,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 상태 목록"
+            "state": "translated",
+            "value": "메시지 상태"
           }
         },
         "pt-BR": {
@@ -57694,8 +59327,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 내용 200바이트 초과입니다."
+            "state": "translated",
+            "value": "메시지 내용이 200바이트를 초과합니다."
           }
         },
         "pt-BR": {
@@ -57743,10 +59376,26 @@
       }
     },
     "Message from %@: %@": {
-      "comment": "VoiceOver: label for a received chat message. First value is the sender, second is the message text"
+      "comment": "VoiceOver: label for a received chat message. First value is the sender, second is the message text",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보낸 사람: %@, 메시지: %@"
+          }
+        }
+      }
     },
     "Message status": {
-      "comment": "VoiceOver label for the message delivery status button"
+      "comment": "VoiceOver label for the message delivery status button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메시지 상태"
+          }
+        }
+      }
     },
     "Message was relayed but not confirmed by the final recipient.": {
       "comment": "Text displayed in a help item that describes an acknowledged message.",
@@ -57784,8 +59433,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지가 전송되었지만 최종 수신자에게 확인되지 않았습니다."
+            "state": "translated",
+            "value": "메시지가 중계되었지만 최종 수신자가 수신을 확인하지 않았습니다."
           }
         },
         "pt-BR": {
@@ -57866,7 +59515,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "메시지"
           }
         },
@@ -57966,8 +59615,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지는 |로 구분됩니다."
+            "state": "translated",
+            "value": "메시지는 | 기호로 구분합니다."
           }
         },
         "pt-BR": {
@@ -58048,7 +59697,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "메시징"
           }
         },
@@ -58132,8 +59781,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Metadata"
+            "state": "translated",
+            "value": "메타데이터"
           }
         },
         "pt-BR": {
@@ -58170,6 +59819,12 @@
     },
     "Min Interval (s)": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최소 간격(초)"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -58224,7 +59879,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "최소 거리"
           }
         },
@@ -58274,6 +59929,12 @@
     },
     "Minimum interval in seconds between position updates from the same node.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동일한 노드의 위치 업데이트 간 최소 간격을 초 단위로 설정합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -58324,8 +59985,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최소 요구되는 버전: **%@**"
+            "state": "translated",
+            "value": "최소 요구 버전: **%@**"
           }
         },
         "pt-BR": {
@@ -58400,8 +60061,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "탐지 방송 사이의 최소 시간. 기본값은 45초입니다."
+            "state": "translated",
+            "value": "감지 신호 전송 간 최소 시간입니다. 기본값은 45초입니다."
           }
         },
         "pt-BR": {
@@ -58494,7 +60155,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "모드"
           }
         },
@@ -58590,8 +60251,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모뎀 설정"
+            "state": "translated",
+            "value": "모뎀 프리셋"
           }
         },
         "pt-BR": {
@@ -58672,7 +60333,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "모듈 구성"
           }
         },
@@ -58732,7 +60393,16 @@
         }
       }
     },
-    "More than one tag detected. Please present only one.": {},
+    "More than one tag detected. Please present only one.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그가 두 개 이상 감지되었습니다. 한 번에 하나의 태그만 인식시켜 주세요."
+          }
+        }
+      }
+    },
     "Most nodes discovered on **%@** (%lld nodes)": {
       "comment": "A heading that highlights the best preset based on the number of unique nodes discovered. The argument is the name of the best preset, and the second argument is the number of unique nodes discovered.",
       "isCommentAutoGenerated": true,
@@ -58769,8 +60439,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최대 %1$@에서 %2$lld개의 고유한 노드가 발견되었습니다."
+            "state": "translated",
+            "value": "**%1$@**에서 가장 많은 노드를 발견했습니다(%2$lld개)"
           }
         },
         "pt-BR": {
@@ -58800,19 +60470,59 @@
       }
     },
     "Move east": {
-      "comment": "VoiceOver custom action: nudge the geofence/region area right"
+      "comment": "VoiceOver custom action: nudge the geofence/region area right",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동쪽으로 이동"
+          }
+        }
+      }
     },
     "Move north": {
-      "comment": "VoiceOver custom action: nudge the geofence/region area up"
+      "comment": "VoiceOver custom action: nudge the geofence/region area up",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "북쪽으로 이동"
+          }
+        }
+      }
     },
     "Move selection": {
-      "comment": "VoiceOver label for the geofence/region rectangle's move handle"
+      "comment": "VoiceOver label for the geofence/region rectangle's move handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택 영역 이동"
+          }
+        }
+      }
     },
     "Move south": {
-      "comment": "VoiceOver custom action: nudge the geofence/region area down"
+      "comment": "VoiceOver custom action: nudge the geofence/region area down",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "남쪽으로 이동"
+          }
+        }
+      }
     },
     "Move west": {
-      "comment": "VoiceOver custom action: nudge the geofence/region area left"
+      "comment": "VoiceOver custom action: nudge the geofence/region area left",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서쪽으로 이동"
+          }
+        }
+      }
     },
     "Multiplier": {
       "localizations": {
@@ -58860,7 +60570,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "배율"
           }
         },
@@ -58960,8 +60670,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "📱"
+            "state": "translated",
+            "value": "이모지 한 개만 입력해야 합니다."
           }
         },
         "pt-BR": {
@@ -59012,6 +60722,12 @@
       "comment": "A label for a button that mutes notifications.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알림 음소거"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -59027,16 +60743,65 @@
       }
     },
     "Muted": {
-      "comment": "VoiceOver: channel notifications are muted"
+      "comment": "VoiceOver: channel notifications are muted",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음소거됨"
+          }
+        }
+      }
     },
     "My Location": {
-      "comment": "Map settings toggle: show the device's own location (blue dot) and the follow control"
+      "comment": "Map settings toggle: show the device's own location (blue dot) and the follow control",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내 위치"
+          }
+        }
+      }
     },
-    "NFC Tags": {},
-    "NFC tag read successfully.": {},
-    "NFC tag written successfully.": {},
+    "NFC Tags": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NFC 태그"
+          }
+        }
+      }
+    },
+    "NFC tag read successfully.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NFC 태그를 성공적으로 읽었습니다."
+          }
+        }
+      }
+    },
+    "NFC tag written successfully.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NFC 태그에 성공적으로 기록했습니다."
+          }
+        }
+      }
+    },
     "NTP Server": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NTP 서버"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -59091,7 +60856,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "이름"
           }
         },
@@ -59175,6 +60940,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "名前は30バイト未満である必要があります"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름은 30바이트 미만이어야 합니다."
           }
         },
         "pt-BR": {
@@ -59261,8 +61032,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드 이동"
+            "state": "translated",
+            "value": "노드로 이동"
           }
         },
         "pt-BR": {
@@ -59343,8 +61114,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "근처 기기"
+            "state": "translated",
+            "value": "주변 기기"
           }
         },
         "pt-BR": {
@@ -59419,8 +61190,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "근처 주제"
+            "state": "translated",
+            "value": "주변 토픽"
           }
         },
         "pt-BR": {
@@ -59469,6 +61240,12 @@
     },
     "Neighbor Info": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이웃 노드 정보"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -59487,6 +61264,12 @@
       "comment": "The title of the Neighbor Info configuration screen.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이웃 노드 정보 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -59547,7 +61330,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "네트워크"
           }
         },
@@ -59653,7 +61436,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "네트워크 설정"
           }
         },
@@ -59747,7 +61530,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "네트워크 위치"
           }
         },
@@ -59819,8 +61602,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Wi-Fi 네트워크 이름 입력"
+            "state": "translated",
+            "value": "Wi-Fi 네트워크 이름"
           }
         },
         "pt-BR": {
@@ -59857,6 +61640,12 @@
     },
     "Network Servers": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네트워크 서버"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -59911,8 +61700,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "네트워크 상태: 오렌지"
+            "state": "translated",
+            "value": "네트워크 상태: 주황색"
           }
         },
         "pt-BR": {
@@ -59999,8 +61788,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "네트워크 상태 빨간색"
+            "state": "translated",
+            "value": "네트워크 상태: 빨간색"
           }
         },
         "pt-BR": {
@@ -60077,6 +61866,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "新しいノード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 노드"
           }
         },
         "pt-BR": {
@@ -60159,8 +61954,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "새 스캔 시작"
+            "state": "translated",
+            "value": "새 스캔"
           }
         },
         "pt-BR": {
@@ -60196,13 +61991,37 @@
       }
     },
     "Next match": {
-      "comment": "VoiceOver label for the next search match button"
+      "comment": "VoiceOver label for the next search match button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 일치 항목"
+          }
+        }
+      }
     },
     "No Air Quality Metrics": {
-      "comment": "Empty state shown when a node has no air quality telemetry."
+      "comment": "Empty state shown when a node has no air quality telemetry.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공기질 측정 데이터 없음"
+          }
+        }
+      }
     },
     "No Bluetooth device connected": {
-      "comment": "VoiceOver label when no Bluetooth device is connected"
+      "comment": "VoiceOver label when no Bluetooth device is connected",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 Bluetooth 기기가 없습니다."
+          }
+        }
+      }
     },
     "No Connected Node": {
       "localizations": {
@@ -60240,6 +62059,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "接続されたノードがありません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 노드 없음"
           }
         },
         "pt-BR": {
@@ -60321,8 +62146,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "데이터가 없습니다."
+            "state": "translated",
+            "value": "데이터 없음"
           }
         },
         "pt-BR": {
@@ -60409,8 +62234,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치 측정이 없습니다."
+            "state": "translated",
+            "value": "장치 측정 데이터 없음"
           }
         },
         "pt-BR": {
@@ -60493,8 +62318,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "탐색 세션이 아직 완료되지 않았습니다."
+            "state": "translated",
+            "value": "탐색 세션 없음"
           }
         },
         "pt-BR": {
@@ -60569,8 +62394,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "환경 측정을 수행하지 않았습니다."
+            "state": "translated",
+            "value": "환경 측정 데이터 없음"
           }
         },
         "pt-BR": {
@@ -60619,6 +62444,12 @@
     },
     "No Local Stats": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 통계 없음"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -60669,8 +62500,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "LocalStats 데이터 수집이 아직 완료되지 않았습니다."
+            "state": "translated",
+            "value": "아직 수집된 로컬 통계 데이터가 없습니다."
           }
         },
         "pt-BR": {
@@ -60705,7 +62536,16 @@
         }
       }
     },
-    "No Meshtastic link found on this tag.": {},
+    "No Meshtastic link found on this tag.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 태그에서 Meshtastic 링크를 찾을 수 없습니다."
+          }
+        }
+      }
+    },
     "No PAX Counter Logs": {
       "localizations": {
         "da": {
@@ -60746,8 +62586,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "PAX 카운터 로그가 없습니다."
+            "state": "translated",
+            "value": "PAX 카운터 로그 없음"
           }
         },
         "pt-BR": {
@@ -60840,7 +62680,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치 없음"
           }
         },
@@ -60928,8 +62768,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전력 측정이 없습니다."
+            "state": "translated",
+            "value": "전력 측정 데이터 없음"
           }
         },
         "pt-BR": {
@@ -60978,6 +62818,12 @@
     },
     "No Reading": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "측정값 없음"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -61020,8 +62866,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "SSH 클라이언트가 없습니다. 앱스토어를 열어 설치할 수 있습니다."
+            "state": "translated",
+            "value": "SSH 클라이언트를 찾을 수 없습니다. 설치를 위해 App Store를 엽니다."
           }
         },
         "pt-BR": {
@@ -61060,6 +62906,12 @@
       "comment": "A title for a view that shows when there are no trace routes.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 추적 기록 없음"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -61072,6 +62924,12 @@
       "comment": "A message displayed when a user has no backups.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 가능한 백업 없음"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -61086,7 +62944,16 @@
         }
       }
     },
-    "No data found on this tag.": {},
+    "No data found on this tag.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 태그에서 데이터를 찾을 수 없습니다."
+          }
+        }
+      }
+    },
     "No device connected": {
       "localizations": {
         "da": {
@@ -61133,8 +63000,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결된 장치가 없습니다"
+            "state": "translated",
+            "value": "연결된 장치 없음"
           }
         },
         "pl": {
@@ -61229,8 +63096,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치가 연결되지 않았습니다. 첫 번째로 발견된 장치가 사용됩니다."
+            "state": "translated",
+            "value": "연결된 장치가 없습니다. 처음 발견된 장치를 사용합니다."
           }
         },
         "pt-BR": {
@@ -61299,8 +63166,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "업로드된 파일이 없습니다."
+            "state": "translated",
+            "value": "업로드된 파일 없음"
           }
         },
         "pt-BR": {
@@ -61383,8 +63250,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 기기에 대한 드라이버가 다운로드되지 않았습니다."
+            "state": "translated",
+            "value": "이 장치용으로 다운로드된 펌웨어가 없습니다."
           }
         },
         "pt-BR": {
@@ -61454,8 +63321,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 데이터 파일 업로드되지 않았습니다"
+            "state": "translated",
+            "value": "업로드된 지도 데이터 파일 없음"
           }
         },
         "pt-BR": {
@@ -61503,12 +63370,26 @@
       }
     },
     "No matches": {
-      "comment": "VoiceOver: no search matches found"
+      "comment": "VoiceOver: no search matches found",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일치 항목 없음"
+          }
+        }
+      }
     },
     "No offline maps yet. Download an area to use the map without a connection.": {
       "comment": "A message displayed when there are no offline maps available.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 오프라인 지도가 없습니다. 인터넷 연결 없이 지도를 사용하려면 지역을 다운로드하세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -61553,8 +63434,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "예약된 데이터가 없습니다"
+            "state": "translated",
+            "value": "사용 가능한 프리셋 데이터 없음"
           }
         },
         "pt-BR": {
@@ -61590,7 +63471,15 @@
       }
     },
     "No reading": {
-      "comment": "VoiceOver value spoken when a metric data point has no reading."
+      "comment": "VoiceOver value spoken when a metric data point has no reading.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "측정값 없음"
+          }
+        }
+      }
     },
     "No records found for %@": {
       "comment": "A view that shows when a list is empty. The argument is the name of the entity being listed.",
@@ -61628,8 +63517,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%@에 대한 기록이 없습니다."
+            "state": "translated",
+            "value": "%@에 대한 기록을 찾을 수 없습니다."
           }
         },
         "pt-BR": {
@@ -61704,7 +63593,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드"
           }
         },
@@ -61756,6 +63645,12 @@
       "comment": "A heading for the list of node backups.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 백업"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -61778,6 +63673,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Node Core Data Backup %1$@ - %2$@ - %3$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 Core Data 백업 %1$@ - %2$@ - %3$@"
           }
         },
         "uk": {
@@ -61841,8 +63742,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "네드 코어 데이터 백업 %1$@/%2$@ - %3$@ - %4$@"
+            "state": "translated",
+            "value": "노드 Core Data 백업 %1$@/%2$@ - %3$@ - %4$@"
           }
         },
         "pt-BR": {
@@ -61929,8 +63830,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드 역사"
+            "state": "translated",
+            "value": "노드 기록"
           }
         },
         "pt-BR": {
@@ -62011,7 +63912,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드 레이아웃"
           }
         },
@@ -62081,8 +63982,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드 리스트 밀도"
+            "state": "translated",
+            "value": "노드 목록 밀도"
           }
         },
         "pt-BR": {
@@ -62147,6 +64048,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "ノードリストのヘルプ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 목록 도움말"
           }
         },
         "pt-BR": {
@@ -62221,7 +64128,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드 매핑"
           }
         },
@@ -62303,6 +64210,12 @@
             "value": "接続されたノードの名前: %@"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 이름: %@"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -62375,7 +64288,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드 번호"
           }
         },
@@ -62457,7 +64370,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드 상태"
           }
         },
@@ -62529,8 +64442,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최근 2시간 이내에 노드가 감지되었습니다. 지도에 박동하는 반지름이 표시됩니다."
+            "state": "translated",
+            "value": "최근 2시간 이내에 신호가 수신된 노드입니다. 지도에서 깜빡이는 원으로 표시됩니다."
           }
         },
         "pt-BR": {
@@ -62601,8 +64514,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최근에는 듣지 못했습니다. 지도에는 박동하는 링이 없습니다."
+            "state": "translated",
+            "value": "최근 신호가 수신되지 않은 노드입니다. 지도에서 깜빡이는 원 없이 표시됩니다."
           }
         },
         "pt-BR": {
@@ -62667,8 +64580,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "활성 감지 센서 모듈이 있는 노드입니다."
+            "state": "translated",
+            "value": "감지 센서 모듈이 활성화된 노드입니다."
           }
         },
         "pt-BR": {
@@ -62705,6 +64618,12 @@
     },
     "NodeInfo Direct Response": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NodeInfo 직접 응답"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -62765,7 +64684,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드"
           }
         },
@@ -62849,8 +64768,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "발견된 노드"
+            "state": "translated",
+            "value": "발견된 노드 수"
           }
         },
         "pt-BR": {
@@ -62887,6 +64806,12 @@
     },
     "Nodes Online": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "온라인 노드 수"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -62903,6 +64828,12 @@
     },
     "Noise": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노이즈"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -62919,6 +64850,12 @@
     },
     "Noise Floor": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노이즈 플로어"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -62935,6 +64872,12 @@
     },
     "Noise Floor %d dBm": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노이즈 플로어 %d dBm"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -62951,6 +64894,12 @@
     },
     "Noise Floor Info": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노이즈 플로어 정보"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -62967,6 +64916,12 @@
     },
     "Noise Floor No Reading": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노이즈 플로어 측정값 없음"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -63017,8 +64972,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드릭 DFU 업데이트"
+            "state": "translated",
+            "value": "Nordic DFU 업데이트"
           }
         },
         "pt-BR": {
@@ -63089,8 +65044,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지금은 아니오"
+            "state": "translated",
+            "value": "지금 안 함"
           }
         },
         "pt-BR": {
@@ -63161,8 +65116,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비안 암호화"
+            "state": "translated",
+            "value": "안전하게 암호화되지 않음"
           }
         },
         "pt-BR": {
@@ -63237,8 +65192,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "유효하지 않은 경로 파일입니다."
+            "state": "translated",
+            "value": "유효한 경로 파일이 아닙니다."
           }
         },
         "pt-BR": {
@@ -63321,8 +65276,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "업데이트 중에 잠시 기기를 분리합니다."
+            "state": "translated",
+            "value": "참고: 업데이트 중에는 기기 연결이 일시적으로 끊어집니다."
           }
         },
         "pt-BR": {
@@ -63397,8 +65352,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지"
+            "state": "translated",
+            "value": "메모"
           }
         },
         "pt-BR": {
@@ -63479,8 +65434,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 및 직접 메시지 알림"
+            "state": "translated",
+            "value": "채널 메시지 및 다이렉트 메시지에 알림입니다."
           }
         },
         "pt-BR": {
@@ -63561,8 +65516,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결된 기기용 저전력 알림 알림"
+            "state": "translated",
+            "value": "연결된 기기의 배터리 잔량 부족 알림입니다."
           }
         },
         "pt-BR": {
@@ -63643,8 +65598,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "새로 발견된 노드 알림"
+            "state": "translated",
+            "value": "새로 발견된 노드 알림입니다."
           }
         },
         "pt-BR": {
@@ -63693,6 +65648,12 @@
     },
     "Notify on Enter": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "진입 시 알림"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -63703,6 +65664,12 @@
     },
     "Notify on Exit": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이탈 시 알림"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -63751,8 +65718,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "횟수"
+            "state": "translated",
+            "value": "홉 수"
           }
         },
         "pt-BR": {
@@ -63839,8 +65806,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기록의 수"
+            "state": "translated",
+            "value": "레코드 수"
           }
         },
         "pt-BR": {
@@ -63927,8 +65894,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위성 수량"
+            "state": "translated",
+            "value": "위성 수"
           }
         },
         "pt-BR": {
@@ -63979,6 +65946,12 @@
       "comment": "A label displayed in the top-center of the map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오프라인 지도"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -64027,8 +66000,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "좋아요"
+            "state": "translated",
+            "value": "확인"
           }
         },
         "pt-BR": {
@@ -64115,8 +66088,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "OLED 유형"
+            "state": "translated",
+            "value": "OLED 종류"
           }
         },
         "pt-BR": {
@@ -64203,8 +66176,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "OS 로그 엔트리 디테일"
+            "state": "translated",
+            "value": "OS 로그 항목 세부 정보"
           }
         },
         "pt-BR": {
@@ -64255,6 +66228,12 @@
       "comment": "A label indicating that a trace route was observed.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "관측됨"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -64265,6 +66244,12 @@
     },
     "Off": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "끔"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -64277,6 +66262,12 @@
       "comment": "Default name for an offline map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오프라인 지도"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -64287,6 +66278,12 @@
     },
     "Offline Maps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오프라인 지도"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -64329,6 +66326,12 @@
             "value": "オフラインノード"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오프라인 노드"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -64365,6 +66368,12 @@
       "comment": "The title of a view that displays a map of a city with offline tiles.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오프라인 지도 타일"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -64407,8 +66416,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알겠습니다"
+            "state": "translated",
+            "value": "확인"
           }
         },
         "pt-BR": {
@@ -64495,8 +66504,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "MQTT가 허용됩니다"
+            "state": "translated",
+            "value": "MQTT로 전달 허용"
           }
         },
         "pt-BR": {
@@ -64583,8 +66592,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "허가된 운영자는 2.0.20 또는 더 높은 버전의 하드웨어 설정을 해야 합니다. 지역 규정을 참조하고 지역 아마추어 주파수 조정자와 문의하십시오."
+            "state": "translated",
+            "value": "아마추어 무선 자격 보유자의 초기 설정에는 펌웨어 2.0.20 이상이 필요합니다. 현지 규정을 반드시 확인하고, 궁금한 점은 지역 아마추어 무선 주파수 조정 담당자에게 문의하세요."
           }
         },
         "pt-BR": {
@@ -64677,7 +66686,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "1시간"
           }
         },
@@ -64783,7 +66792,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "1분"
           }
         },
@@ -64883,7 +66892,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "온라인"
           }
         },
@@ -64967,7 +66976,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "온라인 노드"
           }
         },
@@ -65004,7 +67013,15 @@
       }
     },
     "Only show and process cryptographically authenticated mesh packets. Older nodes and oversized packets may disappear.": {
-      "comment": "Description of the Strict packet authenticity policy."
+      "comment": "Description of the Strict packet authenticity policy.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "암호학적으로 인증된 메시 패킷만 표시하고 처리합니다. 오래된 노드와 크기가 큰 패킷은 표시되지 않을 수 있습니다."
+          }
+        }
+      }
     },
     "Open %@ documentation": {
       "localizations": {
@@ -65040,7 +67057,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "%@ 문서 열기"
           }
         },
@@ -65110,8 +67127,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "meshtastic.org에서 %@를 열기"
+            "state": "translated",
+            "value": "meshtastic.org에서 %@ 열기"
           }
         },
         "pt-BR": {
@@ -65180,8 +67197,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "마커스 오픈"
+            "state": "translated",
+            "value": "나침반 열기"
           }
         },
         "pt-BR": {
@@ -65256,8 +67273,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지역 파일 열기"
+            "state": "translated",
+            "value": "로컬 파일 열기…"
           }
         },
         "pt-BR": {
@@ -65326,7 +67343,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "SSH 클라이언트 열기"
           }
         },
@@ -65402,8 +67419,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "설정을 엽니다."
+            "state": "translated",
+            "value": "설정 열기"
           }
         },
         "pt-BR": {
@@ -65480,8 +67497,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "웹 플래시어를 열기"
+            "state": "translated",
+            "value": "Web Flasher 열기"
           }
         },
         "pt-BR": {
@@ -65518,6 +67535,12 @@
     },
     "Open in Maps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도에서 열기"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -65533,7 +67556,15 @@
       }
     },
     "Open map in new window": {
-      "comment": "VoiceOver label for the open map in a new window button"
+      "comment": "VoiceOver label for the open map in a new window button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 창에서 지도 열기"
+          }
+        }
+      }
     },
     "Opens %@ documentation": {
       "comment": "A hint that describes an action.",
@@ -65571,8 +67602,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%@ 문서 열기"
+            "state": "translated",
+            "value": "%@ 문서를 엽니다"
           }
         },
         "pt-BR": {
@@ -65608,13 +67639,37 @@
       }
     },
     "Opens Firmware Updates": {
-      "comment": "VoiceOver hint: tapping this notice opens the Firmware Updates screen"
+      "comment": "VoiceOver hint: tapping this notice opens the Firmware Updates screen",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펌웨어 업데이트 화면을 엽니다"
+          }
+        }
+      }
     },
     "Opens Meshtastic Flasher": {
-      "comment": "VoiceOver hint: tapping this notice opens the Meshtastic Flasher site"
+      "comment": "VoiceOver hint: tapping this notice opens the Meshtastic Flasher site",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meshtastic Flasher 사이트를 엽니다"
+          }
+        }
+      }
     },
     "Opens Settings": {
-      "comment": "VoiceOver hint: tapping the Bluetooth-is-off row in Connect opens the Settings app (#2175)"
+      "comment": "VoiceOver hint: tapping the Bluetooth-is-off row in Connect opens the Settings app (#2175)",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 앱을 엽니다"
+          }
+        }
+      }
     },
     "Optional GPIO": {
       "localizations": {
@@ -65656,8 +67711,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "선택 가능한 GPIO"
+            "state": "translated",
+            "value": "선택적 GPIO"
           }
         },
         "pt-BR": {
@@ -65744,8 +67799,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 메시지를 구성할 때 포함할 수 있는 선택적 필드입니다. 더 많은 필드가 포함되면 메시지가 커지고, 이로 인해 대기 시간이 길어지고 패킷 손실이 증가할 위험이 있습니다."
+            "state": "translated",
+            "value": "위치 메시지를 구성할 때 포함할 수 있는 선택적 필드입니다. 포함하는 필드가 많을수록 메시지 크기가 커지며, 송신 시간이 길어지고 패킷 손실 위험도 높아집니다."
           }
         },
         "pt-BR": {
@@ -65838,7 +67893,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "옵션"
           }
         },
@@ -65934,8 +67989,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 설정에서 직접 수정하고 다시 이 화면으로 돌아가세요."
+            "state": "translated",
+            "value": "또는 채널 설정에서 직접 수정한 다음 이 화면으로 돌아오세요."
           }
         },
         "pt-BR": {
@@ -65974,6 +68029,12 @@
       "comment": "A label displayed for the originator and target nodes in a trace route.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "출발 노드 및 대상 노드"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -66018,8 +68079,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다른 네트워크"
+            "state": "translated",
+            "value": "기타 네트워크"
           }
         },
         "pt-BR": {
@@ -66090,8 +68151,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비밀 네트워크..."
+            "state": "translated",
+            "value": "기타 네트워크…"
           }
         },
         "pt-BR": {
@@ -66166,8 +68227,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다른 데이터 소스"
+            "state": "translated",
+            "value": "기타 데이터 소스"
           }
         },
         "pt-BR": {
@@ -66218,6 +68279,12 @@
       "comment": "A description of the path taken by a message on its way to the target.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대상 방향 경로"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -66266,8 +68333,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "실시간 디버깅 로그를 시리얼, 뷰 및 블루투스로 출력합니다. 위치가 숨겨진 장치 로그를 블루투스로 출력합니다."
+            "state": "translated",
+            "value": "시리얼을 통해 실시간 디버그 로그를 출력하고, Bluetooth를 통해 위치 정보가 제거된 기기 로그를 확인하고 내보낼 수 있습니다."
           }
         },
         "pt-BR": {
@@ -66354,8 +68421,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "출력 핀 GPIO"
+            "state": "translated",
+            "value": "GPIO 출력 핀"
           }
         },
         "pt-BR": {
@@ -66442,8 +68509,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "출력 핀 비저 GPIO"
+            "state": "translated",
+            "value": "버저 GPIO 출력 핀"
           }
         },
         "pt-BR": {
@@ -66530,8 +68597,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "출력 핀 vibra GPIO"
+            "state": "translated",
+            "value": "진동 모터 GPIO 출력 핀"
           }
         },
         "pt-BR": {
@@ -66582,6 +68649,12 @@
       "comment": "A warning to show when the selected area overlaps an existing map. The argument is the name of the existing map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@” 지도와 겹칩니다. 기존 지도와 겹치지 않도록 이동하거나 크기를 조절하세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -66630,8 +68703,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "자동 OLED 화면 감지 오류를 수정합니다."
+            "state": "translated",
+            "value": "OLED 화면 자동 감지를 재정의합니다."
           }
         },
         "pt-BR": {
@@ -66712,8 +68785,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 화면 레이아웃을 대체합니다."
+            "state": "translated",
+            "value": "기본 화면 레이아웃을 재정의합니다."
           }
         },
         "pt-BR": {
@@ -66806,7 +68879,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "PAX 카운터"
           }
         },
@@ -66912,7 +68985,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "PAX 카운터 설정"
           }
         },
@@ -67006,7 +69079,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "PAX 카운터 로그"
           }
         },
@@ -67100,8 +69173,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "PKI 기반 노드 관리는 2.5 이상 버전을 요구합니다."
+            "state": "translated",
+            "value": "PKI 기반 노드 관리에는 펌웨어 2.5 이상이 필요합니다."
           }
         },
         "pt-BR": {
@@ -67150,6 +69223,12 @@
     },
     "PTT Pin": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PTT 핀"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -67204,8 +69283,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비밀번호"
+            "state": "translated",
+            "value": "전원"
           }
         },
         "pt-BR": {
@@ -67252,7 +69331,16 @@
         }
       }
     },
-    "Packet Authenticity": {},
+    "Packet Authenticity": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패킷 인증"
+          }
+        }
+      }
+    },
     "Packet Count": {
       "localizations": {
         "de": {
@@ -67287,7 +69375,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "패킷 수"
           }
         },
@@ -67337,6 +69425,12 @@
     },
     "Packet Stream": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패킷 스트림"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -67353,6 +69447,12 @@
     },
     "Packets": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패킷"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -67369,6 +69469,12 @@
     },
     "Packets Rx": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수신 패킷"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -67385,6 +69491,12 @@
     },
     "Packets Tx": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "송신 패킷"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -67403,6 +69515,12 @@
       "comment": "Text displayed in a help item that describes how MQTT uplink packets from a channel can be forwarded to MQTT when MQTT is",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MQTT가 설정되어 있으면 이 채널의 패킷을 MQTT로 전달할 수 있습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -67457,8 +69575,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결 모드"
+            "state": "translated",
+            "value": "페어링 모드"
           }
         },
         "pl": {
@@ -67551,8 +69669,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "분산 번역에 참여하세요"
+            "state": "translated",
+            "value": "분산 번역 참여"
           }
         },
         "pt-BR": {
@@ -67588,7 +69706,15 @@
       }
     },
     "Passphrase length %lld of 32 bytes": {
-      "comment": "VoiceOver: current passphrase byte count out of the 32-byte maximum"
+      "comment": "VoiceOver: current passphrase byte count out of the 32-byte maximum",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "암호 길이: 32바이트 중 %lld바이트"
+          }
+        }
+      }
     },
     "Password": {
       "localizations": {
@@ -67636,7 +69762,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "암호"
           }
         },
@@ -67742,8 +69868,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "잠시 멈추세요"
+            "state": "translated",
+            "value": "일시 정지"
           }
         },
         "pl": {
@@ -67838,8 +69964,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "각 설정의 결과"
+            "state": "translated",
+            "value": "프리셋별 결과"
           }
         },
         "pt-BR": {
@@ -67914,8 +70040,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결된 노드에 대한 공장 재설정을 수행합니다."
+            "state": "translated",
+            "value": "현재 연결된 노드를 공장 초기화합니다."
           }
         },
         "pt-BR": {
@@ -68008,8 +70134,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전화 GPS"
+            "state": "translated",
+            "value": "스마트폰 GPS"
           }
         },
         "pl": {
@@ -68102,8 +70228,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전화 위치"
+            "state": "translated",
+            "value": "스마트폰 위치"
           }
         },
         "pt-BR": {
@@ -68190,7 +70316,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "핀 %lld"
           }
         },
@@ -68278,7 +70404,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "핀 A"
           }
         },
@@ -68366,7 +70492,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "핀 B"
           }
         },
@@ -68450,8 +70576,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치를 DFU 모드로 설정하고 USB를 통해 연결하세요."
+            "state": "translated",
+            "value": "장치를 DFU 모드로 전환한 다음 USB로 연결하세요."
           }
         },
         "pt-BR": {
@@ -68522,8 +70648,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "플랫폼 IO"
+            "state": "translated",
+            "value": "Platform IO"
           }
         },
         "pt-BR": {
@@ -68598,8 +70724,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 보고서가 암호화되지 않았기 때문에, 귀하의 데이터는 타사에게 영구적으로 저장 및 표시될 수 있습니다. Meshtastic는 이러한 데이터의 저장, 표시 또는 공개에 대해 책임을 지지 않습니다."
+            "state": "translated",
+            "value": "지도 정보는 암호화되지 않은 상태로 전송되므로, 전송된 데이터가 제3자에 의해 영구적으로 저장되거나 표시될 수 있습니다. Meshtastic는 이러한 데이터의 저장, 표시 또는 공개에 대해 책임을 지지 않습니다."
           }
         },
         "pt-BR": {
@@ -68682,8 +70808,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이것이 맞는지 확인하세요. 진행하기 전에."
+            "state": "translated",
+            "value": "계속하기 전에 이 정보가 올바른지 확인하세요."
           }
         },
         "pt-BR": {
@@ -68758,8 +70884,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "무선기를 연결하여 설정을 구성하세요."
+            "state": "translated",
+            "value": "설정을 변경하려면 노드에 연결하세요."
           }
         },
         "pt-BR": {
@@ -68842,8 +70968,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 프로세스가 완료될 때까지 화면을 떠나지 마십시오."
+            "state": "translated",
+            "value": "이 과정이 완료될 때까지 이 화면을 벗어나지 마세요."
           }
         },
         "pt-BR": {
@@ -68914,8 +71040,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치를 다시 연결하여 로더에 대한 정보를 로드하세요."
+            "state": "translated",
+            "value": "펌웨어 정보를 불러오려면 장치를 다시 연결하세요."
           }
         },
         "pt-BR": {
@@ -68951,7 +71077,15 @@
       }
     },
     "Plugged in": {
-      "comment": "VoiceOver value when the device is plugged in"
+      "comment": "VoiceOver value when the device is plugged in",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전원에 연결됨"
+          }
+        }
+      }
     },
     "Points of Interest": {
       "localizations": {
@@ -68993,8 +71127,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "관심사"
+            "state": "translated",
+            "value": "관심 지점"
           }
         },
         "pt-BR": {
@@ -69075,7 +71209,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "포트"
           }
         },
@@ -69157,7 +71291,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치"
           }
         },
@@ -69257,7 +71391,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치 설정"
           }
         },
@@ -69319,6 +71453,12 @@
     },
     "Position Dedup": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 중복 제거"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -69335,6 +71475,12 @@
     },
     "Position Deduplication": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 중복 제거"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -69389,8 +71535,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 교환 실패했습니다"
+            "state": "translated",
+            "value": "위치 주고받기에 실패했습니다"
           }
         },
         "pt-BR": {
@@ -69471,8 +71617,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 교환 요청됨"
+            "state": "translated",
+            "value": "위치 주고받기를 요청했습니다"
           }
         },
         "ru": {
@@ -69553,8 +71699,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 플래그"
+            "state": "translated",
+            "value": "위치 정보 항목"
           }
         },
         "pt-BR": {
@@ -69635,6 +71781,12 @@
             "value": "ノードの位置履歴"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 기록"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -69703,7 +71855,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치 기록 지점"
           }
         },
@@ -69779,7 +71931,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치 로그"
           }
         },
@@ -69867,8 +72019,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 로그 %lld 포인트"
+            "state": "translated",
+            "value": "위치 로그 (%lld개 지점)"
           }
         },
         "ru": {
@@ -69949,8 +72101,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "포맷 데이터 위치"
+            "state": "translated",
+            "value": "위치 패킷"
           }
         },
         "pt-BR": {
@@ -70031,8 +72183,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 정확도"
+            "state": "translated",
+            "value": "위치 정밀도"
           }
         },
         "pt-BR": {
@@ -70103,8 +72255,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 정확도 원"
+            "state": "translated",
+            "value": "위치 정밀도 범위"
           }
         },
         "pt-BR": {
@@ -70179,8 +72331,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 전송"
+            "state": "translated",
+            "value": "위치를 전송했습니다"
           }
         },
         "pt-BR": {
@@ -70228,7 +72380,15 @@
       }
     },
     "Position sharing": {
-      "comment": "VoiceOver: this channel shares location"
+      "comment": "VoiceOver: this channel shares location",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 공유 중"
+          }
+        }
+      }
     },
     "Position with Heading": {
       "comment": "A description of a position history point that shows the direction of travel.",
@@ -70266,8 +72426,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 정보: 방향"
+            "state": "translated",
+            "value": "이동 방향이 표시된 위치"
           }
         },
         "pt-BR": {
@@ -70336,7 +72496,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치"
           }
         },
@@ -70412,8 +72572,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "활성화된 위치"
+            "state": "translated",
+            "value": "위치 활성화"
           }
         },
         "pt-BR": {
@@ -70500,8 +72660,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위치 정보는 기기 GPS를 통해 제공되며, 비활성화 또는 존재하지 않는 경우 고정된 위치를 설정할 수 있습니다."
+            "state": "translated",
+            "value": "위치 정보는 기기의 GPS에서 제공됩니다. '사용 안 함' 또는 '없음'을 선택하면 고정 위치를 설정할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -70594,8 +72754,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전력"
+            "state": "translated",
+            "value": "전원"
           }
         },
         "pl": {
@@ -70700,8 +72860,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전력 설정"
+            "state": "translated",
+            "value": "전원 설정"
           }
         },
         "pl": {
@@ -70800,7 +72960,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "전력 측정 로그"
           }
         },
@@ -70888,8 +73048,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전원 꺼짐"
+            "state": "translated",
+            "value": "전원 끄기"
           }
         },
         "pt-BR": {
@@ -70982,8 +73142,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전력 절약"
+            "state": "translated",
+            "value": "절전"
           }
         },
         "pl": {
@@ -71082,8 +73242,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전력 표시기"
+            "state": "translated",
+            "value": "전력 정보 화면"
           }
         },
         "pt-BR": {
@@ -71164,7 +73324,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "전력 센서 옵션"
           }
         },
@@ -71246,8 +73406,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지원"
+            "state": "translated",
+            "value": "전원 연결"
           }
         },
         "pt-BR": {
@@ -71332,6 +73492,12 @@
             "value": "精密位置"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정확한 위치"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -71380,6 +73546,12 @@
       "comment": "A message displayed when an offline map is being prepared.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "준비 중…"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -71428,8 +73600,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 설정"
+            "state": "translated",
+            "value": "프리셋"
           }
         },
         "pt-BR": {
@@ -71512,8 +73684,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "탐색 시 스캔된 설정 수"
+            "state": "translated",
+            "value": "스캔한 프리셋 수"
           }
         },
         "pt-BR": {
@@ -71584,6 +73756,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "プレスピン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버튼 핀"
           }
         },
         "pt-BR": {
@@ -71670,7 +73848,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "압력"
           }
         },
@@ -71719,7 +73897,15 @@
       }
     },
     "Previous match": {
-      "comment": "VoiceOver label for the previous search match button"
+      "comment": "VoiceOver label for the previous search match button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전 일치 항목"
+          }
+        }
+      }
     },
     "Primary": {
       "localizations": {
@@ -71767,7 +73953,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "기본"
           }
         },
@@ -71867,8 +74053,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 관리 키"
+            "state": "translated",
+            "value": "주 관리자 키"
           }
         },
         "pt-BR": {
@@ -71951,8 +74137,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "주요 채널"
+            "state": "translated",
+            "value": "기본 채널"
           }
         },
         "pt-BR": {
@@ -72027,8 +74213,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 GPIO"
+            "state": "translated",
+            "value": "주 GPIO"
           }
         },
         "pt-BR": {
@@ -72115,8 +74301,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비밀 키"
+            "state": "translated",
+            "value": "개인 키"
           }
         },
         "pt-BR": {
@@ -72197,8 +74383,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "파일 처리 중입니다."
+            "state": "translated",
+            "value": "파일 처리 중..."
           }
         },
         "pt-BR": {
@@ -72285,7 +74471,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "프로젝트 정보"
           }
         },
@@ -72369,7 +74555,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "속성 (%lld)"
           }
         },
@@ -72405,7 +74591,16 @@
         }
       }
     },
-    "Protection Level": {},
+    "Protection Level": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보호 수준"
+          }
+        }
+      }
+    },
     "Provide Confirmation": {
       "localizations": {
         "de": {
@@ -72440,7 +74635,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "확인"
           }
         },
@@ -72522,8 +74717,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비공개 사용 통계 및 충돌 보고서를 제공합니다."
+            "state": "translated",
+            "value": "익명 사용 통계 및 충돌 보고서를 제공합니다."
           }
         },
         "pt-BR": {
@@ -72604,7 +74799,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "프로비저닝 실패"
           }
         },
@@ -72676,6 +74871,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "公開キー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공개 키"
           }
         },
         "pt-BR": {
@@ -72762,7 +74963,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "공개 키 암호화"
           }
         },
@@ -72850,7 +75051,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "공개 키 불일치"
           }
         },
@@ -72900,6 +75101,12 @@
     },
     "Push-to-talk GPIO pin number.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PTT GPIO 핀 번호입니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -72950,7 +75157,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "질문 입력"
           }
         },
@@ -72994,6 +75201,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Quietest channel: **%1$@** (%2$@ dBm noise floor)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잡음이 가장 적은 채널: %1$@ (노이즈 플로어 %2$@ dBm)"
           }
         },
         "uk": {
@@ -73046,8 +75259,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "무선 건강"
+            "state": "translated",
+            "value": "RF 상태"
           }
         },
         "pt-BR": {
@@ -73404,6 +75617,12 @@
     },
     "RSSI threshold for BLE device counting. Default is −80 dBm.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BLE 장치 수 집계에 사용할 RSSI 임계값입니다. 기본값은 −80 dBm입니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -73420,6 +75639,12 @@
     },
     "RSSI threshold for WiFi device counting. Default is −80 dBm.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi 장치 수 집계에 사용할 RSSI 임계값입니다. 기본값은 −80 dBm입니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -73474,8 +75699,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "RX 강화된 증폭"
+            "state": "translated",
+            "value": "RX 부스트 게인"
           }
         },
         "pt-BR": {
@@ -73562,7 +75787,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "방사선"
           }
         },
@@ -73656,8 +75881,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "라디오 설정"
+            "state": "translated",
+            "value": "무선 설정"
           }
         },
         "pl": {
@@ -73718,6 +75943,12 @@
     },
     "Radius": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "반경"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -73772,8 +76003,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "범위 테스트"
+            "state": "translated",
+            "value": "통신 거리 테스트"
           }
         },
         "pl": {
@@ -73878,8 +76109,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "범위 테스트 설정"
+            "state": "translated",
+            "value": "통신 거리 테스트 설정"
           }
         },
         "pl": {
@@ -73972,8 +76203,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "라디오로부터 범위 테스트 설정이 수신되지 않았습니다. 장치가 다시 연결되도록 시도하세요."
+            "state": "translated",
+            "value": "노드에서 통신 거리 테스트 설정을 받지 못했습니다. 장치를 다시 연결해 보세요."
           }
         },
         "pt-BR": {
@@ -74042,8 +76273,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 테스트에는 암호화된 개인 채널이 필요합니다. 이 노드의 기본 채널은 기본 또는 빈 키를 사용합니다."
+            "state": "translated",
+            "value": "통신 거리 테스트에는 암호화된 비공개 채널이 필요합니다. 이 노드의 기본 채널은 기본 키 또는 빈 키를 사용하고 있습니다."
           }
         },
         "pt-BR": {
@@ -74080,6 +76311,12 @@
     },
     "Rate Limiting": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전송 빈도 제한"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -74130,8 +76367,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "분석 재시작"
+            "state": "translated",
+            "value": "분석 다시 실행"
           }
         },
         "pt-BR": {
@@ -74167,9 +76404,26 @@
       }
     },
     "Reaction %@ from %@": {
-      "comment": "VoiceOver: a single emoji reaction and who sent it. First value is the emoji, second is the sender"
+      "comment": "VoiceOver: a single emoji reaction and who sent it. First value is the emoji, second is the sender",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@의 반응: %1$@"
+          }
+        }
+      }
     },
-    "Read a Meshtastic tag to add the contact or channel it contains.": {},
+    "Read a Meshtastic tag to add the contact or channel it contains.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meshtastic 태그를 읽어 태그에 포함된 연락처 또는 채널을 추가합니다."
+          }
+        }
+      }
+    },
     "Read and reply to Meshtastic channel and direct messages directly from your car's display using CarPlay.": {
       "comment": "A description of how to use CarPlay with Meshtastic.",
       "isCommentAutoGenerated": true,
@@ -74206,8 +76460,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Meshtastic 채널과 메시지 읽기 및 CarPlay를 통해 차량 디스플레이에서 직접 응답하기"
+            "state": "translated",
+            "value": "CarPlay를 통해 차량 디스플레이에서 Meshtastic 채널 메시지와 다이렉트 메시지를 직접 읽고 답장할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -74278,8 +76532,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "타크 서버의 읽기 전용 모드를 활성화하거나 비활성화합니다."
+            "state": "translated",
+            "value": "읽기 전용 모드"
           }
         },
         "pt-BR": {
@@ -74318,6 +76572,12 @@
       "comment": "A description of how noise floor readings can change.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "측정값은 주변 송신기, 안테나 구성, 필터 및 주변 전파 간섭에 따라 빠르게 변할 수 있습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -74378,7 +76638,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "재부팅"
           }
         },
@@ -74472,7 +76732,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "재부팅 및 업데이트 시작"
           }
         },
@@ -74550,6 +76810,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ノードを再起動しますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드를 재부팅할까요?"
           }
         },
         "pl": {
@@ -74648,8 +76914,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다시 송신 모드"
+            "state": "translated",
+            "value": "중계 모드"
           }
         },
         "pt-BR": {
@@ -74736,8 +77002,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "rxd 핀에서 데이터를 수신합니다."
+            "state": "translated",
+            "value": "수신 데이터(RXD) GPIO 핀"
           }
         },
         "pt-BR": {
@@ -74821,8 +77087,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "배경에서도 도착한 메시지와 중요한 알림을 받을 수 있습니다."
+            "state": "translated",
+            "value": "앱이 백그라운드에 있어도 새 메시지와 긴급 알림을 받을 수 있습니다."
           }
         },
         "pt-BR": {
@@ -74891,8 +77157,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "수신한 확인: %@"
+            "state": "translated",
+            "value": "ACK 수신: %@"
           }
         },
         "pt-BR": {
@@ -74967,8 +77233,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "수신자 확인: %@"
+            "state": "translated",
+            "value": "수신자 ACK: %@"
           }
         },
         "pt-BR": {
@@ -75045,7 +77311,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "추천"
           }
         },
@@ -75117,8 +77383,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "추천된 보안 버전: **%@**"
+            "state": "translated",
+            "value": "권장 보안 버전: **%@**"
           }
         },
         "pt-BR": {
@@ -75154,7 +77420,15 @@
       }
     },
     "Recommended. Reject unsigned downgrade attempts from nodes known to sign.": {
-      "comment": "Description of the Balanced packet authenticity policy."
+      "comment": "Description of the Balanced packet authenticity policy.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "권장. 서명 가능한 것으로 알려진 노드의 서명되지 않은 다운그레이드 시도를 거부합니다."
+          }
+        }
+      }
     },
     "Recorded trace route paths showing the hops a message took through the mesh to reach this node.": {
       "localizations": {
@@ -75186,6 +77460,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "メッシュを通ってメッセージがこのノードに到達するまでのホップを示す記録されたトラースルートパスを表示します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메시지가 메시 네트워크를 거쳐 이 노드에 도달한 경로를 보여줍니다."
           }
         },
         "pt-BR": {
@@ -75260,8 +77540,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "경로 녹음"
+            "state": "translated",
+            "value": "경로 기록 중"
           }
         },
         "pt-BR": {
@@ -75309,7 +77589,15 @@
       }
     },
     "Recording route, view details": {
-      "comment": "VoiceOver label for the route recording button while a recording is in progress"
+      "comment": "VoiceOver label for the route recording button while a recording is in progress",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 기록 중, 세부사항 보기"
+          }
+        }
+      }
     },
     "Refresh device metadata": {
       "localizations": {
@@ -75351,8 +77639,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치 메타데이터를 새로 불러오세요."
+            "state": "translated",
+            "value": "장치 메타데이터 새로고침"
           }
         },
         "pt-BR": {
@@ -75400,10 +77688,26 @@
       }
     },
     "Refresh firmware list": {
-      "comment": "VoiceOver label for the refresh firmware list button"
+      "comment": "VoiceOver label for the refresh firmware list button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펌웨어 목록 새로고침"
+          }
+        }
+      }
     },
     "Refresh logs": {
-      "comment": "VoiceOver label for the refresh application logs button"
+      "comment": "VoiceOver label for the refresh application logs button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그 새로고침"
+          }
+        }
+      }
     },
     "Regenerate Private Key": {
       "localizations": {
@@ -75439,8 +77743,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "개인 키 재설정"
+            "state": "translated",
+            "value": "개인 키 다시 생성"
           }
         },
         "pt-BR": {
@@ -75488,7 +77792,15 @@
       }
     },
     "Regenerate private key": {
-      "comment": "VoiceOver label for the regenerate private key button"
+      "comment": "VoiceOver label for the regenerate private key button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인 키 다시 생성"
+          }
+        }
+      }
     },
     "Region": {
       "localizations": {
@@ -75530,7 +77842,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지역"
           }
         },
@@ -75612,8 +77924,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최종 들었던 시간"
+            "state": "translated",
+            "value": "마지막 수신 시간"
           }
         },
         "pt-BR": {
@@ -75650,6 +77962,12 @@
     },
     "Relayed": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중계됨"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -75704,8 +78022,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%d %@를 통해 전송됨"
+            "state": "translated",
+            "value": "%d %@를 통해 중계됨"
           }
         },
         "pt-BR": {
@@ -75748,6 +78066,12 @@
     },
     "Relayed: %d": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중계: %d"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -75802,8 +78126,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "버전 노트"
+            "state": "translated",
+            "value": "릴리즈 노트"
           }
         },
         "pt-BR": {
@@ -75884,8 +78208,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "배달된 인증서 재부팅"
+            "state": "translated",
+            "value": "번들 인증서 다시 불러오기"
           }
         },
         "pt-BR": {
@@ -75960,8 +78284,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "원격 레거시 관리자: %@"
+            "state": "translated",
+            "value": "레거시 원격 관리: %@"
           }
         },
         "pt-BR": {
@@ -76048,8 +78372,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "원격 PKI 관리자: %@"
+            "state": "translated",
+            "value": "PKI 원격 관리: %@"
           }
         },
         "pt-BR": {
@@ -76136,8 +78460,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬스틱의 원격 관리"
+            "state": "translated",
+            "value": "원격 관리 대상: %@"
           }
         },
         "pt-BR": {
@@ -76224,8 +78548,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "제거합니다"
+            "state": "translated",
+            "value": "제거"
           }
         },
         "pt-BR": {
@@ -76274,6 +78598,12 @@
     },
     "Remove Bounding Box": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경계 영역 제거"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -76286,6 +78616,12 @@
       "comment": "A button that deletes a map from the user's device.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드한 지도 삭제"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -76324,6 +78660,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "お気に入りから削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "즐겨찾기에서 제거"
           }
         },
         "pt-BR": {
@@ -76404,8 +78746,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Ignored에서 제거합니다"
+            "state": "translated",
+            "value": "무시 목록에서 제거"
           }
         },
         "pt-BR": {
@@ -76456,6 +78798,12 @@
       "comment": "A confirmation dialog for removing an offline map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 오프라인 지도를 삭제할까요?"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -76468,6 +78816,12 @@
       "comment": "A button that renames a downloaded map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름 변경"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -76480,6 +78834,12 @@
       "comment": "A dialog that appears when the user taps the rename button.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도 이름 변경"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -76528,8 +78888,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널을 교체하세요"
+            "state": "translated",
+            "value": "채널 교체"
           }
         },
         "pt-BR": {
@@ -76622,8 +78982,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "답변"
+            "state": "translated",
+            "value": "답장"
           }
         },
         "pl": {
@@ -76683,13 +79043,37 @@
       }
     },
     "Replying to: %@": {
-      "comment": "VoiceOver: button that jumps to the quoted message being replied to. %@ is the quoted text"
+      "comment": "VoiceOver: button that jumps to the quoted message being replied to. %@ is the quoted text",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "답장 중: %@"
+          }
+        }
+      }
     },
     "Repositions the geofence area on the map": {
-      "comment": "VoiceOver hint for the geofence rectangle's move handle"
+      "comment": "VoiceOver hint for the geofence rectangle's move handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도에서 지오펜스 영역의 위치를 변경합니다."
+          }
+        }
+      }
     },
     "Repositions the selected download area on the map": {
-      "comment": "VoiceOver hint for the region rectangle's move handle"
+      "comment": "VoiceOver hint for the region rectangle's move handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도에서 선택한 다운로드 영역의 위치를 변경합니다."
+          }
+        }
+      }
     },
     "Request Legacy Admin: %@": {
       "localizations": {
@@ -76731,8 +79115,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "고급 관리자 요청: %@"
+            "state": "translated",
+            "value": "레거시 원격 관리 요청: %@"
           }
         },
         "pt-BR": {
@@ -76781,6 +79165,12 @@
     },
     "Request Local Stats": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 통계 요청"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -76835,8 +79225,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬스틱 PKI 관리자 요청: %@"
+            "state": "translated",
+            "value": "PKI 원격 관리 요청: %@"
           }
         },
         "pt-BR": {
@@ -76887,6 +79277,12 @@
       "comment": "A label indicating that a trace route was requested.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청됨"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -76931,7 +79327,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "필수"
           }
         },
@@ -77001,8 +79397,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "휴대폰에서 정확한 GPS 위치 정보를 요구합니다."
+            "state": "translated",
+            "value": "휴대폰의 정확한 GPS 위치가 필요합니다."
           }
         },
         "pt-BR": {
@@ -77077,8 +79473,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치가 가속도계를 갖추어야 합니다."
+            "state": "translated",
+            "value": "장치에 가속도계가 필요합니다."
           }
         },
         "pt-BR": {
@@ -77165,8 +79561,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "앱 설정을 초기화합니다."
+            "state": "translated",
+            "value": "앱 설정 초기화"
           }
         },
         "pt-BR": {
@@ -77253,8 +79649,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드DB 초기화"
+            "state": "translated",
+            "value": "NodeDB 초기화"
           }
         },
         "pt-BR": {
@@ -77305,6 +79701,12 @@
       "comment": "A button that resets all active contact filters.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연락처 필터 초기화"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77321,6 +79723,12 @@
     },
     "Reset node database and favorites?": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 데이터베이스와 즐겨찾기를 초기화할까요?"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77337,6 +79745,12 @@
     },
     "Reset node database, preserving favorites?": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "즐겨찾기를 유지하고 노드 데이터베이스를 초기화할까요?"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77355,6 +79769,12 @@
       "comment": "A button that resets all active node filters.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 필터 초기화"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77403,8 +79823,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본값으로 초기화합니다."
+            "state": "translated",
+            "value": "기본값으로 초기화"
           }
         },
         "pt-BR": {
@@ -77441,6 +79861,12 @@
     },
     "Resetting…": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "초기화 중…"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77459,6 +79885,12 @@
       "comment": "A button that opens a map view for resizing a downloaded region.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영역 크기 변경"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77469,6 +79901,12 @@
     },
     "Respond to NodeInfo requests directly from local cache.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로컬 캐시에서 NodeInfo 요청에 직접 응답합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77523,7 +79961,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "재시작"
           }
         },
@@ -77605,7 +80043,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "서버 재시작"
           }
         },
@@ -77671,6 +80109,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "接続しているノードを再起動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 노드 재시작"
           }
         },
         "pt-BR": {
@@ -77751,8 +80195,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "복구"
+            "state": "translated",
+            "value": "복원"
           }
         },
         "pt-BR": {
@@ -77801,6 +80245,12 @@
     },
     "Restore Failed": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복원 실패"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77816,10 +80266,24 @@
       }
     },
     "Restore backup": {
-      "comment": "VoiceOver label for the restore backup button"
+      "comment": "VoiceOver label for the restore backup button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백업 복원"
+          }
+        }
+      }
     },
     "Restoring Backup": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백업 복원 중"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -77880,8 +80344,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "요약"
+            "state": "translated",
+            "value": "재개"
           }
         },
         "pl": {
@@ -77972,6 +80436,12 @@
             "value": "ノードを取得しています。"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 불러오는 중..."
+          }
+        },
         "ru": {
           "stringUnit": {
             "state": "translated",
@@ -78044,8 +80514,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드 검색"
+            "state": "translated",
+            "value": "노드 불러오는 중"
           }
         },
         "pt-BR": {
@@ -78120,8 +80590,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "%lld개의 노드를 검색합니다."
+            "state": "translated",
+            "value": "%lld개의 노드를 불러오는 중"
           }
         },
         "pt-BR": {
@@ -78202,8 +80672,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다시 시도하세요"
+            "state": "translated",
+            "value": "다시 시도"
           }
         },
         "pt-BR": {
@@ -78272,8 +80742,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다시 업데이트 하세요"
+            "state": "translated",
+            "value": "업데이트 다시 시도"
           }
         },
         "pt-BR": {
@@ -78342,8 +80812,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다시 시도 (시도 %@)"
+            "state": "translated",
+            "value": "다시 시도 중 (%@번째 시도)"
           }
         },
         "pt-BR": {
@@ -78412,8 +80882,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다시 시도 (시도 %lld)"
+            "state": "translated",
+            "value": "다시 시도 중 (%lld번째 시도)"
           }
         },
         "pt-BR": {
@@ -78464,6 +80934,12 @@
       "comment": "A description of the return path of a trace route.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "돌아오는 경로"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -78512,8 +80988,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "앱을 검토하세요."
+            "state": "translated",
+            "value": "앱 평가하기"
           }
         },
         "pt-BR": {
@@ -78606,8 +81082,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "음성 알림"
+            "state": "translated",
+            "value": "벨소리"
           }
         },
         "pl": {
@@ -78712,8 +81188,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "음성 설정"
+            "state": "translated",
+            "value": "벨소리 설정"
           }
         },
         "pl": {
@@ -78812,8 +81288,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "링톤 전송 언어"
+            "state": "translated",
+            "value": "벨소리 전송 언어"
           }
         },
         "pt-BR": {
@@ -78912,8 +81388,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "RTTTL(링톤 전송 언어) 외부 알림에서 지원되는 진동기에 사용되는 리듬 문자열"
+            "state": "translated",
+            "value": "외부 알림에서 지원되는 버저에 사용할 RTTTL(Ringtone Transfer Language) 형식의 벨소리 문자열입니다."
           }
         },
         "pl": {
@@ -79012,7 +81488,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "역할"
           }
         },
@@ -79100,7 +81576,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "역할"
           }
         },
@@ -79188,8 +81664,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "근본 주제"
+            "state": "translated",
+            "value": "루트 토픽"
           }
         },
         "pt-BR": {
@@ -79276,8 +81752,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "회전 1"
+            "state": "translated",
+            "value": "로터리 인코더 1"
           }
         },
         "pt-BR": {
@@ -79364,8 +81840,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "반복 경로: %@"
+            "state": "translated",
+            "value": "돌아오는 경로: %@"
           }
         },
         "pt-BR": {
@@ -79448,8 +81924,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "경로 끝점"
+            "state": "translated",
+            "value": "경로 종점"
           }
         },
         "pt-BR": {
@@ -79520,8 +81996,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "도로 노선"
+            "state": "translated",
+            "value": "경로선"
           }
         },
         "pt-BR": {
@@ -79596,7 +82072,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "경로선"
           }
         },
@@ -79678,7 +82154,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "경로 목록"
           }
         },
@@ -79766,8 +82242,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "로터리 레코더"
+            "state": "translated",
+            "value": "경로 기록"
           }
         },
         "pt-BR": {
@@ -79850,8 +82326,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "경로 시작"
+            "state": "translated",
+            "value": "경로 시작점"
           }
         },
         "pt-BR": {
@@ -79926,8 +82402,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "레코딩 중지"
+            "state": "translated",
+            "value": "경로 기록 일시 정지"
           }
         },
         "pt-BR": {
@@ -80014,7 +82490,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "경로: %@"
           }
         },
@@ -80102,7 +82578,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "경로"
           }
         },
@@ -80152,6 +82628,12 @@
     },
     "Rsyslog Server": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rsyslog 서버"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -80167,7 +82649,15 @@
       }
     },
     "Runs a Site Planner coverage estimate and adds it to the map.": {
-      "comment": "VoiceOver hint for the coverage estimate button"
+      "comment": "VoiceOver hint for the coverage estimate button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site Planner에서 커버리지를 추정하고 지도에 추가합니다."
+          }
+        }
+      }
     },
     "SNR": {
       "localizations": {
@@ -80467,8 +82957,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "현재 모뎀 설정에서 SNR이 상한선을 초과했습니다. 강력한 안정적인 신호입니다."
+            "state": "translated",
+            "value": "SNR이 현재 모뎀 프리셋의 기준값보다 높습니다. 강하고 안정적인 신호입니다."
           }
         },
         "pt-BR": {
@@ -80537,8 +83027,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "SNR이 모뎀 기본 설정 상한선보다 훨씬 낮습니다. 이 신호 수준에서는 통신이 거의 불가능합니다."
+            "state": "translated",
+            "value": "SNR이 모뎀 프리셋의 기준값보다 훨씬 낮습니다. 이 신호 수준에서는 통신이 어려울 수 있습니다."
           }
         },
         "pt-BR": {
@@ -80607,8 +83097,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "SNR은 모뎀 기본 설정 상한선에 약간 미치지 못합니다. 연결이 간헐적일 수 있습니다."
+            "state": "translated",
+            "value": "SNR이 모뎀 프리셋의 기준값보다 약간 낮습니다. 연결이 불안정할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -80677,8 +83167,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "SNR이 모뎀 기본 설정 상한선보다 훨씬 낮습니다. 패킷 손실과 불안정한 전달을 예상하세요."
+            "state": "translated",
+            "value": "SNR이 모뎀 프리셋의 기준값보다 상당히 낮습니다. 패킷 손실과 불안정한 전송이 발생할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -80759,7 +83249,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "SSID"
           }
         },
@@ -80859,8 +83349,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Sats"
+            "state": "translated",
+            "value": "위성"
           }
         },
         "pt-BR": {
@@ -80947,8 +83437,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "센서 추정 %lld"
+            "state": "translated",
+            "value": "추정 위성 수: %lld"
           }
         },
         "pt-BR": {
@@ -81035,8 +83525,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보이는 센서: %@"
+            "state": "translated",
+            "value": "보이는 위성: %@"
           }
         },
         "pt-BR": {
@@ -81129,7 +83619,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "저장"
           }
         },
@@ -81229,7 +83719,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 설정 저장"
           }
         },
@@ -81311,8 +83801,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "USB에 유닛 소프트웨어를 저장합니다."
+            "state": "translated",
+            "value": "펌웨어를 USB에 저장"
           }
         },
         "pt-BR": {
@@ -81371,8 +83861,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 인증을 저장"
+            "state": "translated",
+            "value": "TAK 식별 정보 저장"
           }
         },
         "pt-BR": {
@@ -81447,8 +83937,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 설정 저장하기 %@?"
+            "state": "translated",
+            "value": "사용자 설정을 %@에 저장할까요?"
           }
         },
         "pt-BR": {
@@ -81535,8 +84025,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "ESP32 기기 및 웹 서버가 있는 경우에만 테스트 메시지 세부 정보를 포함하는 CSV 파일을 저장합니다."
+            "state": "translated",
+            "value": "거리 테스트 메시지의 세부 정보를 CSV 파일로 저장합니다. 현재는 웹 서버가 있는 ESP32 장치에서만 사용할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -81619,7 +84109,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "저장 중..."
           }
         },
@@ -81655,7 +84145,16 @@
         }
       }
     },
-    "Scan NFC Tag": {},
+    "Scan NFC Tag": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NFC 태그 스캔"
+          }
+        }
+      }
+    },
     "Scan Progress": {
       "comment": "A section that displays the current state of the discovery scan.",
       "isCommentAutoGenerated": true,
@@ -81692,8 +84191,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "탐색 진행 상황"
+            "state": "translated",
+            "value": "스캔 진행 상황"
           }
         },
         "pt-BR": {
@@ -81764,8 +84263,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "탐색 세션 요약 보기"
+            "state": "translated",
+            "value": "스캔 요약"
           }
         },
         "pt-BR": {
@@ -81834,8 +84333,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "QR코드를 스캔하여 다른 기기에 %@를 추가하세요."
+            "state": "translated",
+            "value": "이 QR 코드를 스캔하여 %@를 다른 기기에 추가하세요."
           }
         },
         "pt-BR": {
@@ -81918,8 +84417,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스캔 중입니다..."
+            "state": "translated",
+            "value": "스캔 중…"
           }
         },
         "pt-BR": {
@@ -81994,8 +84493,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스크린 켜짐"
+            "state": "translated",
+            "value": "화면 켜짐 시간"
           }
         },
         "pt-BR": {
@@ -82046,6 +84545,12 @@
       "comment": "A hint for the accessibility of the \"Latest\" button.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "차트를 최신 측정값으로 스크롤합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -82100,7 +84605,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "검색"
           }
         },
@@ -82184,8 +84689,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "검색 문서"
+            "state": "translated",
+            "value": "문서 검색"
           }
         },
         "pt-BR": {
@@ -82260,8 +84765,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "두 번째"
+            "state": "translated",
+            "value": "초"
           }
         },
         "pt-BR": {
@@ -82354,8 +84859,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "부서"
+            "state": "translated",
+            "value": "보조"
           }
         },
         "pl": {
@@ -82454,8 +84959,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "부서 관리 키"
+            "state": "translated",
+            "value": "보조 관리자 키"
           }
         },
         "pt-BR": {
@@ -82504,6 +85009,12 @@
     },
     "Seconds": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "초"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -82554,8 +85065,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안된 mTLS 연결이 8089 포트에서 이루어집니다. 서버와 클라이언트 인증서가 모두 필요합니다. TAK 채널 인덱스는 TAK 메시지가 전송될 채널 인덱스를 선택합니다."
+            "state": "translated",
+            "value": "8089 포트에서 보안 mTLS 연결을 사용합니다. 서버와 클라이언트 인증서가 모두 필요합니다. TAK 채널 인덱스는 TAK 메시지를 전송할 채널 인덱스를 선택합니다."
           }
         },
         "pt-BR": {
@@ -82626,8 +85137,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안적으로 암호화"
+            "state": "translated",
+            "value": "안전하게 암호화됨"
           }
         },
         "pt-BR": {
@@ -82702,7 +85213,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "보안"
           }
         },
@@ -82786,8 +85297,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안 알림"
+            "state": "translated",
+            "value": "보안 권고"
           }
         },
         "pt-BR": {
@@ -82862,7 +85373,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "보안 설정"
           }
         },
@@ -82950,8 +85461,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안 설정은 2.5 이상의 버전을 요구합니다."
+            "state": "translated",
+            "value": "보안 설정은 펌웨어 버전 2.5 이상이 필요합니다."
           }
         },
         "pt-BR": {
@@ -83034,7 +85545,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "보안 업데이트 권장"
           }
         },
@@ -83110,7 +85621,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 선택"
           }
         },
@@ -83192,7 +85703,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지도 파일 선택"
           }
         },
@@ -83274,8 +85785,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드를 선택하세요"
+            "state": "translated",
+            "value": "노드 선택"
           }
         },
         "pt-BR": {
@@ -83317,7 +85828,15 @@
       }
     },
     "Select an Item (%@)": {
-      "comment": "Title of the map picker shown when a tapped cluster or coincident stack contains more than one item (nodes and/or waypoints). %@ is the item count."
+      "comment": "Title of the map picker shown when a tapped cluster or coincident stack contains more than one item (nodes and/or waypoints). %@ is the item count.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "항목 선택 (%@)"
+          }
+        }
+      }
     },
     "Select a Trace Route": {
       "localizations": {
@@ -83359,8 +85878,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래스 루트를 선택하세요"
+            "state": "translated",
+            "value": "추적 경로를 선택하세요"
           }
         },
         "pt-BR": {
@@ -83447,8 +85966,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널을 선택하세요"
+            "state": "translated",
+            "value": "채널 선택"
           }
         },
         "pt-BR": {
@@ -83535,8 +86054,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "대화 선택하세요"
+            "state": "translated",
+            "value": "대화 선택"
           }
         },
         "pt-BR": {
@@ -83623,8 +86142,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "대화 유형을 선택하세요"
+            "state": "translated",
+            "value": "대화 유형 선택"
           }
         },
         "pt-BR": {
@@ -83711,8 +86230,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "드롭다운에서 연결된 또는 원격 장치를 관리하려면 노드를 선택하세요."
+            "state": "translated",
+            "value": "드롭다운에서 노드를 선택하여 연결된 장치 또는 원격 장치를 관리합니다."
           }
         },
         "pt-BR": {
@@ -83793,8 +86312,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "아이콘을 선택하세요"
+            "state": "translated",
+            "value": "이모지 선택"
           }
         },
         "pt-BR": {
@@ -83869,8 +86388,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "크리티컬 패킷만 전송하면 OS 알림 센터의 음소거 스위치와 'Do Not Disturb' 설정이 무시됩니다."
+            "state": "translated",
+            "value": "중요로 표시된 패킷은 OS 알림 센터의 음소거 스위치와 방해 금지 설정을 무시합니다."
           }
         },
         "pt-BR": {
@@ -83957,7 +86476,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "보내기"
           }
         },
@@ -84045,8 +86564,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 내용을 ${messageContent}에 ${channelNumber}로 보내세요"
+            "state": "translated",
+            "value": "${messageContent}을(를) ${channelNumber} 채널로 보내기"
           }
         },
         "pt-BR": {
@@ -84133,8 +86652,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 내용을 ${messageContent}에 ${nodeNumber}에 전송합니다."
+            "state": "translated",
+            "value": "${messageContent}을(를) ${nodeNumber} 노드로 보내기"
           }
         },
         "pt-BR": {
@@ -84221,8 +86740,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알림 메시지를 전송하여 벨 소리에 외부 알림을 트리거합니다."
+            "state": "translated",
+            "value": "알림 메시지와 함께 ASCII 벨 신호를 전송합니다. 벨 신호로 외부 알림을 트리거할 때 유용합니다."
           }
         },
         "pt-BR": {
@@ -84309,8 +86828,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "벨 소리 보내기"
+            "state": "translated",
+            "value": "벨 신호 보내기"
           }
         },
         "pt-BR": {
@@ -84403,8 +86922,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "심박수 전송"
+            "state": "translated",
+            "value": "하트비트 전송"
           }
         },
         "pl": {
@@ -84497,8 +87016,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알림 전송"
+            "state": "translated",
+            "value": "알림 보내기"
           }
         },
         "pt-BR": {
@@ -84585,8 +87104,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "직접 메시지를 보내세요"
+            "state": "translated",
+            "value": "개인 메시지 보내기"
           }
         },
         "pt-BR": {
@@ -84673,8 +87192,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "그룹 메시지를 보내세요"
+            "state": "translated",
+            "value": "그룹 메시지 보내기"
           }
         },
         "pt-BR": {
@@ -84761,8 +87280,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "경로 지정을 보내세요"
+            "state": "translated",
+            "value": "웨이포인트 보내기"
           }
         },
         "pt-BR": {
@@ -84849,8 +87368,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "서버의 존재를 알리기 위해 심박수를 전송합니다."
+            "state": "translated",
+            "value": "서버의 존재를 알리기 위해 하트비트를 전송합니다."
           }
         },
         "pt-BR": {
@@ -84937,8 +87456,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "특정 Meshtastic 채널에 메시지를 보내세요."
+            "state": "translated",
+            "value": "특정 Meshtastic 채널로 메시지 보내기"
           }
         },
         "pt-BR": {
@@ -85025,8 +87544,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "특정 Meshtastic 노드에 메시지를 전송합니다."
+            "state": "translated",
+            "value": "특정 Meshtastic 노드로 메시지 보내기"
           }
         },
         "pt-BR": {
@@ -85113,8 +87632,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 버튼을 세 번 클릭할 때 기본 채널에 위치를 전송합니다."
+            "state": "translated",
+            "value": "사용자 버튼을 세 번 누르면 기본 채널로 위치 정보를 전송합니다."
           }
         },
         "pt-BR": {
@@ -85199,6 +87718,12 @@
             "value": "接続しているノードにシャットダウン信号を送信"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 노드에 종료 명령 보내기"
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -85280,8 +87805,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Siri와 CarPlay를 사용하여 Meshtastic 메시지를 손쉽게 보내고 받을 수 있습니다."
+            "state": "translated",
+            "value": "Siri와 CarPlay를 사용하여 핸즈프리로 Meshtastic 메시지를 보내고 받을 수 있습니다."
           }
         },
         "pt-BR": {
@@ -85352,8 +87877,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시지 채널 방송 및 직접 메시지를 전송합니다. 메시지를 길게 누르면 복사, 답장, 타이핑백, 배송 세부 정보 등의 작업을 수행할 수 있습니다."
+            "state": "translated",
+            "value": "채널 메시지와 개인 메시지를 보낼 수 있습니다. 메시지를 길게 눌러 복사, 답장, Tapback, 전송 세부사항 등의 작업을 사용할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -85389,7 +87914,15 @@
       }
     },
     "Send message": {
-      "comment": "VoiceOver: send the composed message"
+      "comment": "VoiceOver: send the composed message",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메시지 전송"
+          }
+        }
+      }
     },
     "Send question to Chirpy": {
       "localizations": {
@@ -85425,8 +87958,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "치르피에게 질문을 보내세요"
+            "state": "translated",
+            "value": "Chirpy에게 질문 보내기"
           }
         },
         "pt-BR": {
@@ -85501,7 +88034,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "센서"
           }
         },
@@ -85585,7 +88118,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "센서 패킷 수"
           }
         },
@@ -85655,8 +88188,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드에서 보고된 온도, 습도, 기압 등의 센서 데이터"
+            "state": "translated",
+            "value": "노드에서 보고한 온도, 습도, 기압 등의 센서 데이터입니다."
           }
         },
         "pt-BR": {
@@ -85731,7 +88264,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "센서 옵션"
           }
         },
@@ -85815,8 +88348,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "센서 지배: %@"
+            "state": "translated",
+            "value": "센서 데이터 중심: %@"
           }
         },
         "pt-BR": {
@@ -85898,8 +88431,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "애플 기기의 GPS에서 노드: %@@에 위치 패킷을 전송했습니다."
+            "state": "translated",
+            "value": "Apple 기기의 GPS 위치 패킷을 노드 %@@에 전송했습니다."
           }
         },
         "pl": {
@@ -85998,7 +88531,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시퀀스 번호"
           }
         },
@@ -86086,7 +88619,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시퀀스: %@"
           }
         },
@@ -86180,7 +88713,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시리얼"
           }
         },
@@ -86286,7 +88819,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시리얼 설정"
           }
         },
@@ -86386,7 +88919,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시리얼 콘솔"
           }
         },
@@ -86474,8 +89007,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스트림 API를 통한 시리얼 콘솔"
+            "state": "translated",
+            "value": "Stream API를 통한 시리얼 콘솔입니다."
           }
         },
         "pt-BR": {
@@ -86562,8 +89095,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시리즈"
+            "state": "translated",
+            "value": "계열"
           }
         },
         "pt-BR": {
@@ -86650,7 +89183,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "서버"
           }
         },
@@ -86738,7 +89271,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "서버 주소"
           }
         },
@@ -86820,7 +89353,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "서버 인증서"
           }
         },
@@ -86896,7 +89429,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "서버 옵션"
           }
         },
@@ -86978,7 +89511,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "서버 상태"
           }
         },
@@ -87016,6 +89549,12 @@
     },
     "Server:Port": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서버:포트"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -87060,7 +89599,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "탐색 세션 세부 정보"
           }
         },
@@ -87132,7 +89671,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "탐색 기록"
           }
         },
@@ -87204,7 +89743,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "세션 개요"
           }
         },
@@ -87280,7 +89819,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "설정"
           }
         },
@@ -87330,6 +89869,12 @@
     },
     "Set Bounding Box": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경계 영역 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -87384,8 +89929,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "LoRa 지역을 설정합니다."
+            "state": "translated",
+            "value": "LoRa 지역 설정"
           }
         },
         "pl": {
@@ -87480,7 +90025,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Wi-Fi 설정"
           }
         },
@@ -87552,8 +90097,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 이름을 설정하세요"
+            "state": "translated",
+            "value": "채널 이름 설정"
           }
         },
         "pt-BR": {
@@ -87628,8 +90173,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "RXD와 TXD 핀을 설정합니다."
+            "state": "translated",
+            "value": "RXD와 TXD의 GPIO 핀을 설정합니다."
           }
         },
         "pt-BR": {
@@ -87710,8 +90255,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "현재 위치로 설정합니다."
+            "state": "translated",
+            "value": "현재 위치로 설정"
           }
         },
         "pt-BR": {
@@ -87798,8 +90343,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최대 연결 횟수를 설정합니다. 기본값은 3입니다. 연결 횟수를 늘리면 혼잡도가 증가하므로 주의해야 합니다. 0 연결 broadcast 메시지는 ACK를 받지 않습니다."
+            "state": "translated",
+            "value": "최대 홉 수를 설정합니다. 기본값은 3입니다. 홉 수를 늘리면 네트워크 혼잡이 증가하므로 주의해서 사용해야 합니다. 0홉 브로드캐스트 메시지는 ACK를 받지 않습니다."
           }
         },
         "pt-BR": {
@@ -87880,8 +90425,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시계 형식을 12시간으로 설정합니다."
+            "state": "translated",
+            "value": "화면 시계 형식을 12시간제로 설정합니다."
           }
         },
         "pt-BR": {
@@ -87974,7 +90519,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "설정"
           }
         },
@@ -88070,8 +90615,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널 공유하기"
+            "state": "translated",
+            "value": "채널 공유"
           }
         },
         "pt-BR": {
@@ -88106,7 +90651,16 @@
         }
       }
     },
-    "Share Connected Node": {},
+    "Share Connected Node": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 노드 공유"
+          }
+        }
+      }
+    },
     "Share Contact QR": {
       "localizations": {
         "de": {
@@ -88141,8 +90695,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연락처 QR 공유"
+            "state": "translated",
+            "value": "연락처 QR 코드 공유"
           }
         },
         "pt-BR": {
@@ -88223,7 +90777,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치 공유"
           }
         },
@@ -88317,8 +90871,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "QR코드를 공유하세요"
+            "state": "translated",
+            "value": "QR 코드 공유"
           }
         },
         "pl": {
@@ -88417,8 +90971,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "QR 코드 및 링크를 공유하세요"
+            "state": "translated",
+            "value": "QR 코드 및 링크 공유"
           }
         },
         "pt-BR": {
@@ -88501,8 +91055,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 친구들과 QR 코드를 공유합니다."
+            "state": "translated",
+            "value": "TAK 친구들과 공유"
           }
         },
         "pt-BR": {
@@ -88572,8 +91126,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "실시간으로 위치를 공유하고 그룹을 통합된 GPS 기능으로 조정하세요."
+            "state": "translated",
+            "value": "실시간으로 위치를 공유하고 내장된 GPS 기능을 사용하여 그룹과 서로의 위치를 확인할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -88660,8 +91214,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "공용 키"
+            "state": "translated",
+            "value": "공유 키"
           }
         },
         "pt-BR": {
@@ -88748,7 +91302,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "짧은 이름"
           }
         },
@@ -88830,8 +91384,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "단축명 & 긴명"
+            "state": "translated",
+            "value": "짧은 이름 및 긴 이름"
           }
         },
         "pt-BR": {
@@ -88906,7 +91460,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "알림 표시"
           }
         },
@@ -88990,8 +91544,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "원본 보기"
+            "state": "translated",
+            "value": "원문 보기"
           }
         },
         "pt-BR": {
@@ -89062,8 +91616,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "번역 표시"
+            "state": "translated",
+            "value": "번역 보기"
           }
         },
         "pt-BR": {
@@ -89132,8 +91686,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "공장 초기화를 수행하기 전에 확인 대화 상자를 표시합니다."
+            "state": "translated",
+            "value": "공장 초기화를 수행하기 전에 확인 대화상자를 표시합니다."
           }
         },
         "pt-BR": {
@@ -89221,8 +91775,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알림을 표시합니다"
+            "state": "translated",
+            "value": "알림 표시"
           }
         },
         "pt-BR": {
@@ -89270,13 +91824,37 @@
       }
     },
     "Show altitude chart": {
-      "comment": "VoiceOver label for the altitude chart toggle button when the chart is hidden"
+      "comment": "VoiceOver label for the altitude chart toggle button when the chart is hidden",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고도 차트 표시"
+          }
+        }
+      }
     },
     "Show contact filters": {
-      "comment": "VoiceOver label for the contact filter toggle button when filters are hidden"
+      "comment": "VoiceOver label for the contact filter toggle button when filters are hidden",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연락처 필터 표시"
+          }
+        }
+      }
     },
     "Show help": {
-      "comment": "VoiceOver label for the help toggle button when help is hidden"
+      "comment": "VoiceOver label for the help toggle button when help is hidden",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도움말 표시"
+          }
+        }
+      }
     },
     "Show legend": {
       "comment": "A label for a button that shows/hides the map legend.",
@@ -89314,8 +91892,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "레거시 표시"
+            "state": "translated",
+            "value": "범례 표시"
           }
         },
         "pt-BR": {
@@ -89384,8 +91962,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 레이블 보기"
+            "state": "translated",
+            "value": "지도 범례 표시"
           }
         },
         "pt-BR": {
@@ -89421,10 +91999,24 @@
       }
     },
     "Show map settings": {
-      "comment": "VoiceOver label to show the map settings panel"
+      "comment": "VoiceOver label to show the map settings panel",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도 설정 표시"
+          }
+        }
+      }
     },
     "Show node filters": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 필터 표시"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -89473,7 +92065,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드 표시"
           }
         },
@@ -89517,6 +92109,12 @@
     },
     "Show on Map": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도에서 보기"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -89565,8 +92163,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치 화면에 표시합니다."
+            "state": "translated",
+            "value": "장치 화면에 표시"
           }
         },
         "pt-BR": {
@@ -89653,8 +92251,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시드 지도를 통해 표시합니다."
+            "state": "translated",
+            "value": "메시 지도에 표시합니다."
           }
         },
         "pt-BR": {
@@ -89703,6 +92301,12 @@
     },
     "Show password": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "암호 표시"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -89725,6 +92329,12 @@
             "value": "Showing latest %1$lld of %2$lld positions. Export includes all positions."
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 %2$lld개의 위치 중 최근 %1$lld개를 표시합니다. 내보내기에는 모든 위치가 포함됩니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -89740,10 +92350,24 @@
       }
     },
     "Showing translated text": {
-      "comment": "VoiceOver label for the translated message badge"
+      "comment": "VoiceOver label for the translated message badge",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "번역된 텍스트 표시 중"
+          }
+        }
+      }
     },
     "Shows a saved offline map over the covered area, so it still works without an internet connection.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "해당 영역에 저장된 오프라인 지도를 표시하여 인터넷에 연결되어 있지 않아도 사용할 수 있습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -89786,8 +92410,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "GPS 위치 기반 노드 방향 및 거리 표시. 장치와 원격 노드가 위치 공유를 요구합니다."
+            "state": "translated",
+            "value": "GPS 위치를 기반으로 노드까지의 방향과 거리를 표시합니다. 사용 중인 장치와 원격 노드 모두 위치를 공유해야 합니다."
           }
         },
         "pt-BR": {
@@ -89856,8 +92480,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 레이블을 보여줍니다."
+            "state": "translated",
+            "value": "지도 범례를 표시합니다."
           }
         },
         "pt-BR": {
@@ -89893,10 +92517,24 @@
       }
     },
     "Shows the map settings panel.": {
-      "comment": "VoiceOver hint to show the map settings panel"
+      "comment": "VoiceOver hint to show the map settings panel",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도 설정 패널을 표시합니다."
+          }
+        }
+      }
     },
     "Shows the node filter options.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 필터 옵션을 표시합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -89951,8 +92589,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "끄세요"
+            "state": "translated",
+            "value": "종료"
           }
         },
         "pt-BR": {
@@ -90035,7 +92673,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "노드 종료 / 재시작"
           }
         },
@@ -90107,6 +92745,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ノードをシャットダウンしますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드를 종료할까요?"
           }
         },
         "pt-BR": {
@@ -90189,6 +92833,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ノードをシャットダウンしますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드를 종료할까요?"
           }
         },
         "pt-BR": {
@@ -90275,8 +92925,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전원 부족 시 종료"
+            "state": "translated",
+            "value": "외부 전원 차단 시 종료"
           }
         },
         "pl": {
@@ -90369,8 +93019,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "SSH를 통해 기본 사용자 이름과 비밀번호를 변경하세요."
+            "state": "translated",
+            "value": "SSH로 로그인하여 기본 사용자 이름과 비밀번호를 변경하세요."
           }
         },
         "pt-BR": {
@@ -90445,7 +93095,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "신호 %@"
           }
         },
@@ -90527,8 +93177,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "신호(직접만)"
+            "state": "translated",
+            "value": "신호 (직접 수신만)"
           }
         },
         "pt-BR": {
@@ -90567,6 +93217,12 @@
       "comment": "A label displayed above the signal strength legend.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "신호 강도"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -90609,8 +93265,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "신호 강도 측정기"
+            "state": "translated",
+            "value": "신호 강도계"
           }
         },
         "pt-BR": {
@@ -90646,7 +93302,15 @@
       }
     },
     "Signal strength": {
-      "comment": "VoiceOver label for the signal strength indicator"
+      "comment": "VoiceOver label for the signal strength indicator",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "신호 강도"
+          }
+        }
+      }
     },
     "Signal: Bad": {
       "localizations": {
@@ -90682,8 +93346,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "신호: 좋지 않습니다"
+            "state": "translated",
+            "value": "신호: 나뿜"
           }
         },
         "pt-BR": {
@@ -90752,7 +93416,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "신호: 보통"
           }
         },
@@ -90822,7 +93486,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "신호: 좋음"
           }
         },
@@ -90892,7 +93556,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "신호: 매우 나쁨"
           }
         },
@@ -90936,6 +93600,12 @@
             "value": "Signed node"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서명된 노드"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -90950,6 +93620,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Signed · verified"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서명됨 · 검증됨"
           }
         },
         "uk": {
@@ -90997,8 +93673,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Siri & CarPlay"
+            "state": "translated",
+            "value": "Siri 및 CarPlay"
           }
         },
         "pt-BR": {
@@ -91069,8 +93745,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시리, 스팟키트, 카플레이"
+            "state": "translated",
+            "value": "Siri, 단축어 및 CarPlay"
           }
         },
         "pt-BR": {
@@ -91106,12 +93782,26 @@
       }
     },
     "Site name": {
-      "comment": "VoiceOver label for the site name field"
+      "comment": "VoiceOver label for the site name field",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지점 이름"
+          }
+        }
+      }
     },
     "Size": {
       "comment": "A label that describes the size of a map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "면적"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -91124,6 +93814,12 @@
       "comment": "A label that shows the size of the selected map area. The value is a localized string that describes the area in square kilometers. The argument is the string “—”.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 지도 면적: %@"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -91172,7 +93868,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "스마트 위치"
           }
         },
@@ -91260,7 +93956,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "토양 수분"
           }
         },
@@ -91348,7 +94044,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "토양 온도"
           }
         },
@@ -91398,6 +94094,12 @@
     },
     "Solid line toward the target; arrows point in the direction of travel.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대상을 향하는 실선이며, 화살표는 진행 방향을 나타냅니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -91410,6 +94112,12 @@
       "comment": "A label that displays the source of a map.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "출처"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -91458,7 +94166,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "속도"
           }
         },
@@ -91546,7 +94254,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "속도 %@"
           }
         },
@@ -91634,7 +94342,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "속도: %@"
           }
         },
@@ -91716,8 +94424,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "후원 앱 개발"
+            "state": "translated",
+            "value": "앱 개발 후원"
           }
         },
         "pt-BR": {
@@ -91804,8 +94512,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "분산 계수"
+            "state": "translated",
+            "value": "확산 계수"
           }
         },
         "pt-BR": {
@@ -91888,8 +94596,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최신 안정형 소프트웨어"
+            "state": "translated",
+            "value": "안정 버전"
           }
         },
         "pt-BR": {
@@ -91928,6 +94636,12 @@
       "comment": "Label for a high-detail offline map download.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표준"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -91982,7 +94696,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시작"
           }
         },
@@ -92078,7 +94792,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "스캔 시작"
           }
         },
@@ -92118,6 +94832,12 @@
       "comment": "A button that starts a flyover over the trace route.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 둘러보기 시작"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -92162,7 +94882,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "상태"
           }
         },
@@ -92200,6 +94920,12 @@
     },
     "Static": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -92216,6 +94942,12 @@
     },
     "Static IPv4 Configuration": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고정 IPv4 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -92264,7 +94996,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "상태"
           }
         },
@@ -92302,6 +95034,12 @@
     },
     "Status Message": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상태 메시지"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -92320,6 +95058,12 @@
       "comment": "The title of the screen that allows the user to configure the status message that is broadcast to other nodes.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상태 메시지 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -92370,8 +95114,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "1단계: 기기를 연결하세요"
+            "state": "translated",
+            "value": "1단계: 기기 연결"
           }
         },
         "pt-BR": {
@@ -92442,8 +95186,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "2단계: 파일을 저장하세요"
+            "state": "translated",
+            "value": "2단계: 파일 저장"
           }
         },
         "pt-BR": {
@@ -92514,8 +95258,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스캔 중단"
+            "state": "translated",
+            "value": "스캔 중지"
           }
         },
         "pt-BR": {
@@ -92554,6 +95298,12 @@
       "comment": "A button that stops a flyover.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 둘러보기 중지"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -92602,7 +95352,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "스토어 & 포워드"
           }
         },
@@ -92690,7 +95440,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "스토어 & 포워드 설정"
           }
         },
@@ -92739,7 +95489,15 @@
       }
     },
     "Store and forward message": {
-      "comment": "VoiceOver label for the store-and-forward badge"
+      "comment": "VoiceOver label for the store-and-forward badge",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스토어 & 포워드 메시지"
+          }
+        }
+      }
     },
     "Store and forward servers require an ESP32 device with PSRAM or Linux Native.": {
       "localizations": {
@@ -92781,8 +95539,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "ESP32 장치에 PSRAM 또는 Linux Native가 필요합니다."
+            "state": "translated",
+            "value": "스토어 & 포워드 서버는 PSRAM이 탑재된 ESP32 장치 또는 Linux Native가 필요합니다."
           }
         },
         "pt-BR": {
@@ -92830,16 +95588,46 @@
       }
     },
     "Strict ignores every remote mesh packet that is not cryptographically authenticated. Older firmware, licensed or ham nodes without PKI keys, and oversized packets may disappear. PKI-authenticated direct messages remain available.": {
-      "comment": "Warning shown before enabling the Strict packet authenticity policy."
+      "comment": "Warning shown before enabling the Strict packet authenticity policy.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "엄격 모드는 암호학적으로 인증되지 않은 모든 원격 메시 패킷을 무시합니다. 오래된 펌웨어, PKI 키가 없는 허가 사용자 또는 아마추어 무선 노드, 크기가 큰 패킷은 표시되지 않을 수 있습니다. PKI 인증된 직접 메시지는 계속 사용할 수 있습니다."
+          }
+        }
+      }
     },
     "Strict — Require authentication": {
-      "comment": "Strict packet authenticity policy option."
+      "comment": "Strict packet authenticity policy option.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "엄격 — 인증 필요"
+          }
+        }
+      }
     },
     "Strikethrough": {
-      "comment": "VoiceOver: strikethrough formatting toolbar button"
+      "comment": "VoiceOver: strikethrough formatting toolbar button",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소선"
+          }
+        }
+      }
     },
     "Subnet": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서브넷"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -92900,7 +95688,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "구독됨"
           }
         },
@@ -92988,8 +95776,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Meshtastic를 %2$lld개의 오버레이와 함께 성공적으로 업로드했습니다."
+            "state": "translated",
+            "value": "'%1$@'을(를) %2$lld개의 오버레이와 함께 성공적으로 업로드했습니다"
           }
         },
         "pt-BR": {
@@ -93076,7 +95864,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지원됨"
           }
         },
@@ -93164,8 +95952,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지원되는 I2C 연결 센서는 자동으로 감지됩니다. 센서는 BMP280, BME280, BME680, MCP9808, INA219, INA260, LPS22 및 SHTC3입니다."
+            "state": "translated",
+            "value": "지원되는 I2C 연결 센서는 자동으로 감지됩니다. 지원 센서는 BMP280, BME280, BME680, MCP9808, INA219, INA260, LPS22 및 SHTC3입니다."
           }
         },
         "pt-BR": {
@@ -93246,6 +96034,12 @@
             "value": "左にスワイプして切断します。長押ししてライブアクティビティを開始します。"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왼쪽으로 스와이프하여 연결을 해제합니다. 길게 눌러 실시간 현황을 표시합니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -93274,6 +96068,12 @@
     },
     "Switching Radio": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드 전환 중"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -93328,7 +96128,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "TAK"
           }
         },
@@ -93412,8 +96212,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "타크는 공개 채널에서 사용할 수 없습니다."
+            "state": "translated",
+            "value": "TAK은 공개 채널에서 사용할 수 없습니다."
           }
         },
         "pt-BR": {
@@ -93484,7 +96284,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "TAK 채널 인덱스"
           }
         },
@@ -93556,8 +96356,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 구성"
+            "state": "translated",
+            "value": "TAK 설정"
           }
         },
         "pt-BR": {
@@ -93628,8 +96428,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 인증"
+            "state": "translated",
+            "value": "TAK 식별 정보"
           }
         },
         "pt-BR": {
@@ -93698,7 +96498,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "TAK 서버"
           }
         },
@@ -93768,7 +96568,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "TLS 인증서"
           }
         },
@@ -93844,8 +96644,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TLS가 활성화되었습니다."
+            "state": "translated",
+            "value": "TLS 활성화됨"
           }
         },
         "pt-BR": {
@@ -93926,8 +96726,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "공개 Meshtastic MQTT 서버에는 TLS가 필요합니다."
+            "state": "translated",
+            "value": "공개 Meshtastic MQTT 서버를 사용하려면 TLS가 필요합니다."
           }
         },
         "pt-BR": {
@@ -93998,8 +96798,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "리스트가 비어 있습니다"
+            "state": "translated",
+            "value": "목록이 비어 있습니다"
           }
         },
         "pt-BR": {
@@ -94034,9 +96834,36 @@
         }
       }
     },
-    "Tag does not support NDEF.": {},
-    "Tag is read-only.": {},
-    "Tag too small to hold this data.": {},
+    "Tag does not support NDEF.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그가 NDEF를 지원하지 않습니다."
+          }
+        }
+      }
+    },
+    "Tag is read-only.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그가 읽기 전용입니다."
+          }
+        }
+      }
+    },
+    "Tag too small to hold this data.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "태그 용량이 부족하여 이 데이터를 저장할 수 없습니다."
+          }
+        }
+      }
+    },
     "Takes a Meshtastic channel URL and saves the channel settings.": {
       "localizations": {
         "da": {
@@ -94077,8 +96904,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시틱 채널 URL를 가져와 채널 설정을 저장합니다."
+            "state": "translated",
+            "value": "Meshtastic 채널 URL을 가져와 채널 설정을 저장합니다."
           }
         },
         "pt-BR": {
@@ -94159,8 +96986,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬틱 연락처 URL을 노드 데이터베이스에 저장합니다."
+            "state": "translated",
+            "value": "Meshtastic 연락처 URL을 가져와 노드 데이터베이스에 저장합니다."
           }
         },
         "pt-BR": {
@@ -94241,8 +97068,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "아이콘을 탭하여 입력하세요"
+            "state": "translated",
+            "value": "탭하여 이모지를 입력합니다"
           }
         },
         "pt-BR": {
@@ -94284,7 +97111,15 @@
       }
     },
     "Tap to jump or swipe down to crouch": {
-      "comment": "VoiceOver hint for the Chirpy game controls"
+      "comment": "VoiceOver hint for the Chirpy game controls",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭하여 점프하거나 아래로 스와이프하여 웅크립니다"
+          }
+        }
+      }
     },
     "Tapback": {
       "localizations": {
@@ -94332,8 +97167,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "타프백"
+            "state": "translated",
+            "value": "Tapback"
           }
         },
         "pl": {
@@ -94428,7 +97263,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "팀"
           }
         },
@@ -94510,8 +97345,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "테레미트리"
+            "state": "translated",
+            "value": "텔레메트리"
           }
         },
         "pl": {
@@ -94616,8 +97451,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "테레미터 설정"
+            "state": "translated",
+            "value": "텔레메트리 설정"
           }
         },
         "pl": {
@@ -94716,7 +97551,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "온도"
           }
         },
@@ -94765,7 +97600,15 @@
       }
     },
     "Temperature at %@": {
-      "comment": "VoiceOver label for a temperature point on the weather forecast chart. %@ is the time of day."
+      "comment": "VoiceOver label for a temperature point on the weather forecast chart. %@ is the time of day.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 온도"
+          }
+        }
+      }
     },
     "Ten Minutes": {
       "localizations": {
@@ -94813,7 +97656,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "10분"
           }
         },
@@ -94913,8 +97756,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "세미관리자 키"
+            "state": "translated",
+            "value": "3차 관리자 키"
           }
         },
         "pt-BR": {
@@ -94997,7 +97840,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "메시지 수"
           }
         },
@@ -95067,8 +97910,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "웹 플래시러는 이 기기나 USB, BLE를 통해 업데이트를 지원하지 않습니다."
+            "state": "translated",
+            "value": "이 기기에서는 **Web Flasher**를 사용하거나 USB 또는 BLE를 통한 업데이트를 지원하지 않습니다."
           }
         },
         "pt-BR": {
@@ -95137,8 +97980,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "모든 가능한 노드 데이터를 표시하는 완전한 레이아웃입니다. 데이터가 없는 필드는 자동으로 숨겨집니다."
+            "state": "translated",
+            "value": "전체 레이아웃은 사용 가능한 모든 노드 데이터를 표시합니다. 데이터가 없는 필드는 자동으로 숨겨집니다."
           }
         },
         "pt-BR": {
@@ -95209,8 +98052,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시틱 애플 앱은 %@ 또는 더 높은 버전의 시리얼러를 요구합니다. 오래된 시리얼러 버전은 더 이상 지원되지 않으며 호환성 문제나 기능 누락이 발생할 수 있습니다."
+            "state": "translated",
+            "value": "Meshtastic Apple 앱은 %@ 이상의 펌웨어 버전이 필요합니다. 이전 펌웨어 버전은 더 이상 지원되지 않으며 호환성 문제나 일부 기능 누락이 발생할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -95285,7 +98128,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "채널 설정 URL"
           }
         },
@@ -95367,7 +98210,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "추가할 노드의 URL"
           }
         },
@@ -95455,8 +98298,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "포켓이 완료될 때까지 기다릴 시간"
+            "state": "translated",
+            "value": "패킷이 완료된 것으로 간주하기 전까지 기다리는 시간입니다."
           }
         },
         "pt-BR": {
@@ -95505,6 +98348,12 @@
     },
     "The audio sample rate to use for Codec2. Lower bitrates use less bandwidth but reduce audio quality.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codec2에서 사용할 오디오 샘플링 레이트입니다. 낮은 비트레이트는 대역폭을 적게 사용하지만 음질이 저하됩니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -95555,8 +98404,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널은 128 또는 256비트 AES 키로 암호화됩니다."
+            "state": "translated",
+            "value": "채널은 128비트 또는 256비트 AES 키로 암호화되어 있습니다."
           }
         },
         "pt-BR": {
@@ -95627,8 +98476,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널은 암호화되지 않고 정확한 위치 데이터를 위해 사용됩니다."
+            "state": "translated",
+            "value": "채널은 안전하게 암호화되어 있지 않으며, 정밀 위치 데이터에 사용됩니다."
           }
         },
         "pt-BR": {
@@ -95699,8 +98548,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "채널은 암호화되지 않고 정확한 위치 데이터가 MQTT를 통해 인터넷으로 업로드되고 있습니다."
+            "state": "translated",
+            "value": "채널은 안전하게 암호화되어 있지 않으며, 정밀 위치 데이터가 MQTT를 통해 인터넷으로 전송되고 있습니다."
           }
         },
         "pt-BR": {
@@ -95771,8 +98620,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "키가 없거나 1바이트의 알려진 키를 사용하지만 정확한 위치 데이터는 아닙니다."
+            "state": "translated",
+            "value": "채널은 키를 사용하지 않거나 알려진 1바이트 키를 사용하지만, 정밀 위치 데이터에는 사용되지 않습니다."
           }
         },
         "pt-BR": {
@@ -95847,8 +98696,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스크린 밖의 원형에서 나침반 방향이 항상 북쪽으로 향합니다."
+            "state": "translated",
+            "value": "원 바깥쪽 화면의 나침반 방향은 항상 북쪽을 가리킵니다."
           }
         },
         "pt-BR": {
@@ -95935,8 +98784,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "현재 습도는 %@입니다."
+            "state": "translated",
+            "value": "현재 이슬점은 %@입니다."
           }
         },
         "pt-BR": {
@@ -96019,8 +98868,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "문서 패키지가 로드되지 않았습니다."
+            "state": "translated",
+            "value": "문서 번들을 불러올 수 없습니다."
           }
         },
         "pt-BR": {
@@ -96095,8 +98944,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "최소 거리 조건이 충족되면 가장 빠른 위치 업데이트가 전송됩니다."
+            "state": "translated",
+            "value": "최소 거리 조건이 충족된 경우 위치 업데이트를 전송하는 가장 짧은 간격입니다."
           }
         },
         "pt-BR": {
@@ -96177,8 +99026,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "완성 레이아웃의 선형 막대는 전체 신호 품질을 빨간색(신호 없음)에서 주황색, 노란색, 녹색(좋은 신호)까지 보여줍니다. SNR과 RSSI를 모뎀 기본 설정에 대해 결합합니다."
+            "state": "translated",
+            "value": "전체 레이아웃의 그라데이션 막대는 빨간색(신호 없음)부터 주황색, 노란색을 거쳐 녹색(좋은 신호)까지 전체 신호 품질을 표시합니다. 모뎀 프리셋을 기준으로 SNR과 RSSI를 결합하여 표시합니다."
           }
         },
         "pt-BR": {
@@ -96253,8 +99102,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치의 MAC 주소 마지막 4자리(4바이트)를 짧은 이름으로 추가하여 장치가 BLE 이름(Short Name)을 설정합니다. 짧은 이름은 최대 4바이트(4자리)입니다."
+            "state": "translated",
+            "value": "장치의 BLE 이름을 설정하기 위해 MAC 주소의 마지막 4자리가 짧은 이름 뒤에 추가됩니다. 짧은 이름은 최대 4바이트까지 가능합니다."
           }
         },
         "pt-BR": {
@@ -96341,8 +99190,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드에서 위치 방송이 이루어지지 않는 최대 시간 간격"
+            "state": "translated",
+            "value": "노드가 위치를 브로드캐스트하지 않고 경과할 수 있는 최대 간격"
           }
         },
         "pt-BR": {
@@ -96429,8 +99278,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "스마트 위치 방송에 대한 최소 거리 변화(미터)"
+            "state": "translated",
+            "value": "스마트 위치 브로드캐스트에 반영할 최소 거리 변화(미터)"
           }
         },
         "pt-BR": {
@@ -96513,8 +99362,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 노드의 최신 공개 키는 이전에 기록된 키와 일치하지 않습니다. 직접 또는 전화로 상대방에게 공개 키를 비교하여 누가 메시지를 보내고 있는지 확인하세요."
+            "state": "translated",
+            "value": "이 노드의 최신 공개 키가 이전에 기록된 키와 일치하지 않습니다. 직접 만나거나 전화로 공개 키를 비교하여 메시지를 주고받는 상대를 확인하세요."
           }
         },
         "pt-BR": {
@@ -96583,6 +99432,12 @@
             "value": "最近、ノードが聞こえており、オンラインとみなされています。"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드가 최근에 확인되었으며 온라인 상태로 간주됩니다."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -96645,6 +99500,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "最近、ノードは音を聞かれていないため、眠っているか、範囲外にある可能性があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노드가 최근에 확인되지 않았으며, 절전 상태이거나 범위를 벗어났을 수 있습니다."
           }
         },
         "pt-BR": {
@@ -96713,8 +99574,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "당신과 이 노드 사이의 중간 노드 수입니다. 횟수가 없으면 직접 통신입니다."
+            "state": "translated",
+            "value": "사용자와 이 노드 사이에서 메시지를 중계하는 중간 노드의 수입니다. 홉이 없으면 직접 통신입니다."
           }
         },
         "pt-BR": {
@@ -96783,8 +99644,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "숫자 표시된 원은 노드가 사용하는 채널을 나타냅니다. 기본 채널 0이 아닌 보조 채널에서만 표시됩니다."
+            "state": "translated",
+            "value": "숫자가 표시된 원은 노드가 사용하는 채널을 나타냅니다. 기본 채널 0이 아닌 보조 채널을 사용할 때만 표시됩니다."
           }
         },
         "pt-BR": {
@@ -96856,8 +99717,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "주요 채널은 방송 트래픽을 처리합니다. 별도의 메시징 그룹을 위한 보조 채널을 추가하여 각 채널은 자체 키로 보호됩니다. [더 알아보기](https://meshtastic.org/docs/configuration/tips/)"
+            "state": "translated",
+            "value": "기본 채널은 브로드캐스트 트래픽을 처리합니다. 별도의 메시지 그룹을 위한 보조 채널을 추가할 수 있으며, 각 채널은 자체 키로 보호됩니다. [자세히 알아보기](https://meshtastic.org/docs/configuration/tips/)"
           }
         },
         "pt-BR": {
@@ -96896,6 +99757,12 @@
       "comment": "A description of the channels screen.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 채널은 브로드캐스트 트래픽을 처리합니다. 위치 아이콘은 내 위치를 전송하는 채널을 나타내며, 구름 아이콘은 MQTT 업링크 및 다운링크를 표시합니다. 별도의 메시지 그룹을 위한 보조 채널을 추가할 수 있습니다. [자세히 알아보기](https://meshtastic.org/docs/configuration/tips/)"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -96941,8 +99808,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 키를 사용하여 주파수 스캔을 수행해야 합니다."
+            "state": "translated",
+            "value": "탐색 스캔을 수행하려면 기본 채널에서 기본 키를 사용해야 합니다."
           }
         },
         "pt-BR": {
@@ -97017,8 +99884,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 노드에 대한 관리 메시지를 전송할 수 있는 기본 공개 키입니다."
+            "state": "translated",
+            "value": "이 노드에 관리자 메시지를 전송하도록 승인된 기본 공개 키입니다."
           }
         },
         "pt-BR": {
@@ -97099,8 +99966,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "ESP32 장치를 업데이트하는 권장 방법은 데스크톱 컴퓨터(크롬 기반 브라우저)에서 **웹 플래시어**를 사용하는 것입니다."
+            "state": "translated",
+            "value": "ESP32 장치를 업데이트하는 권장 방법은 데스크톱 컴퓨터의 Chrome 기반 브라우저에서 **Web Flasher**를 사용하는 것입니다."
           }
         },
         "pt-BR": {
@@ -97139,6 +100006,12 @@
       "comment": "A warning that the noise floor is not a hard failure threshold.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빨간색 기준선은 혼잡한 환경에서의 -85 dBm 기준선을 나타내며, 절대적인 실패 임계값이 아닙니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -97193,8 +100066,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "무선기를 사용할 지역입니다."
+            "state": "translated",
+            "value": "장치를 사용할 지역입니다."
           }
         },
         "pt-BR": {
@@ -97281,8 +100154,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "MQTT의 기본 주제는 <<<입니다.>>>"
+            "state": "translated",
+            "value": "MQTT에서 사용할 루트 토픽입니다."
           }
         },
         "pt-BR": {
@@ -97369,8 +100242,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 노드에 대한 관리 메시지를 보내는 데 사용될 두 번째 공개 키입니다."
+            "state": "translated",
+            "value": "이 노드에 관리자 메시지를 전송하도록 승인된 보조 공개 키입니다."
           }
         },
         "pt-BR": {
@@ -97457,8 +100330,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "LED 상태 (켜기/끄기)"
+            "state": "translated",
+            "value": "LED 상태 (켜짐/꺼짐)"
           }
         },
         "pt-BR": {
@@ -97539,8 +100412,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 노드에 대한 관리 메시지를 보내는 데 사용될 세 번째 공개 키입니다."
+            "state": "translated",
+            "value": "이 노드에 관리자 메시지를 전송하도록 승인된 3차 공개 키입니다."
           }
         },
         "pt-BR": {
@@ -97621,8 +100494,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "PKC 관리자에서 이 노드에 대한 장치 메타데이터 요청에 대한 응답이 없습니다."
+            "state": "translated",
+            "value": "PKC 관리자를 통한 이 노드의 장치 메타데이터 요청에 대한 응답이 없습니다."
           }
         },
         "pt-BR": {
@@ -97703,7 +100576,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "이 연락처의 공개 키에 문제가 있습니다."
           }
         },
@@ -97785,8 +100658,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 설정은 TAK 또는 TAK Tracker 역할에서만 적용됩니다."
+            "state": "translated",
+            "value": "이 설정은 장치 역할이 TAK 또는 TAK Tracker인 경우에만 적용됩니다."
           }
         },
         "pt-BR": {
@@ -97857,8 +100730,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 설정은 %@를 %@합니다."
+            "state": "translated",
+            "value": "이 설정은 %@합니다."
           }
         },
         "pt-BR": {
@@ -97935,8 +100808,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 위치 보고서에 포함된 값입니다. 기본값으로 두 설정을 유지하면 로컬 및 팀원이 사용하도록 하세요."
+            "state": "translated",
+            "value": "이 값은 TAK 위치 보고서에 포함됩니다. 펌웨어가 Cyan 및 Team Member를 사용하도록 하려면 설정을 기본값으로 유지하세요."
           }
         },
         "pt-BR": {
@@ -98005,8 +100878,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "생각 중입니다."
+            "state": "translated",
+            "value": "생각 중…"
           }
         },
         "pt-BR": {
@@ -98087,8 +100960,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "세십분"
+            "state": "translated",
+            "value": "30분"
           }
         },
         "pl": {
@@ -98154,7 +101027,15 @@
       "comment": "Validation message shown when the configured LoRa bandwidth is incompatible with the selected region or radio."
     },
     "This connected device does not support packet signature verification.": {
-      "comment": "Summary shown when the connected radio lacks XEdDSA packet signature verification."
+      "comment": "Summary shown when the connected radio lacks XEdDSA packet signature verification.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 장치는 패킷 서명 검증을 지원하지 않습니다."
+          }
+        }
+      }
     },
     "This conversation will be deleted.": {
       "localizations": {
@@ -98196,7 +101077,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "이 대화는 삭제됩니다."
           }
         },
@@ -98284,8 +101165,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 작업은 시간이 걸릴 수 있으며, 응답은 전송된 노드에 대한 트래스 루트 로그에 나타날 것입니다."
+            "state": "translated",
+            "value": "시간이 걸릴 수 있습니다. 응답은 전송 대상 노드의 경로 추적 로그에 표시됩니다."
           }
         },
         "pt-BR": {
@@ -98333,10 +101214,26 @@
       }
     },
     "This device has not reported whether it supports packet signature verification. Update its firmware to configure this setting.": {
-      "comment": "Note shown when a radio has not reported its packet signature verification capability."
+      "comment": "Note shown when a radio has not reported its packet signature verification capability.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 장치는 패킷 서명 검증 지원 여부를 보고하지 않았습니다. 이 설정을 구성하려면 펌웨어를 업데이트하세요."
+          }
+        }
+      }
     },
     "This device reported a packet authenticity policy that this app version does not recognize.": {
-      "comment": "Description shown for an unrecognized packet authenticity policy."
+      "comment": "Description shown for an unrecognized packet authenticity policy.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 장치는 현재 앱 버전에서 인식할 수 없는 패킷 인증 정책을 보고했습니다."
+          }
+        }
+      }
     },
     "This device will send out range test messages on the selected interval.": {
       "localizations": {
@@ -98378,8 +101275,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 장치는 선택된 간격에 범위 테스트 메시지를 전송합니다."
+            "state": "translated",
+            "value": "이 장치는 선택한 간격으로 거리 테스트 메시지를 전송합니다."
           }
         },
         "pt-BR": {
@@ -98430,6 +101327,12 @@
       "comment": "A description of an error that might occur when downloading a map. The argument is the size limit, formatted in bytes.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 지도는 지도당 제한 크기 %@보다 큽니다. 확대하거나 세부 수준을 낮추세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -98478,8 +101381,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 메시지는 전달되지 않았을 가능성이 큽니다."
+            "state": "translated",
+            "value": "이 메시지는 전달되지 않았을 가능성이 높습니다."
           }
         },
         "pt-BR": {
@@ -98564,6 +101467,12 @@
             "value": "このノードは設定可能なモジュールをサポートしていません。"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 노드는 설정 가능한 모듈을 지원하지 않습니다."
+          }
+        },
         "pt-BR": {
           "stringUnit": {
             "state": "needs_review",
@@ -98608,7 +101517,16 @@
         }
       }
     },
-    "This tag doesn't hold a Meshtastic contact or channel link.": {},
+    "This tag doesn't hold a Meshtastic contact or channel link.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 태그에는 Meshtastic 연락처 또는 채널 링크가 포함되어 있지 않습니다."
+          }
+        }
+      }
+    },
     "This tool scans your local area to find nearby Meshtastic radios on different frequency settings. It switches between settings automatically, listens for a few minutes on each one, and then shows you which setting works best for your location based on how many radios it finds and how busy the airwaves are. On supported devices, local on-device AI will analyze your scan results and recommend the best setting — no internet connection required.": {
       "comment": "A description of the functionality of the discovery scan tool.",
       "isCommentAutoGenerated": true,
@@ -98645,8 +101563,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 도구는 귀하의 지역 주변 Meshtastic 라디오를 다양한 주파수 설정에서 찾아 자동으로 설정 전환, 각 설정에서 몇 분 동안 수신, 그리고 라디오 수와 무선 대역의 혼잡도에 따라 귀하의 위치에서 가장 적합한 설정이 무엇인지 표시합니다. 지원되는 장치에서는 로컬 장치 AI가 스캔 결과를 분석하고 인터넷 연결 없이 최상의 설정을 추천합니다."
+            "state": "translated",
+            "value": "이 도구는 주변 지역을 스캔하여 서로 다른 주파수 설정을 사용하는 가까운 Meshtastic 노드를 찾습니다. 설정을 자동으로 전환하고 각 설정에서 몇 분간 수신한 뒤, 발견된 노드 수와 무선 대역의 혼잡도를 바탕으로 현재 위치에 가장 적합한 설정을 보여줍니다. 지원되는 장치에서는 온디바이스 AI가 스캔 결과를 로컬에서 분석하여 최적의 설정을 추천하며, 인터넷 연결은 필요하지 않습니다."
           }
         },
         "pt-BR": {
@@ -98717,8 +101635,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이것이 당신의 기본 채널을 변경합니다: \n• 이름: TAK \n• 암호화: 새로운 256비트 AES 키 \n• LoRa 설정: 짧은 빠른 (TAK 권장) \n\n이것이 TAK 서버가 제대로 작동하려면 필요합니다. 기존 채널 공유 링크는 유효하지 않습니다."
+            "state": "translated",
+            "value": "기본 채널이 다음과 같이 변경됩니다:\n• 이름: TAK\n• 암호화: 새로운 256비트 AES 키\n• LoRa 프리셋: Short Fast (TAK 권장)\n\nTAK Server가 정상적으로 작동하려면 이 설정이 필요합니다. 기존 채널 공유 링크는 모두 유효하지 않게 됩니다."
           }
         },
         "pt-BR": {
@@ -98793,8 +101711,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이것으로 고정된 위치를 비활성화하고 현재 설정된 위치를 제거합니다."
+            "state": "translated",
+            "value": "고정 위치가 비활성화되고 현재 설정된 위치가 제거됩니다."
           }
         },
         "pt-BR": {
@@ -98851,6 +101769,12 @@
             "value": "This will permanently delete the backup for %1$@ and free %2$@ of storage."
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@의 백업이 영구적으로 삭제되고 저장 공간 %2$@가 확보됩니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -98899,8 +101823,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이동 상태를 휴대폰에서 전송하고 고정된 위치를 활성화합니다."
+            "state": "translated",
+            "value": "휴대폰의 현재 위치를 전송하고 고정 위치를 활성화합니다."
           }
         },
         "pt-BR": {
@@ -98949,6 +101873,12 @@
     },
     "This would exceed the %@ total offline storage limit. Remove a map first.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 오프라인 저장 공간 제한 %@를 초과합니다. 먼저 지도를 하나 제거하세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -98959,6 +101889,12 @@
     },
     "Threshold": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "임계값"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -99013,7 +101949,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시간"
           }
         },
@@ -99097,7 +102033,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "남은 시간"
           }
         },
@@ -99173,8 +102109,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시간표"
+            "state": "translated",
+            "value": "타임스탬프"
           }
         },
         "pt-BR": {
@@ -99261,7 +102197,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시간대"
           }
         },
@@ -99311,6 +102247,12 @@
     },
     "Time window in seconds for rate limiting calculations.": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "속도 제한 계산에 사용할 시간 구간(초)입니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -99365,8 +102307,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치의 화면과 로그에서 표시되는 날짜의 시간대"
+            "state": "translated",
+            "value": "장치 화면과 로그에 표시되는 날짜 및 시간에 사용할 시간대입니다."
           }
         },
         "pt-BR": {
@@ -99459,7 +102401,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "시간 초과"
           }
         },
@@ -99565,8 +102507,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시작 시간"
+            "state": "translated",
+            "value": "타임스탬프"
           }
         },
         "pl": {
@@ -99627,6 +102569,12 @@
     },
     "Timestamps": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "타임스탬프"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -99675,8 +102623,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "시작 시간 및 우선순위"
+            "state": "translated",
+            "value": "타이밍 및 재정의"
           }
         },
         "pt-BR": {
@@ -99757,8 +102705,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "무선(TX): %lld"
+            "state": "translated",
+            "value": "노드로 전송(TX): %lld"
           }
         },
         "pt-BR": {
@@ -99845,8 +102793,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "CCPA와 GDPR와 같은 개인정보 보호 법규를 준수하기 위해, 정확한 위치 데이터를 공유하지 않습니다. 대신, 익명화되거나 대략적인(불확실) 위치 정보를 사용하여 귀하의 개인정보를 보호합니다."
+            "state": "translated",
+            "value": "CCPA 및 GDPR과 같은 개인정보 보호 법규를 준수하기 위해 정확한 위치 데이터를 공유하지 않습니다. 대신 개인정보 보호를 위해 익명화되거나 대략적인(부정확한) 위치 정보를 사용합니다."
           }
         },
         "pt-BR": {
@@ -99929,8 +102877,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 레이블을 전환합니다."
+            "state": "translated",
+            "value": "지도 범례를 전환합니다."
           }
         },
         "pt-BR": {
@@ -99999,7 +102947,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "도구"
           }
         },
@@ -100036,10 +102984,26 @@
       }
     },
     "Top leading corner handle": {
-      "comment": "VoiceOver label for the geofence/region rectangle's top leading resize handle"
+      "comment": "VoiceOver label for the geofence/region rectangle's top leading resize handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왼쪽 위 모서리 조절 핸들"
+          }
+        }
+      }
     },
     "Top trailing corner handle": {
-      "comment": "VoiceOver label for the geofence/region rectangle's top trailing resize handle"
+      "comment": "VoiceOver label for the geofence/region rectangle's top trailing resize handle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오른쪽 위 모서리 조절 핸들"
+          }
+        }
+      }
     },
     "Total": {
       "localizations": {
@@ -100081,7 +103045,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "총계"
           }
         },
@@ -100133,6 +103097,12 @@
       "comment": "A label displayed above the total storage usage of all node backups.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백업 저장 공간 총계"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -100183,8 +103153,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "탐색 세션의 총 대기 시간"
+            "state": "translated",
+            "value": "탐색 세션의 총 유지 시간"
           }
         },
         "pt-BR": {
@@ -100259,8 +103229,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "총 탑승자"
+            "state": "translated",
+            "value": "총 인원"
           }
         },
         "pt-BR": {
@@ -100314,7 +103284,15 @@
       }
     },
     "Total PAX at %@": {
-      "comment": "VoiceOver label for a total PAX point on the PAX counter chart. %@ is the timestamp."
+      "comment": "VoiceOver label for a total PAX point on the PAX counter chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 총 인원"
+          }
+        }
+      }
     },
     "Total Unique Nodes": {
       "comment": "A label for the total number of unique nodes found during a scan.",
@@ -100352,7 +103330,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "총 고유 노드 수"
           }
         },
@@ -100428,8 +103406,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래스 루트"
+            "state": "translated",
+            "value": "경로 추적"
           }
         },
         "pt-BR": {
@@ -100510,8 +103488,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래스 루트(%@s)"
+            "state": "translated",
+            "value": "경로 추적(%@초)"
           }
         },
         "pt-BR": {
@@ -100598,8 +103576,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래스 루트 로그"
+            "state": "translated",
+            "value": "경로 추적 로그"
           }
         },
         "pt-BR": {
@@ -100686,8 +103664,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래스 루트 전송"
+            "state": "translated",
+            "value": "경로 추적 전송됨"
           }
         },
         "pt-BR": {
@@ -100774,8 +103752,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래스 루트는 제한되었습니다. 최대 30초마다 한 번만 트래스 루트를 보낼 수 있습니다."
+            "state": "translated",
+            "value": "경로 추적 요청이 제한되었습니다. 경로 추적은 30초마다 최대 한 번만 보낼 수 있습니다."
           }
         },
         "pt-BR": {
@@ -100832,6 +103810,12 @@
             "value": "Trace Route: %1$@ → %2$@"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 추적: %1$@ → %2$@"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -100874,8 +103858,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래킹 루트 보기"
+            "state": "translated",
+            "value": "경로 추적"
           }
         },
         "pt-BR": {
@@ -100950,8 +103934,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래스 루트 전송: %@"
+            "state": "translated",
+            "value": "%@에 경로 추적 요청을 전송했습니다."
           }
         },
         "pt-BR": {
@@ -101038,8 +104022,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메시스트릭스 트래스 루트를 %@로 전송되지 않았습니다."
+            "state": "translated",
+            "value": "%@으로 경로 추적 요청을 보내지 못했습니다."
           }
         },
         "pt-BR": {
@@ -101115,7 +104099,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "위치 추적 및 공유"
           }
         },
@@ -101197,8 +104181,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "교통"
+            "state": "translated",
+            "value": "트래픽"
           }
         },
         "pt-BR": {
@@ -101247,6 +104231,12 @@
     },
     "Traffic Management": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "트래픽 관리"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -101263,6 +104253,12 @@
     },
     "Traffic Management Config": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "트래픽 관리 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -101313,7 +104309,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "번역"
           }
         },
@@ -101351,6 +104347,12 @@
     },
     "Translate Documentation": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문서 번역"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -101401,8 +104403,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "번역 중입니다..."
+            "state": "translated",
+            "value": "번역 중..."
           }
         },
         "pt-BR": {
@@ -101471,8 +104473,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "번역 중입니다..."
+            "state": "translated",
+            "value": "번역 진행 중..."
           }
         },
         "pt-BR": {
@@ -101547,8 +104549,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "전송이 가능합니다"
+            "state": "translated",
+            "value": "송신 활성화"
           }
         },
         "pt-BR": {
@@ -101635,8 +104637,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "데이터를 전송하는 GPIO 핀"
+            "state": "translated",
+            "value": "송신 데이터(TXD) GPIO 핀"
           }
         },
         "pt-BR": {
@@ -101687,6 +104689,12 @@
       "comment": "A toggle that enables or disables transmitting neighbor info over LoRa.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LoRa를 통한 송신"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -101741,8 +104749,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "두 개의 가속도 센서를 지원하는 경우, 두 번 탭하여 사용자 버튼을 눌러주세요."
+            "state": "translated",
+            "value": "지원되는 가속도 센서의 두 번 탭을 사용자 버튼 누름으로 처리합니다."
           }
         },
         "pt-BR": {
@@ -101829,8 +104837,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래거타입"
+            "state": "translated",
+            "value": "트리거 유형"
           }
         },
         "pt-BR": {
@@ -101917,8 +104925,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "삼중 클릭 위성 간 연결 Ping"
+            "state": "translated",
+            "value": "세 번 클릭하여 수동 핑"
           }
         },
         "pt-BR": {
@@ -102001,8 +105009,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "true"
+            "state": "translated",
+            "value": "예"
           }
         },
         "pt-BR": {
@@ -102077,8 +105085,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다시 시도하세요"
+            "state": "translated",
+            "value": "다시 시도"
           }
         },
         "pt-BR": {
@@ -102126,7 +105134,15 @@
       }
     },
     "Turn on Bluetooth in Settings to see nearby radios.": {
-      "comment": "Connect tab: subtitle shown in Available Radios when the BLE transport reports Bluetooth is powered off (#2175)"
+      "comment": "Connect tab: subtitle shown in Available Radios when the BLE transport reports Bluetooth is powered off (#2175)",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "근처 노드를 보려면 설정에서 Bluetooth를 켜세요."
+          }
+        }
+      }
     },
     "Two Hours": {
       "localizations": {
@@ -102174,8 +105190,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "두 시간"
+            "state": "translated",
+            "value": "2시간"
           }
         },
         "pl": {
@@ -102270,7 +105286,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "유형"
           }
         },
@@ -102346,8 +105362,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "UDP 방송"
+            "state": "translated",
+            "value": "UDP 브로드캐스트"
           }
         },
         "pt-BR": {
@@ -102430,8 +105446,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "UF2 파일"
+            "state": "translated",
+            "value": "UF2"
           }
         },
         "pt-BR": {
@@ -102502,8 +105518,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "UF2 소프트웨어 업데이트"
+            "state": "translated",
+            "value": "UF2 펌웨어 업데이트"
           }
         },
         "pt-BR": {
@@ -102578,8 +105594,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "좋아요를 취소합니다"
+            "state": "translated",
+            "value": "즐겨찾기 해제"
           }
         },
         "pt-BR": {
@@ -102660,8 +105676,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용 불가"
+            "state": "translated",
+            "value": "사용할 수 없음"
           }
         },
         "pt-BR": {
@@ -102736,8 +105752,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치의 화면에 표시되는 단위"
+            "state": "translated",
+            "value": "장치 화면에 표시되는 단위"
           }
         },
         "pt-BR": {
@@ -102830,7 +105846,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "알 수 없음"
           }
         },
@@ -102936,8 +105952,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알 수 없는 연령"
+            "state": "translated",
+            "value": "경과 시간 알 수 없음"
           }
         },
         "pl": {
@@ -102998,6 +106014,12 @@
     },
     "Unknown Packet Handling": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알 수 없는 패킷 처리"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -103013,7 +106035,15 @@
       }
     },
     "Unknown policy": {
-      "comment": "Fallback title for an unrecognized packet authenticity policy."
+      "comment": "Fallback title for an unrecognized packet authenticity policy.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알 수 없는 정책"
+          }
+        }
+      }
     },
     "Unmessagable": {
       "localizations": {
@@ -103049,8 +106079,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "무시할 수 없습니다"
+            "state": "translated",
+            "value": "메시지 대상 아님"
           }
         },
         "pt-BR": {
@@ -103131,8 +106161,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "무관시"
+            "state": "translated",
+            "value": "모니터링되지 않음"
           }
         },
         "pt-BR": {
@@ -103183,6 +106213,12 @@
       "comment": "A label for a button that unmutes notifications.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음소거 해제"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -103243,8 +106279,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "설정되지 않았습니다."
+            "state": "translated",
+            "value": "설정되지 않음"
           }
         },
         "pl": {
@@ -103343,8 +106379,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지원되지 않습니다."
+            "state": "translated",
+            "value": "지원되지 않음"
           }
         },
         "pt-BR": {
@@ -103391,7 +106427,16 @@
         }
       }
     },
-    "Unsupported tag status.": {},
+    "Unsupported tag status.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지원되지 않는 태그 상태입니다."
+          }
+        }
+      }
+    },
     "Up Down 1": {
       "localizations": {
         "da": {
@@ -103432,8 +106477,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "상하 1"
+            "state": "translated",
+            "value": "위아래 1"
           }
         },
         "pt-BR": {
@@ -103520,8 +106565,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "업데이트 빈도"
+            "state": "translated",
+            "value": "업데이트 간격"
           }
         },
         "pt-BR": {
@@ -103604,8 +106649,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "새로운 Nordic DFU 버전을 플래시할 때 주의하세요."
+            "state": "translated",
+            "value": "업데이트 경고"
           }
         },
         "pt-BR": {
@@ -103686,8 +106731,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "firmware를 업데이트하세요"
+            "state": "translated",
+            "value": "펌웨어를 업데이트하세요"
           }
         },
         "pl": {
@@ -103747,10 +106792,26 @@
       }
     },
     "Update in": {
-      "comment": "VoiceOver: label for the Live Activity countdown timer showing time until the next update"
+      "comment": "VoiceOver: label for the Live Activity countdown timer showing time until the next update",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트까지"
+          }
+        }
+      }
     },
     "Update progress": {
-      "comment": "VoiceOver label for the firmware update progress ring"
+      "comment": "VoiceOver label for the firmware update progress ring",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 진행률"
+          }
+        }
+      }
     },
     "Updated Node Stats Data.": {
       "localizations": {
@@ -103792,8 +106853,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Node Stat Data 업데이트되었습니다."
+            "state": "translated",
+            "value": "노드 통계 데이터를 업데이트했습니다."
           }
         },
         "pt-BR": {
@@ -103881,8 +106942,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "업데이트: %@"
+            "state": "translated",
+            "value": "업데이트됨: %@"
           }
         },
         "pt-BR": {
@@ -103965,8 +107026,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지금 업데이트 중입니다..."
+            "state": "translated",
+            "value": "업데이트 중..."
           }
         },
         "pt-BR": {
@@ -104041,8 +107102,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "업링크 활성화됨"
+            "state": "translated",
+            "value": "업링크 활성화"
           }
         },
         "pt-BR": {
@@ -104123,7 +107184,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "업로드 오류"
           }
         },
@@ -104205,8 +107266,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "개별 지도 오버레이를 표시하기 위해 GeoJSON 파일을 업로드하세요. 파일은 로컬로 저장되며 최대 10MB까지 가능합니다."
+            "state": "translated",
+            "value": "사용자 지정 지도 오버레이를 표시하려면 GeoJSON 파일을 업로드하세요. 파일은 로컬에 저장되며 최대 10MB까지 사용할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -104288,7 +107349,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지도 데이터 업로드"
           }
         },
@@ -104370,7 +107431,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "지도 오버레이 업로드"
           }
         },
@@ -104452,7 +107513,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "업로드 성공"
           }
         },
@@ -104535,8 +107596,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지도 데이터를 업로드하여 오버레이를 활성화하세요"
+            "state": "translated",
+            "value": "오버레이를 활성화하려면 지도 데이터를 업로드하세요"
           }
         },
         "pt-BR": {
@@ -104617,8 +107678,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "장치에서 번역된 문서를 업로드하여 커뮤니티의 번역을 개선하세요. 번역된 문서는 익명으로 공유되므로 다른 사용자들이 즉각적인 번역을 받을 수 있습니다. 장치 모델이 필요하지 않습니다."
+            "state": "translated",
+            "value": "기기에서 번역된 문서를 업로드하여 커뮤니티 번역 개선에 기여하세요. 번역된 문서는 익명으로 공유되며, 다른 사용자는 기기 내 모델 없이도 즉시 번역을 이용할 수 있습니다."
           }
         },
         "pt-BR": {
@@ -104687,7 +107748,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "업로드된 지도 오버레이"
           }
         },
@@ -104775,8 +107836,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "업타임"
+            "state": "translated",
+            "value": "가동 시간"
           }
         },
         "pt-BR": {
@@ -104863,7 +107924,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "사용 및 충돌 데이터"
           }
         },
@@ -104951,8 +108012,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "I2S를 통해 진동기 사용"
+            "state": "translated",
+            "value": "I2S를 버저로 사용"
           }
         },
         "pt-BR": {
@@ -105039,8 +108100,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "PWM Buzzer를 사용하세요."
+            "state": "translated",
+            "value": "PWM 버저 사용"
           }
         },
         "pt-BR": {
@@ -105127,8 +108188,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 설정 사용"
+            "state": "translated",
+            "value": "프리셋 사용"
           }
         },
         "pt-BR": {
@@ -105211,8 +108272,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "주요 채널에 256비트 암호화 키를 사용하세요."
+            "state": "translated",
+            "value": "256비트 암호화 키 사용"
           }
         },
         "pt-BR": {
@@ -105287,8 +108348,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "RAK Buzzer를 사용하여 타임을 위한 PWM 출력을 사용하세요. 이는 출력, 출력 지속 시간 및 활성 설정을 무시하고 장치 구성 buzzer GPIO 옵션을 사용합니다."
+            "state": "translated",
+            "value": "멜로디를 재생할 때 켜기/끄기 출력 대신 PWM 출력(RAK Buzzer 등)을 사용합니다. 이 옵션을 사용하면 출력, 출력 지속 시간 및 활성화 설정은 무시되며, 대신 장치 설정의 버저 GPIO 옵션을 사용합니다."
           }
         },
         "pt-BR": {
@@ -105369,7 +108430,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "내 위치 사용"
           }
         },
@@ -105445,8 +108506,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "휴대폰 GPS를 사용하여 노드에 위치를 전송하세요. 노드에 하드웨어 GPS를 사용하지 마세요."
+            "state": "translated",
+            "value": "노드의 하드웨어 GPS 대신 휴대폰 GPS를 사용하여 위치 정보를 노드로 전송합니다."
           }
         },
         "pt-BR": {
@@ -105533,8 +108594,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "멀티디바이스와 공유키를 생성하기 위해 사용됨."
+            "state": "translated",
+            "value": "원격 장치와 공유 키를 생성하는 데 사용됩니다."
           }
         },
         "pt-BR": {
@@ -105615,8 +108676,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "무인 또는 인프라 노드를 식별하여 메시징이 응답하지 않을 노드에 도달하지 않도록 합니다."
+            "state": "translated",
+            "value": "무인 또는 인프라 노드임을 표시하여 응답하지 않는 노드에는 메시지를 보낼 수 없도록 합니다."
           }
         },
         "pt-BR": {
@@ -105709,7 +108770,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "사용자"
           }
         },
@@ -105809,7 +108870,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "사용자 설정"
           }
         },
@@ -105897,7 +108958,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "사용자 정보"
           }
         },
@@ -105985,7 +109046,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "사용자 ID"
           }
         },
@@ -106067,8 +109128,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 정보 교환 실패했습니다."
+            "state": "translated",
+            "value": "사용자 정보 교환 실패"
           }
         },
         "pt-BR": {
@@ -106143,7 +109204,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "사용자 정보 전송됨"
           }
         },
@@ -106220,8 +109281,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 개인 정보"
+            "state": "translated",
+            "value": "사용자 개인정보 보호"
           }
         },
         "pt-BR": {
@@ -106297,7 +109358,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "사용자 업로드"
           }
         },
@@ -106391,8 +109452,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "닉네임"
+            "state": "translated",
+            "value": "사용자 이름"
           }
         },
         "pl": {
@@ -106491,8 +109552,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "풀업 저항을 사용합니다."
+            "state": "translated",
+            "value": "풀업 저항 사용"
           }
         },
         "pt-BR": {
@@ -106541,6 +109602,12 @@
     },
     "Using your connected device's position": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결된 장치의 위치 사용"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -106595,7 +109662,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "휴대폰의 네트워크 연결을 사용하여 MQTT에 연결합니다."
           }
         },
@@ -106683,8 +109750,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "차량 방향"
+            "state": "translated",
+            "value": "차량 방위"
           }
         },
         "pt-BR": {
@@ -106771,7 +109838,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "차량 속도"
           }
         },
@@ -106820,7 +109887,15 @@
       }
     },
     "Verified": {
-      "comment": "VoiceOver: message signature was cryptographically verified"
+      "comment": "VoiceOver: message signature was cryptographically verified",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검증됨"
+          }
+        }
+      }
     },
     "Verified automatically": {
       "localizations": {
@@ -106828,6 +109903,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verified automatically"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동으로 확인됨"
           }
         },
         "uk": {
@@ -106839,7 +109920,15 @@
       }
     },
     "Verified sender": {
-      "comment": "VoiceOver label for the signed and verified broadcast badge"
+      "comment": "VoiceOver label for the signed and verified broadcast badge",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인된 발신자"
+          }
+        }
+      }
     },
     "Verified with the sender's key.": {
       "localizations": {
@@ -106847,6 +109936,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verified with the sender's key."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "발신자의 키로 확인되었습니다."
           }
         },
         "uk": {
@@ -106891,8 +109986,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "공개 키를 직접 확인하거나 전화로 확인하여 누구와 메시지를 주고받는지 확인하세요. 이 노드의 최신 공개 키는 이전에 기록된 키와 일치하지 않습니다. 제조 재설정이나 의도적인 행위로 인한 키 변경이라면 노드를 삭제하고 키를 다시 교환할 수 있지만, 이는 더 심각한 보안 문제를 나타낼 수도 있습니다."
+            "state": "translated",
+            "value": "공개 키를 직접 만나거나 전화로 비교하여 메시지를 주고받는 상대를 확인하세요. 이 노드의 최신 공개 키가 이전에 기록된 키와 일치하지 않습니다. 키 변경이 초기화나 기타 의도적인 작업으로 인해 발생한 경우 노드를 삭제하고 다시 키를 교환할 수 있지만, 이는 더 심각한 보안 문제를 나타낼 수도 있습니다."
           }
         },
         "pt-BR": {
@@ -106975,8 +110070,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "올바른 시리얼 번호를 선택했는지 확인하세요."
+            "state": "translated",
+            "value": "올바른 펌웨어를 선택했는지 확인하세요."
           }
         },
         "pt-BR": {
@@ -107057,7 +110152,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "버전: %1$@ (%2$@)"
           }
         },
@@ -107145,8 +110240,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Lora를 통해"
+            "state": "translated",
+            "value": "LoRa를 통해"
           }
         },
         "pt-BR": {
@@ -107233,8 +110328,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Mqtt를 통해"
+            "state": "translated",
+            "value": "MQTT를 통해"
           }
         },
         "pt-BR": {
@@ -107317,8 +110412,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "탐색 세션의 전체 요약 보기"
+            "state": "translated",
+            "value": "탐색 세션 전체 요약 보기"
           }
         },
         "pt-BR": {
@@ -107389,7 +110484,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "탐색 세션 요약 보기"
           }
         },
@@ -107426,12 +110521,26 @@
       }
     },
     "View route recording details": {
-      "comment": "VoiceOver label for the route recording button when idle"
+      "comment": "VoiceOver label for the route recording button when idle",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 기록 세부 정보 보기"
+          }
+        }
+      }
     },
     "Visible Range": {
       "comment": "A label that displays the currently selected range of the chart.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표시 범위"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -107492,7 +110601,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "전압"
           }
         },
@@ -107553,7 +110662,15 @@
       }
     },
     "Voltage at %@": {
-      "comment": "VoiceOver label for a voltage point on the power metrics chart. %@ is the timestamp."
+      "comment": "VoiceOver label for a voltage point on the power metrics chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 전압"
+          }
+        }
+      }
     },
     "Volts %@": {
       "localizations": {
@@ -107595,8 +110712,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "볼트 %@"
+            "state": "translated",
+            "value": "%@ 볼트"
           }
         },
         "pt-BR": {
@@ -107689,8 +110806,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "잠시만 기다려 주세요."
+            "state": "translated",
+            "value": "대기 중"
           }
         },
         "pl": {
@@ -107751,6 +110868,12 @@
     },
     "Waiting for packets…": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패킷 대기 중…"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -107805,8 +110928,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "알림 기다리고 있습니다..."
+            "state": "translated",
+            "value": "확인 응답 대기 중..."
           }
         },
         "pt-BR": {
@@ -107893,8 +111016,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "누르거나 움직이면 잠금 화면이 나타납니다."
+            "state": "translated",
+            "value": "탭 또는 움직임으로 화면 깨우기"
           }
         },
         "pt-BR": {
@@ -107977,7 +111100,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "경고"
           }
         },
@@ -108049,8 +111172,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지점"
+            "state": "translated",
+            "value": "웨이포인트"
           }
         },
         "pt-BR": {
@@ -108119,8 +111242,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위성 경로 전송 실패"
+            "state": "translated",
+            "value": "웨이포인트 전송 실패"
           }
         },
         "pt-BR": {
@@ -108207,8 +111330,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위성 옵션"
+            "state": "translated",
+            "value": "웨이포인트 옵션"
           }
         },
         "pt-BR": {
@@ -108289,8 +111412,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "위지점"
+            "state": "translated",
+            "value": "웨이포인트"
           }
         },
         "pt-BR": {
@@ -108371,7 +111494,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "기상 조건"
           }
         },
@@ -108455,8 +111578,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "웹 뷰에서 %@ 문서가 표시됩니다."
+            "state": "translated",
+            "value": "%@ 문서를 표시하는 웹 뷰"
           }
         },
         "pt-BR": {
@@ -108531,7 +111654,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "웹사이트"
           }
         },
@@ -108619,7 +111742,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "무게"
           }
         },
@@ -108704,8 +111827,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬스틱을 환영합니다"
+            "state": "translated",
+            "value": "Meshtastic에 오신 것을 환영합니다"
           }
         },
         "pt-BR": {
@@ -108776,8 +111899,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 도구는 무엇인가요?"
+            "state": "translated",
+            "value": "이 기능은 무엇을 하나요?"
           }
         },
         "pt-BR": {
@@ -108852,8 +111975,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "메쉬스티카란 무엇인가요?"
+            "state": "translated",
+            "value": "Meshtastic이 무엇인가요?"
           }
         },
         "pt-BR": {
@@ -108940,8 +112063,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "허가된 운영 모드는 다음과 같습니다: \n* 노드 이름을 호출기 로컬 ID로 설정합니다.\n* 10분마다 노드 정보를 방송합니다.\n* 주파수, 타이밍, Tx 전력 등을 재정의합니다.\n* 암호화 기능을 비활성화합니다."
+            "state": "translated",
+            "value": "허가된 운영자 모드의 기능:\n* 노드 이름을 자신의 호출 부호로 설정합니다.\n* 10분마다 노드 정보를 브로드캐스트합니다.\n* 주파수, 듀티 사이클 및 송신 전력을 재정의합니다.\n* 암호화를 비활성화합니다."
           }
         },
         "pt-BR": {
@@ -109034,8 +112157,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "PAX 카운터 모듈이 WiFi와 블루투스를 통해 이동하는 사람의 수를 계산합니다. PAX 카운터 모듈이 작동하려면 WiFi와 블루투스가 모두 비활성화되어야 합니다."
+            "state": "translated",
+            "value": "활성화하면 PAX 카운터 모듈이 WiFi와 Bluetooth를 사용하여 주변을 지나가는 사람 수를 계산합니다. PAX 카운터가 작동하려면 WiFi와 Bluetooth가 모두 비활성화되어 있어야 합니다."
           }
         },
         "pt-BR": {
@@ -109128,8 +112251,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "GPIO 모드에서 출력을 이만큼 오래 유지하세요."
+            "state": "translated",
+            "value": "GPIO 모드에서 사용할 때 출력을 이 시간 동안 켜 둡니다."
           }
         },
         "pt-BR": {
@@ -109216,8 +112339,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "GPIO 핀에 INPUT_PULLUP 모드를 사용할지 여부는 핀에 푸시업 저항이 있는 보드에만 적용됩니다."
+            "state": "translated",
+            "value": "GPIO 핀에 INPUT_PULLUP 모드를 사용할지 여부입니다. 핀에 풀업 저항을 사용하는 보드에서만 적용됩니다."
           }
         },
         "pt-BR": {
@@ -109268,6 +112391,12 @@
       "comment": "A description of the neighbor info transmission option.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MQTT 및 PhoneAPI와 함께 LoRa를 통해 이웃 정보를 전송할지 여부입니다. 기본 키와 이름을 사용하는 채널에서는 사용할 수 없습니다."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -109316,8 +112445,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "Wi-Fi Provisioning"
+            "state": "translated",
+            "value": "Wi-Fi 프로비저닝"
           }
         },
         "pt-BR": {
@@ -109386,7 +112515,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Wi-Fi 설정"
           }
         },
@@ -109423,7 +112552,15 @@
       }
     },
     "Wi-Fi devices at %@": {
-      "comment": "VoiceOver label for a Wi-Fi device-count point on the PAX counter chart. %@ is the timestamp."
+      "comment": "VoiceOver label for a Wi-Fi device-count point on the PAX counter chart. %@ is the timestamp.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 Wi-Fi 장치 수"
+          }
+        }
+      }
     },
     "WiFi": {
       "localizations": {
@@ -109465,7 +112602,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Wi-Fi"
           }
         },
@@ -109553,7 +112690,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Wi-Fi OTA 업데이트"
           }
         },
@@ -109629,7 +112766,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "Wi-Fi 옵션"
           }
         },
@@ -109679,6 +112816,12 @@
     },
     "WiFi Threshold": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wi-Fi 임계값"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -109739,8 +112882,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "트래커 및 센서 역할에는 로라 라디오를 포함하여 가능한 한 모든 것을 잠그겠습니다. 휴대폰 앱이나 사용자 버튼이 없는 기기를 사용하는 경우 이 설정을 사용하지 마십시오."
+            "state": "translated",
+            "value": "가능한 한 모든 기능을 최대한 절전 상태로 전환합니다. Tracker 및 Sensor 역할에서는 LoRa 라디오도 절전 상태가 됩니다. 휴대폰 앱과 함께 사용하거나 사용자 버튼이 없는 장치를 사용하는 경우 이 설정을 사용하지 마세요."
           }
         },
         "pl": {
@@ -109839,7 +112982,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "바람"
           }
         },
@@ -109889,6 +113032,12 @@
     },
     "Window (s)": {
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시간 창 (초)"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -109939,8 +113088,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "NFC 태그에 연락처를 기록합니다."
+            "state": "translated",
+            "value": "NFC 태그에 연락처 기록"
           }
         },
         "pt-BR": {
@@ -109975,7 +113124,16 @@
         }
       }
     },
-    "Write to NFC Tag": {},
+    "Write to NFC Tag": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NFC 태그에 쓰기"
+          }
+        }
+      }
+    },
     "X: %@, Y: %d": {
       "localizations": {
         "da": {
@@ -110279,7 +113437,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "네, 이 노드를 제어합니다."
           }
         },
@@ -110361,7 +113519,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "어제"
           }
         },
@@ -110445,8 +113603,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "새로운 소프트웨어 업데이트를 실행하려고 합니다. 이 과정에는 위험이 따릅니다. 업데이트가 실패하면 다시 부팅 로더를 업데이트해야 할 수도 있습니다."
+            "state": "translated",
+            "value": "장치에 새 펌웨어를 플래시하려고 합니다. 이 과정에는 위험이 따릅니다. 업데이트가 실패할 수 있으며, 경우에 따라 부트로더를 다시 플래시해야 할 수도 있습니다."
           }
         },
         "pt-BR": {
@@ -110517,8 +113675,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "이 문제를 직접 해결하려면 기본 채널을 변경하세요."
+            "state": "translated",
+            "value": "기본 채널을 변경하여 직접 해결할 수 있습니다:"
           }
         },
         "pt-BR": {
@@ -110557,6 +113715,12 @@
       "comment": "A message that a map can't be downloaded because the user has reached the maximum number of offline maps.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld개까지 오프라인 지도를 저장할 수 있습니다. 다른 지도를 다운로드하려면 하나를 삭제하세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -110566,7 +113730,15 @@
       }
     },
     "You sent: %@": {
-      "comment": "VoiceOver: label for a message you sent. %@ is the message text"
+      "comment": "VoiceOver: label for a message you sent. %@ is the message text",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보냄: %@"
+          }
+        }
+      }
     },
     "Your MQTT Server must support TLS.": {
       "localizations": {
@@ -110608,7 +113780,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "MQTT 서버는 TLS를 지원해야 합니다."
           }
         },
@@ -110686,8 +113858,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "TAK 채널이 성공적으로 설정되었습니다. QR 코드를 공유하려면 설정 > QR 코드 공유로 이동하세요"
+            "state": "translated",
+            "value": "채널이 TAK용으로 설정되었습니다. QR 코드를 공유하려면 설정 > QR 코드 공유로 이동하세요."
           }
         },
         "pt-BR": {
@@ -110752,8 +113924,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "연결된 장치는 **%@**보다 오래된 버전을 실행 중이며, 이는 알려진 보안 취약성을 포함하고 있습니다. 장치가와 메시 네트워크를 보호하기 위해 버전을 업데이트하는 것이 강력히 권장됩니다."
+            "state": "translated",
+            "value": "연결된 장치가 알려진 보안 취약점을 포함한 **%@**보다 이전 버전의 펌웨어를 실행하고 있습니다. 장치와 메시 네트워크를 보호하려면 펌웨어 업데이트를 강력히 권장합니다."
           }
         },
         "pt-BR": {
@@ -110828,8 +114000,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "현재 위치는 고정된 위치로 설정되며, 위치 간격에 따라 메시지 네트워크를 통해 전송됩니다."
+            "state": "translated",
+            "value": "현재 위치가 고정 위치로 설정되며, 위치 업데이트 간격에 따라 메시 네트워크를 통해 전송됩니다."
           }
         },
         "pt-BR": {
@@ -110910,8 +114082,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "mPWRD-OS 기기가 Wi-Fi 네트워크에 연결되었습니다."
+            "state": "translated",
+            "value": "mPWRD-OS 장치가 Wi-Fi 네트워크에 연결되었습니다."
           }
         },
         "pt-BR": {
@@ -110986,8 +114158,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "네트워크 노드는 주기적으로 설정된 MQTT 서버에 암호화되지 않은 지오매핑 보고 패킷을 전송합니다. 여기에는 ID, 짧은 이름, 긴 이름, 대략적인 위치, 하드웨어 모델, 역할, 소프트웨어 버전, LoRa 지역, 모뎀 설정, 기본 채널 이름 등이 포함됩니다."
+            "state": "translated",
+            "value": "노드는 설정된 MQTT 서버로 주기적으로 암호화되지 않은 지도 보고 패킷을 전송합니다. 여기에는 ID, 짧은 이름과 긴 이름, 대략적인 위치, 하드웨어 모델, 역할, 펌웨어 버전, LoRa 지역, 모뎀 프리셋 및 기본 채널 이름이 포함됩니다."
           }
         },
         "pt-BR": {
@@ -111074,8 +114246,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "노드의 작동 주파수는 지역, 모뎀 기본 설정, 이 필드에 따라 계산됩니다. 0일 경우, 슬롯은 기본 채널 이름에 따라 자동으로 계산됩니다."
+            "state": "translated",
+            "value": "노드의 동작 주파수는 지역, 모뎀 프리셋 및 이 필드를 기반으로 계산됩니다. 값이 0이면 슬롯은 기본 채널 이름을 기반으로 자동 계산됩니다."
           }
         },
         "pt-BR": {
@@ -111158,8 +114330,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "비밀번호는 블루투스 통신을 통해 장치로 직접 전송되며 절대 저장되지 않습니다."
+            "state": "translated",
+            "value": "비밀번호는 Bluetooth를 통해 장치로 직접 전송되며 저장되지 않습니다."
           }
         },
         "pt-BR": {
@@ -111234,8 +114406,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "당신의 위치 요청에 대한 응답을 보내기 위해 귀하의 위치를 보냈습니다. 위치가 반환되면 알림을 받으실 수 있습니다."
+            "state": "translated",
+            "value": "현재 위치가 상대방의 위치 응답 요청과 함께 전송되었습니다. 상대방의 위치가 반환되면 알림을 받습니다."
           }
         },
         "pt-BR": {
@@ -111318,8 +114490,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "기본 설정으로 설정된 채널이 있으며, 이름이나 기본 암호화 키가 없습니다. TAK 서버는 읽기 전용 모드로 실행되고 있습니다."
+            "state": "translated",
+            "value": "기본 채널이 기본 설정(이름 없음 또는 기본 암호화 키)을 사용하고 있습니다. TAK Server는 읽기 전용 모드로 실행 중입니다."
           }
         },
         "pt-BR": {
@@ -111388,8 +114560,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "보안 키는 개인 키에서 생성되어 메시지 네트워크의 다른 노드에 전송되어 두 사람이 공유 비밀 키를 계산할 수 있습니다."
+            "state": "translated",
+            "value": "공개 키는 개인 키에서 생성되며, 다른 메시 네트워크 노드에 전송되어 서로 공유 비밀 키를 계산할 수 있도록 합니다."
           }
         },
         "pt-BR": {
@@ -111470,8 +114642,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지역은 %lld%%의 전압 주파수입니다. MQTT는 전압 주파수가 제한된 경우 권장되지 않으며, 추가적인 트래픽이 LoRa 네트워크를 빠르게 압도할 것입니다."
+            "state": "translated",
+            "value": "해당 지역의 듀티 사이클은 %lld%%입니다. 듀티 사이클 제한이 있는 경우 MQTT 사용은 권장되지 않습니다. 추가 트래픽이 LoRa 메시 네트워크를 빠르게 과부하시킬 수 있습니다."
           }
         },
         "pt-BR": {
@@ -111558,8 +114730,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "지역은 %lld%%의 시간당 작업 주기로, 라디오는 시간 제한을 초과하면 패킷 전송을 중단합니다."
+            "state": "translated",
+            "value": "해당 지역의 시간당 듀티 사이클은 %lld%%입니다. 무선 장치는 시간당 제한에 도달하면 패킷 전송을 중단합니다."
           }
         },
         "pt-BR": {
@@ -111646,8 +114818,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "경도와 경로를 포함하는 경로 파일을 작성해야 합니다."
+            "state": "translated",
+            "value": "경로 파일에는 Latitude와 Longitude 열 및 헤더가 모두 있어야 합니다."
           }
         },
         "pt-BR": {
@@ -111728,8 +114900,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "사용자 정보가 요청에 따라 전송되었습니다."
+            "state": "translated",
+            "value": "사용자 정보가 상대방의 사용자 정보 응답 요청과 함께 전송되었습니다."
           }
         },
         "pt-BR": {
@@ -111806,7 +114978,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "ZIP 파일"
           }
         },
@@ -111872,6 +115044,12 @@
           "stringUnit": {
             "state": "needs_review",
             "value": "[%lld アイテム]"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[%lld개 항목]"
           }
         },
         "pt-BR": {
@@ -112003,6 +115181,12 @@
             "value": "Try again in %lld s"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld초 후 다시 시도하세요"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112018,6 +115202,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Wait for the timer to elapse before trying again."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "타이머가 끝날 때까지 기다린 후 다시 시도하세요."
           }
         },
         "uk": {
@@ -112037,6 +115227,12 @@
             "value": "Too many attempts"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시도 횟수 초과"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112052,6 +115248,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Connecting to device…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "장치 연결 중…"
           }
         },
         "uk": {
@@ -112071,6 +115273,12 @@
             "value": "Stored passphrase no longer works. Enter the current one."
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장된 암호가 더 이상 작동하지 않습니다. 현재 암호를 입력하세요"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112086,6 +115294,12 @@
           "stringUnit": {
             "state": "new",
             "value": "This device is locked. Enter the passphrase to continue."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 장치는 잠겨 있습니다. 계속하려면 암호를 입력하세요."
           }
         },
         "uk": {
@@ -112105,6 +115319,12 @@
             "value": "Your session has expired. Re-enter the passphrase."
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세션이 만료되었습니다. 암호를 다시 입력하세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112120,6 +115340,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Device clock unavailable; passphrase required."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "장치 시계를 사용할 수 없습니다. 암호가 필요합니다."
           }
         },
         "uk": {
@@ -112139,6 +115365,12 @@
             "value": "Stored credentials invalid; re-enter the passphrase."
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장된 자격 증명이 유효하지 않습니다. 암호를 다시 입력하세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112154,6 +115386,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Passphrase"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "암호"
           }
         },
         "uk": {
@@ -112173,6 +115411,12 @@
             "value": "Wrong passphrase. Try again."
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잘못된 암호입니다. 다시 시도하세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112188,6 +115432,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Leave empty for firmware default."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비워 두면 펌웨어 기본값을 사용합니다."
           }
         },
         "uk": {
@@ -112207,6 +115457,12 @@
             "value": "Boots remaining (optional)"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "남은 부팅 횟수 (선택 사항)"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112222,6 +115478,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Per-boot uptime cap. Leave empty for no cap. Device reboots when the cap elapses; next boot auto-unlocks via the boot-count TTL."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "부팅당 실행 시간 제한입니다. 제한을 두지 않으려면 비워 두세요. 제한 시간이 지나면 장치가 재부팅되며, 다음 부팅 시 부팅 횟수 TTL을 통해 자동으로 잠금 해제됩니다."
           }
         },
         "uk": {
@@ -112241,6 +115503,12 @@
             "value": "Session cap (minutes)"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세션 제한 시간 (분)"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112256,6 +115524,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Leave empty for no time limit."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시간 제한을 사용하지 않으려면 비워 두세요."
           }
         },
         "uk": {
@@ -112275,6 +115549,12 @@
             "value": "Hours valid (optional)"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유효 시간 (선택 사항)"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112290,6 +115570,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Session"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세션"
           }
         },
         "uk": {
@@ -112309,6 +115595,12 @@
             "value": "First-time setup. Pick a passphrase you can re-enter."
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최초 설정입니다. 나중에 다시 입력할 수 있는 암호 문구를 선택하세요."
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112324,6 +115616,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Set Passphrase"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "암호 설정"
           }
         },
         "uk": {
@@ -112343,6 +115641,12 @@
             "value": "Set device passphrase"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "장치 암호 설정"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112360,6 +115664,12 @@
             "value": "Unlock"
           }
         },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잠금 해제"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112375,6 +115685,12 @@
           "stringUnit": {
             "state": "new",
             "value": "Unlock device"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "장치 잠금 해제"
           }
         },
         "uk": {
@@ -112419,7 +115735,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "mTLS"
           }
         },
@@ -112475,6 +115791,12 @@
       "comment": "A label that links to a specific device link. The argument is the short code of the device link.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "msh.to/%@"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -112525,7 +115847,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "없음"
           }
         },
@@ -112683,7 +116005,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "설정"
           }
         },
@@ -112771,7 +116093,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "ssh %1$@@%2$@"
           }
         },
@@ -112847,7 +116169,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "x"
           }
         },
@@ -112935,7 +116257,7 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": "y"
           }
         },
@@ -113017,8 +116339,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "---"
+            "state": "translated",
+            "value": "—"
           }
         },
         "pt-BR": {
@@ -113057,6 +116379,12 @@
       "comment": "A separator between date and time.",
       "isCommentAutoGenerated": true,
       "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
+          }
+        },
         "uk": {
           "stringUnit": {
             "state": "translated",
@@ -113172,8 +116500,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "파일을 선택하기 위한 파일 탐색기에서 **위치**로 이동하세요."
+            "state": "translated",
+            "value": "• 파일 선택기에서 **위치** 화면으로 돌아가세요."
           }
         },
         "pt-BR": {
@@ -113244,8 +116572,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "USB 장치를 선택하고 **저장**을 눌러주세요."
+            "state": "translated",
+            "value": "• USB 장치를 선택한 다음 **저장**을 누르세요."
           }
         },
         "pt-BR": {
@@ -113316,8 +116644,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "USB에 **firmware를 저장**하려면 아래 버튼을 탭하세요."
+            "state": "translated",
+            "value": "• 아래의 **펌웨어를 USB에 저장** 버튼을 누르세요."
           }
         },
         "pt-BR": {
@@ -113388,8 +116716,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "다운로드된 펌웨어 파일 이름은 `.uf2`로 끝나는 랜덤 문자열입니다."
+            "state": "translated",
+            "value": "• 다운로드된 펌웨어 파일 이름은 iOS 캐싱을 방지하기 위해 `.uf2`로 끝나는 임의의 문자열입니다."
           }
         },
         "pt-BR": {
@@ -113460,8 +116788,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "업데이트 후 바로 연결이 끊겨서 파일 저장이 실패할 수 있습니다."
+            "state": "translated",
+            "value": "• 업데이트가 완료되면 장치 연결이 바로 끊기므로 파일 저장 실패 오류가 표시될 수 있습니다. 이는 정상적인 현상입니다."
           }
         },
         "pt-BR": {
@@ -113532,8 +116860,8 @@
         },
         "ko": {
           "stringUnit": {
-            "state": "needs_review",
-            "value": "선택된 값: (%@)는 최적화된 옵션 중 하나가 아닙니다."
+            "state": "translated",
+            "value": "⚠️ 설정한 값 (%@)은 최적화된 값이 아닙니다."
           }
         },
         "pt-BR": {


### PR DESCRIPTION
## What changed?

Reviewed and improved the Korean (`ko`) localizations in `Localizable.xcstrings`.

- Added Korean localizations for 495 existing catalog entries.
- Revised 843 existing Korean strings for clearer, more natural phrasing and consistent terminology.
- Updated reviewed Korean entries from `needs_review` to `translated`.
- Kept product names and technical identifiers such as `Meshtastic`, `LoRa`, `MQTT`, `GPIO`, `RSSI`, `SNR`, `IAQ`, and `dBm` unchanged where appropriate.
- Limited the semantic changes to the Korean localization; no other locales or app behavior are modified.

## Why did it change?

The existing Korean localization included machine-translated, unnatural, or inconsistent wording and still had many entries awaiting review.

This update improves readability, consistency, and technical accuracy for Korean-speaking users while preserving established product and protocol terminology.

## How is this tested?

- Built and manually tested the app.
- Verified that the semantic changes are limited to the Korean localization.
- Checked format placeholders in the changed Korean strings against the source strings; no mismatches were found.
- Compiled and validated the string catalog for all supported locales.
- Ran `git diff --check`.

## Screenshots/Videos (when applicable)

N/A — localization-only change.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my changes.
- [x] No source code or complex logic was changed, so code comments are not applicable.
- [x] No documentation update is required for this localization-only change.
- [x] I have tested and validated the localization catalog.
