### PR TITLE
Suppress beacon offers for channels the radio already has

### DIFF
--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -24,6 +24,21 @@ func projectedDisplayChannels(from channels: [ChannelEntity]) -> [ChannelEntity]
 	canonicalValidUniqueChannels(from: channels)
 }
 
+/// The connected radio's channels as name|key identity strings, for suppressing beacon
+/// offers the radio already has (design#140 behavior 10 — a beacon inviting you to a
+/// mesh you are already on is not an invitation).
+@MainActor
+func configuredChannelOfferKeys(context: ModelContext) -> Set<String> {
+	let num = Int64(UserDefaults.preferredPeripheralNum)
+	guard num > 0 else { return [] }
+	var descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+	descriptor.fetchLimit = 1
+	guard let node = (try? context.fetch(descriptor))?.first else { return [] }
+	return Set(canonicalValidUniqueChannels(from: node.myInfo?.channels ?? []).map {
+		"\($0.name ?? "")|\(($0.psk ?? Data()).base64EncodedString())"
+	})
+}
+
 func canonicalValidUniqueChannels(from channels: [ChannelEntity]) -> [ChannelEntity] {
 	var byIndex: [Int32: ChannelEntity] = [:]
 	for channel in channels where (Int32(0)...Int32(7)).contains(channel.index) {

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -27,6 +27,10 @@ func projectedDisplayChannels(from channels: [ChannelEntity]) -> [ChannelEntity]
 /// The connected radio's channels as name|key identity strings, for suppressing beacon
 /// offers the radio already has (design#140 behavior 10 — a beacon inviting you to a
 /// mesh you are already on is not an invitation).
+///
+/// A fetch failure returns an empty set on purpose: suppression quietly turns off and
+/// every offer stays visible, which is the pre-suppression behavior and the safe
+/// direction — hiding an offer on bad data would be the harmful failure.
 @MainActor
 func configuredChannelOfferKeys(context: ModelContext) -> Set<String> {
 	let num = Int64(UserDefaults.preferredPeripheralNum)

--- a/Meshtastic/Views/Settings/Discovery/DiscoveryBeaconsView.swift
+++ b/Meshtastic/Views/Settings/Discovery/DiscoveryBeaconsView.swift
@@ -27,11 +27,7 @@ struct DiscoveryBeaconsView: View {
 		allBeacons.filter { $0.session == nil }
 	}
 
-	/// Channels the connected radio already has — their beacons get an Already Joined
-	/// chip instead of reading as new meshes (design#140 behavior 10).
-	private var joinedChannelKeys: Set<String> {
-		configuredChannelOfferKeys(context: context)
-	}
+
 
 	var body: some View {
 		List {
@@ -42,9 +38,12 @@ struct DiscoveryBeaconsView: View {
 					description: Text("Meshes heard advertising themselves via beacons will appear here.")
 				)
 			} else {
+				// Resolved once per render — the per-row chip builder must not re-fetch
+				// the radio's channels for every beacon.
+				let joinedChannelKeys = configuredChannelOfferKeys(context: context)
 				Section {
 					ForEach(passiveBeacons) { beacon in
-						beaconRow(beacon)
+						beaconRow(beacon, joinedChannelKeys: joinedChannelKeys)
 					}
 					.onDelete(perform: deleteBeacons)
 				} footer: {
@@ -56,7 +55,7 @@ struct DiscoveryBeaconsView: View {
 	}
 
 	@ViewBuilder
-	private func beaconRow(_ beacon: DiscoveredBeaconEntity) -> some View {
+	private func beaconRow(_ beacon: DiscoveredBeaconEntity, joinedChannelKeys: Set<String>) -> some View {
 		VStack(alignment: .leading, spacing: 6) {
 			HStack {
 				Text(beacon.displayName)
@@ -74,7 +73,7 @@ struct DiscoveryBeaconsView: View {
 					.fixedSize(horizontal: false, vertical: true)
 			}
 
-			let chips = beaconChips(beacon)
+			let chips = beaconChips(beacon, joinedChannelKeys: joinedChannelKeys)
 			if !chips.isEmpty {
 				HStack(spacing: 6) {
 					ForEach(chips, id: \.self) { chip in
@@ -94,7 +93,7 @@ struct DiscoveryBeaconsView: View {
 		.padding(.vertical, 4)
 	}
 
-	private func beaconChips(_ beacon: DiscoveredBeaconEntity) -> [String] {
+	private func beaconChips(_ beacon: DiscoveredBeaconEntity, joinedChannelKeys: Set<String>) -> [String] {
 		var chips: [String] = []
 		if let preset = beacon.offeredPreset {
 			chips.append(preset.description)

--- a/Meshtastic/Views/Settings/Discovery/DiscoveryBeaconsView.swift
+++ b/Meshtastic/Views/Settings/Discovery/DiscoveryBeaconsView.swift
@@ -27,6 +27,12 @@ struct DiscoveryBeaconsView: View {
 		allBeacons.filter { $0.session == nil }
 	}
 
+	/// Channels the connected radio already has — their beacons get an Already Joined
+	/// chip instead of reading as new meshes (design#140 behavior 10).
+	private var joinedChannelKeys: Set<String> {
+		configuredChannelOfferKeys(context: context)
+	}
+
 	var body: some View {
 		List {
 			if passiveBeacons.isEmpty {
@@ -98,6 +104,9 @@ struct DiscoveryBeaconsView: View {
 		}
 		if beacon.hasOfferChannel, !beacon.offerChannelName.isEmpty {
 			chips.append("#\(beacon.offerChannelName)")
+			if joinedChannelKeys.contains("\(beacon.offerChannelName)|\(beacon.offerChannelPSK.base64EncodedString())") {
+				chips.append(String(localized: "Already Joined"))
+			}
 		}
 		return chips
 	}

--- a/Meshtastic/Views/Settings/Discovery/DiscoveryScanView.swift
+++ b/Meshtastic/Views/Settings/Discovery/DiscoveryScanView.swift
@@ -446,10 +446,13 @@ extension DiscoveryScanView {
 	var beaconChannels: [BeaconChannel] {
 		let descriptor = FetchDescriptor<DiscoveredBeaconEntity>()
 		guard let beacons = try? context.fetch(descriptor) else { return [] }
+		// Offers for channels the radio already has are not invitations (design#140).
+		let joined = configuredChannelOfferKeys(context: context)
 		var seen = Set<String>()
 		var channels: [BeaconChannel] = []
 		for beacon in beacons where beacon.hasOfferChannel && !beacon.offerChannelName.isEmpty {
 			guard let preset = beacon.offeredPreset else { continue }
+			if joined.contains("\(beacon.offerChannelName)|\(beacon.offerChannelPSK.base64EncodedString())") { continue }
 			let channel = BeaconChannel(name: beacon.offerChannelName, psk: beacon.offerChannelPSK,
 										preset: preset, regionRaw: beacon.offerRegion)
 			if seen.insert(channel.id).inserted { channels.append(channel) }


### PR DESCRIPTION
## Summary
A beacon inviting you to a mesh you are already on is not an invitation. Implements design#140 behavior 10 (from the triage of meshtastic/firmware#11645) on iOS.

## What changed
- The scan setup's Beacon Channels section no longer lists offers whose channel matches one the radio already has configured (same name and key), so they also stop pre-selecting as scan targets
- Nearby Meshes rows for such beacons get an "Already Joined" chip instead of reading as new meshes
- Shared helper next to canonicalValidUniqueChannels resolves the connected radio's channels as name+key identity strings

## Testing
DiscoveryScanEngine suite passing (12 tests). Built for the iOS simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discovery results now identify channels you have already joined.
  * Channels already configured on your radio are hidden from available channel offers.
  * Existing channels are matched using both their name and security credentials for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->