### PR TITLE
Update protobufs and migrate the beacon config to targets-only

### DIFF
--- a/Meshtastic/Enums/FirmwareEditionEnum.swift
+++ b/Meshtastic/Enums/FirmwareEditionEnum.swift
@@ -17,6 +17,8 @@ enum FirmwareEditions: Int, CaseIterable, Identifiable {
 	case burningMan = 18
 	case hamvention = 19
 	case fab = 20
+	case dragonCon = 21
+	case ccc = 22
 	case diyEdition = 127
 
 	var id: Int { self.rawValue }
@@ -37,6 +39,10 @@ enum FirmwareEditions: Int, CaseIterable, Identifiable {
 			return "Hamvention".localized
 		case .fab:
 			return "FAB".localized
+		case .dragonCon:
+			return "Dragon Con".localized
+		case .ccc:
+			return "CCC".localized
 		case .diyEdition:
 			return "DIY Edition".localized
 		}
@@ -58,6 +64,10 @@ enum FirmwareEditions: Int, CaseIterable, Identifiable {
 			return "Event firmware for Hamvention, the Dayton amateur radio convention.".localized
 		case .fab:
 			return "Event firmware for FAB, the international Fab Lab digital fabrication conference.".localized
+		case .dragonCon:
+			return "Event firmware for Dragon Con, the annual multigenre convention in Atlanta.".localized
+		case .ccc:
+			return "Event firmware for the Chaos Communication Congress, the annual CCC hacker conference.".localized
 		case .diyEdition:
 			return "Firmware for DIY and unofficial community events.".localized
 		}
@@ -85,6 +95,10 @@ enum FirmwareEditions: Int, CaseIterable, Identifiable {
 			return "HAMVENTION"
 		case .fab:
 			return "FAB"
+		case .dragonCon:
+			return "DRAGON_CON"
+		case .ccc:
+			return "CCC"
 		case .diyEdition:
 			return "DIY_EDITION"
 		}

--- a/Meshtastic/Model/ConfigModels.swift
+++ b/Meshtastic/Model/ConfigModels.swift
@@ -94,19 +94,17 @@ final class MeshBeaconConfigEntity {
 	var broadcastOfferRegion: Int32 = 0
 	/// ModemPresets raw value advertised in offer_preset, or -1 when not offered (0 = LongFast).
 	var broadcastOfferPreset: Int32 = -1
-	/// Single-target TX channel (broadcast_on_channel); used only when `broadcastTargets` is empty.
 	// The broadcast-on fields and send-as-node were removed from the protobuf
-	// (TX destinations consolidated onto broadcast_targets). The columns stay so
-	// the SwiftData schema is untouched; nothing writes or reads them anymore.
+	// (TX destinations consolidated onto broadcast_targets). The columns below are
+	// retained only for schema compatibility; the editor reads them once to migrate
+	// a pre-consolidation destination into a target row, and nothing writes them.
 	var broadcastOnChannelName: String = ""
 	var broadcastOnChannelPSK: Data = Data()
-	/// RegionCodes raw value for single-target TX (broadcast_on_region); 0 = unset (running config).
 	var broadcastOnRegion: Int32 = 0
-	/// ModemPresets raw value for single-target TX, or -1 when unset (running config).
 	var broadcastOnPreset: Int32 = -1
 	/// How often to broadcast; firmware minimum & default is 3600 s.
 	var broadcastIntervalSecs: Int32 = 3600
-	/// Spoof the `from` of outgoing beacons as this node id; 0 = local node.
+	/// Retained for schema compatibility; removed from the protobuf, never written.
 	var broadcastSendAsNode: Int64 = 0
 
 	@Relationship(deleteRule: .cascade, inverse: \BroadcastTargetEntity.meshBeaconConfig)

--- a/Meshtastic/Model/ConfigModels.swift
+++ b/Meshtastic/Model/ConfigModels.swift
@@ -95,6 +95,9 @@ final class MeshBeaconConfigEntity {
 	/// ModemPresets raw value advertised in offer_preset, or -1 when not offered (0 = LongFast).
 	var broadcastOfferPreset: Int32 = -1
 	/// Single-target TX channel (broadcast_on_channel); used only when `broadcastTargets` is empty.
+	// The broadcast-on fields and send-as-node were removed from the protobuf
+	// (TX destinations consolidated onto broadcast_targets). The columns stay so
+	// the SwiftData schema is untouched; nothing writes or reads them anymore.
 	var broadcastOnChannelName: String = ""
 	var broadcastOnChannelPSK: Data = Data()
 	/// RegionCodes raw value for single-target TX (broadcast_on_region); 0 = unset (running config).

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -1420,12 +1420,7 @@ extension MeshPackets {
 				entity.broadcastOfferChannelPSK = config.hasBroadcastOfferChannel ? config.broadcastOfferChannel.psk : Data()
 				entity.broadcastOfferRegion = Int32(config.broadcastOfferRegion.rawValue)
 				entity.broadcastOfferPreset = config.hasBroadcastOfferPreset ? Int32(config.broadcastOfferPreset.rawValue) : -1
-				entity.broadcastOnChannelName = config.hasBroadcastOnChannel ? config.broadcastOnChannel.name : ""
-				entity.broadcastOnChannelPSK = config.hasBroadcastOnChannel ? config.broadcastOnChannel.psk : Data()
-				entity.broadcastOnRegion = Int32(config.broadcastOnRegion.rawValue)
-				entity.broadcastOnPreset = config.hasBroadcastOnPreset ? Int32(config.broadcastOnPreset.rawValue) : -1
 				entity.broadcastIntervalSecs = config.broadcastIntervalSecs > 0 ? Int32(truncatingIfNeeded: config.broadcastIntervalSecs) : 3600
-				entity.broadcastSendAsNode = Int64(config.broadcastSendAsNode)
 
 				// Rebuild the multi-target list from the incoming config (cascade replaces the old rows).
 				for old in entity.broadcastTargets {

--- a/Meshtastic/Views/Settings/Config/Module/MeshBeaconConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MeshBeaconConfig.swift
@@ -38,8 +38,8 @@ struct MeshBeaconConfig: View {
 	@State private var targets: [BroadcastTargetDraft] = [BroadcastTargetDraft()]
 	@State private var seededTargetKeys: [[Int32]] = []
 
-	/// In-memory draft for one broadcast row. A single row saves as the broadcast-on
-	/// config; multiple rows save as `broadcast_targets`, one beacon each.
+	/// In-memory draft for one broadcast row. Every row saves as a `broadcast_targets`
+	/// entry — one beacon each; the protobuf has no other TX destination.
 	struct BroadcastTargetDraft: Identifiable, Equatable {
 		let id = UUID()
 		var preset: Int32 = -1   // -1 = falls back to running config
@@ -379,7 +379,18 @@ struct MeshBeaconConfig: View {
 			($0.channelIndex, $0.preset) < ($1.channelIndex, $1.preset)
 		}
 		if storedTargets.isEmpty {
-			targets = [BroadcastTargetDraft()]
+			// A pre-consolidation config kept its destination in the legacy broadcast-on
+			// columns. Seed the row from them so an unrelated save doesn't replace the
+			// radio's destination with the default. An unmatched name+key pair (-2) can't
+			// be expressed as an index-based target; it falls back to the default channel.
+			let legacyIndex = resolveChannelIndex(
+				name: node?.meshBeaconConfig?.broadcastOnChannelName ?? "",
+				psk: node?.meshBeaconConfig?.broadcastOnChannelPSK ?? Data()
+			)
+			targets = [BroadcastTargetDraft(
+				preset: node?.meshBeaconConfig?.broadcastOnPreset ?? -1,
+				channelIndex: max(legacyIndex, -1)
+			)]
 		} else {
 			targets = storedTargets.map { BroadcastTargetDraft(preset: $0.preset, channelIndex: $0.channelIndex) }
 		}

--- a/Meshtastic/Views/Settings/Config/Module/MeshBeaconConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MeshBeaconConfig.swift
@@ -34,10 +34,6 @@ struct MeshBeaconConfig: View {
 	@State private var offerChannelName = ""
 	@State private var offerChannelPSK = Data()
 	@State private var offerChannelIndex: Int32 = -1
-	// Stored broadcast-on name+key pair, kept only to pass through unchanged when the
-	// seeded selection matches none of the radio's channels (a pair set from another client).
-	@State private var onChannelName = ""
-	@State private var onChannelPSK = Data()
 	@State private var beaconInterval = UpdateInterval(from: 3_600)
 	@State private var targets: [BroadcastTargetDraft] = [BroadcastTargetDraft()]
 	@State private var seededTargetKeys: [[Int32]] = []
@@ -286,7 +282,7 @@ struct MeshBeaconConfig: View {
 		Section(header: Text("Broadcast On"), footer: Text("The channel and preset the beacon transmits on. Add a target to broadcast on more channels.")) {
 			ForEach($targets) { $target in
 				VStack(alignment: .leading, spacing: 6) {
-					channelPicker("Channel", selection: $target.channelIndex, customName: onChannelName, noneLabel: "Default")
+					channelPicker("Channel", selection: $target.channelIndex, customName: "", noneLabel: "Default")
 					presetPicker("Preset", selection: $target.preset)
 				}
 			}
@@ -367,8 +363,6 @@ struct MeshBeaconConfig: View {
 		broadcastMessage = config?.broadcastMessage ?? ""
 		offerChannelName = config?.broadcastOfferChannelName ?? ""
 		offerChannelPSK = config?.broadcastOfferChannelPSK ?? Data()
-		onChannelName = config?.broadcastOnChannelName ?? ""
-		onChannelPSK = config?.broadcastOnChannelPSK ?? Data()
 		offerChannelIndex = resolveChannelIndex(name: offerChannelName, psk: offerChannelPSK)
 		// A beacon must offer a channel to join; a stored config without one gets the
 		// primary channel.
@@ -378,16 +372,14 @@ struct MeshBeaconConfig: View {
 			offerChannelPSK = first.psk ?? Data()
 		}
 		beaconInterval = UpdateInterval(from: Int(config?.broadcastIntervalSecs ?? 3_600))
-		// Stored targets when present, otherwise a single row from the broadcast-on
-		// fields. The relationship's order isn't guaranteed, so sort for a stable list.
+		// Targets are the only broadcast model since the protobuf consolidated TX
+		// destinations onto broadcast_targets. The relationship's order isn't
+		// guaranteed, so sort for a stable list; an empty config seeds one default row.
 		let storedTargets = (config?.broadcastTargets ?? []).sorted {
 			($0.channelIndex, $0.preset) < ($1.channelIndex, $1.preset)
 		}
 		if storedTargets.isEmpty {
-			targets = [BroadcastTargetDraft(
-				preset: config?.broadcastOnPreset ?? -1,
-				channelIndex: resolveChannelIndex(name: onChannelName, psk: onChannelPSK)
-			)]
+			targets = [BroadcastTargetDraft()]
 		} else {
 			targets = storedTargets.map { BroadcastTargetDraft(preset: $0.preset, channelIndex: $0.channelIndex) }
 		}
@@ -417,36 +409,10 @@ struct MeshBeaconConfig: View {
 			config.broadcastOfferPreset = preset
 		}
 
-		// The first row is the broadcast-on config. A custom row (-2) passes the stored
-		// name+key pair through unchanged.
-		if let first = targets.first {
-			if first.channelIndex >= 0, let channel = nodeChannels.first(where: { $0.index == first.channelIndex }) {
-				var settings = ChannelSettings()
-				settings.name = channel.name ?? ""
-				settings.psk = channel.psk ?? Data()
-				config.broadcastOnChannel = settings
-			} else if first.channelIndex == -2 {
-				var settings = ChannelSettings()
-				settings.name = onChannelName
-				settings.psk = onChannelPSK
-				config.broadcastOnChannel = settings
-			}
-			if first.preset >= 0, let preset = Config.LoRaConfig.ModemPreset(rawValue: Int(first.preset)) {
-				config.broadcastOnPreset = preset
-			}
-		}
-		if let region = Config.LoRaConfig.RegionCode(rawValue: Int(nodeRegion)) {
-			config.broadcastOnRegion = region
-		}
-
 		config.broadcastIntervalSecs = UInt32(truncatingIfNeeded: beaconInterval.intValue)
-		// No longer exposed in this editor; ride the stored value along unchanged (D4) so
-		// saving other fields cannot clear a value set from the CLI or another client.
-		config.broadcastSendAsNode = UInt32(truncatingIfNeeded: node?.meshBeaconConfig?.broadcastSendAsNode ?? 0)
 
-		// A single row rides in the broadcast-on fields alone; targets are written only
-		// when there is more than one beacon to send.
-		config.broadcastTargets = targets.count <= 1 ? [] : targets.map { draft in
+		// Every row is a broadcast target — the protobuf's only TX destination model.
+		config.broadcastTargets = targets.map { draft in
 			var target = ModuleConfig.MeshBeaconConfig.BroadcastTarget()
 			if draft.preset >= 0, let preset = Config.LoRaConfig.ModemPreset(rawValue: Int(draft.preset)) {
 				target.preset = preset

--- a/MeshtasticProtobufs/Sources/meshtastic/admin.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/admin.pb.swift
@@ -78,7 +78,7 @@ public enum OTAMode: SwiftProtobuf.Enum, Swift.CaseIterable {
 /// This message is handled by the Admin module and is responsible for all settings/channel read/write operations.
 /// This message is used to do settings operations to both remote AND local nodes.
 /// (Prior to 1.2 these operations were done via special ToRadio operations)
-public struct AdminMessage: @unchecked Sendable {
+public struct AdminMessage: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -87,207 +87,201 @@ public struct AdminMessage: @unchecked Sendable {
   /// The node generates this key and sends it with any get_x_response packets.
   /// The client MUST include the same key with any set_x commands. Key expires after 300 seconds.
   /// Prevents replay attacks for admin messages.
-  public var sessionPasskey: Data {
-    get {_storage._sessionPasskey}
-    set {_uniqueStorage()._sessionPasskey = newValue}
-  }
+  public var sessionPasskey: Data = Data()
 
   ///
   /// TODO: REPLACE
-  public var payloadVariant: OneOf_PayloadVariant? {
-    get {return _storage._payloadVariant}
-    set {_uniqueStorage()._payloadVariant = newValue}
-  }
+  public var payloadVariant: AdminMessage.OneOf_PayloadVariant? = nil
 
   ///
   /// Send the specified channel in the response to this message
   /// NOTE: This field is sent with the channel index + 1 (to ensure we never try to send 'zero' - which protobufs treats as not present)
   public var getChannelRequest: UInt32 {
     get {
-      if case .getChannelRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getChannelRequest(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .getChannelRequest(newValue)}
+    set {payloadVariant = .getChannelRequest(newValue)}
   }
 
   ///
   /// TODO: REPLACE
   public var getChannelResponse: Channel {
     get {
-      if case .getChannelResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getChannelResponse(let v)? = payloadVariant {return v}
       return Channel()
     }
-    set {_uniqueStorage()._payloadVariant = .getChannelResponse(newValue)}
+    set {payloadVariant = .getChannelResponse(newValue)}
   }
 
   ///
   /// Send the current owner data in the response to this message.
   public var getOwnerRequest: Bool {
     get {
-      if case .getOwnerRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getOwnerRequest(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .getOwnerRequest(newValue)}
+    set {payloadVariant = .getOwnerRequest(newValue)}
   }
 
   ///
   /// TODO: REPLACE
   public var getOwnerResponse: User {
     get {
-      if case .getOwnerResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getOwnerResponse(let v)? = payloadVariant {return v}
       return User()
     }
-    set {_uniqueStorage()._payloadVariant = .getOwnerResponse(newValue)}
+    set {payloadVariant = .getOwnerResponse(newValue)}
   }
 
   ///
   /// Ask for the following config data to be sent
   public var getConfigRequest: AdminMessage.ConfigType {
     get {
-      if case .getConfigRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getConfigRequest(let v)? = payloadVariant {return v}
       return .deviceConfig
     }
-    set {_uniqueStorage()._payloadVariant = .getConfigRequest(newValue)}
+    set {payloadVariant = .getConfigRequest(newValue)}
   }
 
   ///
   /// Send the current Config in the response to this message.
   public var getConfigResponse: Config {
     get {
-      if case .getConfigResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getConfigResponse(let v)? = payloadVariant {return v}
       return Config()
     }
-    set {_uniqueStorage()._payloadVariant = .getConfigResponse(newValue)}
+    set {payloadVariant = .getConfigResponse(newValue)}
   }
 
   ///
   /// Ask for the following config data to be sent
   public var getModuleConfigRequest: AdminMessage.ModuleConfigType {
     get {
-      if case .getModuleConfigRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getModuleConfigRequest(let v)? = payloadVariant {return v}
       return .mqttConfig
     }
-    set {_uniqueStorage()._payloadVariant = .getModuleConfigRequest(newValue)}
+    set {payloadVariant = .getModuleConfigRequest(newValue)}
   }
 
   ///
   /// Send the current Config in the response to this message.
   public var getModuleConfigResponse: ModuleConfig {
     get {
-      if case .getModuleConfigResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getModuleConfigResponse(let v)? = payloadVariant {return v}
       return ModuleConfig()
     }
-    set {_uniqueStorage()._payloadVariant = .getModuleConfigResponse(newValue)}
+    set {payloadVariant = .getModuleConfigResponse(newValue)}
   }
 
   ///
   /// Get the Canned Message Module messages in the response to this message.
   public var getCannedMessageModuleMessagesRequest: Bool {
     get {
-      if case .getCannedMessageModuleMessagesRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getCannedMessageModuleMessagesRequest(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .getCannedMessageModuleMessagesRequest(newValue)}
+    set {payloadVariant = .getCannedMessageModuleMessagesRequest(newValue)}
   }
 
   ///
   /// Get the Canned Message Module messages in the response to this message.
   public var getCannedMessageModuleMessagesResponse: String {
     get {
-      if case .getCannedMessageModuleMessagesResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getCannedMessageModuleMessagesResponse(let v)? = payloadVariant {return v}
       return String()
     }
-    set {_uniqueStorage()._payloadVariant = .getCannedMessageModuleMessagesResponse(newValue)}
+    set {payloadVariant = .getCannedMessageModuleMessagesResponse(newValue)}
   }
 
   ///
   /// Request the node to send device metadata (firmware, protobuf version, etc)
   public var getDeviceMetadataRequest: Bool {
     get {
-      if case .getDeviceMetadataRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getDeviceMetadataRequest(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .getDeviceMetadataRequest(newValue)}
+    set {payloadVariant = .getDeviceMetadataRequest(newValue)}
   }
 
   ///
   /// Device metadata response
   public var getDeviceMetadataResponse: DeviceMetadata {
     get {
-      if case .getDeviceMetadataResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getDeviceMetadataResponse(let v)? = payloadVariant {return v}
       return DeviceMetadata()
     }
-    set {_uniqueStorage()._payloadVariant = .getDeviceMetadataResponse(newValue)}
+    set {payloadVariant = .getDeviceMetadataResponse(newValue)}
   }
 
   ///
   /// Get the Ringtone in the response to this message.
   public var getRingtoneRequest: Bool {
     get {
-      if case .getRingtoneRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getRingtoneRequest(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .getRingtoneRequest(newValue)}
+    set {payloadVariant = .getRingtoneRequest(newValue)}
   }
 
   ///
   /// Get the Ringtone in the response to this message.
   public var getRingtoneResponse: String {
     get {
-      if case .getRingtoneResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getRingtoneResponse(let v)? = payloadVariant {return v}
       return String()
     }
-    set {_uniqueStorage()._payloadVariant = .getRingtoneResponse(newValue)}
+    set {payloadVariant = .getRingtoneResponse(newValue)}
   }
 
   ///
   /// Request the node to send it's connection status
   public var getDeviceConnectionStatusRequest: Bool {
     get {
-      if case .getDeviceConnectionStatusRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getDeviceConnectionStatusRequest(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .getDeviceConnectionStatusRequest(newValue)}
+    set {payloadVariant = .getDeviceConnectionStatusRequest(newValue)}
   }
 
   ///
   /// Device connection status response
   public var getDeviceConnectionStatusResponse: DeviceConnectionStatus {
     get {
-      if case .getDeviceConnectionStatusResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getDeviceConnectionStatusResponse(let v)? = payloadVariant {return v}
       return DeviceConnectionStatus()
     }
-    set {_uniqueStorage()._payloadVariant = .getDeviceConnectionStatusResponse(newValue)}
+    set {payloadVariant = .getDeviceConnectionStatusResponse(newValue)}
   }
 
   ///
   /// Setup a node for licensed amateur (ham) radio operation
   public var setHamMode: HamParameters {
     get {
-      if case .setHamMode(let v)? = _storage._payloadVariant {return v}
+      if case .setHamMode(let v)? = payloadVariant {return v}
       return HamParameters()
     }
-    set {_uniqueStorage()._payloadVariant = .setHamMode(newValue)}
+    set {payloadVariant = .setHamMode(newValue)}
   }
 
   ///
   /// Get the mesh's nodes with their available gpio pins for RemoteHardware module use
   public var getNodeRemoteHardwarePinsRequest: Bool {
     get {
-      if case .getNodeRemoteHardwarePinsRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getNodeRemoteHardwarePinsRequest(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .getNodeRemoteHardwarePinsRequest(newValue)}
+    set {payloadVariant = .getNodeRemoteHardwarePinsRequest(newValue)}
   }
 
   ///
   /// Respond with the mesh's nodes with their available gpio pins for RemoteHardware module use
   public var getNodeRemoteHardwarePinsResponse: NodeRemoteHardwarePinsResponse {
     get {
-      if case .getNodeRemoteHardwarePinsResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getNodeRemoteHardwarePinsResponse(let v)? = payloadVariant {return v}
       return NodeRemoteHardwarePinsResponse()
     }
-    set {_uniqueStorage()._payloadVariant = .getNodeRemoteHardwarePinsResponse(newValue)}
+    set {payloadVariant = .getNodeRemoteHardwarePinsResponse(newValue)}
   }
 
   ///
@@ -295,60 +289,60 @@ public struct AdminMessage: @unchecked Sendable {
   /// Only implemented on NRF52 currently
   public var enterDfuModeRequest: Bool {
     get {
-      if case .enterDfuModeRequest(let v)? = _storage._payloadVariant {return v}
+      if case .enterDfuModeRequest(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .enterDfuModeRequest(newValue)}
+    set {payloadVariant = .enterDfuModeRequest(newValue)}
   }
 
   ///
   /// Delete the file by the specified path from the device
   public var deleteFileRequest: String {
     get {
-      if case .deleteFileRequest(let v)? = _storage._payloadVariant {return v}
+      if case .deleteFileRequest(let v)? = payloadVariant {return v}
       return String()
     }
-    set {_uniqueStorage()._payloadVariant = .deleteFileRequest(newValue)}
+    set {payloadVariant = .deleteFileRequest(newValue)}
   }
 
   ///
   /// Set zero and offset for scale chips
   public var setScale: UInt32 {
     get {
-      if case .setScale(let v)? = _storage._payloadVariant {return v}
+      if case .setScale(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .setScale(newValue)}
+    set {payloadVariant = .setScale(newValue)}
   }
 
   ///
   /// Backup the node's preferences
   public var backupPreferences: AdminMessage.BackupLocation {
     get {
-      if case .backupPreferences(let v)? = _storage._payloadVariant {return v}
+      if case .backupPreferences(let v)? = payloadVariant {return v}
       return .flash
     }
-    set {_uniqueStorage()._payloadVariant = .backupPreferences(newValue)}
+    set {payloadVariant = .backupPreferences(newValue)}
   }
 
   ///
   /// Restore the node's preferences
   public var restorePreferences: AdminMessage.BackupLocation {
     get {
-      if case .restorePreferences(let v)? = _storage._payloadVariant {return v}
+      if case .restorePreferences(let v)? = payloadVariant {return v}
       return .flash
     }
-    set {_uniqueStorage()._payloadVariant = .restorePreferences(newValue)}
+    set {payloadVariant = .restorePreferences(newValue)}
   }
 
   ///
   /// Remove backups of the node's preferences
   public var removeBackupPreferences: AdminMessage.BackupLocation {
     get {
-      if case .removeBackupPreferences(let v)? = _storage._payloadVariant {return v}
+      if case .removeBackupPreferences(let v)? = payloadVariant {return v}
       return .flash
     }
-    set {_uniqueStorage()._payloadVariant = .removeBackupPreferences(newValue)}
+    set {payloadVariant = .removeBackupPreferences(newValue)}
   }
 
   ///
@@ -356,20 +350,20 @@ public struct AdminMessage: @unchecked Sendable {
   /// This is used to trigger physical input events like button presses, touch events, etc.
   public var sendInputEvent: AdminMessage.InputEvent {
     get {
-      if case .sendInputEvent(let v)? = _storage._payloadVariant {return v}
+      if case .sendInputEvent(let v)? = payloadVariant {return v}
       return AdminMessage.InputEvent()
     }
-    set {_uniqueStorage()._payloadVariant = .sendInputEvent(newValue)}
+    set {payloadVariant = .sendInputEvent(newValue)}
   }
 
   ///
   /// Set the owner for this node
   public var setOwner: User {
     get {
-      if case .setOwner(let v)? = _storage._payloadVariant {return v}
+      if case .setOwner(let v)? = payloadVariant {return v}
       return User()
     }
-    set {_uniqueStorage()._payloadVariant = .setOwner(newValue)}
+    set {payloadVariant = .setOwner(newValue)}
   }
 
   ///
@@ -380,100 +374,100 @@ public struct AdminMessage: @unchecked Sendable {
   /// If the client sets a particular channel to be primary, the previous channel will be set to SECONDARY automatically.
   public var setChannel: Channel {
     get {
-      if case .setChannel(let v)? = _storage._payloadVariant {return v}
+      if case .setChannel(let v)? = payloadVariant {return v}
       return Channel()
     }
-    set {_uniqueStorage()._payloadVariant = .setChannel(newValue)}
+    set {payloadVariant = .setChannel(newValue)}
   }
 
   ///
   /// Set the current Config
   public var setConfig: Config {
     get {
-      if case .setConfig(let v)? = _storage._payloadVariant {return v}
+      if case .setConfig(let v)? = payloadVariant {return v}
       return Config()
     }
-    set {_uniqueStorage()._payloadVariant = .setConfig(newValue)}
+    set {payloadVariant = .setConfig(newValue)}
   }
 
   ///
   /// Set the current Config
   public var setModuleConfig: ModuleConfig {
     get {
-      if case .setModuleConfig(let v)? = _storage._payloadVariant {return v}
+      if case .setModuleConfig(let v)? = payloadVariant {return v}
       return ModuleConfig()
     }
-    set {_uniqueStorage()._payloadVariant = .setModuleConfig(newValue)}
+    set {payloadVariant = .setModuleConfig(newValue)}
   }
 
   ///
   /// Set the Canned Message Module messages text.
   public var setCannedMessageModuleMessages: String {
     get {
-      if case .setCannedMessageModuleMessages(let v)? = _storage._payloadVariant {return v}
+      if case .setCannedMessageModuleMessages(let v)? = payloadVariant {return v}
       return String()
     }
-    set {_uniqueStorage()._payloadVariant = .setCannedMessageModuleMessages(newValue)}
+    set {payloadVariant = .setCannedMessageModuleMessages(newValue)}
   }
 
   ///
   /// Set the ringtone for ExternalNotification.
   public var setRingtoneMessage: String {
     get {
-      if case .setRingtoneMessage(let v)? = _storage._payloadVariant {return v}
+      if case .setRingtoneMessage(let v)? = payloadVariant {return v}
       return String()
     }
-    set {_uniqueStorage()._payloadVariant = .setRingtoneMessage(newValue)}
+    set {payloadVariant = .setRingtoneMessage(newValue)}
   }
 
   ///
   /// Remove the node by the specified node-num from the NodeDB on the device
   public var removeByNodenum: UInt32 {
     get {
-      if case .removeByNodenum(let v)? = _storage._payloadVariant {return v}
+      if case .removeByNodenum(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .removeByNodenum(newValue)}
+    set {payloadVariant = .removeByNodenum(newValue)}
   }
 
   ///
   /// Set specified node-num to be favorited on the NodeDB on the device
   public var setFavoriteNode: UInt32 {
     get {
-      if case .setFavoriteNode(let v)? = _storage._payloadVariant {return v}
+      if case .setFavoriteNode(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .setFavoriteNode(newValue)}
+    set {payloadVariant = .setFavoriteNode(newValue)}
   }
 
   ///
   /// Set specified node-num to be un-favorited on the NodeDB on the device
   public var removeFavoriteNode: UInt32 {
     get {
-      if case .removeFavoriteNode(let v)? = _storage._payloadVariant {return v}
+      if case .removeFavoriteNode(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .removeFavoriteNode(newValue)}
+    set {payloadVariant = .removeFavoriteNode(newValue)}
   }
 
   ///
   /// Set fixed position data on the node and then set the position.fixed_position = true
   public var setFixedPosition: Position {
     get {
-      if case .setFixedPosition(let v)? = _storage._payloadVariant {return v}
+      if case .setFixedPosition(let v)? = payloadVariant {return v}
       return Position()
     }
-    set {_uniqueStorage()._payloadVariant = .setFixedPosition(newValue)}
+    set {payloadVariant = .setFixedPosition(newValue)}
   }
 
   ///
   /// Clear fixed position coordinates and then set position.fixed_position = false
   public var removeFixedPosition: Bool {
     get {
-      if case .removeFixedPosition(let v)? = _storage._payloadVariant {return v}
+      if case .removeFixedPosition(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .removeFixedPosition(newValue)}
+    set {payloadVariant = .removeFixedPosition(newValue)}
   }
 
   ///
@@ -481,70 +475,70 @@ public struct AdminMessage: @unchecked Sendable {
   /// Convenience method to set the time on the node (as Net quality) without any other position data
   public var setTimeOnly: UInt32 {
     get {
-      if case .setTimeOnly(let v)? = _storage._payloadVariant {return v}
+      if case .setTimeOnly(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .setTimeOnly(newValue)}
+    set {payloadVariant = .setTimeOnly(newValue)}
   }
 
   ///
   /// Tell the node to send the stored ui data.
   public var getUiConfigRequest: Bool {
     get {
-      if case .getUiConfigRequest(let v)? = _storage._payloadVariant {return v}
+      if case .getUiConfigRequest(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .getUiConfigRequest(newValue)}
+    set {payloadVariant = .getUiConfigRequest(newValue)}
   }
 
   ///
   /// Reply stored device ui data.
   public var getUiConfigResponse: DeviceUIConfig {
     get {
-      if case .getUiConfigResponse(let v)? = _storage._payloadVariant {return v}
+      if case .getUiConfigResponse(let v)? = payloadVariant {return v}
       return DeviceUIConfig()
     }
-    set {_uniqueStorage()._payloadVariant = .getUiConfigResponse(newValue)}
+    set {payloadVariant = .getUiConfigResponse(newValue)}
   }
 
   ///
   /// Tell the node to store UI data persistently.
   public var storeUiConfig: DeviceUIConfig {
     get {
-      if case .storeUiConfig(let v)? = _storage._payloadVariant {return v}
+      if case .storeUiConfig(let v)? = payloadVariant {return v}
       return DeviceUIConfig()
     }
-    set {_uniqueStorage()._payloadVariant = .storeUiConfig(newValue)}
+    set {payloadVariant = .storeUiConfig(newValue)}
   }
 
   ///
   /// Set specified node-num to be ignored on the NodeDB on the device
   public var setIgnoredNode: UInt32 {
     get {
-      if case .setIgnoredNode(let v)? = _storage._payloadVariant {return v}
+      if case .setIgnoredNode(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .setIgnoredNode(newValue)}
+    set {payloadVariant = .setIgnoredNode(newValue)}
   }
 
   ///
   /// Set specified node-num to be un-ignored on the NodeDB on the device
   public var removeIgnoredNode: UInt32 {
     get {
-      if case .removeIgnoredNode(let v)? = _storage._payloadVariant {return v}
+      if case .removeIgnoredNode(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .removeIgnoredNode(newValue)}
+    set {payloadVariant = .removeIgnoredNode(newValue)}
   }
 
   ///
   /// Set specified node-num to be muted
   public var toggleMutedNode: UInt32 {
     get {
-      if case .toggleMutedNode(let v)? = _storage._payloadVariant {return v}
+      if case .toggleMutedNode(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .toggleMutedNode(newValue)}
+    set {payloadVariant = .toggleMutedNode(newValue)}
   }
 
   ///
@@ -552,50 +546,50 @@ public struct AdminMessage: @unchecked Sendable {
   /// This will delay the standard *implicit* save to the file system and subsequent reboot behavior until committed (commit_edit_settings)
   public var beginEditSettings: Bool {
     get {
-      if case .beginEditSettings(let v)? = _storage._payloadVariant {return v}
+      if case .beginEditSettings(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .beginEditSettings(newValue)}
+    set {payloadVariant = .beginEditSettings(newValue)}
   }
 
   ///
   /// Commits an open transaction for any edits made to config, module config, owner, and channel settings
   public var commitEditSettings: Bool {
     get {
-      if case .commitEditSettings(let v)? = _storage._payloadVariant {return v}
+      if case .commitEditSettings(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .commitEditSettings(newValue)}
+    set {payloadVariant = .commitEditSettings(newValue)}
   }
 
   ///
   /// Add a contact (User) to the nodedb
   public var addContact: SharedContact {
     get {
-      if case .addContact(let v)? = _storage._payloadVariant {return v}
+      if case .addContact(let v)? = payloadVariant {return v}
       return SharedContact()
     }
-    set {_uniqueStorage()._payloadVariant = .addContact(newValue)}
+    set {payloadVariant = .addContact(newValue)}
   }
 
   ///
   /// Initiate or respond to a key verification request
   public var keyVerification: KeyVerificationAdmin {
     get {
-      if case .keyVerification(let v)? = _storage._payloadVariant {return v}
+      if case .keyVerification(let v)? = payloadVariant {return v}
       return KeyVerificationAdmin()
     }
-    set {_uniqueStorage()._payloadVariant = .keyVerification(newValue)}
+    set {payloadVariant = .keyVerification(newValue)}
   }
 
   ///
   /// Tell the node to factory reset config everything; all device state and configuration will be returned to factory defaults and BLE bonds will be cleared.
   public var factoryResetDevice: Int32 {
     get {
-      if case .factoryResetDevice(let v)? = _storage._payloadVariant {return v}
+      if case .factoryResetDevice(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .factoryResetDevice(newValue)}
+    set {payloadVariant = .factoryResetDevice(newValue)}
   }
 
   ///
@@ -606,10 +600,10 @@ public struct AdminMessage: @unchecked Sendable {
   /// NOTE: This field was marked as deprecated in the .proto file.
   public var rebootOtaSeconds: Int32 {
     get {
-      if case .rebootOtaSeconds(let v)? = _storage._payloadVariant {return v}
+      if case .rebootOtaSeconds(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .rebootOtaSeconds(newValue)}
+    set {payloadVariant = .rebootOtaSeconds(newValue)}
   }
 
   ///
@@ -617,40 +611,40 @@ public struct AdminMessage: @unchecked Sendable {
   /// If received the simulator will exit successfully.
   public var exitSimulator: Bool {
     get {
-      if case .exitSimulator(let v)? = _storage._payloadVariant {return v}
+      if case .exitSimulator(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .exitSimulator(newValue)}
+    set {payloadVariant = .exitSimulator(newValue)}
   }
 
   ///
   /// Tell the node to reboot in this many seconds (or <0 to cancel reboot)
   public var rebootSeconds: Int32 {
     get {
-      if case .rebootSeconds(let v)? = _storage._payloadVariant {return v}
+      if case .rebootSeconds(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .rebootSeconds(newValue)}
+    set {payloadVariant = .rebootSeconds(newValue)}
   }
 
   ///
   /// Tell the node to shutdown in this many seconds (or <0 to cancel shutdown)
   public var shutdownSeconds: Int32 {
     get {
-      if case .shutdownSeconds(let v)? = _storage._payloadVariant {return v}
+      if case .shutdownSeconds(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .shutdownSeconds(newValue)}
+    set {payloadVariant = .shutdownSeconds(newValue)}
   }
 
   ///
   /// Tell the node to factory reset config; all device state and configuration will be returned to factory defaults; BLE bonds will be preserved.
   public var factoryResetConfig: Int32 {
     get {
-      if case .factoryResetConfig(let v)? = _storage._payloadVariant {return v}
+      if case .factoryResetConfig(let v)? = payloadVariant {return v}
       return 0
     }
-    set {_uniqueStorage()._payloadVariant = .factoryResetConfig(newValue)}
+    set {payloadVariant = .factoryResetConfig(newValue)}
   }
 
   ///
@@ -658,30 +652,30 @@ public struct AdminMessage: @unchecked Sendable {
   /// When true, favorites are preserved through reset.
   public var nodedbReset: Bool {
     get {
-      if case .nodedbReset(let v)? = _storage._payloadVariant {return v}
+      if case .nodedbReset(let v)? = payloadVariant {return v}
       return false
     }
-    set {_uniqueStorage()._payloadVariant = .nodedbReset(newValue)}
+    set {payloadVariant = .nodedbReset(newValue)}
   }
 
   ///
   /// Tell the node to reset into the OTA Loader
   public var otaRequest: AdminMessage.OTAEvent {
     get {
-      if case .otaRequest(let v)? = _storage._payloadVariant {return v}
+      if case .otaRequest(let v)? = payloadVariant {return v}
       return AdminMessage.OTAEvent()
     }
-    set {_uniqueStorage()._payloadVariant = .otaRequest(newValue)}
+    set {payloadVariant = .otaRequest(newValue)}
   }
 
   ///
   /// Parameters and sensor configuration
   public var sensorConfig: SensorConfig {
     get {
-      if case .sensorConfig(let v)? = _storage._payloadVariant {return v}
+      if case .sensorConfig(let v)? = payloadVariant {return v}
       return SensorConfig()
     }
-    set {_uniqueStorage()._payloadVariant = .sensorConfig(newValue)}
+    set {payloadVariant = .sensorConfig(newValue)}
   }
 
   ///
@@ -695,10 +689,10 @@ public struct AdminMessage: @unchecked Sendable {
   /// to carry passphrase bytes; that hack is retired.
   public var lockdownAuth: LockdownAuth {
     get {
-      if case .lockdownAuth(let v)? = _storage._payloadVariant {return v}
+      if case .lockdownAuth(let v)? = payloadVariant {return v}
       return LockdownAuth()
     }
-    set {_uniqueStorage()._payloadVariant = .lockdownAuth(newValue)}
+    set {payloadVariant = .lockdownAuth(newValue)}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -1241,8 +1235,6 @@ public struct AdminMessage: @unchecked Sendable {
   }
 
   public init() {}
-
-  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 ///
@@ -1534,7 +1526,7 @@ public struct KeyVerificationAdmin: Sendable {
   fileprivate var _securityNumber: UInt32? = nil
 }
 
-public struct SensorConfig: Sendable {
+public struct SensorConfig: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1542,55 +1534,85 @@ public struct SensorConfig: Sendable {
   ///
   /// SCD4X CO2 Sensor configuration
   public var scd4XConfig: SCD4X_config {
-    get {_scd4XConfig ?? SCD4X_config()}
-    set {_scd4XConfig = newValue}
+    get {_storage._scd4XConfig ?? SCD4X_config()}
+    set {_uniqueStorage()._scd4XConfig = newValue}
   }
   /// Returns true if `scd4XConfig` has been explicitly set.
-  public var hasScd4XConfig: Bool {self._scd4XConfig != nil}
+  public var hasScd4XConfig: Bool {_storage._scd4XConfig != nil}
   /// Clears the value of `scd4XConfig`. Subsequent reads from it will return its default value.
-  public mutating func clearScd4XConfig() {self._scd4XConfig = nil}
+  public mutating func clearScd4XConfig() {_uniqueStorage()._scd4XConfig = nil}
 
   ///
   /// SEN5X PM Sensor configuration
   public var sen5XConfig: SEN5X_config {
-    get {_sen5XConfig ?? SEN5X_config()}
-    set {_sen5XConfig = newValue}
+    get {_storage._sen5XConfig ?? SEN5X_config()}
+    set {_uniqueStorage()._sen5XConfig = newValue}
   }
   /// Returns true if `sen5XConfig` has been explicitly set.
-  public var hasSen5XConfig: Bool {self._sen5XConfig != nil}
+  public var hasSen5XConfig: Bool {_storage._sen5XConfig != nil}
   /// Clears the value of `sen5XConfig`. Subsequent reads from it will return its default value.
-  public mutating func clearSen5XConfig() {self._sen5XConfig = nil}
+  public mutating func clearSen5XConfig() {_uniqueStorage()._sen5XConfig = nil}
 
   ///
   /// SCD30 CO2 Sensor configuration
   public var scd30Config: SCD30_config {
-    get {_scd30Config ?? SCD30_config()}
-    set {_scd30Config = newValue}
+    get {_storage._scd30Config ?? SCD30_config()}
+    set {_uniqueStorage()._scd30Config = newValue}
   }
   /// Returns true if `scd30Config` has been explicitly set.
-  public var hasScd30Config: Bool {self._scd30Config != nil}
+  public var hasScd30Config: Bool {_storage._scd30Config != nil}
   /// Clears the value of `scd30Config`. Subsequent reads from it will return its default value.
-  public mutating func clearScd30Config() {self._scd30Config = nil}
+  public mutating func clearScd30Config() {_uniqueStorage()._scd30Config = nil}
 
   ///
   /// SHTXX temperature and relative humidity sensor configuration
   public var shtxxConfig: SHTXX_config {
-    get {_shtxxConfig ?? SHTXX_config()}
-    set {_shtxxConfig = newValue}
+    get {_storage._shtxxConfig ?? SHTXX_config()}
+    set {_uniqueStorage()._shtxxConfig = newValue}
   }
   /// Returns true if `shtxxConfig` has been explicitly set.
-  public var hasShtxxConfig: Bool {self._shtxxConfig != nil}
+  public var hasShtxxConfig: Bool {_storage._shtxxConfig != nil}
   /// Clears the value of `shtxxConfig`. Subsequent reads from it will return its default value.
-  public mutating func clearShtxxConfig() {self._shtxxConfig = nil}
+  public mutating func clearShtxxConfig() {_uniqueStorage()._shtxxConfig = nil}
+
+  ///
+  /// DS248X-800 temperature sensor configuration
+  public var ds248XConfig: DS248X_config {
+    get {_storage._ds248XConfig ?? DS248X_config()}
+    set {_uniqueStorage()._ds248XConfig = newValue}
+  }
+  /// Returns true if `ds248XConfig` has been explicitly set.
+  public var hasDs248XConfig: Bool {_storage._ds248XConfig != nil}
+  /// Clears the value of `ds248XConfig`. Subsequent reads from it will return its default value.
+  public mutating func clearDs248XConfig() {_uniqueStorage()._ds248XConfig = nil}
+
+  ///
+  /// SEN6X PM/RHT/VOC/NOx/CO2/HCHO Sensor configuration
+  public var sen6XConfig: SEN6X_config {
+    get {_storage._sen6XConfig ?? SEN6X_config()}
+    set {_uniqueStorage()._sen6XConfig = newValue}
+  }
+  /// Returns true if `sen6XConfig` has been explicitly set.
+  public var hasSen6XConfig: Bool {_storage._sen6XConfig != nil}
+  /// Clears the value of `sen6XConfig`. Subsequent reads from it will return its default value.
+  public mutating func clearSen6XConfig() {_uniqueStorage()._sen6XConfig = nil}
+
+  ///
+  /// AS3935 lightning sensor configuration
+  public var as3935Config: AS3935_config {
+    get {_storage._as3935Config ?? AS3935_config()}
+    set {_uniqueStorage()._as3935Config = newValue}
+  }
+  /// Returns true if `as3935Config` has been explicitly set.
+  public var hasAs3935Config: Bool {_storage._as3935Config != nil}
+  /// Clears the value of `as3935Config`. Subsequent reads from it will return its default value.
+  public mutating func clearAs3935Config() {_uniqueStorage()._as3935Config = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _scd4XConfig: SCD4X_config? = nil
-  fileprivate var _sen5XConfig: SEN5X_config? = nil
-  fileprivate var _scd30Config: SCD30_config? = nil
-  fileprivate var _shtxxConfig: SHTXX_config? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public struct SCD4X_config: Sendable {
@@ -1715,12 +1737,131 @@ public struct SEN5X_config: Sendable {
   /// Clears the value of `setOneShotMode`. Subsequent reads from it will return its default value.
   public mutating func clearSetOneShotMode() {self._setOneShotMode = nil}
 
+  ///
+  /// Trigger a fan cleaning cycle
+  public var startFanCleaning: Bool {
+    get {_startFanCleaning ?? false}
+    set {_startFanCleaning = newValue}
+  }
+  /// Returns true if `startFanCleaning` has been explicitly set.
+  public var hasStartFanCleaning: Bool {self._startFanCleaning != nil}
+  /// Clears the value of `startFanCleaning`. Subsequent reads from it will return its default value.
+  public mutating func clearStartFanCleaning() {self._startFanCleaning = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _setTemperature: Float? = nil
   fileprivate var _setOneShotMode: Bool? = nil
+  fileprivate var _startFanCleaning: Bool? = nil
+}
+
+public struct SEN6X_config: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  ///
+  /// Reference temperature in degC
+  public var setTemperature: Float {
+    get {_setTemperature ?? 0}
+    set {_setTemperature = newValue}
+  }
+  /// Returns true if `setTemperature` has been explicitly set.
+  public var hasSetTemperature: Bool {self._setTemperature != nil}
+  /// Clears the value of `setTemperature`. Subsequent reads from it will return its default value.
+  public mutating func clearSetTemperature() {self._setTemperature = nil}
+
+  ///
+  /// One-shot mode (true for low power - one-shot mode, false for normal - continuous mode)
+  public var setOneShotMode: Bool {
+    get {_setOneShotMode ?? false}
+    set {_setOneShotMode = newValue}
+  }
+  /// Returns true if `setOneShotMode` has been explicitly set.
+  public var hasSetOneShotMode: Bool {self._setOneShotMode != nil}
+  /// Clears the value of `setOneShotMode`. Subsequent reads from it will return its default value.
+  public mutating func clearSetOneShotMode() {self._setOneShotMode = nil}
+
+  ///
+  /// Trigger a fan cleaning cycle
+  public var startFanCleaning: Bool {
+    get {_startFanCleaning ?? false}
+    set {_startFanCleaning = newValue}
+  }
+  /// Returns true if `startFanCleaning` has been explicitly set.
+  public var hasStartFanCleaning: Bool {self._startFanCleaning != nil}
+  /// Clears the value of `startFanCleaning`. Subsequent reads from it will return its default value.
+  public mutating func clearStartFanCleaning() {self._startFanCleaning = nil}
+
+  ///
+  /// Set Automatic self-calibration enabled (CO2-capable variants only: SEN63C, SEN66, SEN69C)
+  public var setAsc: Bool {
+    get {_setAsc ?? false}
+    set {_setAsc = newValue}
+  }
+  /// Returns true if `setAsc` has been explicitly set.
+  public var hasSetAsc: Bool {self._setAsc != nil}
+  /// Clears the value of `setAsc`. Subsequent reads from it will return its default value.
+  public mutating func clearSetAsc() {self._setAsc = nil}
+
+  ///
+  /// Recalibration target CO2 concentration in ppm (FRC only), CO2-capable variants only
+  public var setTargetCo2Conc: UInt32 {
+    get {_setTargetCo2Conc ?? 0}
+    set {_setTargetCo2Conc = newValue}
+  }
+  /// Returns true if `setTargetCo2Conc` has been explicitly set.
+  public var hasSetTargetCo2Conc: Bool {self._setTargetCo2Conc != nil}
+  /// Clears the value of `setTargetCo2Conc`. Subsequent reads from it will return its default value.
+  public mutating func clearSetTargetCo2Conc() {self._setTargetCo2Conc = nil}
+
+  ///
+  /// Altitude of sensor in meters above sea level. 0 - 3000m (overrides ambient pressure), CO2-capable variants only
+  public var setAltitude: UInt32 {
+    get {_setAltitude ?? 0}
+    set {_setAltitude = newValue}
+  }
+  /// Returns true if `setAltitude` has been explicitly set.
+  public var hasSetAltitude: Bool {self._setAltitude != nil}
+  /// Clears the value of `setAltitude`. Subsequent reads from it will return its default value.
+  public mutating func clearSetAltitude() {self._setAltitude = nil}
+
+  ///
+  /// Sensor ambient pressure in Pa. 70000 - 120000 Pa (overrides altitude), CO2-capable variants only
+  public var setAmbientPressure: UInt32 {
+    get {_setAmbientPressure ?? 0}
+    set {_setAmbientPressure = newValue}
+  }
+  /// Returns true if `setAmbientPressure` has been explicitly set.
+  public var hasSetAmbientPressure: Bool {self._setAmbientPressure != nil}
+  /// Clears the value of `setAmbientPressure`. Subsequent reads from it will return its default value.
+  public mutating func clearSetAmbientPressure() {self._setAmbientPressure = nil}
+
+  ///
+  /// Perform a factory reset of the CO2 sensor's calibration, CO2-capable variants only
+  public var factoryReset: Bool {
+    get {_factoryReset ?? false}
+    set {_factoryReset = newValue}
+  }
+  /// Returns true if `factoryReset` has been explicitly set.
+  public var hasFactoryReset: Bool {self._factoryReset != nil}
+  /// Clears the value of `factoryReset`. Subsequent reads from it will return its default value.
+  public mutating func clearFactoryReset() {self._factoryReset = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _setTemperature: Float? = nil
+  fileprivate var _setOneShotMode: Bool? = nil
+  fileprivate var _startFanCleaning: Bool? = nil
+  fileprivate var _setAsc: Bool? = nil
+  fileprivate var _setTargetCo2Conc: UInt32? = nil
+  fileprivate var _setAltitude: UInt32? = nil
+  fileprivate var _setAmbientPressure: UInt32? = nil
+  fileprivate var _factoryReset: Bool? = nil
 }
 
 public struct SCD30_config: Sendable {
@@ -1829,6 +1970,53 @@ public struct SHTXX_config: Sendable {
   fileprivate var _setAccuracy: UInt32? = nil
 }
 
+public struct DS248X_config: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  ///
+  /// Main channel for temperature reporting (0-7)
+  public var mainTemperatureChannel: UInt32 {
+    get {_mainTemperatureChannel ?? 0}
+    set {_mainTemperatureChannel = newValue}
+  }
+  /// Returns true if `mainTemperatureChannel` has been explicitly set.
+  public var hasMainTemperatureChannel: Bool {self._mainTemperatureChannel != nil}
+  /// Clears the value of `mainTemperatureChannel`. Subsequent reads from it will return its default value.
+  public mutating func clearMainTemperatureChannel() {self._mainTemperatureChannel = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _mainTemperatureChannel: UInt32? = nil
+}
+
+public struct AS3935_config: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  ///
+  /// Antenna tuning capacitance in pF, 0 to 120 in steps of 8. The antenna tank must
+  /// resonate within 3.5% of 500kHz; the correct trim is specific to the sensor board.
+  public var setTuningCapPf: UInt32 {
+    get {_setTuningCapPf ?? 0}
+    set {_setTuningCapPf = newValue}
+  }
+  /// Returns true if `setTuningCapPf` has been explicitly set.
+  public var hasSetTuningCapPf: Bool {self._setTuningCapPf != nil}
+  /// Clears the value of `setTuningCapPf`. Subsequent reads from it will return its default value.
+  public mutating func clearSetTuningCapPf() {self._setTuningCapPf = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _setTuningCapPf: UInt32? = nil
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "meshtastic"
@@ -1841,877 +2029,839 @@ extension AdminMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
   public static let protoMessageName: String = _protobuf_package + ".AdminMessage"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}get_channel_request\0\u{3}get_channel_response\0\u{3}get_owner_request\0\u{3}get_owner_response\0\u{3}get_config_request\0\u{3}get_config_response\0\u{3}get_module_config_request\0\u{3}get_module_config_response\0\u{4}\u{2}get_canned_message_module_messages_request\0\u{3}get_canned_message_module_messages_response\0\u{3}get_device_metadata_request\0\u{3}get_device_metadata_response\0\u{3}get_ringtone_request\0\u{3}get_ringtone_response\0\u{3}get_device_connection_status_request\0\u{3}get_device_connection_status_response\0\u{3}set_ham_mode\0\u{3}get_node_remote_hardware_pins_request\0\u{3}get_node_remote_hardware_pins_response\0\u{3}enter_dfu_mode_request\0\u{3}delete_file_request\0\u{3}set_scale\0\u{3}backup_preferences\0\u{3}restore_preferences\0\u{3}remove_backup_preferences\0\u{3}send_input_event\0\u{4}\u{5}set_owner\0\u{3}set_channel\0\u{3}set_config\0\u{3}set_module_config\0\u{3}set_canned_message_module_messages\0\u{3}set_ringtone_message\0\u{3}remove_by_nodenum\0\u{3}set_favorite_node\0\u{3}remove_favorite_node\0\u{3}set_fixed_position\0\u{3}remove_fixed_position\0\u{3}set_time_only\0\u{3}get_ui_config_request\0\u{3}get_ui_config_response\0\u{3}store_ui_config\0\u{3}set_ignored_node\0\u{3}remove_ignored_node\0\u{3}toggle_muted_node\0\u{4}\u{f}begin_edit_settings\0\u{3}commit_edit_settings\0\u{3}add_contact\0\u{3}key_verification\0\u{4}\u{1b}factory_reset_device\0\u{3}reboot_ota_seconds\0\u{3}exit_simulator\0\u{3}reboot_seconds\0\u{3}shutdown_seconds\0\u{3}factory_reset_config\0\u{3}nodedb_reset\0\u{3}session_passkey\0\u{3}ota_request\0\u{3}sensor_config\0\u{3}lockdown_auth\0")
 
-  fileprivate class _StorageClass {
-    var _sessionPasskey: Data = Data()
-    var _payloadVariant: AdminMessage.OneOf_PayloadVariant?
-
-      // This property is used as the initial default value for new instances of the type.
-      // The type itself is protecting the reference to its storage via CoW semantics.
-      // This will force a copy to be made of this reference when the first mutation occurs;
-      // hence, it is safe to mark this as `nonisolated(unsafe)`.
-      static nonisolated(unsafe) let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _sessionPasskey = source._sessionPasskey
-      _payloadVariant = source._payloadVariant
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
-
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getChannelRequest(v)
-          }
-        }()
-        case 2: try {
-          var v: Channel?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .getChannelResponse(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getChannelResponse(v)
-          }
-        }()
-        case 3: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getOwnerRequest(v)
-          }
-        }()
-        case 4: try {
-          var v: User?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .getOwnerResponse(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getOwnerResponse(v)
-          }
-        }()
-        case 5: try {
-          var v: AdminMessage.ConfigType?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getConfigRequest(v)
-          }
-        }()
-        case 6: try {
-          var v: Config?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .getConfigResponse(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getConfigResponse(v)
-          }
-        }()
-        case 7: try {
-          var v: AdminMessage.ModuleConfigType?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getModuleConfigRequest(v)
-          }
-        }()
-        case 8: try {
-          var v: ModuleConfig?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .getModuleConfigResponse(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getModuleConfigResponse(v)
-          }
-        }()
-        case 10: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getCannedMessageModuleMessagesRequest(v)
-          }
-        }()
-        case 11: try {
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getCannedMessageModuleMessagesResponse(v)
-          }
-        }()
-        case 12: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getDeviceMetadataRequest(v)
-          }
-        }()
-        case 13: try {
-          var v: DeviceMetadata?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .getDeviceMetadataResponse(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getDeviceMetadataResponse(v)
-          }
-        }()
-        case 14: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getRingtoneRequest(v)
-          }
-        }()
-        case 15: try {
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getRingtoneResponse(v)
-          }
-        }()
-        case 16: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getDeviceConnectionStatusRequest(v)
-          }
-        }()
-        case 17: try {
-          var v: DeviceConnectionStatus?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .getDeviceConnectionStatusResponse(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getDeviceConnectionStatusResponse(v)
-          }
-        }()
-        case 18: try {
-          var v: HamParameters?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .setHamMode(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setHamMode(v)
-          }
-        }()
-        case 19: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getNodeRemoteHardwarePinsRequest(v)
-          }
-        }()
-        case 20: try {
-          var v: NodeRemoteHardwarePinsResponse?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .getNodeRemoteHardwarePinsResponse(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getNodeRemoteHardwarePinsResponse(v)
-          }
-        }()
-        case 21: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .enterDfuModeRequest(v)
-          }
-        }()
-        case 22: try {
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .deleteFileRequest(v)
-          }
-        }()
-        case 23: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setScale(v)
-          }
-        }()
-        case 24: try {
-          var v: AdminMessage.BackupLocation?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .backupPreferences(v)
-          }
-        }()
-        case 25: try {
-          var v: AdminMessage.BackupLocation?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .restorePreferences(v)
-          }
-        }()
-        case 26: try {
-          var v: AdminMessage.BackupLocation?
-          try decoder.decodeSingularEnumField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .removeBackupPreferences(v)
-          }
-        }()
-        case 27: try {
-          var v: AdminMessage.InputEvent?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .sendInputEvent(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .sendInputEvent(v)
-          }
-        }()
-        case 32: try {
-          var v: User?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .setOwner(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setOwner(v)
-          }
-        }()
-        case 33: try {
-          var v: Channel?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .setChannel(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setChannel(v)
-          }
-        }()
-        case 34: try {
-          var v: Config?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .setConfig(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setConfig(v)
-          }
-        }()
-        case 35: try {
-          var v: ModuleConfig?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .setModuleConfig(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setModuleConfig(v)
-          }
-        }()
-        case 36: try {
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setCannedMessageModuleMessages(v)
-          }
-        }()
-        case 37: try {
-          var v: String?
-          try decoder.decodeSingularStringField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setRingtoneMessage(v)
-          }
-        }()
-        case 38: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .removeByNodenum(v)
-          }
-        }()
-        case 39: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setFavoriteNode(v)
-          }
-        }()
-        case 40: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .removeFavoriteNode(v)
-          }
-        }()
-        case 41: try {
-          var v: Position?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .setFixedPosition(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setFixedPosition(v)
-          }
-        }()
-        case 42: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .removeFixedPosition(v)
-          }
-        }()
-        case 43: try {
-          var v: UInt32?
-          try decoder.decodeSingularFixed32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setTimeOnly(v)
-          }
-        }()
-        case 44: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getUiConfigRequest(v)
-          }
-        }()
-        case 45: try {
-          var v: DeviceUIConfig?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .getUiConfigResponse(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .getUiConfigResponse(v)
-          }
-        }()
-        case 46: try {
-          var v: DeviceUIConfig?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .storeUiConfig(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .storeUiConfig(v)
-          }
-        }()
-        case 47: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .setIgnoredNode(v)
-          }
-        }()
-        case 48: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .removeIgnoredNode(v)
-          }
-        }()
-        case 49: try {
-          var v: UInt32?
-          try decoder.decodeSingularUInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .toggleMutedNode(v)
-          }
-        }()
-        case 64: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .beginEditSettings(v)
-          }
-        }()
-        case 65: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .commitEditSettings(v)
-          }
-        }()
-        case 66: try {
-          var v: SharedContact?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .addContact(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .addContact(v)
-          }
-        }()
-        case 67: try {
-          var v: KeyVerificationAdmin?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .keyVerification(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .keyVerification(v)
-          }
-        }()
-        case 94: try {
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .factoryResetDevice(v)
-          }
-        }()
-        case 95: try {
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .rebootOtaSeconds(v)
-          }
-        }()
-        case 96: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .exitSimulator(v)
-          }
-        }()
-        case 97: try {
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .rebootSeconds(v)
-          }
-        }()
-        case 98: try {
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .shutdownSeconds(v)
-          }
-        }()
-        case 99: try {
-          var v: Int32?
-          try decoder.decodeSingularInt32Field(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .factoryResetConfig(v)
-          }
-        }()
-        case 100: try {
-          var v: Bool?
-          try decoder.decodeSingularBoolField(value: &v)
-          if let v = v {
-            if _storage._payloadVariant != nil {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .nodedbReset(v)
-          }
-        }()
-        case 101: try { try decoder.decodeSingularBytesField(value: &_storage._sessionPasskey) }()
-        case 102: try {
-          var v: AdminMessage.OTAEvent?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .otaRequest(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .otaRequest(v)
-          }
-        }()
-        case 103: try {
-          var v: SensorConfig?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .sensorConfig(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .sensorConfig(v)
-          }
-        }()
-        case 104: try {
-          var v: LockdownAuth?
-          var hadOneofValue = false
-          if let current = _storage._payloadVariant {
-            hadOneofValue = true
-            if case .lockdownAuth(let m) = current {v = m}
-          }
-          try decoder.decodeSingularMessageField(value: &v)
-          if let v = v {
-            if hadOneofValue {try decoder.handleConflictingOneOf()}
-            _storage._payloadVariant = .lockdownAuth(v)
-          }
-        }()
-        default: break
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getChannelRequest(v)
         }
+      }()
+      case 2: try {
+        var v: Channel?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .getChannelResponse(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getChannelResponse(v)
+        }
+      }()
+      case 3: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getOwnerRequest(v)
+        }
+      }()
+      case 4: try {
+        var v: User?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .getOwnerResponse(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getOwnerResponse(v)
+        }
+      }()
+      case 5: try {
+        var v: AdminMessage.ConfigType?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getConfigRequest(v)
+        }
+      }()
+      case 6: try {
+        var v: Config?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .getConfigResponse(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getConfigResponse(v)
+        }
+      }()
+      case 7: try {
+        var v: AdminMessage.ModuleConfigType?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getModuleConfigRequest(v)
+        }
+      }()
+      case 8: try {
+        var v: ModuleConfig?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .getModuleConfigResponse(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getModuleConfigResponse(v)
+        }
+      }()
+      case 10: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getCannedMessageModuleMessagesRequest(v)
+        }
+      }()
+      case 11: try {
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getCannedMessageModuleMessagesResponse(v)
+        }
+      }()
+      case 12: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getDeviceMetadataRequest(v)
+        }
+      }()
+      case 13: try {
+        var v: DeviceMetadata?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .getDeviceMetadataResponse(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getDeviceMetadataResponse(v)
+        }
+      }()
+      case 14: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getRingtoneRequest(v)
+        }
+      }()
+      case 15: try {
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getRingtoneResponse(v)
+        }
+      }()
+      case 16: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getDeviceConnectionStatusRequest(v)
+        }
+      }()
+      case 17: try {
+        var v: DeviceConnectionStatus?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .getDeviceConnectionStatusResponse(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getDeviceConnectionStatusResponse(v)
+        }
+      }()
+      case 18: try {
+        var v: HamParameters?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .setHamMode(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setHamMode(v)
+        }
+      }()
+      case 19: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getNodeRemoteHardwarePinsRequest(v)
+        }
+      }()
+      case 20: try {
+        var v: NodeRemoteHardwarePinsResponse?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .getNodeRemoteHardwarePinsResponse(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getNodeRemoteHardwarePinsResponse(v)
+        }
+      }()
+      case 21: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .enterDfuModeRequest(v)
+        }
+      }()
+      case 22: try {
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .deleteFileRequest(v)
+        }
+      }()
+      case 23: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setScale(v)
+        }
+      }()
+      case 24: try {
+        var v: AdminMessage.BackupLocation?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .backupPreferences(v)
+        }
+      }()
+      case 25: try {
+        var v: AdminMessage.BackupLocation?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .restorePreferences(v)
+        }
+      }()
+      case 26: try {
+        var v: AdminMessage.BackupLocation?
+        try decoder.decodeSingularEnumField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .removeBackupPreferences(v)
+        }
+      }()
+      case 27: try {
+        var v: AdminMessage.InputEvent?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .sendInputEvent(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .sendInputEvent(v)
+        }
+      }()
+      case 32: try {
+        var v: User?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .setOwner(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setOwner(v)
+        }
+      }()
+      case 33: try {
+        var v: Channel?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .setChannel(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setChannel(v)
+        }
+      }()
+      case 34: try {
+        var v: Config?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .setConfig(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setConfig(v)
+        }
+      }()
+      case 35: try {
+        var v: ModuleConfig?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .setModuleConfig(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setModuleConfig(v)
+        }
+      }()
+      case 36: try {
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setCannedMessageModuleMessages(v)
+        }
+      }()
+      case 37: try {
+        var v: String?
+        try decoder.decodeSingularStringField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setRingtoneMessage(v)
+        }
+      }()
+      case 38: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .removeByNodenum(v)
+        }
+      }()
+      case 39: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setFavoriteNode(v)
+        }
+      }()
+      case 40: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .removeFavoriteNode(v)
+        }
+      }()
+      case 41: try {
+        var v: Position?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .setFixedPosition(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setFixedPosition(v)
+        }
+      }()
+      case 42: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .removeFixedPosition(v)
+        }
+      }()
+      case 43: try {
+        var v: UInt32?
+        try decoder.decodeSingularFixed32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setTimeOnly(v)
+        }
+      }()
+      case 44: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getUiConfigRequest(v)
+        }
+      }()
+      case 45: try {
+        var v: DeviceUIConfig?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .getUiConfigResponse(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .getUiConfigResponse(v)
+        }
+      }()
+      case 46: try {
+        var v: DeviceUIConfig?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .storeUiConfig(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .storeUiConfig(v)
+        }
+      }()
+      case 47: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .setIgnoredNode(v)
+        }
+      }()
+      case 48: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .removeIgnoredNode(v)
+        }
+      }()
+      case 49: try {
+        var v: UInt32?
+        try decoder.decodeSingularUInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .toggleMutedNode(v)
+        }
+      }()
+      case 64: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .beginEditSettings(v)
+        }
+      }()
+      case 65: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .commitEditSettings(v)
+        }
+      }()
+      case 66: try {
+        var v: SharedContact?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .addContact(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .addContact(v)
+        }
+      }()
+      case 67: try {
+        var v: KeyVerificationAdmin?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .keyVerification(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .keyVerification(v)
+        }
+      }()
+      case 94: try {
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .factoryResetDevice(v)
+        }
+      }()
+      case 95: try {
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .rebootOtaSeconds(v)
+        }
+      }()
+      case 96: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .exitSimulator(v)
+        }
+      }()
+      case 97: try {
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .rebootSeconds(v)
+        }
+      }()
+      case 98: try {
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .shutdownSeconds(v)
+        }
+      }()
+      case 99: try {
+        var v: Int32?
+        try decoder.decodeSingularInt32Field(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .factoryResetConfig(v)
+        }
+      }()
+      case 100: try {
+        var v: Bool?
+        try decoder.decodeSingularBoolField(value: &v)
+        if let v = v {
+          if self.payloadVariant != nil {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .nodedbReset(v)
+        }
+      }()
+      case 101: try { try decoder.decodeSingularBytesField(value: &self.sessionPasskey) }()
+      case 102: try {
+        var v: AdminMessage.OTAEvent?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .otaRequest(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .otaRequest(v)
+        }
+      }()
+      case 103: try {
+        var v: SensorConfig?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .sensorConfig(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .sensorConfig(v)
+        }
+      }()
+      case 104: try {
+        var v: LockdownAuth?
+        var hadOneofValue = false
+        if let current = self.payloadVariant {
+          hadOneofValue = true
+          if case .lockdownAuth(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payloadVariant = .lockdownAuth(v)
+        }
+      }()
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every if/case branch local when no optimizations
-      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-      // https://github.com/apple/swift-protobuf/issues/1182
-      switch _storage._payloadVariant {
-      case .getChannelRequest?: try {
-        guard case .getChannelRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 1)
-      }()
-      case .getChannelResponse?: try {
-        guard case .getChannelResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }()
-      case .getOwnerRequest?: try {
-        guard case .getOwnerRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 3)
-      }()
-      case .getOwnerResponse?: try {
-        guard case .getOwnerResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-      }()
-      case .getConfigRequest?: try {
-        guard case .getConfigRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-      }()
-      case .getConfigResponse?: try {
-        guard case .getConfigResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      }()
-      case .getModuleConfigRequest?: try {
-        guard case .getModuleConfigRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 7)
-      }()
-      case .getModuleConfigResponse?: try {
-        guard case .getModuleConfigResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      }()
-      case .getCannedMessageModuleMessagesRequest?: try {
-        guard case .getCannedMessageModuleMessagesRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 10)
-      }()
-      case .getCannedMessageModuleMessagesResponse?: try {
-        guard case .getCannedMessageModuleMessagesResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 11)
-      }()
-      case .getDeviceMetadataRequest?: try {
-        guard case .getDeviceMetadataRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 12)
-      }()
-      case .getDeviceMetadataResponse?: try {
-        guard case .getDeviceMetadataResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-      }()
-      case .getRingtoneRequest?: try {
-        guard case .getRingtoneRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 14)
-      }()
-      case .getRingtoneResponse?: try {
-        guard case .getRingtoneResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 15)
-      }()
-      case .getDeviceConnectionStatusRequest?: try {
-        guard case .getDeviceConnectionStatusRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 16)
-      }()
-      case .getDeviceConnectionStatusResponse?: try {
-        guard case .getDeviceConnectionStatusResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
-      }()
-      case .setHamMode?: try {
-        guard case .setHamMode(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-      }()
-      case .getNodeRemoteHardwarePinsRequest?: try {
-        guard case .getNodeRemoteHardwarePinsRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 19)
-      }()
-      case .getNodeRemoteHardwarePinsResponse?: try {
-        guard case .getNodeRemoteHardwarePinsResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 20)
-      }()
-      case .enterDfuModeRequest?: try {
-        guard case .enterDfuModeRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 21)
-      }()
-      case .deleteFileRequest?: try {
-        guard case .deleteFileRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 22)
-      }()
-      case .setScale?: try {
-        guard case .setScale(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 23)
-      }()
-      case .backupPreferences?: try {
-        guard case .backupPreferences(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 24)
-      }()
-      case .restorePreferences?: try {
-        guard case .restorePreferences(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 25)
-      }()
-      case .removeBackupPreferences?: try {
-        guard case .removeBackupPreferences(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 26)
-      }()
-      case .sendInputEvent?: try {
-        guard case .sendInputEvent(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 27)
-      }()
-      case .setOwner?: try {
-        guard case .setOwner(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 32)
-      }()
-      case .setChannel?: try {
-        guard case .setChannel(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 33)
-      }()
-      case .setConfig?: try {
-        guard case .setConfig(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 34)
-      }()
-      case .setModuleConfig?: try {
-        guard case .setModuleConfig(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 35)
-      }()
-      case .setCannedMessageModuleMessages?: try {
-        guard case .setCannedMessageModuleMessages(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 36)
-      }()
-      case .setRingtoneMessage?: try {
-        guard case .setRingtoneMessage(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularStringField(value: v, fieldNumber: 37)
-      }()
-      case .removeByNodenum?: try {
-        guard case .removeByNodenum(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 38)
-      }()
-      case .setFavoriteNode?: try {
-        guard case .setFavoriteNode(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 39)
-      }()
-      case .removeFavoriteNode?: try {
-        guard case .removeFavoriteNode(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 40)
-      }()
-      case .setFixedPosition?: try {
-        guard case .setFixedPosition(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 41)
-      }()
-      case .removeFixedPosition?: try {
-        guard case .removeFixedPosition(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 42)
-      }()
-      case .setTimeOnly?: try {
-        guard case .setTimeOnly(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 43)
-      }()
-      case .getUiConfigRequest?: try {
-        guard case .getUiConfigRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 44)
-      }()
-      case .getUiConfigResponse?: try {
-        guard case .getUiConfigResponse(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 45)
-      }()
-      case .storeUiConfig?: try {
-        guard case .storeUiConfig(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 46)
-      }()
-      case .setIgnoredNode?: try {
-        guard case .setIgnoredNode(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 47)
-      }()
-      case .removeIgnoredNode?: try {
-        guard case .removeIgnoredNode(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 48)
-      }()
-      case .toggleMutedNode?: try {
-        guard case .toggleMutedNode(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 49)
-      }()
-      case .beginEditSettings?: try {
-        guard case .beginEditSettings(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 64)
-      }()
-      case .commitEditSettings?: try {
-        guard case .commitEditSettings(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 65)
-      }()
-      case .addContact?: try {
-        guard case .addContact(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 66)
-      }()
-      case .keyVerification?: try {
-        guard case .keyVerification(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 67)
-      }()
-      case .factoryResetDevice?: try {
-        guard case .factoryResetDevice(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 94)
-      }()
-      case .rebootOtaSeconds?: try {
-        guard case .rebootOtaSeconds(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 95)
-      }()
-      case .exitSimulator?: try {
-        guard case .exitSimulator(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 96)
-      }()
-      case .rebootSeconds?: try {
-        guard case .rebootSeconds(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 97)
-      }()
-      case .shutdownSeconds?: try {
-        guard case .shutdownSeconds(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 98)
-      }()
-      case .factoryResetConfig?: try {
-        guard case .factoryResetConfig(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularInt32Field(value: v, fieldNumber: 99)
-      }()
-      case .nodedbReset?: try {
-        guard case .nodedbReset(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularBoolField(value: v, fieldNumber: 100)
-      }()
-      default: break
-      }
-      if !_storage._sessionPasskey.isEmpty {
-        try visitor.visitSingularBytesField(value: _storage._sessionPasskey, fieldNumber: 101)
-      }
-      switch _storage._payloadVariant {
-      case .otaRequest?: try {
-        guard case .otaRequest(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 102)
-      }()
-      case .sensorConfig?: try {
-        guard case .sensorConfig(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 103)
-      }()
-      case .lockdownAuth?: try {
-        guard case .lockdownAuth(let v)? = _storage._payloadVariant else { preconditionFailure() }
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 104)
-      }()
-      default: break
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    switch self.payloadVariant {
+    case .getChannelRequest?: try {
+      guard case .getChannelRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 1)
+    }()
+    case .getChannelResponse?: try {
+      guard case .getChannelResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    }()
+    case .getOwnerRequest?: try {
+      guard case .getOwnerRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 3)
+    }()
+    case .getOwnerResponse?: try {
+      guard case .getOwnerResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }()
+    case .getConfigRequest?: try {
+      guard case .getConfigRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    }()
+    case .getConfigResponse?: try {
+      guard case .getConfigResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
+    case .getModuleConfigRequest?: try {
+      guard case .getModuleConfigRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 7)
+    }()
+    case .getModuleConfigResponse?: try {
+      guard case .getModuleConfigResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    }()
+    case .getCannedMessageModuleMessagesRequest?: try {
+      guard case .getCannedMessageModuleMessagesRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 10)
+    }()
+    case .getCannedMessageModuleMessagesResponse?: try {
+      guard case .getCannedMessageModuleMessagesResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 11)
+    }()
+    case .getDeviceMetadataRequest?: try {
+      guard case .getDeviceMetadataRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 12)
+    }()
+    case .getDeviceMetadataResponse?: try {
+      guard case .getDeviceMetadataResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+    }()
+    case .getRingtoneRequest?: try {
+      guard case .getRingtoneRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 14)
+    }()
+    case .getRingtoneResponse?: try {
+      guard case .getRingtoneResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 15)
+    }()
+    case .getDeviceConnectionStatusRequest?: try {
+      guard case .getDeviceConnectionStatusRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 16)
+    }()
+    case .getDeviceConnectionStatusResponse?: try {
+      guard case .getDeviceConnectionStatusResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+    }()
+    case .setHamMode?: try {
+      guard case .setHamMode(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+    }()
+    case .getNodeRemoteHardwarePinsRequest?: try {
+      guard case .getNodeRemoteHardwarePinsRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 19)
+    }()
+    case .getNodeRemoteHardwarePinsResponse?: try {
+      guard case .getNodeRemoteHardwarePinsResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 20)
+    }()
+    case .enterDfuModeRequest?: try {
+      guard case .enterDfuModeRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 21)
+    }()
+    case .deleteFileRequest?: try {
+      guard case .deleteFileRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 22)
+    }()
+    case .setScale?: try {
+      guard case .setScale(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 23)
+    }()
+    case .backupPreferences?: try {
+      guard case .backupPreferences(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 24)
+    }()
+    case .restorePreferences?: try {
+      guard case .restorePreferences(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 25)
+    }()
+    case .removeBackupPreferences?: try {
+      guard case .removeBackupPreferences(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 26)
+    }()
+    case .sendInputEvent?: try {
+      guard case .sendInputEvent(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 27)
+    }()
+    case .setOwner?: try {
+      guard case .setOwner(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 32)
+    }()
+    case .setChannel?: try {
+      guard case .setChannel(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 33)
+    }()
+    case .setConfig?: try {
+      guard case .setConfig(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 34)
+    }()
+    case .setModuleConfig?: try {
+      guard case .setModuleConfig(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 35)
+    }()
+    case .setCannedMessageModuleMessages?: try {
+      guard case .setCannedMessageModuleMessages(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 36)
+    }()
+    case .setRingtoneMessage?: try {
+      guard case .setRingtoneMessage(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularStringField(value: v, fieldNumber: 37)
+    }()
+    case .removeByNodenum?: try {
+      guard case .removeByNodenum(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 38)
+    }()
+    case .setFavoriteNode?: try {
+      guard case .setFavoriteNode(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 39)
+    }()
+    case .removeFavoriteNode?: try {
+      guard case .removeFavoriteNode(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 40)
+    }()
+    case .setFixedPosition?: try {
+      guard case .setFixedPosition(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 41)
+    }()
+    case .removeFixedPosition?: try {
+      guard case .removeFixedPosition(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 42)
+    }()
+    case .setTimeOnly?: try {
+      guard case .setTimeOnly(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularFixed32Field(value: v, fieldNumber: 43)
+    }()
+    case .getUiConfigRequest?: try {
+      guard case .getUiConfigRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 44)
+    }()
+    case .getUiConfigResponse?: try {
+      guard case .getUiConfigResponse(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 45)
+    }()
+    case .storeUiConfig?: try {
+      guard case .storeUiConfig(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 46)
+    }()
+    case .setIgnoredNode?: try {
+      guard case .setIgnoredNode(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 47)
+    }()
+    case .removeIgnoredNode?: try {
+      guard case .removeIgnoredNode(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 48)
+    }()
+    case .toggleMutedNode?: try {
+      guard case .toggleMutedNode(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 49)
+    }()
+    case .beginEditSettings?: try {
+      guard case .beginEditSettings(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 64)
+    }()
+    case .commitEditSettings?: try {
+      guard case .commitEditSettings(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 65)
+    }()
+    case .addContact?: try {
+      guard case .addContact(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 66)
+    }()
+    case .keyVerification?: try {
+      guard case .keyVerification(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 67)
+    }()
+    case .factoryResetDevice?: try {
+      guard case .factoryResetDevice(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 94)
+    }()
+    case .rebootOtaSeconds?: try {
+      guard case .rebootOtaSeconds(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 95)
+    }()
+    case .exitSimulator?: try {
+      guard case .exitSimulator(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 96)
+    }()
+    case .rebootSeconds?: try {
+      guard case .rebootSeconds(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 97)
+    }()
+    case .shutdownSeconds?: try {
+      guard case .shutdownSeconds(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 98)
+    }()
+    case .factoryResetConfig?: try {
+      guard case .factoryResetConfig(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 99)
+    }()
+    case .nodedbReset?: try {
+      guard case .nodedbReset(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 100)
+    }()
+    default: break
+    }
+    if !self.sessionPasskey.isEmpty {
+      try visitor.visitSingularBytesField(value: self.sessionPasskey, fieldNumber: 101)
+    }
+    switch self.payloadVariant {
+    case .otaRequest?: try {
+      guard case .otaRequest(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 102)
+    }()
+    case .sensorConfig?: try {
+      guard case .sensorConfig(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 103)
+    }()
+    case .lockdownAuth?: try {
+      guard case .lockdownAuth(let v)? = self.payloadVariant else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 104)
+    }()
+    default: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: AdminMessage, rhs: AdminMessage) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._sessionPasskey != rhs_storage._sessionPasskey {return false}
-        if _storage._payloadVariant != rhs_storage._payloadVariant {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.sessionPasskey != rhs.sessionPasskey {return false}
+    if lhs.payloadVariant != rhs.payloadVariant {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3048,48 +3198,111 @@ extension KeyVerificationAdmin.MessageType: SwiftProtobuf._ProtoNameProviding {
 
 extension SensorConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SensorConfig"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}scd4x_config\0\u{3}sen5x_config\0\u{3}scd30_config\0\u{3}shtxx_config\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}scd4x_config\0\u{3}sen5x_config\0\u{3}scd30_config\0\u{3}shtxx_config\0\u{3}ds248x_config\0\u{3}sen6x_config\0\u{3}as3935_config\0")
+
+  fileprivate class _StorageClass {
+    var _scd4XConfig: SCD4X_config? = nil
+    var _sen5XConfig: SEN5X_config? = nil
+    var _scd30Config: SCD30_config? = nil
+    var _shtxxConfig: SHTXX_config? = nil
+    var _ds248XConfig: DS248X_config? = nil
+    var _sen6XConfig: SEN6X_config? = nil
+    var _as3935Config: AS3935_config? = nil
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _scd4XConfig = source._scd4XConfig
+      _sen5XConfig = source._sen5XConfig
+      _scd30Config = source._scd30Config
+      _shtxxConfig = source._shtxxConfig
+      _ds248XConfig = source._ds248XConfig
+      _sen6XConfig = source._sen6XConfig
+      _as3935Config = source._as3935Config
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularMessageField(value: &self._scd4XConfig) }()
-      case 2: try { try decoder.decodeSingularMessageField(value: &self._sen5XConfig) }()
-      case 3: try { try decoder.decodeSingularMessageField(value: &self._scd30Config) }()
-      case 4: try { try decoder.decodeSingularMessageField(value: &self._shtxxConfig) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularMessageField(value: &_storage._scd4XConfig) }()
+        case 2: try { try decoder.decodeSingularMessageField(value: &_storage._sen5XConfig) }()
+        case 3: try { try decoder.decodeSingularMessageField(value: &_storage._scd30Config) }()
+        case 4: try { try decoder.decodeSingularMessageField(value: &_storage._shtxxConfig) }()
+        case 5: try { try decoder.decodeSingularMessageField(value: &_storage._ds248XConfig) }()
+        case 6: try { try decoder.decodeSingularMessageField(value: &_storage._sen6XConfig) }()
+        case 7: try { try decoder.decodeSingularMessageField(value: &_storage._as3935Config) }()
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    try { if let v = self._scd4XConfig {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    } }()
-    try { if let v = self._sen5XConfig {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    } }()
-    try { if let v = self._scd30Config {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    } }()
-    try { if let v = self._shtxxConfig {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-    } }()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      try { if let v = _storage._scd4XConfig {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      } }()
+      try { if let v = _storage._sen5XConfig {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      } }()
+      try { if let v = _storage._scd30Config {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      } }()
+      try { if let v = _storage._shtxxConfig {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      } }()
+      try { if let v = _storage._ds248XConfig {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      } }()
+      try { if let v = _storage._sen6XConfig {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      } }()
+      try { if let v = _storage._as3935Config {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      } }()
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: SensorConfig, rhs: SensorConfig) -> Bool {
-    if lhs._scd4XConfig != rhs._scd4XConfig {return false}
-    if lhs._sen5XConfig != rhs._sen5XConfig {return false}
-    if lhs._scd30Config != rhs._scd30Config {return false}
-    if lhs._shtxxConfig != rhs._shtxxConfig {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._scd4XConfig != rhs_storage._scd4XConfig {return false}
+        if _storage._sen5XConfig != rhs_storage._sen5XConfig {return false}
+        if _storage._scd30Config != rhs_storage._scd30Config {return false}
+        if _storage._shtxxConfig != rhs_storage._shtxxConfig {return false}
+        if _storage._ds248XConfig != rhs_storage._ds248XConfig {return false}
+        if _storage._sen6XConfig != rhs_storage._sen6XConfig {return false}
+        if _storage._as3935Config != rhs_storage._as3935Config {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3161,7 +3374,7 @@ extension SCD4X_config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
 
 extension SEN5X_config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SEN5X_config"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}set_temperature\0\u{3}set_one_shot_mode\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}set_temperature\0\u{3}set_one_shot_mode\0\u{3}start_fan_cleaning\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -3171,6 +3384,7 @@ extension SEN5X_config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularFloatField(value: &self._setTemperature) }()
       case 2: try { try decoder.decodeSingularBoolField(value: &self._setOneShotMode) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self._startFanCleaning) }()
       default: break
       }
     }
@@ -3187,12 +3401,85 @@ extension SEN5X_config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
     try { if let v = self._setOneShotMode {
       try visitor.visitSingularBoolField(value: v, fieldNumber: 2)
     } }()
+    try { if let v = self._startFanCleaning {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 3)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: SEN5X_config, rhs: SEN5X_config) -> Bool {
     if lhs._setTemperature != rhs._setTemperature {return false}
     if lhs._setOneShotMode != rhs._setOneShotMode {return false}
+    if lhs._startFanCleaning != rhs._startFanCleaning {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension SEN6X_config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SEN6X_config"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}set_temperature\0\u{3}set_one_shot_mode\0\u{3}start_fan_cleaning\0\u{3}set_asc\0\u{3}set_target_co2_conc\0\u{3}set_altitude\0\u{3}set_ambient_pressure\0\u{3}factory_reset\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularFloatField(value: &self._setTemperature) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self._setOneShotMode) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self._startFanCleaning) }()
+      case 4: try { try decoder.decodeSingularBoolField(value: &self._setAsc) }()
+      case 5: try { try decoder.decodeSingularUInt32Field(value: &self._setTargetCo2Conc) }()
+      case 6: try { try decoder.decodeSingularUInt32Field(value: &self._setAltitude) }()
+      case 7: try { try decoder.decodeSingularUInt32Field(value: &self._setAmbientPressure) }()
+      case 8: try { try decoder.decodeSingularBoolField(value: &self._factoryReset) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._setTemperature {
+      try visitor.visitSingularFloatField(value: v, fieldNumber: 1)
+    } }()
+    try { if let v = self._setOneShotMode {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 2)
+    } }()
+    try { if let v = self._startFanCleaning {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 3)
+    } }()
+    try { if let v = self._setAsc {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
+    } }()
+    try { if let v = self._setTargetCo2Conc {
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 5)
+    } }()
+    try { if let v = self._setAltitude {
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 6)
+    } }()
+    try { if let v = self._setAmbientPressure {
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 7)
+    } }()
+    try { if let v = self._factoryReset {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 8)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: SEN6X_config, rhs: SEN6X_config) -> Bool {
+    if lhs._setTemperature != rhs._setTemperature {return false}
+    if lhs._setOneShotMode != rhs._setOneShotMode {return false}
+    if lhs._startFanCleaning != rhs._startFanCleaning {return false}
+    if lhs._setAsc != rhs._setAsc {return false}
+    if lhs._setTargetCo2Conc != rhs._setTargetCo2Conc {return false}
+    if lhs._setAltitude != rhs._setAltitude {return false}
+    if lhs._setAmbientPressure != rhs._setAmbientPressure {return false}
+    if lhs._factoryReset != rhs._factoryReset {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3286,6 +3573,74 @@ extension SHTXX_config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
 
   public static func ==(lhs: SHTXX_config, rhs: SHTXX_config) -> Bool {
     if lhs._setAccuracy != rhs._setAccuracy {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension DS248X_config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".DS248X_config"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}main_temperature_channel\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self._mainTemperatureChannel) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._mainTemperatureChannel {
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 1)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: DS248X_config, rhs: DS248X_config) -> Bool {
+    if lhs._mainTemperatureChannel != rhs._mainTemperatureChannel {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension AS3935_config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".AS3935_config"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}set_tuning_cap_pf\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self._setTuningCapPf) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._setTuningCapPf {
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 1)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: AS3935_config, rhs: AS3935_config) -> Bool {
+    if lhs._setTuningCapPf != rhs._setTuningCapPf {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/MeshtasticProtobufs/Sources/meshtastic/mesh.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/mesh.pb.swift
@@ -627,6 +627,18 @@ public enum HardwareModel: SwiftProtobuf.Enum, Swift.CaseIterable {
   case heltecRcc6 // = 143
 
   ///
+  /// Seeed Wio Tracker L1 Pro 1W, nRF52840 + SX1262 with 1 W external PA
+  case seeedWioTrackerL1Pro1W // = 144
+
+  ///
+  /// Meshnology W12
+  case meshnologyW12 // = 145
+
+  ///
+  /// Seeed Studio MeshPager X2
+  case meshpagerX2 // = 146
+
+  ///
   /// ------------------------------------------------------------------------------------------------------------------------------------------
   /// Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
   /// ------------------------------------------------------------------------------------------------------------------------------------------
@@ -783,6 +795,9 @@ public enum HardwareModel: SwiftProtobuf.Enum, Swift.CaseIterable {
     case 141: self = .heltecRc32
     case 142: self = .heltecRc52
     case 143: self = .heltecRcc6
+    case 144: self = .seeedWioTrackerL1Pro1W
+    case 145: self = .meshnologyW12
+    case 146: self = .meshpagerX2
     case 255: self = .privateHw
     default: self = .UNRECOGNIZED(rawValue)
     }
@@ -934,6 +949,9 @@ public enum HardwareModel: SwiftProtobuf.Enum, Swift.CaseIterable {
     case .heltecRc32: return 141
     case .heltecRc52: return 142
     case .heltecRcc6: return 143
+    case .seeedWioTrackerL1Pro1W: return 144
+    case .meshnologyW12: return 145
+    case .meshpagerX2: return 146
     case .privateHw: return 255
     case .UNRECOGNIZED(let i): return i
     }
@@ -1085,6 +1103,9 @@ public enum HardwareModel: SwiftProtobuf.Enum, Swift.CaseIterable {
     .heltecRc32,
     .heltecRc52,
     .heltecRcc6,
+    .seeedWioTrackerL1Pro1W,
+    .meshnologyW12,
+    .meshpagerX2,
     .privateHw,
   ]
 
@@ -1304,6 +1325,14 @@ public enum FirmwareEdition: SwiftProtobuf.Enum, Swift.CaseIterable {
   case fab // = 20
 
   ///
+  /// Dragon Con, the yearly pop culture convention in Atlanta, GA
+  case dragonCon // = 21
+
+  ///
+  /// Chaos Communication Congress, the hacker conference held yearly in Germany
+  case ccc // = 22
+
+  ///
   /// Placeholder for DIY and unofficial events
   case diyEdition // = 127
   case UNRECOGNIZED(Int)
@@ -1321,6 +1350,8 @@ public enum FirmwareEdition: SwiftProtobuf.Enum, Swift.CaseIterable {
     case 18: self = .burningMan
     case 19: self = .hamvention
     case 20: self = .fab
+    case 21: self = .dragonCon
+    case 22: self = .ccc
     case 127: self = .diyEdition
     default: self = .UNRECOGNIZED(rawValue)
     }
@@ -1335,6 +1366,8 @@ public enum FirmwareEdition: SwiftProtobuf.Enum, Swift.CaseIterable {
     case .burningMan: return 18
     case .hamvention: return 19
     case .fab: return 20
+    case .dragonCon: return 21
+    case .ccc: return 22
     case .diyEdition: return 127
     case .UNRECOGNIZED(let i): return i
     }
@@ -1349,6 +1382,8 @@ public enum FirmwareEdition: SwiftProtobuf.Enum, Swift.CaseIterable {
     .burningMan,
     .hamvention,
     .fab,
+    .dragonCon,
+    .ccc,
     .diyEdition,
   ]
 
@@ -1632,7 +1667,7 @@ public struct Position: @unchecked Sendable {
   }
 
   ///
-  /// Ground speed in m/s and True North TRACK in 1/100 degrees
+  /// Ground speed in km/h and True North TRACK in 1/100 degrees
   /// Clarification of terms:
   /// - "track" is the direction of motion (measured in horizontal plane)
   /// - "heading" is where the fuselage points (measured in horizontal plane)
@@ -4671,7 +4706,7 @@ public struct ChunkedPayloadResponse: Sendable {
 fileprivate let _protobuf_package = "meshtastic"
 
 extension HardwareModel: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNSET\0\u{1}TLORA_V2\0\u{1}TLORA_V1\0\u{1}TLORA_V2_1_1P6\0\u{1}TBEAM\0\u{1}HELTEC_V2_0\0\u{1}TBEAM_V0P7\0\u{1}T_ECHO\0\u{1}TLORA_V1_1P3\0\u{1}RAK4631\0\u{1}HELTEC_V2_1\0\u{1}HELTEC_V1\0\u{1}LILYGO_TBEAM_S3_CORE\0\u{1}RAK11200\0\u{1}NANO_G1\0\u{1}TLORA_V2_1_1P8\0\u{1}TLORA_T3_S3\0\u{1}NANO_G1_EXPLORER\0\u{1}NANO_G2_ULTRA\0\u{1}LORA_TYPE\0\u{1}WIPHONE\0\u{1}WIO_WM1110\0\u{1}RAK2560\0\u{1}HELTEC_HRU_3601\0\u{1}HELTEC_WIRELESS_BRIDGE\0\u{1}STATION_G1\0\u{1}RAK11310\0\u{1}MAKERFABS_TRACKER\0\u{1}MAKERFABS_RESERVED\0\u{1}CANARYONE\0\u{1}RP2040_LORA\0\u{1}STATION_G2\0\u{1}LORA_RELAY_V1\0\u{1}T_ECHO_PLUS\0\u{1}PPR\0\u{1}GENIEBLOCKS\0\u{1}NRF52_UNKNOWN\0\u{1}PORTDUINO\0\u{1}ANDROID_SIM\0\u{1}DIY_V1\0\u{1}NRF52840_PCA10059\0\u{1}DR_DEV\0\u{1}M5STACK\0\u{1}HELTEC_V3\0\u{1}HELTEC_WSL_V3\0\u{1}BETAFPV_2400_TX\0\u{1}BETAFPV_900_NANO_TX\0\u{1}RPI_PICO\0\u{1}HELTEC_WIRELESS_TRACKER\0\u{1}HELTEC_WIRELESS_PAPER\0\u{1}T_DECK\0\u{1}T_WATCH_S3\0\u{1}PICOMPUTER_S3\0\u{1}HELTEC_HT62\0\u{1}EBYTE_ESP32_S3\0\u{1}ESP32_S3_PICO\0\u{1}CHATTER_2\0\u{1}HELTEC_WIRELESS_PAPER_V1_0\0\u{1}HELTEC_WIRELESS_TRACKER_V1_0\0\u{1}UNPHONE\0\u{1}TD_LORAC\0\u{1}CDEBYTE_EORA_S3\0\u{1}TWC_MESH_V4\0\u{1}NRF52_PROMICRO_DIY\0\u{1}RADIOMASTER_900_BANDIT_NANO\0\u{1}HELTEC_CAPSULE_SENSOR_V3\0\u{1}HELTEC_VISION_MASTER_T190\0\u{1}HELTEC_VISION_MASTER_E213\0\u{1}HELTEC_VISION_MASTER_E290\0\u{1}HELTEC_MESH_NODE_T114\0\u{1}SENSECAP_INDICATOR\0\u{1}TRACKER_T1000_E\0\u{1}RAK3172\0\u{1}WIO_E5\0\u{1}RADIOMASTER_900_BANDIT\0\u{1}ME25LS01_4Y10TD\0\u{1}RP2040_FEATHER_RFM95\0\u{1}M5STACK_COREBASIC\0\u{1}M5STACK_CORE2\0\u{1}RPI_PICO2\0\u{1}M5STACK_CORES3\0\u{1}SEEED_XIAO_S3\0\u{1}MS24SF1\0\u{1}TLORA_C6\0\u{1}WISMESH_TAP\0\u{1}ROUTASTIC\0\u{1}MESH_TAB\0\u{1}MESHLINK\0\u{1}XIAO_NRF52_KIT\0\u{1}THINKNODE_M1\0\u{1}THINKNODE_M2\0\u{1}T_ETH_ELITE\0\u{1}HELTEC_SENSOR_HUB\0\u{1}MUZI_BASE\0\u{1}HELTEC_MESH_POCKET\0\u{1}SEEED_SOLAR_NODE\0\u{1}NOMADSTAR_METEOR_PRO\0\u{1}CROWPANEL\0\u{1}LINK_32\0\u{1}SEEED_WIO_TRACKER_L1\0\u{1}SEEED_WIO_TRACKER_L1_EINK\0\u{1}MUZI_R1_NEO\0\u{1}T_DECK_PRO\0\u{1}T_LORA_PAGER\0\u{1}M5STACK_RESERVED\0\u{1}WISMESH_TAG\0\u{1}RAK3312\0\u{1}THINKNODE_M5\0\u{1}HELTEC_MESH_SOLAR\0\u{1}T_ECHO_LITE\0\u{1}HELTEC_V4\0\u{1}M5STACK_C6L\0\u{1}M5STACK_CARDPUTER_ADV\0\u{1}HELTEC_WIRELESS_TRACKER_V2\0\u{1}T_WATCH_ULTRA\0\u{1}THINKNODE_M3\0\u{1}WISMESH_TAP_V2\0\u{1}RAK3401\0\u{1}RAK6421\0\u{1}THINKNODE_M4\0\u{1}THINKNODE_M6\0\u{1}MESHSTICK_1262\0\u{1}TBEAM_1_WATT\0\u{1}T5_S3_EPAPER_PRO\0\u{1}TBEAM_BPF\0\u{1}MINI_EPAPER_S3\0\u{1}TDISPLAY_S3_PRO\0\u{1}HELTEC_MESH_NODE_T096\0\u{1}MESH_TRACKER_X1\0\u{1}THINKNODE_M7\0\u{1}THINKNODE_M8\0\u{1}THINKNODE_M9\0\u{1}HELTEC_V4_R8\0\u{1}HELTEC_MESH_NODE_T1\0\u{1}STATION_G3\0\u{1}T_IMPULSE_PLUS\0\u{1}T_ECHO_CARD\0\u{1}SEEED_WIO_TRACKER_L2\0\u{1}CROWPANEL_P4\0\u{1}HELTEC_MESH_TOWER_V2\0\u{1}MESHNOLOGY_W10\0\u{1}HELTEC_RC32\0\u{1}HELTEC_RC52\0\u{1}HELTEC_RCC6\0\u{2}p\u{1}PRIVATE_HW\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNSET\0\u{1}TLORA_V2\0\u{1}TLORA_V1\0\u{1}TLORA_V2_1_1P6\0\u{1}TBEAM\0\u{1}HELTEC_V2_0\0\u{1}TBEAM_V0P7\0\u{1}T_ECHO\0\u{1}TLORA_V1_1P3\0\u{1}RAK4631\0\u{1}HELTEC_V2_1\0\u{1}HELTEC_V1\0\u{1}LILYGO_TBEAM_S3_CORE\0\u{1}RAK11200\0\u{1}NANO_G1\0\u{1}TLORA_V2_1_1P8\0\u{1}TLORA_T3_S3\0\u{1}NANO_G1_EXPLORER\0\u{1}NANO_G2_ULTRA\0\u{1}LORA_TYPE\0\u{1}WIPHONE\0\u{1}WIO_WM1110\0\u{1}RAK2560\0\u{1}HELTEC_HRU_3601\0\u{1}HELTEC_WIRELESS_BRIDGE\0\u{1}STATION_G1\0\u{1}RAK11310\0\u{1}MAKERFABS_TRACKER\0\u{1}MAKERFABS_RESERVED\0\u{1}CANARYONE\0\u{1}RP2040_LORA\0\u{1}STATION_G2\0\u{1}LORA_RELAY_V1\0\u{1}T_ECHO_PLUS\0\u{1}PPR\0\u{1}GENIEBLOCKS\0\u{1}NRF52_UNKNOWN\0\u{1}PORTDUINO\0\u{1}ANDROID_SIM\0\u{1}DIY_V1\0\u{1}NRF52840_PCA10059\0\u{1}DR_DEV\0\u{1}M5STACK\0\u{1}HELTEC_V3\0\u{1}HELTEC_WSL_V3\0\u{1}BETAFPV_2400_TX\0\u{1}BETAFPV_900_NANO_TX\0\u{1}RPI_PICO\0\u{1}HELTEC_WIRELESS_TRACKER\0\u{1}HELTEC_WIRELESS_PAPER\0\u{1}T_DECK\0\u{1}T_WATCH_S3\0\u{1}PICOMPUTER_S3\0\u{1}HELTEC_HT62\0\u{1}EBYTE_ESP32_S3\0\u{1}ESP32_S3_PICO\0\u{1}CHATTER_2\0\u{1}HELTEC_WIRELESS_PAPER_V1_0\0\u{1}HELTEC_WIRELESS_TRACKER_V1_0\0\u{1}UNPHONE\0\u{1}TD_LORAC\0\u{1}CDEBYTE_EORA_S3\0\u{1}TWC_MESH_V4\0\u{1}NRF52_PROMICRO_DIY\0\u{1}RADIOMASTER_900_BANDIT_NANO\0\u{1}HELTEC_CAPSULE_SENSOR_V3\0\u{1}HELTEC_VISION_MASTER_T190\0\u{1}HELTEC_VISION_MASTER_E213\0\u{1}HELTEC_VISION_MASTER_E290\0\u{1}HELTEC_MESH_NODE_T114\0\u{1}SENSECAP_INDICATOR\0\u{1}TRACKER_T1000_E\0\u{1}RAK3172\0\u{1}WIO_E5\0\u{1}RADIOMASTER_900_BANDIT\0\u{1}ME25LS01_4Y10TD\0\u{1}RP2040_FEATHER_RFM95\0\u{1}M5STACK_COREBASIC\0\u{1}M5STACK_CORE2\0\u{1}RPI_PICO2\0\u{1}M5STACK_CORES3\0\u{1}SEEED_XIAO_S3\0\u{1}MS24SF1\0\u{1}TLORA_C6\0\u{1}WISMESH_TAP\0\u{1}ROUTASTIC\0\u{1}MESH_TAB\0\u{1}MESHLINK\0\u{1}XIAO_NRF52_KIT\0\u{1}THINKNODE_M1\0\u{1}THINKNODE_M2\0\u{1}T_ETH_ELITE\0\u{1}HELTEC_SENSOR_HUB\0\u{1}MUZI_BASE\0\u{1}HELTEC_MESH_POCKET\0\u{1}SEEED_SOLAR_NODE\0\u{1}NOMADSTAR_METEOR_PRO\0\u{1}CROWPANEL\0\u{1}LINK_32\0\u{1}SEEED_WIO_TRACKER_L1\0\u{1}SEEED_WIO_TRACKER_L1_EINK\0\u{1}MUZI_R1_NEO\0\u{1}T_DECK_PRO\0\u{1}T_LORA_PAGER\0\u{1}M5STACK_RESERVED\0\u{1}WISMESH_TAG\0\u{1}RAK3312\0\u{1}THINKNODE_M5\0\u{1}HELTEC_MESH_SOLAR\0\u{1}T_ECHO_LITE\0\u{1}HELTEC_V4\0\u{1}M5STACK_C6L\0\u{1}M5STACK_CARDPUTER_ADV\0\u{1}HELTEC_WIRELESS_TRACKER_V2\0\u{1}T_WATCH_ULTRA\0\u{1}THINKNODE_M3\0\u{1}WISMESH_TAP_V2\0\u{1}RAK3401\0\u{1}RAK6421\0\u{1}THINKNODE_M4\0\u{1}THINKNODE_M6\0\u{1}MESHSTICK_1262\0\u{1}TBEAM_1_WATT\0\u{1}T5_S3_EPAPER_PRO\0\u{1}TBEAM_BPF\0\u{1}MINI_EPAPER_S3\0\u{1}TDISPLAY_S3_PRO\0\u{1}HELTEC_MESH_NODE_T096\0\u{1}MESH_TRACKER_X1\0\u{1}THINKNODE_M7\0\u{1}THINKNODE_M8\0\u{1}THINKNODE_M9\0\u{1}HELTEC_V4_R8\0\u{1}HELTEC_MESH_NODE_T1\0\u{1}STATION_G3\0\u{1}T_IMPULSE_PLUS\0\u{1}T_ECHO_CARD\0\u{1}SEEED_WIO_TRACKER_L2\0\u{1}CROWPANEL_P4\0\u{1}HELTEC_MESH_TOWER_V2\0\u{1}MESHNOLOGY_W10\0\u{1}HELTEC_RC32\0\u{1}HELTEC_RC52\0\u{1}HELTEC_RCC6\0\u{1}SEEED_WIO_TRACKER_L1_PRO_1W\0\u{1}MESHNOLOGY_W12\0\u{1}MESHPAGER_X2\0\u{2}m\u{1}PRIVATE_HW\0")
 }
 
 extension Constants: SwiftProtobuf._ProtoNameProviding {
@@ -4683,7 +4718,7 @@ extension CriticalErrorCode: SwiftProtobuf._ProtoNameProviding {
 }
 
 extension FirmwareEdition: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0VANILLA\0\u{1}SMART_CITIZEN\0\u{2}\u{f}OPEN_SAUCE\0\u{1}DEFCON\0\u{1}BURNING_MAN\0\u{1}HAMVENTION\0\u{1}FAB\0\u{2}k\u{1}DIY_EDITION\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0VANILLA\0\u{1}SMART_CITIZEN\0\u{2}\u{f}OPEN_SAUCE\0\u{1}DEFCON\0\u{1}BURNING_MAN\0\u{1}HAMVENTION\0\u{1}FAB\0\u{1}DRAGON_CON\0\u{1}CCC\0\u{2}i\u{1}DIY_EDITION\0")
 }
 
 extension ExcludedModules: SwiftProtobuf._ProtoNameProviding {

--- a/MeshtasticProtobufs/Sources/meshtastic/module_config.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/module_config.pb.swift
@@ -1392,120 +1392,58 @@ public struct ModuleConfig: Sendable {
 
   ///
   /// MeshBeacon module config
-  public struct MeshBeaconConfig: @unchecked Sendable {
+  public struct MeshBeaconConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
     ///
     /// Bitwise-OR of Flags values (listen / broadcast / legacy-split toggles).
-    public var flags: UInt32 {
-      get {_storage._flags}
-      set {_uniqueStorage()._flags = newValue}
-    }
-
-    ///
-    /// Optional: node ID to send beacon messages AS.
-    /// When set, the `from` field of outgoing beacon packets is set to this node ID,
-    /// making beacons appear to originate from that node.
-    /// When unset (0), beacons are sent as the local node.
-    /// A remote admin can only set this field to their own node ID.
-    public var broadcastSendAsNode: UInt32 {
-      get {_storage._broadcastSendAsNode}
-      set {_uniqueStorage()._broadcastSendAsNode = newValue}
-    }
+    public var flags: UInt32 = 0
 
     ///
     /// Message to include in each beacon broadcast. Max 100 bytes enforced by firmware.
-    public var broadcastMessage: String {
-      get {_storage._broadcastMessage}
-      set {_uniqueStorage()._broadcastMessage = newValue}
-    }
+    public var broadcastMessage: String = String()
 
     ///
     /// Optional channel (name + PSK) to advertise in the MeshBeacon offer_channel field.
     public var broadcastOfferChannel: ChannelSettings {
-      get {_storage._broadcastOfferChannel ?? ChannelSettings()}
-      set {_uniqueStorage()._broadcastOfferChannel = newValue}
+      get {_broadcastOfferChannel ?? ChannelSettings()}
+      set {_broadcastOfferChannel = newValue}
     }
     /// Returns true if `broadcastOfferChannel` has been explicitly set.
-    public var hasBroadcastOfferChannel: Bool {_storage._broadcastOfferChannel != nil}
+    public var hasBroadcastOfferChannel: Bool {self._broadcastOfferChannel != nil}
     /// Clears the value of `broadcastOfferChannel`. Subsequent reads from it will return its default value.
-    public mutating func clearBroadcastOfferChannel() {_uniqueStorage()._broadcastOfferChannel = nil}
+    public mutating func clearBroadcastOfferChannel() {self._broadcastOfferChannel = nil}
 
     ///
     /// Optional region to advertise in the MeshBeacon offer_region field.
-    public var broadcastOfferRegion: Config.LoRaConfig.RegionCode {
-      get {_storage._broadcastOfferRegion}
-      set {_uniqueStorage()._broadcastOfferRegion = newValue}
-    }
+    public var broadcastOfferRegion: Config.LoRaConfig.RegionCode = .unset
 
     ///
     /// Optional modem preset to advertise in the MeshBeacon offer_preset field.
     public var broadcastOfferPreset: Config.LoRaConfig.ModemPreset {
-      get {_storage._broadcastOfferPreset ?? .longFast}
-      set {_uniqueStorage()._broadcastOfferPreset = newValue}
+      get {_broadcastOfferPreset ?? .longFast}
+      set {_broadcastOfferPreset = newValue}
     }
     /// Returns true if `broadcastOfferPreset` has been explicitly set.
-    public var hasBroadcastOfferPreset: Bool {_storage._broadcastOfferPreset != nil}
+    public var hasBroadcastOfferPreset: Bool {self._broadcastOfferPreset != nil}
     /// Clears the value of `broadcastOfferPreset`. Subsequent reads from it will return its default value.
-    public mutating func clearBroadcastOfferPreset() {_uniqueStorage()._broadcastOfferPreset = nil}
-
-    ///
-    /// Single-target TX channel: channel settings (name + PSK) to send beacons on.
-    /// If unset, beacons go out on the primary channel. Used only when broadcast_targets is empty.
-    /// NOTE: the single-target path embeds the ChannelSettings inline here, whereas a
-    /// broadcast_targets entry references a channel-table slot by channel_index instead — see
-    /// BroadcastTarget. The two paths are equal, first-class options; only this representation differs.
-    public var broadcastOnChannel: ChannelSettings {
-      get {_storage._broadcastOnChannel ?? ChannelSettings()}
-      set {_uniqueStorage()._broadcastOnChannel = newValue}
-    }
-    /// Returns true if `broadcastOnChannel` has been explicitly set.
-    public var hasBroadcastOnChannel: Bool {_storage._broadcastOnChannel != nil}
-    /// Clears the value of `broadcastOnChannel`. Subsequent reads from it will return its default value.
-    public mutating func clearBroadcastOnChannel() {_uniqueStorage()._broadcastOnChannel = nil}
-
-    ///
-    /// Region to use when sending beacons on broadcast_on_preset.
-    public var broadcastOnRegion: Config.LoRaConfig.RegionCode {
-      get {_storage._broadcastOnRegion}
-      set {_uniqueStorage()._broadcastOnRegion = newValue}
-    }
-
-    ///
-    /// Modem preset to use when sending beacons.
-    /// If different from current config, the radio is temporarily switched for TX.
-    public var broadcastOnPreset: Config.LoRaConfig.ModemPreset {
-      get {_storage._broadcastOnPreset ?? .longFast}
-      set {_uniqueStorage()._broadcastOnPreset = newValue}
-    }
-    /// Returns true if `broadcastOnPreset` has been explicitly set.
-    public var hasBroadcastOnPreset: Bool {_storage._broadcastOnPreset != nil}
-    /// Clears the value of `broadcastOnPreset`. Subsequent reads from it will return its default value.
-    public mutating func clearBroadcastOnPreset() {_uniqueStorage()._broadcastOnPreset = nil}
+    public mutating func clearBroadcastOfferPreset() {self._broadcastOfferPreset = nil}
 
     ///
     /// How often to broadcast, in seconds. Min 3600 (1 h), default 3600.
-    public var broadcastIntervalSecs: UInt32 {
-      get {_storage._broadcastIntervalSecs}
-      set {_uniqueStorage()._broadcastIntervalSecs = newValue}
-    }
+    public var broadcastIntervalSecs: UInt32 = 0
 
     ///
-    /// Multi-target broadcast list.
-    /// When non-empty the broadcaster transmits one beacon copy per entry in sequence,
-    /// each temporarily switching the radio to that entry's preset/region/channel.
-    /// When empty, the broadcaster uses the scalar broadcast_on_preset / broadcast_on_region /
-    /// broadcast_on_channel fields instead (the single-target path).
-    /// Single- and multi-target are equal, first-class options — neither is preferred or
-    /// deprecated. They differ only in how the TX channel is named: broadcast_on_channel embeds a
-    /// ChannelSettings inline, while a target references an existing channel-table slot by
-    /// channel_index (see BroadcastTarget).
-    public var broadcastTargets: [ModuleConfig.MeshBeaconConfig.BroadcastTarget] {
-      get {_storage._broadcastTargets}
-      set {_uniqueStorage()._broadcastTargets = newValue}
-    }
+    /// Broadcast destination list.
+    /// The broadcaster sends one beacon copy per distinct destination, in sequence, temporarily
+    /// switching the radio to that entry's preset/region/channel for each.
+    /// When empty, a single beacon is sent on the node's running preset and region over the
+    /// primary channel.
+    /// Entries that resolve to the same effective preset, region and channel are deduplicated, so
+    /// a duplicate entry does not produce a second transmission.
+    public var broadcastTargets: [ModuleConfig.MeshBeaconConfig.BroadcastTarget] = []
 
     public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1571,8 +1509,8 @@ public struct ModuleConfig: Sendable {
     }
 
     ///
-    /// One entry in the multi-target broadcast list.
-    /// The broadcaster transmits one beacon copy per entry, each on its own radio settings.
+    /// One entry in the broadcast destination list.
+    /// Each entry names one set of radio settings to send a beacon copy on.
     public struct BroadcastTarget: Sendable {
       // SwiftProtobuf.Message conformance is added in an extension below. See the
       // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1618,7 +1556,8 @@ public struct ModuleConfig: Sendable {
 
     public init() {}
 
-    fileprivate var _storage = _StorageClass.defaultInstance
+    fileprivate var _broadcastOfferChannel: ChannelSettings? = nil
+    fileprivate var _broadcastOfferPreset: Config.LoRaConfig.ModemPreset? = nil
   }
 
   ///
@@ -2971,139 +2910,63 @@ extension ModuleConfig.StatusMessageConfig: SwiftProtobuf.Message, SwiftProtobuf
 
 extension ModuleConfig.MeshBeaconConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = ModuleConfig.protoMessageName + ".MeshBeaconConfig"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}flags\0\u{4}\u{2}broadcast_send_as_node\0\u{3}broadcast_message\0\u{3}broadcast_offer_channel\0\u{3}broadcast_offer_region\0\u{3}broadcast_offer_preset\0\u{3}broadcast_on_channel\0\u{3}broadcast_on_region\0\u{3}broadcast_on_preset\0\u{3}broadcast_interval_secs\0\u{4}\u{2}broadcast_targets\0")
-
-  fileprivate class _StorageClass {
-    var _flags: UInt32 = 0
-    var _broadcastSendAsNode: UInt32 = 0
-    var _broadcastMessage: String = String()
-    var _broadcastOfferChannel: ChannelSettings? = nil
-    var _broadcastOfferRegion: Config.LoRaConfig.RegionCode = .unset
-    var _broadcastOfferPreset: Config.LoRaConfig.ModemPreset? = nil
-    var _broadcastOnChannel: ChannelSettings? = nil
-    var _broadcastOnRegion: Config.LoRaConfig.RegionCode = .unset
-    var _broadcastOnPreset: Config.LoRaConfig.ModemPreset? = nil
-    var _broadcastIntervalSecs: UInt32 = 0
-    var _broadcastTargets: [ModuleConfig.MeshBeaconConfig.BroadcastTarget] = []
-
-      // This property is used as the initial default value for new instances of the type.
-      // The type itself is protecting the reference to its storage via CoW semantics.
-      // This will force a copy to be made of this reference when the first mutation occurs;
-      // hence, it is safe to mark this as `nonisolated(unsafe)`.
-      static nonisolated(unsafe) let defaultInstance = _StorageClass()
-
-    private init() {}
-
-    init(copying source: _StorageClass) {
-      _flags = source._flags
-      _broadcastSendAsNode = source._broadcastSendAsNode
-      _broadcastMessage = source._broadcastMessage
-      _broadcastOfferChannel = source._broadcastOfferChannel
-      _broadcastOfferRegion = source._broadcastOfferRegion
-      _broadcastOfferPreset = source._broadcastOfferPreset
-      _broadcastOnChannel = source._broadcastOnChannel
-      _broadcastOnRegion = source._broadcastOnRegion
-      _broadcastOnPreset = source._broadcastOnPreset
-      _broadcastIntervalSecs = source._broadcastIntervalSecs
-      _broadcastTargets = source._broadcastTargets
-    }
-  }
-
-  fileprivate mutating func _uniqueStorage() -> _StorageClass {
-    if !isKnownUniquelyReferenced(&_storage) {
-      _storage = _StorageClass(copying: _storage)
-    }
-    return _storage
-  }
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}flags\0\u{4}\u{3}broadcast_message\0\u{3}broadcast_offer_channel\0\u{3}broadcast_offer_region\0\u{3}broadcast_offer_preset\0\u{4}\u{4}broadcast_interval_secs\0\u{4}\u{2}broadcast_targets\0\u{b}broadcast_send_as_node\0\u{b}broadcast_on_channel\0\u{b}broadcast_on_region\0\u{b}broadcast_on_preset\0\u{c}\u{3}\u{1}\u{c}\u{8}\u{1}\u{c}\u{9}\u{1}\u{c}\u{a}\u{1}")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    _ = _uniqueStorage()
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      while let fieldNumber = try decoder.nextFieldNumber() {
-        // The use of inline closures is to circumvent an issue where the compiler
-        // allocates stack space for every case branch when no optimizations are
-        // enabled. https://github.com/apple/swift-protobuf/issues/1034
-        switch fieldNumber {
-        case 1: try { try decoder.decodeSingularUInt32Field(value: &_storage._flags) }()
-        case 3: try { try decoder.decodeSingularUInt32Field(value: &_storage._broadcastSendAsNode) }()
-        case 4: try { try decoder.decodeSingularStringField(value: &_storage._broadcastMessage) }()
-        case 5: try { try decoder.decodeSingularMessageField(value: &_storage._broadcastOfferChannel) }()
-        case 6: try { try decoder.decodeSingularEnumField(value: &_storage._broadcastOfferRegion) }()
-        case 7: try { try decoder.decodeSingularEnumField(value: &_storage._broadcastOfferPreset) }()
-        case 8: try { try decoder.decodeSingularMessageField(value: &_storage._broadcastOnChannel) }()
-        case 9: try { try decoder.decodeSingularEnumField(value: &_storage._broadcastOnRegion) }()
-        case 10: try { try decoder.decodeSingularEnumField(value: &_storage._broadcastOnPreset) }()
-        case 11: try { try decoder.decodeSingularUInt32Field(value: &_storage._broadcastIntervalSecs) }()
-        case 13: try { try decoder.decodeRepeatedMessageField(value: &_storage._broadcastTargets) }()
-        default: break
-        }
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self.flags) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.broadcastMessage) }()
+      case 5: try { try decoder.decodeSingularMessageField(value: &self._broadcastOfferChannel) }()
+      case 6: try { try decoder.decodeSingularEnumField(value: &self.broadcastOfferRegion) }()
+      case 7: try { try decoder.decodeSingularEnumField(value: &self._broadcastOfferPreset) }()
+      case 11: try { try decoder.decodeSingularUInt32Field(value: &self.broadcastIntervalSecs) }()
+      case 13: try { try decoder.decodeRepeatedMessageField(value: &self.broadcastTargets) }()
+      default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every if/case branch local when no optimizations
-      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-      // https://github.com/apple/swift-protobuf/issues/1182
-      if _storage._flags != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._flags, fieldNumber: 1)
-      }
-      if _storage._broadcastSendAsNode != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._broadcastSendAsNode, fieldNumber: 3)
-      }
-      if !_storage._broadcastMessage.isEmpty {
-        try visitor.visitSingularStringField(value: _storage._broadcastMessage, fieldNumber: 4)
-      }
-      try { if let v = _storage._broadcastOfferChannel {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-      } }()
-      if _storage._broadcastOfferRegion != .unset {
-        try visitor.visitSingularEnumField(value: _storage._broadcastOfferRegion, fieldNumber: 6)
-      }
-      try { if let v = _storage._broadcastOfferPreset {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 7)
-      } }()
-      try { if let v = _storage._broadcastOnChannel {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-      } }()
-      if _storage._broadcastOnRegion != .unset {
-        try visitor.visitSingularEnumField(value: _storage._broadcastOnRegion, fieldNumber: 9)
-      }
-      try { if let v = _storage._broadcastOnPreset {
-        try visitor.visitSingularEnumField(value: v, fieldNumber: 10)
-      } }()
-      if _storage._broadcastIntervalSecs != 0 {
-        try visitor.visitSingularUInt32Field(value: _storage._broadcastIntervalSecs, fieldNumber: 11)
-      }
-      if !_storage._broadcastTargets.isEmpty {
-        try visitor.visitRepeatedMessageField(value: _storage._broadcastTargets, fieldNumber: 13)
-      }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.flags != 0 {
+      try visitor.visitSingularUInt32Field(value: self.flags, fieldNumber: 1)
+    }
+    if !self.broadcastMessage.isEmpty {
+      try visitor.visitSingularStringField(value: self.broadcastMessage, fieldNumber: 4)
+    }
+    try { if let v = self._broadcastOfferChannel {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    } }()
+    if self.broadcastOfferRegion != .unset {
+      try visitor.visitSingularEnumField(value: self.broadcastOfferRegion, fieldNumber: 6)
+    }
+    try { if let v = self._broadcastOfferPreset {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 7)
+    } }()
+    if self.broadcastIntervalSecs != 0 {
+      try visitor.visitSingularUInt32Field(value: self.broadcastIntervalSecs, fieldNumber: 11)
+    }
+    if !self.broadcastTargets.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.broadcastTargets, fieldNumber: 13)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: ModuleConfig.MeshBeaconConfig, rhs: ModuleConfig.MeshBeaconConfig) -> Bool {
-    if lhs._storage !== rhs._storage {
-      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
-        let _storage = _args.0
-        let rhs_storage = _args.1
-        if _storage._flags != rhs_storage._flags {return false}
-        if _storage._broadcastSendAsNode != rhs_storage._broadcastSendAsNode {return false}
-        if _storage._broadcastMessage != rhs_storage._broadcastMessage {return false}
-        if _storage._broadcastOfferChannel != rhs_storage._broadcastOfferChannel {return false}
-        if _storage._broadcastOfferRegion != rhs_storage._broadcastOfferRegion {return false}
-        if _storage._broadcastOfferPreset != rhs_storage._broadcastOfferPreset {return false}
-        if _storage._broadcastOnChannel != rhs_storage._broadcastOnChannel {return false}
-        if _storage._broadcastOnRegion != rhs_storage._broadcastOnRegion {return false}
-        if _storage._broadcastOnPreset != rhs_storage._broadcastOnPreset {return false}
-        if _storage._broadcastIntervalSecs != rhs_storage._broadcastIntervalSecs {return false}
-        if _storage._broadcastTargets != rhs_storage._broadcastTargets {return false}
-        return true
-      }
-      if !storagesAreEqual {return false}
-    }
+    if lhs.flags != rhs.flags {return false}
+    if lhs.broadcastMessage != rhs.broadcastMessage {return false}
+    if lhs._broadcastOfferChannel != rhs._broadcastOfferChannel {return false}
+    if lhs.broadcastOfferRegion != rhs.broadcastOfferRegion {return false}
+    if lhs._broadcastOfferPreset != rhs._broadcastOfferPreset {return false}
+    if lhs.broadcastIntervalSecs != rhs.broadcastIntervalSecs {return false}
+    if lhs.broadcastTargets != rhs.broadcastTargets {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/MeshtasticProtobufs/Sources/meshtastic/telemetry.pb.swift
+++ b/MeshtasticProtobufs/Sources/meshtastic/telemetry.pb.swift
@@ -55,6 +55,8 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
 
   ///
   /// TODO - REMOVE High accuracy temperature and humidity
+  ///
+  /// NOTE: This enum value was marked as deprecated in the .proto file
   case shtc3 // = 7
 
   ///
@@ -75,6 +77,8 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
 
   ///
   /// TODO - REMOVE High accuracy temperature and humidity
+  ///
+  /// NOTE: This enum value was marked as deprecated in the .proto file
   case sht31 // = 12
 
   ///
@@ -95,6 +99,8 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
 
   ///
   /// TODO - REMOVE Sensirion High accuracy temperature and humidity
+  ///
+  /// NOTE: This enum value was marked as deprecated in the .proto file
   case sht4X // = 17
 
   ///
@@ -215,6 +221,8 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
 
   ///
   /// TODO - REMOVE STH21 Temperature and R. Humidity sensor
+  ///
+  /// NOTE: This enum value was marked as deprecated in the .proto file
   case sht21 // = 47
 
   ///
@@ -248,6 +256,14 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
   ///
   /// HM330X PM SENSOR
   case hm330X // = 55
+
+  ///
+  /// Sensirion SEN6X PM/RHT/VOC/NOx/CO2/HCHO sensor family (SEN62, SEN63C, SEN65, SEN66, SEN68, SEN69C)
+  case sen6X // = 56
+
+  ///
+  /// AS3935 Franklin lightning sensor
+  case as3935 // = 57
   case UNRECOGNIZED(Int)
 
   public init() {
@@ -312,6 +328,8 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
     case 53: self = .icm42607P
     case 54: self = .spa06
     case 55: self = .hm330X
+    case 56: self = .sen6X
+    case 57: self = .as3935
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
@@ -374,6 +392,8 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
     case .icm42607P: return 53
     case .spa06: return 54
     case .hm330X: return 55
+    case .sen6X: return 56
+    case .as3935: return 57
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -436,6 +456,8 @@ public enum TelemetrySensorType: SwiftProtobuf.Enum, Swift.CaseIterable {
     .icm42607P,
     .spa06,
     .hm330X,
+    .sen6X,
+    .as3935,
   ]
 
 }
@@ -765,11 +787,211 @@ public struct EnvironmentMetrics: @unchecked Sendable {
   public mutating func clearSoilTemperature() {_uniqueStorage()._soilTemperature = nil}
 
   ///
-  /// One-wire temperature (*C)
+  /// Never implemented, but Voltage may be mis-interpreted by old clients as temperature
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var oneWireTemperature: [Float] {
     get {_storage._oneWireTemperature}
     set {_uniqueStorage()._oneWireTemperature = newValue}
   }
+
+  ///
+  /// Multi-channel ADC Voltage Channel 0 (V)
+  public var adcVoltageCh0: Float {
+    get {_storage._adcVoltageCh0 ?? 0}
+    set {_uniqueStorage()._adcVoltageCh0 = newValue}
+  }
+  /// Returns true if `adcVoltageCh0` has been explicitly set.
+  public var hasAdcVoltageCh0: Bool {_storage._adcVoltageCh0 != nil}
+  /// Clears the value of `adcVoltageCh0`. Subsequent reads from it will return its default value.
+  public mutating func clearAdcVoltageCh0() {_uniqueStorage()._adcVoltageCh0 = nil}
+
+  ///
+  /// Multi-channel ADC Voltage Channel 1 (V)
+  public var adcVoltageCh1: Float {
+    get {_storage._adcVoltageCh1 ?? 0}
+    set {_uniqueStorage()._adcVoltageCh1 = newValue}
+  }
+  /// Returns true if `adcVoltageCh1` has been explicitly set.
+  public var hasAdcVoltageCh1: Bool {_storage._adcVoltageCh1 != nil}
+  /// Clears the value of `adcVoltageCh1`. Subsequent reads from it will return its default value.
+  public mutating func clearAdcVoltageCh1() {_uniqueStorage()._adcVoltageCh1 = nil}
+
+  ///
+  /// Multi-channel ADC Voltage Channel 2 (V)
+  public var adcVoltageCh2: Float {
+    get {_storage._adcVoltageCh2 ?? 0}
+    set {_uniqueStorage()._adcVoltageCh2 = newValue}
+  }
+  /// Returns true if `adcVoltageCh2` has been explicitly set.
+  public var hasAdcVoltageCh2: Bool {_storage._adcVoltageCh2 != nil}
+  /// Clears the value of `adcVoltageCh2`. Subsequent reads from it will return its default value.
+  public mutating func clearAdcVoltageCh2() {_uniqueStorage()._adcVoltageCh2 = nil}
+
+  ///
+  /// Multi-channel ADC Voltage Channel 3 (V)
+  public var adcVoltageCh3: Float {
+    get {_storage._adcVoltageCh3 ?? 0}
+    set {_uniqueStorage()._adcVoltageCh3 = newValue}
+  }
+  /// Returns true if `adcVoltageCh3` has been explicitly set.
+  public var hasAdcVoltageCh3: Bool {_storage._adcVoltageCh3 != nil}
+  /// Clears the value of `adcVoltageCh3`. Subsequent reads from it will return its default value.
+  public mutating func clearAdcVoltageCh3() {_uniqueStorage()._adcVoltageCh3 = nil}
+
+  ///
+  /// Multi-channel ADC Voltage Channel 4 (V)
+  public var adcVoltageCh4: Float {
+    get {_storage._adcVoltageCh4 ?? 0}
+    set {_uniqueStorage()._adcVoltageCh4 = newValue}
+  }
+  /// Returns true if `adcVoltageCh4` has been explicitly set.
+  public var hasAdcVoltageCh4: Bool {_storage._adcVoltageCh4 != nil}
+  /// Clears the value of `adcVoltageCh4`. Subsequent reads from it will return its default value.
+  public mutating func clearAdcVoltageCh4() {_uniqueStorage()._adcVoltageCh4 = nil}
+
+  ///
+  /// Multi-channel ADC Voltage Channel 5 (V)
+  public var adcVoltageCh5: Float {
+    get {_storage._adcVoltageCh5 ?? 0}
+    set {_uniqueStorage()._adcVoltageCh5 = newValue}
+  }
+  /// Returns true if `adcVoltageCh5` has been explicitly set.
+  public var hasAdcVoltageCh5: Bool {_storage._adcVoltageCh5 != nil}
+  /// Clears the value of `adcVoltageCh5`. Subsequent reads from it will return its default value.
+  public mutating func clearAdcVoltageCh5() {_uniqueStorage()._adcVoltageCh5 = nil}
+
+  ///
+  /// Multi-channel ADC Voltage Channel 6 (V)
+  public var adcVoltageCh6: Float {
+    get {_storage._adcVoltageCh6 ?? 0}
+    set {_uniqueStorage()._adcVoltageCh6 = newValue}
+  }
+  /// Returns true if `adcVoltageCh6` has been explicitly set.
+  public var hasAdcVoltageCh6: Bool {_storage._adcVoltageCh6 != nil}
+  /// Clears the value of `adcVoltageCh6`. Subsequent reads from it will return its default value.
+  public mutating func clearAdcVoltageCh6() {_uniqueStorage()._adcVoltageCh6 = nil}
+
+  ///
+  /// Multi-channel ADC Voltage Channel 7 (V)
+  public var adcVoltageCh7: Float {
+    get {_storage._adcVoltageCh7 ?? 0}
+    set {_uniqueStorage()._adcVoltageCh7 = newValue}
+  }
+  /// Returns true if `adcVoltageCh7` has been explicitly set.
+  public var hasAdcVoltageCh7: Bool {_storage._adcVoltageCh7 != nil}
+  /// Clears the value of `adcVoltageCh7`. Subsequent reads from it will return its default value.
+  public mutating func clearAdcVoltageCh7() {_uniqueStorage()._adcVoltageCh7 = nil}
+
+  ///
+  /// Multi-channel One-Wire Temperature Channel 0 (*C)
+  public var oneWireTemperatureCh0: Float {
+    get {_storage._oneWireTemperatureCh0 ?? 0}
+    set {_uniqueStorage()._oneWireTemperatureCh0 = newValue}
+  }
+  /// Returns true if `oneWireTemperatureCh0` has been explicitly set.
+  public var hasOneWireTemperatureCh0: Bool {_storage._oneWireTemperatureCh0 != nil}
+  /// Clears the value of `oneWireTemperatureCh0`. Subsequent reads from it will return its default value.
+  public mutating func clearOneWireTemperatureCh0() {_uniqueStorage()._oneWireTemperatureCh0 = nil}
+
+  ///
+  /// Multi-channel One-Wire Temperature Channel 1 (*C)
+  public var oneWireTemperatureCh1: Float {
+    get {_storage._oneWireTemperatureCh1 ?? 0}
+    set {_uniqueStorage()._oneWireTemperatureCh1 = newValue}
+  }
+  /// Returns true if `oneWireTemperatureCh1` has been explicitly set.
+  public var hasOneWireTemperatureCh1: Bool {_storage._oneWireTemperatureCh1 != nil}
+  /// Clears the value of `oneWireTemperatureCh1`. Subsequent reads from it will return its default value.
+  public mutating func clearOneWireTemperatureCh1() {_uniqueStorage()._oneWireTemperatureCh1 = nil}
+
+  ///
+  /// Multi-channel One-Wire Temperature Channel 2 (*C)
+  public var oneWireTemperatureCh2: Float {
+    get {_storage._oneWireTemperatureCh2 ?? 0}
+    set {_uniqueStorage()._oneWireTemperatureCh2 = newValue}
+  }
+  /// Returns true if `oneWireTemperatureCh2` has been explicitly set.
+  public var hasOneWireTemperatureCh2: Bool {_storage._oneWireTemperatureCh2 != nil}
+  /// Clears the value of `oneWireTemperatureCh2`. Subsequent reads from it will return its default value.
+  public mutating func clearOneWireTemperatureCh2() {_uniqueStorage()._oneWireTemperatureCh2 = nil}
+
+  ///
+  /// Multi-channel One-Wire Temperature Channel 3 (*C)
+  public var oneWireTemperatureCh3: Float {
+    get {_storage._oneWireTemperatureCh3 ?? 0}
+    set {_uniqueStorage()._oneWireTemperatureCh3 = newValue}
+  }
+  /// Returns true if `oneWireTemperatureCh3` has been explicitly set.
+  public var hasOneWireTemperatureCh3: Bool {_storage._oneWireTemperatureCh3 != nil}
+  /// Clears the value of `oneWireTemperatureCh3`. Subsequent reads from it will return its default value.
+  public mutating func clearOneWireTemperatureCh3() {_uniqueStorage()._oneWireTemperatureCh3 = nil}
+
+  ///
+  /// Multi-channel One-Wire Temperature Channel 4 (*C)
+  public var oneWireTemperatureCh4: Float {
+    get {_storage._oneWireTemperatureCh4 ?? 0}
+    set {_uniqueStorage()._oneWireTemperatureCh4 = newValue}
+  }
+  /// Returns true if `oneWireTemperatureCh4` has been explicitly set.
+  public var hasOneWireTemperatureCh4: Bool {_storage._oneWireTemperatureCh4 != nil}
+  /// Clears the value of `oneWireTemperatureCh4`. Subsequent reads from it will return its default value.
+  public mutating func clearOneWireTemperatureCh4() {_uniqueStorage()._oneWireTemperatureCh4 = nil}
+
+  ///
+  /// Multi-channel One-Wire Temperature Channel 5 (*C)
+  public var oneWireTemperatureCh5: Float {
+    get {_storage._oneWireTemperatureCh5 ?? 0}
+    set {_uniqueStorage()._oneWireTemperatureCh5 = newValue}
+  }
+  /// Returns true if `oneWireTemperatureCh5` has been explicitly set.
+  public var hasOneWireTemperatureCh5: Bool {_storage._oneWireTemperatureCh5 != nil}
+  /// Clears the value of `oneWireTemperatureCh5`. Subsequent reads from it will return its default value.
+  public mutating func clearOneWireTemperatureCh5() {_uniqueStorage()._oneWireTemperatureCh5 = nil}
+
+  ///
+  /// Multi-channel One-Wire Temperature Channel 6 (*C)
+  public var oneWireTemperatureCh6: Float {
+    get {_storage._oneWireTemperatureCh6 ?? 0}
+    set {_uniqueStorage()._oneWireTemperatureCh6 = newValue}
+  }
+  /// Returns true if `oneWireTemperatureCh6` has been explicitly set.
+  public var hasOneWireTemperatureCh6: Bool {_storage._oneWireTemperatureCh6 != nil}
+  /// Clears the value of `oneWireTemperatureCh6`. Subsequent reads from it will return its default value.
+  public mutating func clearOneWireTemperatureCh6() {_uniqueStorage()._oneWireTemperatureCh6 = nil}
+
+  ///
+  /// Multi-channel One-Wire Temperature Channel 7 (*C)
+  public var oneWireTemperatureCh7: Float {
+    get {_storage._oneWireTemperatureCh7 ?? 0}
+    set {_uniqueStorage()._oneWireTemperatureCh7 = newValue}
+  }
+  /// Returns true if `oneWireTemperatureCh7` has been explicitly set.
+  public var hasOneWireTemperatureCh7: Bool {_storage._oneWireTemperatureCh7 != nil}
+  /// Clears the value of `oneWireTemperatureCh7`. Subsequent reads from it will return its default value.
+  public mutating func clearOneWireTemperatureCh7() {_uniqueStorage()._oneWireTemperatureCh7 = nil}
+
+  ///
+  /// Lightning strikes detected in the last hour
+  public var lightningStrikeCount1H: UInt32 {
+    get {_storage._lightningStrikeCount1H ?? 0}
+    set {_uniqueStorage()._lightningStrikeCount1H = newValue}
+  }
+  /// Returns true if `lightningStrikeCount1H` has been explicitly set.
+  public var hasLightningStrikeCount1H: Bool {_storage._lightningStrikeCount1H != nil}
+  /// Clears the value of `lightningStrikeCount1H`. Subsequent reads from it will return its default value.
+  public mutating func clearLightningStrikeCount1H() {_uniqueStorage()._lightningStrikeCount1H = nil}
+
+  ///
+  /// Estimated distance to the leading edge of the storm, in km
+  public var lightningDistanceKm: Float {
+    get {_storage._lightningDistanceKm ?? 0}
+    set {_uniqueStorage()._lightningDistanceKm = newValue}
+  }
+  /// Returns true if `lightningDistanceKm` has been explicitly set.
+  public var hasLightningDistanceKm: Bool {_storage._lightningDistanceKm != nil}
+  /// Clears the value of `lightningDistanceKm`. Subsequent reads from it will return its default value.
+  public mutating func clearLightningDistanceKm() {_uniqueStorage()._lightningDistanceKm = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -852,7 +1074,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh3Current() {self._ch3Current = nil}
 
   ///
-  /// Voltage (Ch4)
+  /// Voltage (Ch4) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch4Voltage: Float {
     get {_ch4Voltage ?? 0}
     set {_ch4Voltage = newValue}
@@ -863,7 +1087,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh4Voltage() {self._ch4Voltage = nil}
 
   ///
-  /// Current (Ch4)
+  /// Current (Ch4) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch4Current: Float {
     get {_ch4Current ?? 0}
     set {_ch4Current = newValue}
@@ -874,7 +1100,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh4Current() {self._ch4Current = nil}
 
   ///
-  /// Voltage (Ch5)
+  /// Voltage (Ch5) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch5Voltage: Float {
     get {_ch5Voltage ?? 0}
     set {_ch5Voltage = newValue}
@@ -885,7 +1113,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh5Voltage() {self._ch5Voltage = nil}
 
   ///
-  /// Current (Ch5)
+  /// Current (Ch5) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch5Current: Float {
     get {_ch5Current ?? 0}
     set {_ch5Current = newValue}
@@ -896,7 +1126,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh5Current() {self._ch5Current = nil}
 
   ///
-  /// Voltage (Ch6)
+  /// Voltage (Ch6) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch6Voltage: Float {
     get {_ch6Voltage ?? 0}
     set {_ch6Voltage = newValue}
@@ -907,7 +1139,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh6Voltage() {self._ch6Voltage = nil}
 
   ///
-  /// Current (Ch6)
+  /// Current (Ch6) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch6Current: Float {
     get {_ch6Current ?? 0}
     set {_ch6Current = newValue}
@@ -918,7 +1152,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh6Current() {self._ch6Current = nil}
 
   ///
-  /// Voltage (Ch7)
+  /// Voltage (Ch7) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch7Voltage: Float {
     get {_ch7Voltage ?? 0}
     set {_ch7Voltage = newValue}
@@ -929,7 +1165,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh7Voltage() {self._ch7Voltage = nil}
 
   ///
-  /// Current (Ch7)
+  /// Current (Ch7) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch7Current: Float {
     get {_ch7Current ?? 0}
     set {_ch7Current = newValue}
@@ -940,7 +1178,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh7Current() {self._ch7Current = nil}
 
   ///
-  /// Voltage (Ch8)
+  /// Voltage (Ch8) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch8Voltage: Float {
     get {_ch8Voltage ?? 0}
     set {_ch8Voltage = newValue}
@@ -951,7 +1191,9 @@ public struct PowerMetrics: Sendable {
   public mutating func clearCh8Voltage() {self._ch8Voltage = nil}
 
   ///
-  /// Current (Ch8)
+  /// Current (Ch8) - TODO Remove
+  ///
+  /// NOTE: This field was marked as deprecated in the .proto file.
   public var ch8Current: Float {
     get {_ch8Current ?? 0}
     set {_ch8Current = newValue}
@@ -1264,6 +1506,20 @@ public struct AirQualityMetrics: @unchecked Sendable {
   public var hasParticlesTps: Bool {_storage._particlesTps != nil}
   /// Clears the value of `particlesTps`. Subsequent reads from it will return its default value.
   public mutating func clearParticlesTps() {_uniqueStorage()._particlesTps = nil}
+
+  ///
+  /// Raw PM sensor device status/error register bitmask, as defined by the sensor's own datasheet
+  /// (currently populated by the SEN6X family: bit 4 fan error, bit 6 RH&T error, bit 7 gas/VOC-NOx
+  /// error, bit 9 CO2 error (SEN66), bit 10 HCHO error, bit 11 PM error, bit 12 CO2 error (SEN63C/SEN69C),
+  /// bit 21 fan speed warning)
+  public var pmStatusFlags: UInt32 {
+    get {_storage._pmStatusFlags ?? 0}
+    set {_uniqueStorage()._pmStatusFlags = newValue}
+  }
+  /// Returns true if `pmStatusFlags` has been explicitly set.
+  public var hasPmStatusFlags: Bool {_storage._pmStatusFlags != nil}
+  /// Clears the value of `pmStatusFlags`. Subsequent reads from it will return its default value.
+  public mutating func clearPmStatusFlags() {_uniqueStorage()._pmStatusFlags = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1664,7 +1920,24 @@ public struct Nau7802Config: Sendable {
 }
 
 ///
-/// SEN5X State, for saving to flash
+/// AS3935 lightning sensor configuration, for saving to flash
+public struct AS3935Config: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  ///
+  /// Antenna tuning capacitance in pF, 0 to 120 in steps of 8. The chip does not retain
+  /// this across power loss, so it is stored here and re-applied on every boot.
+  public var tuningCapPf: UInt32 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+///
+/// SEN5X State, for saving to flash (to be merged with SEN6XState)
 public struct SEN5XState: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -1724,12 +1997,73 @@ public struct SEN5XState: Sendable {
   fileprivate var _vocStateArray: UInt64? = nil
 }
 
+///
+/// SEN6X State, for saving to flash
+public struct SEN6XState: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  ///
+  /// Last cleaning time for SEN6X
+  public var lastCleaningTime: UInt32 = 0
+
+  ///
+  /// Last cleaning time for SEN6X - valid flag
+  public var lastCleaningValid: Bool = false
+
+  ///
+  /// Config flag for one-shot mode (see admin.proto)
+  public var oneShotMode: Bool = false
+
+  ///
+  /// Last VOC state time, for models with a VOC sensor (SEN65, SEN66, SEN68, SEN69C)
+  public var vocStateTime: UInt32 {
+    get {_vocStateTime ?? 0}
+    set {_vocStateTime = newValue}
+  }
+  /// Returns true if `vocStateTime` has been explicitly set.
+  public var hasVocStateTime: Bool {self._vocStateTime != nil}
+  /// Clears the value of `vocStateTime`. Subsequent reads from it will return its default value.
+  public mutating func clearVocStateTime() {self._vocStateTime = nil}
+
+  ///
+  /// Last VOC state validity flag, for models with a VOC sensor (SEN65, SEN66, SEN68, SEN69C)
+  public var vocStateValid: Bool {
+    get {_vocStateValid ?? false}
+    set {_vocStateValid = newValue}
+  }
+  /// Returns true if `vocStateValid` has been explicitly set.
+  public var hasVocStateValid: Bool {self._vocStateValid != nil}
+  /// Clears the value of `vocStateValid`. Subsequent reads from it will return its default value.
+  public mutating func clearVocStateValid() {self._vocStateValid = nil}
+
+  ///
+  /// VOC state array (8x uint8t), for models with a VOC sensor (SEN65, SEN66, SEN68, SEN69C)
+  public var vocStateArray: UInt64 {
+    get {_vocStateArray ?? 0}
+    set {_vocStateArray = newValue}
+  }
+  /// Returns true if `vocStateArray` has been explicitly set.
+  public var hasVocStateArray: Bool {self._vocStateArray != nil}
+  /// Clears the value of `vocStateArray`. Subsequent reads from it will return its default value.
+  public mutating func clearVocStateArray() {self._vocStateArray = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _vocStateTime: UInt32? = nil
+  fileprivate var _vocStateValid: Bool? = nil
+  fileprivate var _vocStateArray: UInt64? = nil
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "meshtastic"
 
 extension TelemetrySensorType: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SENSOR_UNSET\0\u{1}BME280\0\u{1}BME680\0\u{1}MCP9808\0\u{1}INA260\0\u{1}INA219\0\u{1}BMP280\0\u{1}SHTC3\0\u{1}LPS22\0\u{1}QMC6310\0\u{1}QMI8658\0\u{1}QMC5883L\0\u{1}SHT31\0\u{1}PMSA003I\0\u{1}INA3221\0\u{1}BMP085\0\u{1}RCWL9620\0\u{1}SHT4X\0\u{1}VEML7700\0\u{1}MLX90632\0\u{1}OPT3001\0\u{1}LTR390UV\0\u{1}TSL25911FN\0\u{1}AHT10\0\u{1}DFROBOT_LARK\0\u{1}NAU7802\0\u{1}BMP3XX\0\u{1}ICM20948\0\u{1}MAX17048\0\u{1}CUSTOM_SENSOR\0\u{1}MAX30102\0\u{1}MLX90614\0\u{1}SCD4X\0\u{1}RADSENS\0\u{1}INA226\0\u{1}DFROBOT_RAIN\0\u{1}DPS310\0\u{1}RAK12035\0\u{1}MAX17261\0\u{1}PCT2075\0\u{1}ADS1X15\0\u{1}ADS1X15_ALT\0\u{1}SFA30\0\u{1}SEN5X\0\u{1}TSL2561\0\u{1}BH1750\0\u{1}HDC1080\0\u{1}SHT21\0\u{1}STC31\0\u{1}SCD30\0\u{1}SHTXX\0\u{1}DS248X\0\u{1}MMC5983MA\0\u{1}ICM42607P\0\u{1}SPA06\0\u{1}HM330X\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SENSOR_UNSET\0\u{1}BME280\0\u{1}BME680\0\u{1}MCP9808\0\u{1}INA260\0\u{1}INA219\0\u{1}BMP280\0\u{1}SHTC3\0\u{1}LPS22\0\u{1}QMC6310\0\u{1}QMI8658\0\u{1}QMC5883L\0\u{1}SHT31\0\u{1}PMSA003I\0\u{1}INA3221\0\u{1}BMP085\0\u{1}RCWL9620\0\u{1}SHT4X\0\u{1}VEML7700\0\u{1}MLX90632\0\u{1}OPT3001\0\u{1}LTR390UV\0\u{1}TSL25911FN\0\u{1}AHT10\0\u{1}DFROBOT_LARK\0\u{1}NAU7802\0\u{1}BMP3XX\0\u{1}ICM20948\0\u{1}MAX17048\0\u{1}CUSTOM_SENSOR\0\u{1}MAX30102\0\u{1}MLX90614\0\u{1}SCD4X\0\u{1}RADSENS\0\u{1}INA226\0\u{1}DFROBOT_RAIN\0\u{1}DPS310\0\u{1}RAK12035\0\u{1}MAX17261\0\u{1}PCT2075\0\u{1}ADS1X15\0\u{1}ADS1X15_ALT\0\u{1}SFA30\0\u{1}SEN5X\0\u{1}TSL2561\0\u{1}BH1750\0\u{1}HDC1080\0\u{1}SHT21\0\u{1}STC31\0\u{1}SCD30\0\u{1}SHTXX\0\u{1}DS248X\0\u{1}MMC5983MA\0\u{1}ICM42607P\0\u{1}SPA06\0\u{1}HM330X\0\u{1}SEN6X\0\u{1}AS3935\0")
 }
 
 extension DeviceMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -1788,7 +2122,7 @@ extension DeviceMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
 
 extension EnvironmentMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".EnvironmentMetrics"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}temperature\0\u{3}relative_humidity\0\u{3}barometric_pressure\0\u{3}gas_resistance\0\u{1}voltage\0\u{1}current\0\u{1}iaq\0\u{1}distance\0\u{1}lux\0\u{3}white_lux\0\u{3}ir_lux\0\u{3}uv_lux\0\u{3}wind_direction\0\u{3}wind_speed\0\u{1}weight\0\u{3}wind_gust\0\u{3}wind_lull\0\u{1}radiation\0\u{3}rainfall_1h\0\u{3}rainfall_24h\0\u{3}soil_moisture\0\u{3}soil_temperature\0\u{3}one_wire_temperature\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}temperature\0\u{3}relative_humidity\0\u{3}barometric_pressure\0\u{3}gas_resistance\0\u{1}voltage\0\u{1}current\0\u{1}iaq\0\u{1}distance\0\u{1}lux\0\u{3}white_lux\0\u{3}ir_lux\0\u{3}uv_lux\0\u{3}wind_direction\0\u{3}wind_speed\0\u{1}weight\0\u{3}wind_gust\0\u{3}wind_lull\0\u{1}radiation\0\u{3}rainfall_1h\0\u{3}rainfall_24h\0\u{3}soil_moisture\0\u{3}soil_temperature\0\u{3}one_wire_temperature\0\u{3}adc_voltage_ch0\0\u{3}adc_voltage_ch1\0\u{3}adc_voltage_ch2\0\u{3}adc_voltage_ch3\0\u{3}adc_voltage_ch4\0\u{3}adc_voltage_ch5\0\u{3}adc_voltage_ch6\0\u{3}adc_voltage_ch7\0\u{3}one_wire_temperature_ch0\0\u{3}one_wire_temperature_ch1\0\u{3}one_wire_temperature_ch2\0\u{3}one_wire_temperature_ch3\0\u{3}one_wire_temperature_ch4\0\u{3}one_wire_temperature_ch5\0\u{3}one_wire_temperature_ch6\0\u{3}one_wire_temperature_ch7\0\u{3}lightning_strike_count_1h\0\u{3}lightning_distance_km\0")
 
   fileprivate class _StorageClass {
     var _temperature: Float? = nil
@@ -1814,6 +2148,24 @@ extension EnvironmentMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     var _soilMoisture: UInt32? = nil
     var _soilTemperature: Float? = nil
     var _oneWireTemperature: [Float] = []
+    var _adcVoltageCh0: Float? = nil
+    var _adcVoltageCh1: Float? = nil
+    var _adcVoltageCh2: Float? = nil
+    var _adcVoltageCh3: Float? = nil
+    var _adcVoltageCh4: Float? = nil
+    var _adcVoltageCh5: Float? = nil
+    var _adcVoltageCh6: Float? = nil
+    var _adcVoltageCh7: Float? = nil
+    var _oneWireTemperatureCh0: Float? = nil
+    var _oneWireTemperatureCh1: Float? = nil
+    var _oneWireTemperatureCh2: Float? = nil
+    var _oneWireTemperatureCh3: Float? = nil
+    var _oneWireTemperatureCh4: Float? = nil
+    var _oneWireTemperatureCh5: Float? = nil
+    var _oneWireTemperatureCh6: Float? = nil
+    var _oneWireTemperatureCh7: Float? = nil
+    var _lightningStrikeCount1H: UInt32? = nil
+    var _lightningDistanceKm: Float? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -1847,6 +2199,24 @@ extension EnvironmentMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
       _soilMoisture = source._soilMoisture
       _soilTemperature = source._soilTemperature
       _oneWireTemperature = source._oneWireTemperature
+      _adcVoltageCh0 = source._adcVoltageCh0
+      _adcVoltageCh1 = source._adcVoltageCh1
+      _adcVoltageCh2 = source._adcVoltageCh2
+      _adcVoltageCh3 = source._adcVoltageCh3
+      _adcVoltageCh4 = source._adcVoltageCh4
+      _adcVoltageCh5 = source._adcVoltageCh5
+      _adcVoltageCh6 = source._adcVoltageCh6
+      _adcVoltageCh7 = source._adcVoltageCh7
+      _oneWireTemperatureCh0 = source._oneWireTemperatureCh0
+      _oneWireTemperatureCh1 = source._oneWireTemperatureCh1
+      _oneWireTemperatureCh2 = source._oneWireTemperatureCh2
+      _oneWireTemperatureCh3 = source._oneWireTemperatureCh3
+      _oneWireTemperatureCh4 = source._oneWireTemperatureCh4
+      _oneWireTemperatureCh5 = source._oneWireTemperatureCh5
+      _oneWireTemperatureCh6 = source._oneWireTemperatureCh6
+      _oneWireTemperatureCh7 = source._oneWireTemperatureCh7
+      _lightningStrikeCount1H = source._lightningStrikeCount1H
+      _lightningDistanceKm = source._lightningDistanceKm
     }
   }
 
@@ -1888,6 +2258,24 @@ extension EnvironmentMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
         case 21: try { try decoder.decodeSingularUInt32Field(value: &_storage._soilMoisture) }()
         case 22: try { try decoder.decodeSingularFloatField(value: &_storage._soilTemperature) }()
         case 23: try { try decoder.decodeRepeatedFloatField(value: &_storage._oneWireTemperature) }()
+        case 24: try { try decoder.decodeSingularFloatField(value: &_storage._adcVoltageCh0) }()
+        case 25: try { try decoder.decodeSingularFloatField(value: &_storage._adcVoltageCh1) }()
+        case 26: try { try decoder.decodeSingularFloatField(value: &_storage._adcVoltageCh2) }()
+        case 27: try { try decoder.decodeSingularFloatField(value: &_storage._adcVoltageCh3) }()
+        case 28: try { try decoder.decodeSingularFloatField(value: &_storage._adcVoltageCh4) }()
+        case 29: try { try decoder.decodeSingularFloatField(value: &_storage._adcVoltageCh5) }()
+        case 30: try { try decoder.decodeSingularFloatField(value: &_storage._adcVoltageCh6) }()
+        case 31: try { try decoder.decodeSingularFloatField(value: &_storage._adcVoltageCh7) }()
+        case 32: try { try decoder.decodeSingularFloatField(value: &_storage._oneWireTemperatureCh0) }()
+        case 33: try { try decoder.decodeSingularFloatField(value: &_storage._oneWireTemperatureCh1) }()
+        case 34: try { try decoder.decodeSingularFloatField(value: &_storage._oneWireTemperatureCh2) }()
+        case 35: try { try decoder.decodeSingularFloatField(value: &_storage._oneWireTemperatureCh3) }()
+        case 36: try { try decoder.decodeSingularFloatField(value: &_storage._oneWireTemperatureCh4) }()
+        case 37: try { try decoder.decodeSingularFloatField(value: &_storage._oneWireTemperatureCh5) }()
+        case 38: try { try decoder.decodeSingularFloatField(value: &_storage._oneWireTemperatureCh6) }()
+        case 39: try { try decoder.decodeSingularFloatField(value: &_storage._oneWireTemperatureCh7) }()
+        case 40: try { try decoder.decodeSingularUInt32Field(value: &_storage._lightningStrikeCount1H) }()
+        case 41: try { try decoder.decodeSingularFloatField(value: &_storage._lightningDistanceKm) }()
         default: break
         }
       }
@@ -1969,6 +2357,60 @@ extension EnvironmentMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
       if !_storage._oneWireTemperature.isEmpty {
         try visitor.visitPackedFloatField(value: _storage._oneWireTemperature, fieldNumber: 23)
       }
+      try { if let v = _storage._adcVoltageCh0 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 24)
+      } }()
+      try { if let v = _storage._adcVoltageCh1 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 25)
+      } }()
+      try { if let v = _storage._adcVoltageCh2 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 26)
+      } }()
+      try { if let v = _storage._adcVoltageCh3 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 27)
+      } }()
+      try { if let v = _storage._adcVoltageCh4 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 28)
+      } }()
+      try { if let v = _storage._adcVoltageCh5 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 29)
+      } }()
+      try { if let v = _storage._adcVoltageCh6 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 30)
+      } }()
+      try { if let v = _storage._adcVoltageCh7 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 31)
+      } }()
+      try { if let v = _storage._oneWireTemperatureCh0 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 32)
+      } }()
+      try { if let v = _storage._oneWireTemperatureCh1 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 33)
+      } }()
+      try { if let v = _storage._oneWireTemperatureCh2 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 34)
+      } }()
+      try { if let v = _storage._oneWireTemperatureCh3 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 35)
+      } }()
+      try { if let v = _storage._oneWireTemperatureCh4 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 36)
+      } }()
+      try { if let v = _storage._oneWireTemperatureCh5 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 37)
+      } }()
+      try { if let v = _storage._oneWireTemperatureCh6 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 38)
+      } }()
+      try { if let v = _storage._oneWireTemperatureCh7 {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 39)
+      } }()
+      try { if let v = _storage._lightningStrikeCount1H {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 40)
+      } }()
+      try { if let v = _storage._lightningDistanceKm {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 41)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2001,6 +2443,24 @@ extension EnvironmentMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
         if _storage._soilMoisture != rhs_storage._soilMoisture {return false}
         if _storage._soilTemperature != rhs_storage._soilTemperature {return false}
         if _storage._oneWireTemperature != rhs_storage._oneWireTemperature {return false}
+        if _storage._adcVoltageCh0 != rhs_storage._adcVoltageCh0 {return false}
+        if _storage._adcVoltageCh1 != rhs_storage._adcVoltageCh1 {return false}
+        if _storage._adcVoltageCh2 != rhs_storage._adcVoltageCh2 {return false}
+        if _storage._adcVoltageCh3 != rhs_storage._adcVoltageCh3 {return false}
+        if _storage._adcVoltageCh4 != rhs_storage._adcVoltageCh4 {return false}
+        if _storage._adcVoltageCh5 != rhs_storage._adcVoltageCh5 {return false}
+        if _storage._adcVoltageCh6 != rhs_storage._adcVoltageCh6 {return false}
+        if _storage._adcVoltageCh7 != rhs_storage._adcVoltageCh7 {return false}
+        if _storage._oneWireTemperatureCh0 != rhs_storage._oneWireTemperatureCh0 {return false}
+        if _storage._oneWireTemperatureCh1 != rhs_storage._oneWireTemperatureCh1 {return false}
+        if _storage._oneWireTemperatureCh2 != rhs_storage._oneWireTemperatureCh2 {return false}
+        if _storage._oneWireTemperatureCh3 != rhs_storage._oneWireTemperatureCh3 {return false}
+        if _storage._oneWireTemperatureCh4 != rhs_storage._oneWireTemperatureCh4 {return false}
+        if _storage._oneWireTemperatureCh5 != rhs_storage._oneWireTemperatureCh5 {return false}
+        if _storage._oneWireTemperatureCh6 != rhs_storage._oneWireTemperatureCh6 {return false}
+        if _storage._oneWireTemperatureCh7 != rhs_storage._oneWireTemperatureCh7 {return false}
+        if _storage._lightningStrikeCount1H != rhs_storage._lightningStrikeCount1H {return false}
+        if _storage._lightningDistanceKm != rhs_storage._lightningDistanceKm {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -2121,7 +2581,7 @@ extension PowerMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
 
 extension AirQualityMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".AirQualityMetrics"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}pm10_standard\0\u{3}pm25_standard\0\u{3}pm100_standard\0\u{3}pm10_environmental\0\u{3}pm25_environmental\0\u{3}pm100_environmental\0\u{3}particles_03um\0\u{3}particles_05um\0\u{3}particles_10um\0\u{3}particles_25um\0\u{3}particles_50um\0\u{3}particles_100um\0\u{1}co2\0\u{3}co2_temperature\0\u{3}co2_humidity\0\u{3}form_formaldehyde\0\u{3}form_humidity\0\u{3}form_temperature\0\u{3}pm40_standard\0\u{3}particles_40um\0\u{3}pm_temperature\0\u{3}pm_humidity\0\u{3}pm_voc_idx\0\u{3}pm_nox_idx\0\u{3}particles_tps\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}pm10_standard\0\u{3}pm25_standard\0\u{3}pm100_standard\0\u{3}pm10_environmental\0\u{3}pm25_environmental\0\u{3}pm100_environmental\0\u{3}particles_03um\0\u{3}particles_05um\0\u{3}particles_10um\0\u{3}particles_25um\0\u{3}particles_50um\0\u{3}particles_100um\0\u{1}co2\0\u{3}co2_temperature\0\u{3}co2_humidity\0\u{3}form_formaldehyde\0\u{3}form_humidity\0\u{3}form_temperature\0\u{3}pm40_standard\0\u{3}particles_40um\0\u{3}pm_temperature\0\u{3}pm_humidity\0\u{3}pm_voc_idx\0\u{3}pm_nox_idx\0\u{3}particles_tps\0\u{3}pm_status_flags\0")
 
   fileprivate class _StorageClass {
     var _pm10Standard: UInt32? = nil
@@ -2149,6 +2609,7 @@ extension AirQualityMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
     var _pmVocIdx: Float? = nil
     var _pmNoxIdx: Float? = nil
     var _particlesTps: Float? = nil
+    var _pmStatusFlags: UInt32? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -2184,6 +2645,7 @@ extension AirQualityMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       _pmVocIdx = source._pmVocIdx
       _pmNoxIdx = source._pmNoxIdx
       _particlesTps = source._particlesTps
+      _pmStatusFlags = source._pmStatusFlags
     }
   }
 
@@ -2227,6 +2689,7 @@ extension AirQualityMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
         case 23: try { try decoder.decodeSingularFloatField(value: &_storage._pmVocIdx) }()
         case 24: try { try decoder.decodeSingularFloatField(value: &_storage._pmNoxIdx) }()
         case 25: try { try decoder.decodeSingularFloatField(value: &_storage._particlesTps) }()
+        case 26: try { try decoder.decodeSingularUInt32Field(value: &_storage._pmStatusFlags) }()
         default: break
         }
       }
@@ -2314,6 +2777,9 @@ extension AirQualityMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
       try { if let v = _storage._particlesTps {
         try visitor.visitSingularFloatField(value: v, fieldNumber: 25)
       } }()
+      try { if let v = _storage._pmStatusFlags {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 26)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2348,6 +2814,7 @@ extension AirQualityMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
         if _storage._pmVocIdx != rhs_storage._pmVocIdx {return false}
         if _storage._pmNoxIdx != rhs_storage._pmNoxIdx {return false}
         if _storage._particlesTps != rhs_storage._particlesTps {return false}
+        if _storage._pmStatusFlags != rhs_storage._pmStatusFlags {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -2882,6 +3349,36 @@ extension Nau7802Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
   }
 }
 
+extension AS3935Config: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".AS3935Config"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}tuning_cap_pf\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self.tuningCapPf) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.tuningCapPf != 0 {
+      try visitor.visitSingularUInt32Field(value: self.tuningCapPf, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: AS3935Config, rhs: AS3935Config) -> Bool {
+    if lhs.tuningCapPf != rhs.tuningCapPf {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension SEN5XState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".SEN5XState"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}last_cleaning_time\0\u{3}last_cleaning_valid\0\u{3}one_shot_mode\0\u{3}voc_state_time\0\u{3}voc_state_valid\0\u{3}voc_state_array\0")
@@ -2930,6 +3427,65 @@ extension SEN5XState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
   }
 
   public static func ==(lhs: SEN5XState, rhs: SEN5XState) -> Bool {
+    if lhs.lastCleaningTime != rhs.lastCleaningTime {return false}
+    if lhs.lastCleaningValid != rhs.lastCleaningValid {return false}
+    if lhs.oneShotMode != rhs.oneShotMode {return false}
+    if lhs._vocStateTime != rhs._vocStateTime {return false}
+    if lhs._vocStateValid != rhs._vocStateValid {return false}
+    if lhs._vocStateArray != rhs._vocStateArray {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension SEN6XState: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".SEN6XState"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}last_cleaning_time\0\u{3}last_cleaning_valid\0\u{3}one_shot_mode\0\u{3}voc_state_time\0\u{3}voc_state_valid\0\u{3}voc_state_array\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self.lastCleaningTime) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.lastCleaningValid) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self.oneShotMode) }()
+      case 4: try { try decoder.decodeSingularUInt32Field(value: &self._vocStateTime) }()
+      case 5: try { try decoder.decodeSingularBoolField(value: &self._vocStateValid) }()
+      case 6: try { try decoder.decodeSingularFixed64Field(value: &self._vocStateArray) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    if self.lastCleaningTime != 0 {
+      try visitor.visitSingularUInt32Field(value: self.lastCleaningTime, fieldNumber: 1)
+    }
+    if self.lastCleaningValid != false {
+      try visitor.visitSingularBoolField(value: self.lastCleaningValid, fieldNumber: 2)
+    }
+    if self.oneShotMode != false {
+      try visitor.visitSingularBoolField(value: self.oneShotMode, fieldNumber: 3)
+    }
+    try { if let v = self._vocStateTime {
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 4)
+    } }()
+    try { if let v = self._vocStateValid {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 5)
+    } }()
+    try { if let v = self._vocStateArray {
+      try visitor.visitSingularFixed64Field(value: v, fieldNumber: 6)
+    } }()
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: SEN6XState, rhs: SEN6XState) -> Bool {
     if lhs.lastCleaningTime != rhs.lastCleaningTime {return false}
     if lhs.lastCleaningValid != rhs.lastCleaningValid {return false}
     if lhs.oneShotMode != rhs.oneShotMode {return false}


### PR DESCRIPTION
## Summary
Bumps the protobufs submodule to upstream master and regenerates with the SPM-pinned protoc-gen-swift (1.36.1), so the generated files keep Sendable, CaseIterable, and the lint header.

## What changed
- Upstream consolidated beacon TX destinations onto broadcast_targets and removed broadcast_send_as_node. The beacon editor now writes every row as a broadcast target (matching the unified Broadcast On list UI), and the upsert stops mapping the removed fields. The entity columns stay so the SwiftData schema is untouched.
- New Dragon Con and CCC firmware editions mirrored into FirmwareEditions (no bundled artwork; they fall back to the standard logo)
- New MESHPAGER_X2 and MESHNOLOGY_W12 hardware models ride along in the generated code

## Testing
Full suite: 2,991 tests in 521 suites, passing. The only fallout was the edition-mirror test, fixed by adding the two new editions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Dragon Con and CCC firmware editions.
  * Updated mesh beacon configuration to use broadcast targets as the sole transmission destinations.

* **Bug Fixes**
  * Removed obsolete mesh beacon broadcast-on settings from configuration handling.
  * Preserved supported broadcast offers and interval settings while maintaining compatibility with existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->