### PR TITLE
Defer entity-cap evictions until the app backgrounds

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -402,10 +402,17 @@ actor MeshPackets {
 	}
 
 	/// Evict down to the strict caps and commit. Called on the background transition —
-	/// the one moment deletes cannot race a view reading the doomed entities.
+	/// the one moment deletes cannot race a view reading the doomed entities. The flag
+	/// is re-checked here on the actor, not just at enqueue: a quick return to the
+	/// foreground can beat this task's turn on the actor, and evicting then would be
+	/// exactly the mid-render delete this exists to avoid.
 	func enforceEntityCapsAndSave() {
-		guard !invalidated else { return }
+		guard !invalidated, !Self.appIsActive else { return }
 		evictNodesIfOverCap(Self.maxTotalNodes)
+		guard !Self.appIsActive else {
+			savePendingChanges()
+			return
+		}
 		evictWaypointsIfOverCap(Self.maxTotalWaypoints)
 		savePendingChanges()
 	}

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -133,6 +133,18 @@ actor MeshPackets {
 	/// incoming channel frames) and the main actor (begin/commit/discard from AccessoryManager).
 	nonisolated(unsafe) private static var channelRefreshStages: [Int64: ChannelRefreshStage] = [:]
 	private static let channelRefreshStagesLock = NSLock()
+
+	// Main-thread views read node/user/position entities during body evaluation, and a
+	// cap eviction on this actor cascades all of them away — the invalid-entity trap
+	// that tops the crash reports (Settings, node detail, node list rows). Evictions
+	// wait for the app to background; while foregrounded only a doubled cap applies,
+	// so a device that never backgrounds (a wall display) still stays bounded.
+	nonisolated(unsafe) private static var _appIsActive = true
+	private static let appActiveLock = NSLock()
+	nonisolated static var appIsActive: Bool {
+		get { appActiveLock.withLock { _appIsActive } }
+		set { appActiveLock.withLock { _appIsActive = newValue } }
+	}
 	#if DEBUG
 	/// Deterministic concurrency checkpoint used by the refresh boundary regression test. Production
 	/// callers leave this nil, so validation and replacement execute without suspension.
@@ -384,8 +396,18 @@ actor MeshPackets {
 	/// Split into cap-parameterized helpers below so the eviction order is unit-testable with
 	/// small datasets rather than needing tens of thousands of inserts.
 	func enforceEntityCaps() {
+		let multiplier = Self.appIsActive ? 2 : 1
+		evictNodesIfOverCap(Self.maxTotalNodes * multiplier)
+		evictWaypointsIfOverCap(Self.maxTotalWaypoints * multiplier)
+	}
+
+	/// Evict down to the strict caps and commit. Called on the background transition —
+	/// the one moment deletes cannot race a view reading the doomed entities.
+	func enforceEntityCapsAndSave() {
+		guard !invalidated else { return }
 		evictNodesIfOverCap(Self.maxTotalNodes)
 		evictWaypointsIfOverCap(Self.maxTotalWaypoints)
+		savePendingChanges()
 	}
 
 	// MARK: - Watch Snapshot

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -266,6 +266,10 @@ struct MeshtasticAppleApp: App {
 			case .background:
 				Logger.services.info("🎬 [App] Scene is in the background")
 				accessoryManager.appDidEnterBackground()
+				// Entity-cap evictions run now, while no view is mid-render on the
+				// doomed entities. Foregrounded, the packet actor defers them.
+				MeshPackets.appIsActive = false
+				Task { await MeshPackets.shared.enforceEntityCapsAndSave() }
 				do {
 					try persistenceController.container.mainContext.save()
 					Logger.services.info("💾 [App] Saved SwiftData context when the app went to the background.")
@@ -278,6 +282,7 @@ struct MeshtasticAppleApp: App {
 				Logger.services.info("🎬 [App] Scene is inactive")
 			case .active:
 				Logger.services.info("🎬 [App] Scene is active")
+				MeshPackets.appIsActive = true
 				accessoryManager.appDidBecomeActive()
 				appState.refreshBadgeCount(context: persistenceController.container.mainContext)
 			@unknown default:


### PR DESCRIPTION
## Summary
The node/waypoint cap evictions run on the packet actor whenever packets flow, including while the app is foregrounded. Evicting a node cascades its user and position rows away while main-thread views are mid-render on them; a view's next property read then traps in SwiftData (guards can't close this — `isDeleted` stays false until the merge lands). This is the same failure class the Watch snapshot rework fixed, showing up in Settings, node detail, and node list rows — currently the largest crash source in the field.

## What changed
- Cap evictions wait for the app to background: the scene-phase handler flips a flag and asks the packet actor to evict and save at that moment, when no view is rendering the doomed entities
- While foregrounded, a doubled cap applies as an overflow valve so a device that never backgrounds (a wall-display iPad) still stays bounded
- Import-path and test callers use the eviction helpers directly and are unchanged

## Testing
EntityCapEvictionTests and WatchNodeSnapshotTests passing (8 tests). Built and exercised foreground/background transitions in the simulator against a TCP radio simulator with a large replayed mesh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased node and waypoint storage capacity while the app is active.
  * Automatically enforces stricter storage limits and saves data when the app moves to the background.
  * Updates storage behavior as the app transitions between active and background states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->