### PR TITLE
Mirror the new firmware editions into the TV edition shim

### DIFF
--- a/Meshtastic TV/Models/EventEdition.swift
+++ b/Meshtastic TV/Models/EventEdition.swift
@@ -37,6 +37,10 @@ struct EventEdition: Equatable {
 			self.init(name: "Hamvention", assetName: "EventFirmwareHAMVENTION")
 		case .fab:
 			self.init(name: "FAB", assetName: "EventFirmwareFAB")
+		case .dragonCon:
+			self.init(name: "Dragon Con", assetName: nil)
+		case .ccc:
+			self.init(name: "CCC", assetName: nil)
 		case .diyEdition:
 			self.init(name: "DIY Edition", assetName: nil)
 		}


### PR DESCRIPTION
## Summary
The protobuf update (#2376) added Dragon Con and CCC to FirmwareEdition. The TV target keeps its own local switch over that enum (EventEdition.swift, deliberately shimmed instead of reusing the iOS enum) and stopped compiling with "switch must be exhaustive".

## What changed
The two new editions added to the TV shim, no bundled artwork — they fall back to the Meshtastic mark like the other editions without assets.

## Testing
Meshtastic TV scheme builds for the tvOS simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying Dragon Con and CCC firmware editions with their appropriate names.
  * These editions appear without an associated image asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->