### PR TITLE
Fold tapback alerts into the message notification settings

### DIFF
--- a/Meshtastic/Extensions/UserDefaults.swift
+++ b/Meshtastic/Extensions/UserDefaults.swift
@@ -72,7 +72,6 @@ extension UserDefaults {
 		case nodeNotificationsUserOverrideForEvent
 		case lowBatteryNotifications
 		case channelMessageNotifications
-		case tapbackNotifications
 		case waypointNotifications
 		case modemPreset
 		case firmwareVersion
@@ -157,8 +156,6 @@ extension UserDefaults {
 	@UserDefault(.channelMessageNotifications, defaultValue: true)
 	static var channelMessageNotifications: Bool
 
-	@UserDefault(.tapbackNotifications, defaultValue: true)
-	static var tapbackNotifications: Bool
 
 	@UserDefault(.waypointNotifications, defaultValue: true)
 	static var waypointNotifications: Bool

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1939,10 +1939,9 @@ actor MeshPackets {
 										userNum: dmUserNum,
 										critical: critical
 									)
-								} else if UserDefaults.tapbackNotifications,
-										  let reactionBody = MeshPackets.reactionNotificationBody(replyID: newMessage.replyID, emoji: messageText, senderName: senderName, context: modelContext) {
-									// Tapback/reaction: only notify when the user hasn't switched tapback
-									// notifications off, and the reacted-to message is known locally.
+								} else if let reactionBody = MeshPackets.reactionNotificationBody(replyID: newMessage.replyID, emoji: messageText, senderName: senderName, context: modelContext) {
+									// Tapback/reaction: follows the same notification rules as the message it
+									// reacts to, and only notifies when the reacted-to message is known locally.
 									// A "phantom" tapback (replyID with no matching local message) is stored but not
 									// surfaced — reactionNotificationBody returns nil in that case.
 									dmNotification = makeMessageNotification(
@@ -1996,10 +1995,9 @@ actor MeshPackets {
 												userNum: channelUserNum,
 												critical: critical
 											)
-										} else if UserDefaults.tapbackNotifications,
-												  let reactionBody = MeshPackets.reactionNotificationBody(replyID: newMessage.replyID, emoji: messageText, senderName: senderName, context: modelContext) {
-											// Tapback/reaction: only notify when the user hasn't switched tapback
-											// notifications off, and the reacted-to message is known locally. A
+										} else if let reactionBody = MeshPackets.reactionNotificationBody(replyID: newMessage.replyID, emoji: messageText, senderName: senderName, context: modelContext) {
+											// Tapback/reaction: follows the channel-notification rules above, and
+											// only notifies when the reacted-to message is known locally. A
 											// "phantom" tapback is stored but not surfaced — the helper returns nil
 											// in that case, per Android's guard.
 											channelNotification = makeMessageNotification(

--- a/MeshtasticTests/NotificationSettingsTests.swift
+++ b/MeshtasticTests/NotificationSettingsTests.swift
@@ -2,7 +2,8 @@
 //  NotificationSettingsTests.swift
 //  MeshtasticTests
 //
-//  Coverage for the `tapbackNotifications` and `waypointNotifications` toggles in
+//  Coverage for tapback notifications following the message notification settings,
+//  and for the `waypointNotifications` toggle in
 //  Settings.bundle. Both notification types used to fire unconditionally, so the only way
 //  to stop them was to turn off notifications for the whole app.
 //
@@ -169,37 +170,8 @@ struct NotificationSettingsTests {
 
 	// MARK: - Tapback notifications
 
-	@Test @MainActor func tapbackNotificationsOff_directMessage_schedulesNothing() async throws {
-		let previous = UserDefaults.tapbackNotifications
-		UserDefaults.tapbackNotifications = false
-		defer { UserDefaults.tapbackNotifications = previous }
-
-		let recorder = NotificationRecorder()
-		let mp = await makeMeshPackets(recorder: recorder)
-		let originalId: Int64 = 0x00D0_0001
-		let reactionId: Int64 = 0x00D0_0002
-		try seedDirectMessageConversation(originalMessageId: originalId)
-
-		await mp.textMessageAppPacket(
-			packet: reactionPacket(id: UInt32(reactionId), from: UInt32(peerNode), to: UInt32(connectedNode), replyID: UInt32(originalId)),
-			wantRangeTestPackets: true,
-			connectedNode: connectedNode,
-			appState: nil
-		)
-
-		await drainScheduledNotificationWork()
-		#expect(recorder.notifications.isEmpty, "tapback must not notify when the setting is off")
-		// The reaction is still stored — the toggle silences the notification, nothing else.
-		let ctx = ModelContext(sharedModelContainer)
-		let stored = try ctx.fetch(FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.messageId == reactionId }))
-		#expect(stored.first?.isEmoji == true, "the reaction itself must still be saved")
-	}
-
-	@Test @MainActor func tapbackNotificationsOn_directMessage_stillNotifies() async throws {
-		let previous = UserDefaults.tapbackNotifications
-		UserDefaults.tapbackNotifications = true
-		defer { UserDefaults.tapbackNotifications = previous }
-
+	/// Direct messages have no notification toggle, so their tapbacks notify unconditionally.
+	@Test @MainActor func directMessageTapback_notifies() async throws {
 		let recorder = NotificationRecorder()
 		let mp = await makeMeshPackets(recorder: recorder)
 		let originalId: Int64 = 0x00D0_0011
@@ -222,13 +194,11 @@ struct NotificationSettingsTests {
 		#expect(recorder.notifications.first?.replyMessageId == originalId)
 	}
 
-	@Test @MainActor func tapbackNotificationsOff_channelMessage_schedulesNothing() async throws {
-		let previousTapback = UserDefaults.tapbackNotifications
+	/// Channel tapbacks follow the channel-message toggle: off silences them too.
+	@Test @MainActor func channelNotificationsOff_silencesChannelTapbacks() async throws {
 		let previousChannel = UserDefaults.channelMessageNotifications
-		UserDefaults.tapbackNotifications = false
-		UserDefaults.channelMessageNotifications = true
+		UserDefaults.channelMessageNotifications = false
 		defer {
-			UserDefaults.tapbackNotifications = previousTapback
 			UserDefaults.channelMessageNotifications = previousChannel
 		}
 
@@ -246,29 +216,34 @@ struct NotificationSettingsTests {
 		)
 
 		await drainScheduledNotificationWork()
-		#expect(recorder.notifications.isEmpty, "channel tapback must not notify when the setting is off")
+		#expect(recorder.notifications.isEmpty, "channel tapback must not notify when channel notifications are off")
 	}
 
-	@Test @MainActor func tapbackNotificationsOff_leavesPlainMessagesAlone() async throws {
-		let previousTapback = UserDefaults.tapbackNotifications
-		UserDefaults.tapbackNotifications = false
-		defer { UserDefaults.tapbackNotifications = previousTapback }
+	/// And on means on: a channel tapback notifies under the same rules as channel messages.
+	@Test @MainActor func channelNotificationsOn_notifiesChannelTapbacks() async throws {
+		let previousChannel = UserDefaults.channelMessageNotifications
+		UserDefaults.channelMessageNotifications = true
+		defer {
+			UserDefaults.channelMessageNotifications = previousChannel
+		}
 
 		let recorder = NotificationRecorder()
 		let mp = await makeMeshPackets(recorder: recorder)
 		let originalId: Int64 = 0x00D0_0031
-		let messageId: Int64 = 0x00D0_0032
-		try seedDirectMessageConversation(originalMessageId: originalId)
+		let reactionId: Int64 = 0x00D0_0032
+		try seedChannelConversation(originalMessageId: originalId)
 
 		await mp.textMessageAppPacket(
-			packet: textPacket(id: UInt32(messageId), from: UInt32(peerNode), to: UInt32(connectedNode)),
+			packet: reactionPacket(id: UInt32(reactionId), from: UInt32(peerNode), to: Constants.maximumNodeNum, replyID: UInt32(originalId)),
 			wantRangeTestPackets: true,
 			connectedNode: connectedNode,
 			appState: nil
 		)
 
 		await recorder.waitForNextNotification()
-		#expect(recorder.notifications.first?.content == "hello mesh", "the tapback toggle must not silence ordinary messages")
+		#expect(recorder.notifications.count == 1)
+		#expect(recorder.notifications.first?.content.contains("👍") == true)
+		#expect(recorder.notifications.first?.replyMessageId == originalId)
 	}
 
 	// MARK: - Waypoint notifications
@@ -311,22 +286,18 @@ struct NotificationSettingsTests {
 
 	// MARK: - Defaults
 
-	/// Both toggles default to on, matching today's behavior for anyone who never opens Settings.
+	/// The toggle defaults to on, matching today's behavior for anyone who never opens Settings.
 	/// The Settings.bundle DefaultValue only applies once the user visits the pane, so the
 	/// `@UserDefault` default is what actually governs a fresh install.
 	@Test func togglesDefaultToOn() async {
 		let store = UserDefaults.standard
-		let previousTapback = store.object(forKey: UserDefaults.Keys.tapbackNotifications.rawValue)
 		let previousWaypoint = store.object(forKey: UserDefaults.Keys.waypointNotifications.rawValue)
 		defer {
-			store.set(previousTapback, forKey: UserDefaults.Keys.tapbackNotifications.rawValue)
 			store.set(previousWaypoint, forKey: UserDefaults.Keys.waypointNotifications.rawValue)
 		}
 
-		store.removeObject(forKey: UserDefaults.Keys.tapbackNotifications.rawValue)
 		store.removeObject(forKey: UserDefaults.Keys.waypointNotifications.rawValue)
 
-		#expect(UserDefaults.tapbackNotifications == true)
 		#expect(UserDefaults.waypointNotifications == true)
 	}
 }

--- a/Settings.bundle/Root.plist
+++ b/Settings.bundle/Root.plist
@@ -97,16 +97,6 @@
 			<key>DefaultValue</key>
 			<true/>
 			<key>Key</key>
-			<string>tapbackNotifications</string>
-			<key>Title</key>
-			<string>Tapbacks</string>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-		</dict>
-		<dict>
-			<key>DefaultValue</key>
-			<true/>
-			<key>Key</key>
 			<string>waypointNotifications</string>
 			<key>Title</key>
 			<string>New Waypoints</string>

--- a/Settings.bundle/de.lproj/Root.strings
+++ b/Settings.bundle/de.lproj/Root.strings
@@ -14,7 +14,6 @@
 "Accurate Locations Only" = "Nur genaue Standorte";
 "Notifications" = "Mitteilungen";
 "Channel Messages" = "Kanalnachrichten";
-"Tapbacks" = "Tapback Antworten";
 "New Waypoints" = "Neue Wegpunkte";
 "New Nodes" = "Neu entdeckte Knoten";
 "Low Battery" = "Niedriger Akkustand";

--- a/Settings.bundle/uk.lproj/Root.strings
+++ b/Settings.bundle/uk.lproj/Root.strings
@@ -14,7 +14,6 @@
 "Accurate Locations Only" = "Лише точні геопозиції";
 "Notifications" = "Сповіщення";
 "Channel Messages" = "Повідомлення каналів";
-"Tapbacks" = "Tapback-реакції";
 "New Waypoints" = "Нові маршрутні точки";
 "New Nodes" = "Нові вузли";
 "Low Battery" = "Низький заряд";

--- a/docs/user/messages.md
+++ b/docs/user/messages.md
@@ -94,7 +94,7 @@ Long press any message and tap **Tapback** to send an emoji reaction.
 
 When someone reacts to a message, you get a notification such as **Alice reacted 👍 to "See you soon"** — unless the sender (for a direct message) or the channel is muted. Reactions notify **without** adding to the conversation's unread badge. If your radio hasn't seen the message that was reacted to, the reaction is saved but no notification is shown (there'd be nothing to display it against).
 
-To stop reaction notifications without silencing messages, turn off **Tapbacks** under **Settings → Meshtastic → Notifications** in the iOS Settings app. Reactions are still received and still show inline in the conversation — only the alert is suppressed.
+Reaction alerts follow the same notification settings as the messages they react to: muting a channel, a sender, or channel message notifications silences their reactions too.
 
 ---
 

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -19,7 +19,6 @@ Which alerts the app raises is set per type in the iOS Settings app, under **Set
 | Setting | Description |
 |---------|-------------|
 | Channel Messages | Alerts for incoming channel messages. Direct messages always notify unless the sender is muted, and a message that @mentions you notifies even with this off. |
-| Tapbacks | Alerts when someone reacts to a message, such as **Alice reacted 👍 to "See you soon"**. |
 | New Waypoints | Alerts when a node shares a new waypoint. |
 | New Nodes | Alerts when a node the app has not seen before joins the mesh. |
 | Low Battery | Alerts when the connected device's battery gets low. |

--- a/docs/user/whats-new.md
+++ b/docs/user/whats-new.md
@@ -14,7 +14,7 @@ Recent user-facing changes from roughly the last 12 months. Newest at the top.
 Show roughly the last 12 months of changes; archive entries older than a year by removing them.
 -->
 
-**Aug 2026** — [Settings](settings.md) — Per-type notification settings for Tapbacks and New Waypoints: reaction alerts and received-waypoint alerts can each be switched off on their own, instead of having to silence the whole app.
+**Aug 2026** — [Settings](settings.md) — New Waypoints notification setting: received-waypoint alerts can be switched off on their own. Reaction alerts follow the existing message notification settings.
 
 **Jul 2026** — [Settings](settings.md) — Packet Authenticity: on firmware that reports XEdDSA support, Security settings gains a Protection Level of Compatible, Balanced, or Strict, controlling whether your radio accepts mesh packets it cannot cryptographically authenticate; Strict asks for confirmation first, and the setting matches the Meshtastic app for Android.
 


### PR DESCRIPTION
## Summary
One toggle fewer. Tapbacks now follow the notification rules of the message they react to instead of having their own switch: channel tapbacks obey the Channel Messages toggle and the channel/sender mute rules, and direct-message tapbacks notify the way direct messages do. Removes the Tapbacks toggle added in #2344 before it ships in a release; the New Waypoints toggle stays.

## What changed
- The two tapback notification sites drop the dedicated toggle check; the channel site already sits inside the channel-notification gate, so the fold is just removing the extra condition
- Tapbacks toggle removed from Settings.bundle, its de/uk strings, and the UserDefaults key
- Tests reworked to assert the folded behavior: DM tapbacks always notify, channel tapbacks notify with Channel Messages on and stay silent with it off
- Docs updated to say reaction alerts follow the message notification settings

## Testing
NotificationSettingsTests: 6 tests passing (folded-behavior cases plus the untouched waypoint coverage).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the separate Tapback Notifications setting from notification preferences.
  * Tapback notifications now follow the relevant message notification settings.
  * Direct-message reactions notify automatically when the related message is available.
  * Channel reactions follow the Channel Messages notification toggle.
  * Other notification preferences remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->