### PR TITLE
Stop the Connect list from crashing during connection flaps

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -439,6 +439,16 @@ struct Connect: View {
 						.textCase(nil)
 					}
 				}
+				// Connection flaps rewrite the connected-device section's rows (0-1 items)
+				// while UIKit is mid batch update, which asserts ("attempt to delete item N
+				// from section 0 which only contains N items" - Datadog eace6abe, crashing on
+				// every version since 2.7.12). A non-animated transaction makes the List
+				// reload instead of batch-update, the same treatment the node-switch gate
+				// below uses for the same assert.
+				.transaction { transaction in
+					transaction.disablesAnimations = true
+					transaction.animation = nil
+				}
 				HStack(alignment: .center) {
 					Spacer()
 #if targetEnvironment(macCatalyst)


### PR DESCRIPTION
## Summary
A long-lived crash (every version since 2.7.12): NSInternalInconsistencyException in a SwiftUI List batch update, always "attempt to delete item N from section 0 which only contains N items" with tiny counts. The failing list is the Connect screen: its connected-device section holds zero or one rows and rewrites on every connection flap, and reconnect cycles are normal operation. When the state flips again mid batch update, UIKit's snapshot no longer matches the diff and it asserts.

## What changed
The Connect List's updates run in a non-animated transaction, so SwiftUI reloads the list instead of batch-updating it. This is the same treatment the node-switch gate in this file already uses for the same assert.

## Testing
Built and exercised connect/disconnect/reconnect cycles in the simulator against a TCP radio simulator; radios appear and disappear in the list without row animations and without the assert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented distracting list animations when connection status changes rapidly.
  * Improved visual stability during intermittent connection flaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->