### PR TITLE
Bound the metrics log charts to a fixed mark budget

### DIFF
--- a/Meshtastic/Helpers/ChartDownsample.swift
+++ b/Meshtastic/Helpers/ChartDownsample.swift
@@ -1,0 +1,25 @@
+//
+//  ChartDownsample.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 8/30/26.
+//
+
+import Foundation
+
+/// Bounds the number of points fed to a Swift Charts plot. Charts lays out every
+/// mark individually, and past roughly a thousand marks the layout pass stalls the
+/// main thread long enough to register as an app hang — the metrics log screens
+/// were the app's top hang source once hang tracking shipped. Decimation keeps a
+/// uniform stride through the series plus the exact first and last points; tables
+/// and CSV exports keep the full data.
+func downsampledForChart<T>(_ points: [T], budget: Int = 600) -> [T] {
+	guard budget > 2, points.count > budget else { return points }
+	let stride = Double(points.count - 1) / Double(budget - 1)
+	var result: [T] = []
+	result.reserveCapacity(budget)
+	for index in 0..<budget {
+		result.append(points[Int((Double(index) * stride).rounded())])
+	}
+	return result
+}

--- a/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/DeviceMetricsLog.swift
@@ -271,9 +271,11 @@ struct DeviceMetricsLog: View {
 		totalReadings = node.telemetryCount(ofType: 0, context: context)
 		deviceMetrics = node.safeTelemetries(ofType: 0)
 		let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date.distantPast
-		chartData = deviceMetrics
-			.filter { ($0.time ?? Date.distantPast) >= oneWeekAgo }
-			.sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
+		chartData = downsampledForChart(
+			deviceMetrics
+				.filter { ($0.time ?? Date.distantPast) >= oneWeekAgo }
+				.sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
+		)
 	}
 }
 

--- a/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
@@ -23,17 +23,19 @@ struct EnvironmentMetricsLog: View {
 
 	@State var isEditingColumnConfiguration = false
 	@State private var chartData: [TelemetryEntity] = []
+	/// Chart input only — the table and export use `chartData` in full.
+	@State private var chartPoints: [TelemetryEntity] = []
 	@State private var totalReadings = 0
 
 	var body: some View {
 		VStack {
 			if totalReadings > 0 {
-				let chartRange = applyMargins(seriesList.chartRange(forData: chartData))
+				let chartRange = applyMargins(seriesList.chartRange(forData: chartPoints))
 				VStack {
 					if chartData.count > 0 {
 						GroupBox(label: Label("\(totalReadings) Readings Total", systemImage: "chart.xyaxis.line")) {
 							Chart(seriesList.visible) { series in
-								ForEach(chartData, id: \.time) { dataPoint in
+								ForEach(chartPoints, id: \.time) { dataPoint in
 									series.body(dataPoint, inChartRange: chartRange)
 								}
 							}
@@ -192,6 +194,7 @@ struct EnvironmentMetricsLog: View {
 		totalReadings = node.telemetryCount(ofType: 1, context: context)
 		let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date.distantPast
 		chartData = node.safeTelemetries(ofType: 1)
+		chartPoints = downsampledForChart(chartData.sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) })
 			.filter { ($0.time ?? Date.distantPast) >= oneWeekAgo }
 			.sorted { ($0.time ?? .distantPast) > ($1.time ?? .distantPast) }
 	}

--- a/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/EnvironmentMetricsLog.swift
@@ -194,9 +194,12 @@ struct EnvironmentMetricsLog: View {
 		totalReadings = node.telemetryCount(ofType: 1, context: context)
 		let oneWeekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date.distantPast
 		chartData = node.safeTelemetries(ofType: 1)
-		chartPoints = downsampledForChart(chartData.sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) })
 			.filter { ($0.time ?? Date.distantPast) >= oneWeekAgo }
 			.sorted { ($0.time ?? .distantPast) > ($1.time ?? .distantPast) }
+		// chartData is sorted newest-first for the table; the chart wants the visible
+		// window oldest-first, decimated AFTER the week filter so the mark budget is
+		// spent entirely on points the chart will draw.
+		chartPoints = downsampledForChart(Array(chartData.reversed()))
 	}
 }
 

--- a/Meshtastic/Views/Nodes/LocalStatsLog.swift
+++ b/Meshtastic/Views/Nodes/LocalStatsLog.swift
@@ -502,7 +502,7 @@ private extension LocalStatsLog {
 				return LocalStatsChartPoint(time: time, noiseFloor: noiseFloor)
 			}.reversed()
 		)
-		noiseFloorReadings = readings
+		noiseFloorReadings = downsampledForChart(readings)
 
 		let values = readings.map { Int($0.noiseFloor) }
 		if let minValue = values.min(), let maxValue = values.max() {

--- a/MeshtasticTests/ChartDownsampleTests.swift
+++ b/MeshtasticTests/ChartDownsampleTests.swift
@@ -1,0 +1,48 @@
+//
+//  ChartDownsampleTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/30/26.
+//
+
+import Testing
+@testable import Meshtastic
+
+@Suite("Chart downsampling")
+struct ChartDownsampleTests {
+
+	@Test func underBudgetPassesThrough() {
+		let points = Array(0..<500)
+		#expect(downsampledForChart(points, budget: 600) == points)
+	}
+
+	@Test func exactBudgetPassesThrough() {
+		let points = Array(0..<600)
+		#expect(downsampledForChart(points, budget: 600) == points)
+	}
+
+	@Test func overBudgetIsBounded() {
+		let points = Array(0..<5_000)
+		let result = downsampledForChart(points, budget: 600)
+		#expect(result.count == 600)
+	}
+
+	@Test func endpointsSurvive() {
+		let points = Array(0..<4_321)
+		let result = downsampledForChart(points, budget: 600)
+		#expect(result.first == 0)
+		#expect(result.last == 4_320)
+	}
+
+	@Test func orderAndDistinctnessPreserved() {
+		let points = Array(0..<10_000)
+		let result = downsampledForChart(points, budget: 600)
+		#expect(result == result.sorted())
+		#expect(Set(result).count == result.count)
+	}
+
+	@Test func degenerateBudgetPassesThrough() {
+		let points = Array(0..<100)
+		#expect(downsampledForChart(points, budget: 2) == points)
+	}
+}


### PR DESCRIPTION
## Summary
The metrics log screens (local stats, device metrics, environment metrics) feed full telemetry history into Swift Charts. Charts lays out every mark individually, so a node with a long history stalls the main thread long enough to register as an app hang — with hang tracking shipping in 2.7.19, these screens are the app's top hang source in the field, and the hang stacks show Charts mid-layout on exactly these views.

## What changed
- New `downsampledForChart` helper: bounds a chart's input to at most 600 points with a uniform stride, always keeping the exact first and last points
- Local stats: the noise-floor series is decimated in `refreshData`
- Device metrics: the (already week-limited) chart input is decimated
- Environment metrics: the chart now plots a decimated, time-sorted series instead of the entire unsorted history across every visible series; the table and CSV export keep their existing data (environment keeps its one-week window, unchanged)

## Testing
- ChartDownsampleTests: 6 tests covering pass-through under budget, the bound, endpoint preservation, order, and distinctness
- Perf-seed rig on the simulator: seeded local-stats history, screen opens and renders the chart normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved metrics and noise-floor charts by limiting the number of plotted points.
  * Preserved the first and last readings while maintaining chronological order.
  * Tables and CSV exports continue to retain the complete set of readings.

* **Testing**
  * Added coverage to verify chart sampling limits, ordering, and boundary behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
