### PR TITLE
Fix the node-switch backup being skipped

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -983,12 +983,13 @@ func performRadioSwitch(_ device: Device, isSwitchingRadio: Binding<Bool>, acces
 	)
 }
 
+// The caller resolves `currentNodeNum` BEFORE starting its switch flow. Re-deriving it
+// here broke after the switch began writing the target's num into preferredPeripheralNum
+// up front and disconnect nils activeDeviceNum — the "current" node resolved to the
+// target and the backup was silently skipped on every switch, losing everything written
+// since the previous backup.
 @MainActor
-func backupCurrentDatabase(forTargetNode targetNodeNum: Int64?, accessoryManager: AccessoryManager) async {
-	let currentNodeNum = accessoryManager.activeDeviceNum ?? {
-		let num = Int64(UserDefaults.preferredPeripheralNum)
-		return num > 0 ? num : nil
-	}()
+func backupCurrentDatabase(forTargetNode targetNodeNum: Int64?, currentNodeNum: Int64?, accessoryManager: AccessoryManager) async {
 	let currentNodeName = currentNodeNum.flatMap { num in
 		accessoryManager.devices.first(where: { $0.num == num })?.longName
 	}
@@ -1020,12 +1021,13 @@ func backupCurrentDatabase(forTargetNode targetNodeNum: Int64?, accessoryManager
 @MainActor
 func backupCurrentAndRestoreDatabase(
 	forNode targetNodeNum: Int64?,
+	currentNodeNum: Int64?,
 	accessoryManager: AccessoryManager,
 	appState: AppState,
 	selectedTab: NavigationState.Tab,
 	disconnectCurrentDevice: Bool = false
 ) async -> NodeBackupResult {
-	await backupCurrentDatabase(forTargetNode: targetNodeNum, accessoryManager: accessoryManager)
+	await backupCurrentDatabase(forTargetNode: targetNodeNum, currentNodeNum: currentNodeNum, accessoryManager: accessoryManager)
 
 	if disconnectCurrentDevice, accessoryManager.allowDisconnect {
 		Logger.backup.info("💾 Disconnecting current device before restore")
@@ -1177,6 +1179,7 @@ func switchToDevice(
 	// and dumped the new radio's nodes on top of the old radio's data.
 	let restoreResult = await backupCurrentAndRestoreDatabase(
 		forNode: targetNodeNum,
+		currentNodeNum: currentNodeNum,
 		accessoryManager: accessoryManager,
 		appState: appState,
 		selectedTab: .connect

--- a/Meshtastic/Views/Settings/BackupManagement/BackupManagement.swift
+++ b/Meshtastic/Views/Settings/BackupManagement/BackupManagement.swift
@@ -191,8 +191,14 @@ struct BackupManagement: View {
 			isRestoringBackup = false
 		}
 
+		// Resolve the outgoing node before the flow disconnects anything.
+		let currentNodeNum = accessoryManager.activeDeviceNum ?? {
+			let num = Int64(UserDefaults.preferredPeripheralNum)
+			return num > 0 ? num : nil
+		}()
 		let restoreResult = await backupCurrentAndRestoreDatabase(
 			forNode: entry.nodeNum,
+			currentNodeNum: currentNodeNum,
 			accessoryManager: accessoryManager,
 			appState: accessoryManager.appState,
 			selectedTab: .settings,


### PR DESCRIPTION
## Summary
Since f5c3bb5b (moving preferredPeripheralNum to switch initiation), the backup of the outgoing node is silently skipped on every node switch. Anything written since the previous good backup — including just-sent messages — is destroyed by the store clear, and switching back restores a stale backup.

## What changed
backupCurrentDatabase re-derived the "current" node as activeDeviceNum ?? preferredPeripheralNum after the switch had already written the target's num into preferredPeripheralNum and disconnect had nil'd activeDeviceNum, so current == target and the backup short-circuited. The callers (switchToDevice, BackupManagement.restoreBackup) now resolve the outgoing node before anything mutates and pass it through explicitly.

## Testing
NodeBackupManagerTests: 15 tests passing. Reproduced the report on device before the fix: send a message, switch to a TCP node, switch back — the message was gone. A follow-up worth doing separately: an orchestration-level test that a write survives a switch-away/switch-back round trip; NodeBackupManagerTests only covers the manager primitives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic backups when switching between connected devices.
  * Fixed backup handling during database restoration, ensuring data from the currently active device is preserved before restoring another backup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->