### PR TITLE
Track administered nodes; edit status message from node details

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -975,7 +975,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 					}
 					await MeshPackets.shared.routingPacket(packet: packet, connectedNodeNum: deviceNum)
 				case .adminApp:
-					await MeshPackets.shared.adminAppPacket(packet: packet)
+					await MeshPackets.shared.adminAppPacket(packet: packet, connectedNodeNum: self.activeDeviceNum)
 				case .replyApp:
 					Logger.mesh.info("[Reply] packet received from \(packet.from.toHex(), privacy: .public)")
 					guard let deviceNum = activeConnection?.device.num else {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1149,7 +1149,7 @@ actor MeshPackets {
 		return nil
 	}
 
-	func adminAppPacket (packet: MeshPacket) {
+	func adminAppPacket (packet: MeshPacket, connectedNodeNum: Int64? = nil) {
 		if let adminMessage = try? AdminMessage(serializedBytes: packet.decoded.payload) {
 
 			if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getCannedMessageModuleMessagesResponse(adminMessage.getCannedMessageModuleMessagesResponse) {
@@ -1238,17 +1238,23 @@ actor MeshPackets {
 			}
 			// An admin *response* carrying a session passkey is proof an admin request we
 			// sent to this node succeeded, so remember that it has been administered.
-			// Response variants only — never a request another node sent. Runs after the
-			// handlers above so a node first heard via a metadata response exists by now.
-			switch adminMessage.payloadVariant {
-			case .getChannelResponse, .getOwnerResponse, .getConfigResponse, .getModuleConfigResponse,
-				 .getCannedMessageModuleMessagesResponse, .getDeviceMetadataResponse, .getRingtoneResponse,
-				 .getDeviceConnectionStatusResponse, .getNodeRemoteHardwarePinsResponse, .getUiConfigResponse:
-				if !adminMessage.sessionPasskey.isEmpty {
+			// Marking requires a response variant (never a request another node sent),
+			// a response correlated to a request (requestID != 0), and a packet addressed
+			// to the connected node — an unsolicited or forwarded admin message never
+			// unlocks the remote-admin UI. Runs after the handlers above so a node first
+			// heard via a metadata response exists by now.
+			if let connectedNodeNum,
+			   packet.decoded.requestID != 0,
+			   Int64(packet.to) == connectedNodeNum,
+			   !adminMessage.sessionPasskey.isEmpty {
+				switch adminMessage.payloadVariant {
+				case .getChannelResponse, .getOwnerResponse, .getConfigResponse, .getModuleConfigResponse,
+					 .getCannedMessageModuleMessagesResponse, .getDeviceMetadataResponse, .getRingtoneResponse,
+					 .getDeviceConnectionStatusResponse, .getNodeRemoteHardwarePinsResponse, .getUiConfigResponse:
 					markNodeAdministered(num: Int64(packet.from))
+				default:
+					break
 				}
-			default:
-				break
 			}
 			// Save an ack for the admin message log for each admin message response received as we stopped sending acks if there is also a response to reduce airtime.
 			self.adminResponseAck(packet: packet)

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1236,6 +1236,20 @@ actor MeshPackets {
 			} else {
 				Logger.admin.error("🕸️ MESH PACKET received Admin App UNHANDLED \((try? packet.decoded.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
 			}
+			// An admin *response* carrying a session passkey is proof an admin request we
+			// sent to this node succeeded, so remember that it has been administered.
+			// Response variants only — never a request another node sent. Runs after the
+			// handlers above so a node first heard via a metadata response exists by now.
+			switch adminMessage.payloadVariant {
+			case .getChannelResponse, .getOwnerResponse, .getConfigResponse, .getModuleConfigResponse,
+				 .getCannedMessageModuleMessagesResponse, .getDeviceMetadataResponse, .getRingtoneResponse,
+				 .getDeviceConnectionStatusResponse, .getNodeRemoteHardwarePinsResponse, .getUiConfigResponse:
+				if !adminMessage.sessionPasskey.isEmpty {
+					markNodeAdministered(num: Int64(packet.from))
+				}
+			default:
+				break
+			}
 			// Save an ack for the admin message log for each admin message response received as we stopped sending acks if there is also a response to reduce airtime.
 			self.adminResponseAck(packet: packet)
 		}

--- a/Meshtastic/Model/NodeInfoEntity.swift
+++ b/Meshtastic/Model/NodeInfoEntity.swift
@@ -14,9 +14,10 @@ final class NodeInfoEntity {
 	var channel: Int32 = 0
 	var favorite: Bool = false
 	var firstHeard: Date?
-	/// True once an admin response carrying a session passkey has been received from this node —
-	/// proof that an admin request we sent succeeded at least once. Set on ingest
-	/// (`MeshPackets.adminAppPacket`), carried through backup restore, never cleared.
+	/// True once an admin response carrying a session passkey has been received from this node,
+	/// correlated to a request this app sent (response variant, requestID set, addressed to the
+	/// connected node) — proof that an admin request we sent succeeded at least once. Set on
+	/// ingest (`MeshPackets.adminAppPacket`), carried through backup restore, never cleared.
 	var hasBeenAdministered: Bool = false
 	/// True when this node signs its broadcast packets via XEdDSA and the radio has verified at least one
 	/// (NodeInfo.has_xeddsa_signed, field 14). Observed automatic trust — not a configurable setting.
@@ -169,6 +170,22 @@ extension NodeInfoEntity {
 	static func adminPickerOrder(_ nodes: [NodeInfoEntity]) -> [NodeInfoEntity] {
 		let liveNodes = nodes.filter { $0.modelContext != nil && !$0.isDeleted }
 		return liveNodes.filter(\.favorite) + liveNodes.filter { !$0.favorite }
+	}
+
+	/// True while the node's admin session is usable for a remote admin write: a non-empty
+	/// session passkey inside the firmware's 5-minute session window. Empty-passkey stamps
+	/// (from the local config download and post-save mirrors) don't count.
+	var hasLiveAdminSession: Bool {
+		sessionPasskey?.isEmpty == false && (sessionExpiration ?? .distantPast) >= Date()
+	}
+
+	/// Whether this node's own reported firmware supports the Status Message module (2.8+,
+	/// the same floor as `AccessoryManager.supportsStatusMessage`). Permissive when the node
+	/// has no known firmware version, matching the capability gates' unknown-version behavior.
+	var firmwareSupportsStatusMessage: Bool {
+		guard let version = metadata?.firmwareVersion, !version.isEmpty else { return true }
+		let comparison = "2.8.0".compare(version, options: .numeric)
+		return comparison == .orderedAscending || comparison == .orderedSame
 	}
 
 	/// The status message to render on read-only surfaces (node list card and node

--- a/Meshtastic/Model/NodeInfoEntity.swift
+++ b/Meshtastic/Model/NodeInfoEntity.swift
@@ -14,6 +14,10 @@ final class NodeInfoEntity {
 	var channel: Int32 = 0
 	var favorite: Bool = false
 	var firstHeard: Date?
+	/// True once an admin response carrying a session passkey has been received from this node —
+	/// proof that an admin request we sent succeeded at least once. Set on ingest
+	/// (`MeshPackets.adminAppPacket`), carried through backup restore, never cleared.
+	var hasBeenAdministered: Bool = false
 	/// True when this node signs its broadcast packets via XEdDSA and the radio has verified at least one
 	/// (NodeInfo.has_xeddsa_signed, field 14). Observed automatic trust — not a configurable setting.
 	var hasXeddsaSigned: Bool = false

--- a/Meshtastic/Persistence/NodeBackupManager+Import.swift
+++ b/Meshtastic/Persistence/NodeBackupManager+Import.swift
@@ -20,6 +20,7 @@ extension NodeBackupManager {
 			dst.channel = src.channel
 			dst.favorite = src.favorite
 			dst.firstHeard = src.firstHeard
+			dst.hasBeenAdministered = src.hasBeenAdministered
 			dst.hopsAway = src.hopsAway
 			dst.ignored = src.ignored
 			dst.lastHeard = src.lastHeard

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -759,6 +759,18 @@ extension MeshPackets {
 		}
 	}
 	
+	/// Marks a node as successfully administered. Called when an admin response arrives
+	/// carrying a session passkey — proof that at least one admin request we sent to this
+	/// node succeeded. Never cleared once set; gates admin-only UI (like the status message
+	/// editor) for nodes other than the connected one.
+	func markNodeAdministered(num: Int64) {
+		var descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate<NodeInfoEntity> { $0.num == num })
+		descriptor.fetchLimit = 1
+		guard let node = try? modelContext.fetch(descriptor).first, !node.hasBeenAdministered else { return }
+		node.hasBeenAdministered = true
+		savePendingChanges()
+	}
+
 	func upsertBluetoothConfigPacket(config: Config.BluetoothConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
 		
 		let logString = String.localizedStringWithFormat("Bluetooth config received: %@".localized, String(nodeNum))

--- a/Meshtastic/Views/Nodes/Helpers/EditStatusMessageView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/EditStatusMessageView.swift
@@ -68,7 +68,31 @@ private struct StatusMessageAlertModifier: ViewModifier {
 				)
 				status = prefill
 				initialStatus = prefill
+				refreshRemoteSessionIfNeeded()
 			}
+	}
+
+	/// A remote save must carry a live session passkey — the firmware rejects writes with a
+	/// stale one (ADMIN_BAD_SESSION_KEY) and the passkey only lasts 5 minutes. When the editor
+	/// opens for a remote node without a live session, request this module's config now so the
+	/// response re-seeds the passkey while the user is still typing — the same on-appear
+	/// refresh the config screens use (`requestRemoteConfig`).
+	private func refreshRemoteSessionIfNeeded() {
+		guard let presentedNode = node,
+			  let deviceNum = accessoryManager.activeDeviceNum,
+			  presentedNode.num != deviceNum,
+			  !presentedNode.hasLiveAdminSession,
+			  let connectedNode = getNodeInfo(id: deviceNum, context: context),
+			  let fromUser = connectedNode.user,
+			  let toUser = presentedNode.user
+		else { return }
+		Task {
+			do {
+				try await accessoryManager.requestStatusMessageModuleConfig(fromUser: fromUser, toUser: toUser)
+			} catch {
+				Logger.mesh.error("🚨 Status message session refresh failed: \(error.localizedDescription)")
+			}
+		}
 	}
 
 	/// Clamp to the 80-byte UTF-8 limit the firmware enforces, dropping whole trailing
@@ -93,6 +117,13 @@ private struct StatusMessageAlertModifier: ViewModifier {
 			  let toUser = presentedNode.user
 		else {
 			Logger.mesh.warning("⚠️ Cannot save status message: missing connected node or user entities")
+			return
+		}
+		// A remote write needs a live admin session; with a stale passkey the target just
+		// rejects it. The editor requested a refresh when it opened — if none arrived by
+		// now, skip the send and the optimistic local update rather than pretending it worked.
+		if presentedNode.num != deviceNum && !presentedNode.hasLiveAdminSession {
+			Logger.mesh.warning("⚠️ Not saving status message for \(toUser.longName ?? "unknown node", privacy: .public): admin session expired")
 			return
 		}
 		var config = ModuleConfig.StatusMessageConfig()

--- a/Meshtastic/Views/Nodes/Helpers/EditStatusMessageView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/EditStatusMessageView.swift
@@ -4,7 +4,7 @@
 //
 //  Copyright(c) Garth Vander Houwen 8/27/26.
 //
-//  Alert-based prompt to set the status message the connected node broadcasts to the mesh.
+//  Alert-based prompt to set the status message a node broadcasts to the mesh.
 //
 
 import MeshtasticProtobufs
@@ -13,9 +13,11 @@ import SwiftData
 import SwiftUI
 
 extension View {
-	/// Presents a native alert with a text field to set the connected node's status message
+	/// Presents a native alert with a text field to set a node's status message
 	/// (firmware 2.8+, gated by `AccessoryManager.supportsStatusMessage` at the call site).
-	/// Driven by `node`: assign the connected node to present the alert, `nil` (or Cancel/Save) dismisses it.
+	/// Works for the connected node, or a remote node that has been successfully
+	/// administered before (`NodeInfoEntity.hasBeenAdministered`).
+	/// Driven by `node`: assign a node to present the alert, `nil` (or Cancel/Save) dismisses it.
 	func statusMessageAlert(node: Binding<NodeInfoEntity?>) -> some View {
 		modifier(StatusMessageAlertModifier(node: node))
 	}
@@ -80,9 +82,12 @@ private struct StatusMessageAlertModifier: ViewModifier {
 	}
 
 	/// Same save path the old Status Message config screen used.
+	/// `fromUser` is always the connected node's user and `toUser` the presented node's user —
+	/// `saveStatusMessageModuleConfig` attaches the session passkey when they differ. The presented
+	/// node must be the connected node or one we have successfully administered before.
 	private func save(for presentedNode: NodeInfoEntity) {
 		guard let deviceNum = accessoryManager.activeDeviceNum,
-			  presentedNode.num == deviceNum,
+			  presentedNode.num == deviceNum || presentedNode.hasBeenAdministered,
 			  let connectedNode = getNodeInfo(id: deviceNum, context: context),
 			  let fromUser = connectedNode.user,
 			  let toUser = presentedNode.user

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -104,10 +104,13 @@ struct NodeDetail: View {
 		return (fromUser, toUser)
 	}
 	/// The status row opens the status message editor for the connected node, or for a remote
-	/// node we have successfully administered before (firmware 2.8+ in both cases).
+	/// node we have successfully administered before. Firmware 2.8+ in both cases: the
+	/// connected node via `supportsStatusMessage`, a remote target additionally via its own
+	/// reported metadata (permissive when unknown, matching the house capability gates).
 	private var canEditStatusMessage: Bool {
-		accessoryManager.supportsStatusMessage &&
-			(accessoryManager.activeDeviceNum == nodeNum || node.hasBeenAdministered)
+		guard accessoryManager.supportsStatusMessage else { return false }
+		if accessoryManager.activeDeviceNum == nodeNum { return true }
+		return node.hasBeenAdministered && node.firmwareSupportsStatusMessage
 	}
 	@State var showingCompassSheet = false
 	@State private var nodeForDisplayNameEdit: NodeInfoEntity?

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -103,8 +103,15 @@ struct NodeDetail: View {
 		}
 		return (fromUser, toUser)
 	}
+	/// The status row opens the status message editor for the connected node, or for a remote
+	/// node we have successfully administered before (firmware 2.8+ in both cases).
+	private var canEditStatusMessage: Bool {
+		accessoryManager.supportsStatusMessage &&
+			(accessoryManager.activeDeviceNum == nodeNum || node.hasBeenAdministered)
+	}
 	@State var showingCompassSheet = false
 	@State private var nodeForDisplayNameEdit: NodeInfoEntity?
+	@State private var nodeForStatusMessageEdit: NodeInfoEntity?
 	/// Bumped whenever a local display name is set/cleared to force this view to re-render —
 	/// NodeDisplayNameStore is plain UserDefaults, not a SwiftData/@Bindable property, so nothing
 	/// else here would pick up the change.
@@ -127,6 +134,7 @@ struct NodeDetail: View {
 							)
 						}
 						.displayNameAlert(node: $nodeForDisplayNameEdit)
+						.statusMessageAlert(node: $nodeForStatusMessageEdit)
 					.onReceive(NotificationCenter.default.publisher(for: NodeDisplayNameStore.didChangeNotification)) { notification in
 						// Scoped to this node: the notification's object is unconditionally `nil`
 						// otherwise, and `displayNameRefresh` drives `.id()` below (which recreates
@@ -338,14 +346,36 @@ struct NodeDetail: View {
 				}
 				.accessibilityElement(children: .combine)
 			}
-			// User-authored status broadcast by the node. Omitted entirely when empty
-			// (no placeholder / em-dash). Untrusted free text — rendered verbatim as
-			// plain text, never markup. `Text(_: String)` does not parse markdown.
+			// User-authored status broadcast by the node. Untrusted free text — rendered
+			// verbatim as plain text, never markup. `Text(_: String)` does not parse markdown.
 			// Detail has more room than the cards (design#115), so it shows the full
 			// status rather than the 2-line card clamp — but still capped so a remote
 			// node broadcasting newline-laden text (the 80-byte cap is only enforced on
 			// the local save path) can't grow the row without bound.
-			if let status = node.statusMessageDisplay {
+			// For the connected node or an administered node the row is a button that opens
+			// the same status editor as the node list context menu, and it stays visible
+			// (with an em-dash) when no status is set. Read-only otherwise, and omitted
+			// entirely when empty (no placeholder).
+			if canEditStatusMessage {
+				Button {
+					nodeForStatusMessageEdit = node
+				} label: {
+					HStack(alignment: .top) {
+						Label {
+							Text("Status Message")
+						} icon: {
+							Image(systemName: NodeStatusStyle.glyph)
+								.symbolRenderingMode(.hierarchical)
+						}
+						Spacer()
+						Text(node.statusMessageDisplay ?? "—")
+							.foregroundStyle(.secondary)
+							.multilineTextAlignment(.trailing)
+							.lineLimit(6)
+					}
+				}
+				.accessibilityElement(children: .combine)
+			} else if let status = node.statusMessageDisplay {
 				HStack(alignment: .top) {
 					Label {
 						Text("Status Message")

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -1,0 +1,178 @@
+//
+//  NodeAdministrationTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 8/30/26.
+//
+//  Covers NodeInfoEntity.hasBeenAdministered: set when an admin response carrying a
+//  session passkey is ingested, and not set by the local config download or by
+//  non-response admin variants.
+//
+
+import Testing
+import Foundation
+import SwiftData
+import MeshtasticProtobufs
+@testable import Meshtastic
+
+@Suite("Node administration tracking", .serialized)
+@MainActor
+struct NodeAdministrationTests {
+
+	private func freshMesh() throws -> (MeshPackets, ModelContainer) {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		return (MeshPackets(modelContainer: container), container)
+	}
+
+	private func seedNode(num: Int64, in container: ModelContainer) throws {
+		let context = ModelContext(container)
+		let node = NodeInfoEntity()
+		node.id = num
+		node.num = num
+		context.insert(node)
+		try context.save()
+	}
+
+	private func fetchNode(num: Int64, in container: ModelContainer) throws -> NodeInfoEntity {
+		let context = ModelContext(container)
+		return try #require(context.fetch(
+			FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })
+		).first)
+	}
+
+	private func adminPacket(from num: Int64, message: AdminMessage) throws -> MeshPacket {
+		var packet = MeshPacket()
+		packet.from = UInt32(num)
+		packet.decoded.portnum = .adminApp
+		packet.decoded.payload = try message.serializedData()
+		return packet
+	}
+
+	@Test func configResponseWithPasskeyMarksAdministered() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x11AA22
+		try seedNode(num: num, in: container)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0xA5, 0x5A, 0x99, 0x01])
+		var config = Config()
+		config.device = Config.DeviceConfig()
+		admin.getConfigResponse = config
+
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.hasBeenAdministered)
+		#expect(node.sessionPasskey == Data([0xA5, 0x5A, 0x99, 0x01]))
+		#expect(node.sessionExpiration != nil)
+	}
+
+	@Test func moduleConfigResponseWithPasskeyMarksAdministered() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x22BB33
+		try seedNode(num: num, in: container)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0x01, 0x02, 0x03])
+		var moduleConfig = ModuleConfig()
+		moduleConfig.statusmessage = ModuleConfig.StatusMessageConfig()
+		admin.getModuleConfigResponse = moduleConfig
+
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.hasBeenAdministered)
+	}
+
+	@Test func metadataResponseWithPasskeyMarksUnknownNode() async throws {
+		// A metadata response is the first admin exchange when selecting a remote node,
+		// and its handler creates the node if it has never been heard.
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x33CC44
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0x0F, 0xF0])
+		var metadata = DeviceMetadata()
+		metadata.firmwareVersion = "2.8.0"
+		admin.getDeviceMetadataResponse = metadata
+
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.hasBeenAdministered)
+	}
+
+	@Test func responseWithoutPasskeyDoesNotMark() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x44DD55
+		try seedNode(num: num, in: container)
+
+		var admin = AdminMessage()
+		var config = Config()
+		config.device = Config.DeviceConfig()
+		admin.getConfigResponse = config
+
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(!node.hasBeenAdministered)
+	}
+
+	@Test func localConfigDownloadDoesNotMark() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x55EE66
+		try seedNode(num: num, in: container)
+
+		var config = Config()
+		config.device = Config.DeviceConfig()
+		await mesh.localConfig(config: config, nodeNum: num, nodeLongName: "Test Node")
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(!node.hasBeenAdministered)
+		// The local download still stamps the (empty) passkey as before.
+		#expect(node.sessionPasskey == Data())
+	}
+
+	@Test func setConfigRequestWithPasskeyDoesNotMark() async throws {
+		// Only response variants count — a set request is something we (or another
+		// node) sent, not proof this node answered us.
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x66FF77
+		try seedNode(num: num, in: container)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0x09, 0x09])
+		var config = Config()
+		config.device = Config.DeviceConfig()
+		admin.setConfig = config
+
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(!node.hasBeenAdministered)
+	}
+
+	@Test func markIsNeverCleared() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x77AA88
+		try seedNode(num: num, in: container)
+
+		var withPasskey = AdminMessage()
+		withPasskey.sessionPasskey = Data([0x01])
+		var config = Config()
+		config.device = Config.DeviceConfig()
+		withPasskey.getConfigResponse = config
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withPasskey))
+
+		// A later response without a passkey must not clear the flag.
+		var withoutPasskey = AdminMessage()
+		withoutPasskey.getConfigResponse = config
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withoutPasskey))
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.hasBeenAdministered)
+	}
+}

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -4,9 +4,10 @@
 //
 //  Copyright(c) Garth Vander Houwen 8/30/26.
 //
-//  Covers NodeInfoEntity.hasBeenAdministered: set when an admin response carrying a
-//  session passkey is ingested, and not set by the local config download or by
-//  non-response admin variants.
+//  Covers NodeInfoEntity.hasBeenAdministered: set when a correlated admin response
+//  carrying a session passkey is ingested, and not set by the local config download,
+//  non-response admin variants, or uncorrelated/unsolicited responses. Also covers
+//  the hasLiveAdminSession and firmwareSupportsStatusMessage gates the editor uses.
 //
 
 import Testing
@@ -18,6 +19,9 @@ import MeshtasticProtobufs
 @Suite("Node administration tracking", .serialized)
 @MainActor
 struct NodeAdministrationTests {
+
+	/// The connected node's number — admin responses are addressed to it.
+	private static let myNum: Int64 = 0x0BEEF
 
 	private func freshMesh() throws -> (MeshPackets, ModelContainer) {
 		let container = try ModelContainer(
@@ -43,12 +47,30 @@ struct NodeAdministrationTests {
 		).first)
 	}
 
-	private func adminPacket(from num: Int64, message: AdminMessage) throws -> MeshPacket {
+	private func adminPacket(
+		from num: Int64,
+		message: AdminMessage,
+		to: Int64 = NodeAdministrationTests.myNum,
+		requestID: UInt32 = 4242
+	) throws -> MeshPacket {
 		var packet = MeshPacket()
 		packet.from = UInt32(num)
+		packet.to = UInt32(to)
 		packet.decoded.portnum = .adminApp
 		packet.decoded.payload = try message.serializedData()
+		packet.decoded.requestID = requestID
 		return packet
+	}
+
+	private func deviceConfigResponse(passkey: Data?) -> AdminMessage {
+		var admin = AdminMessage()
+		if let passkey {
+			admin.sessionPasskey = passkey
+		}
+		var config = Config()
+		config.device = Config.DeviceConfig()
+		admin.getConfigResponse = config
+		return admin
 	}
 
 	@Test func configResponseWithPasskeyMarksAdministered() async throws {
@@ -56,13 +78,8 @@ struct NodeAdministrationTests {
 		let num: Int64 = 0x11AA22
 		try seedNode(num: num, in: container)
 
-		var admin = AdminMessage()
-		admin.sessionPasskey = Data([0xA5, 0x5A, 0x99, 0x01])
-		var config = Config()
-		config.device = Config.DeviceConfig()
-		admin.getConfigResponse = config
-
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+		let admin = deviceConfigResponse(passkey: Data([0xA5, 0x5A, 0x99, 0x01]))
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
@@ -81,7 +98,7 @@ struct NodeAdministrationTests {
 		moduleConfig.statusmessage = ModuleConfig.StatusMessageConfig()
 		admin.getModuleConfigResponse = moduleConfig
 
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
@@ -99,7 +116,7 @@ struct NodeAdministrationTests {
 		metadata.firmwareVersion = "2.8.0"
 		admin.getDeviceMetadataResponse = metadata
 
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
@@ -110,12 +127,8 @@ struct NodeAdministrationTests {
 		let num: Int64 = 0x44DD55
 		try seedNode(num: num, in: container)
 
-		var admin = AdminMessage()
-		var config = Config()
-		config.device = Config.DeviceConfig()
-		admin.getConfigResponse = config
-
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+		let admin = deviceConfigResponse(passkey: nil)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(!node.hasBeenAdministered)
@@ -149,7 +162,50 @@ struct NodeAdministrationTests {
 		config.device = Config.DeviceConfig()
 		admin.setConfig = config
 
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin))
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(!node.hasBeenAdministered)
+	}
+
+	@Test func uncorrelatedResponseDoesNotMark() async throws {
+		// requestID == 0 means the message is not a reply to a request we sent.
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x77AA88
+		try seedNode(num: num, in: container)
+
+		let admin = deviceConfigResponse(passkey: Data([0x01]))
+		await mesh.adminAppPacket(
+			packet: try adminPacket(from: num, message: admin, requestID: 0),
+			connectedNodeNum: Self.myNum
+		)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(!node.hasBeenAdministered)
+	}
+
+	@Test func responseAddressedToAnotherNodeDoesNotMark() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x88BB99
+		try seedNode(num: num, in: container)
+
+		let admin = deviceConfigResponse(passkey: Data([0x01]))
+		await mesh.adminAppPacket(
+			packet: try adminPacket(from: num, message: admin, to: 0x0D00D),
+			connectedNodeNum: Self.myNum
+		)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(!node.hasBeenAdministered)
+	}
+
+	@Test func unknownConnectedNodeDoesNotMark() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x99CC00
+		try seedNode(num: num, in: container)
+
+		let admin = deviceConfigResponse(passkey: Data([0x01]))
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: nil)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(!node.hasBeenAdministered)
@@ -157,22 +213,95 @@ struct NodeAdministrationTests {
 
 	@Test func markIsNeverCleared() async throws {
 		let (mesh, container) = try freshMesh()
-		let num: Int64 = 0x77AA88
+		let num: Int64 = 0xAADD11
 		try seedNode(num: num, in: container)
 
-		var withPasskey = AdminMessage()
-		withPasskey.sessionPasskey = Data([0x01])
-		var config = Config()
-		config.device = Config.DeviceConfig()
-		withPasskey.getConfigResponse = config
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withPasskey))
+		let withPasskey = deviceConfigResponse(passkey: Data([0x01]))
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withPasskey), connectedNodeNum: Self.myNum)
 
 		// A later response without a passkey must not clear the flag.
-		var withoutPasskey = AdminMessage()
-		withoutPasskey.getConfigResponse = config
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withoutPasskey))
+		let withoutPasskey = deviceConfigResponse(passkey: nil)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withoutPasskey), connectedNodeNum: Self.myNum)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
+	}
+}
+
+@Suite("Admin session and firmware gates", .serialized)
+@MainActor
+struct AdminSessionGateTests {
+
+	private func freshNode() throws -> (NodeInfoEntity, ModelContext) {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let node = NodeInfoEntity()
+		node.num = 0x1234
+		node.id = 0x1234
+		context.insert(node)
+		return (node, context)
+	}
+
+	@Test func liveSessionRequiresNonEmptyPasskeyAndFutureExpiration() throws {
+		let (node, _) = try freshNode()
+		node.sessionPasskey = Data([0x01, 0x02])
+		node.sessionExpiration = Date().addingTimeInterval(300)
+		#expect(node.hasLiveAdminSession)
+	}
+
+	@Test func emptyPasskeyIsNotALiveSession() throws {
+		let (node, _) = try freshNode()
+		node.sessionPasskey = Data()
+		node.sessionExpiration = Date().addingTimeInterval(300)
+		#expect(!node.hasLiveAdminSession)
+	}
+
+	@Test func expiredSessionIsNotLive() throws {
+		let (node, _) = try freshNode()
+		node.sessionPasskey = Data([0x01, 0x02])
+		node.sessionExpiration = Date().addingTimeInterval(-1)
+		#expect(!node.hasLiveAdminSession)
+	}
+
+	@Test func missingExpirationIsNotLive() throws {
+		let (node, _) = try freshNode()
+		node.sessionPasskey = Data([0x01, 0x02])
+		node.sessionExpiration = nil
+		#expect(!node.hasLiveAdminSession)
+	}
+
+	@Test func unknownFirmwareIsPermissive() throws {
+		let (node, _) = try freshNode()
+		#expect(node.firmwareSupportsStatusMessage)
+	}
+
+	@Test func olderFirmwareDoesNotSupportStatusMessage() throws {
+		let (node, context) = try freshNode()
+		let metadata = DeviceMetadataEntity()
+		metadata.firmwareVersion = "2.7.15"
+		context.insert(metadata)
+		node.metadata = metadata
+		#expect(!node.firmwareSupportsStatusMessage)
+	}
+
+	@Test func minimumFirmwareSupportsStatusMessage() throws {
+		let (node, context) = try freshNode()
+		let metadata = DeviceMetadataEntity()
+		metadata.firmwareVersion = "2.8.0"
+		context.insert(metadata)
+		node.metadata = metadata
+		#expect(node.firmwareSupportsStatusMessage)
+	}
+
+	@Test func newerFirmwareWithBuildHashSupportsStatusMessage() throws {
+		let (node, context) = try freshNode()
+		let metadata = DeviceMetadataEntity()
+		metadata.firmwareVersion = "2.9.1.3a0c08b"
+		context.insert(metadata)
+		node.metadata = metadata
+		#expect(node.firmwareSupportsStatusMessage)
 	}
 }


### PR DESCRIPTION
## Summary

Track when a node has been successfully remote-administered, and use that to allow editing the status message of administered nodes from Node Details.

Nothing existing meant "an admin request to this node succeeded at least once": `canRemoteAdmin` is only eligibility (the admin toggle or a legacy admin channel), and `sessionPasskey`/`sessionExpiration` are the transient 5-minute session, which the local config download also stamps with an empty value.

## What changed

- New `NodeInfoEntity.hasBeenAdministered` flag (additive, defaults to false). Set in `adminAppPacket` when any admin response variant arrives carrying a session passkey — the one choke point all config, module config, metadata, channel, and ringtone responses flow through. Never cleared, and carried through backup restore.
- The status message alert's save guard now accepts the connected node or an administered node. `fromUser`/`toUser` identity handling is unchanged; `saveStatusMessageModuleConfig` already attaches the session passkey for remote saves.
- Node Details: the status message row is now a button that opens the same status editor, for the connected node or an administered node (firmware 2.8+). For those nodes the row shows even when no status is set. Other nodes keep the read-only row, omitted when empty.

## Testing

- New `NodeAdministrationTests` suite: flag set by config/module-config/metadata responses with a passkey, not set by responses without one, the local config download, or set requests, and never cleared by a later passkey-less response.
- Built the app and ran NodeAdministrationTests, SettingsNodeSortTests, StatusMessageDisplayTests, and StatusMessagePrefillTests on the iOS 18.5 simulator: 38 tests, all passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node administration status is now tracked automatically after successful administrative responses.
  * Previously administered remote nodes retain this status across backup restores.
  * Administrators can edit status messages for eligible remote nodes directly from node details.
  * Empty status messages display a clear placeholder while remaining nodes retain read-only behavior.
* **Bug Fixes**
  * Status-message editing now works consistently for previously administered remote nodes.
* **Tests**
  * Added coverage for administration status detection and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->