### PR TITLE
Fix OTAFIX writes to Files provider drives

### DIFF
--- a/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/BootloaderUpgradeView.swift
+++ b/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/BootloaderUpgradeView.swift
@@ -16,9 +16,32 @@
 //
 
 import CryptoKit
+import Foundation
 import OSLog
 import SwiftUI
 import UniformTypeIdentifiers
+
+/// Coordinates writes to a security-scoped URL returned by the Files picker.
+/// External USB volumes are hosted by a file provider, so writing directly to
+/// the URL can fail even after the app has successfully read INFO_UF2.TXT.
+enum OTAFIXDriveWriter {
+	static func write(_ data: Data, to destination: URL) throws {
+		let coordinator = NSFileCoordinator()
+		var coordinationError: NSError?
+		var writeError: Error?
+
+		coordinator.coordinate(writingItemAt: destination, options: [], error: &coordinationError) { coordinatedDestination in
+			do {
+				try data.write(to: coordinatedDestination)
+			} catch {
+				writeError = error
+			}
+		}
+
+		if let coordinationError { throw coordinationError }
+		if let writeError { throw writeError }
+	}
+}
 
 struct BootloaderUpgradeView: View {
 	@EnvironmentObject var accessoryManager: AccessoryManager
@@ -310,7 +333,7 @@ struct BootloaderUpgradeView: View {
 					return
 				}
 				let destination = driveURL.appendingPathComponent(image.fileName)
-				try data.write(to: destination)
+				try OTAFIXDriveWriter.write(data, to: destination)
 				Logger.services.info("Wrote OTAFIX bootloader \(image.fileName, privacy: .public) to the device drive")
 				phase = .done(fileName: image.fileName)
 			} catch is CancellationError {

--- a/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/BootloaderUpgradeView.swift
+++ b/Meshtastic/Views/Settings/Firmware/UF2 Mass Storage/BootloaderUpgradeView.swift
@@ -24,13 +24,32 @@ import UniformTypeIdentifiers
 /// Coordinates writes to a security-scoped URL returned by the Files picker.
 /// External USB volumes are hosted by a file provider, so writing directly to
 /// the URL can fail even after the app has successfully read INFO_UF2.TXT.
-enum OTAFIXDriveWriter {
-	static func write(_ data: Data, to destination: URL) throws {
+protocol OTAFIXDriveWriteCoordinating {
+	func coordinateWritingItem(at destination: URL, accessor: (URL) -> Void) throws
+}
+
+struct OTAFIXDriveWriteCoordinator: OTAFIXDriveWriteCoordinating {
+	func coordinateWritingItem(at destination: URL, accessor: (URL) -> Void) throws {
 		let coordinator = NSFileCoordinator()
 		var coordinationError: NSError?
-		var writeError: Error?
 
 		coordinator.coordinate(writingItemAt: destination, options: [], error: &coordinationError) { coordinatedDestination in
+			accessor(coordinatedDestination)
+		}
+
+		if let coordinationError { throw coordinationError }
+	}
+}
+
+enum OTAFIXDriveWriter {
+	static func write(
+		_ data: Data,
+		to destination: URL,
+		coordinator: any OTAFIXDriveWriteCoordinating = OTAFIXDriveWriteCoordinator()
+	) throws {
+		var writeError: Error?
+
+		try coordinator.coordinateWritingItem(at: destination) { coordinatedDestination in
 			do {
 				try data.write(to: coordinatedDestination)
 			} catch {
@@ -38,7 +57,6 @@ enum OTAFIXDriveWriter {
 			}
 		}
 
-		if let coordinationError { throw coordinationError }
 		if let writeError { throw writeError }
 	}
 }

--- a/MeshtasticTests/OTAFIXDriveWriterTests.swift
+++ b/MeshtasticTests/OTAFIXDriveWriterTests.swift
@@ -11,18 +11,23 @@ import Testing
 @Suite("OTAFIX drive writer")
 struct OTAFIXDriveWriterTests {
 
-	@Test func writesTheDownloadedImageAtTheSelectedDestination() throws {
+	@Test func coordinatesTheSelectedDestinationBeforeWritingTheImage() throws {
 		let directory = FileManager.default.temporaryDirectory
 			.appendingPathComponent(UUID().uuidString, isDirectory: true)
 		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 		defer { try? FileManager.default.removeItem(at: directory) }
 
 		let destination = directory.appendingPathComponent("update-t1000_e_bootloader.uf2")
+		let coordinatedDestination = directory.appendingPathComponent("coordinated-update.uf2")
+		let coordinator = RecordingCoordinator(coordinatedDestination: coordinatedDestination)
 		let image = Data([0x55, 0x46, 0x32])
 
-		try OTAFIXDriveWriter.write(image, to: destination)
+		try OTAFIXDriveWriter.write(image, to: destination, coordinator: coordinator)
 
-		#expect(try Data(contentsOf: destination) == image)
+		#expect(coordinator.requestedDestination == destination)
+		#expect(coordinator.didInvokeAccessor)
+		#expect(try Data(contentsOf: coordinatedDestination) == image)
+		#expect(!FileManager.default.fileExists(atPath: destination.path))
 	}
 
 	@Test func reportsAWriteErrorFromTheSelectedDestination() throws {
@@ -35,4 +40,40 @@ struct OTAFIXDriveWriterTests {
 			try OTAFIXDriveWriter.write(Data([0x55]), to: directory)
 		}
 	}
+
+	@Test func reportsACoordinationError() {
+		#expect(throws: TestError.self) {
+			try OTAFIXDriveWriter.write(
+				Data([0x55]),
+				to: URL(fileURLWithPath: "/selected-drive/update.uf2"),
+				coordinator: FailingCoordinator()
+			)
+		}
+	}
+}
+
+private final class RecordingCoordinator: OTAFIXDriveWriteCoordinating {
+	let coordinatedDestination: URL
+	private(set) var requestedDestination: URL?
+	private(set) var didInvokeAccessor = false
+
+	init(coordinatedDestination: URL) {
+		self.coordinatedDestination = coordinatedDestination
+	}
+
+	func coordinateWritingItem(at destination: URL, accessor: (URL) -> Void) throws {
+		requestedDestination = destination
+		didInvokeAccessor = true
+		accessor(coordinatedDestination)
+	}
+}
+
+private struct FailingCoordinator: OTAFIXDriveWriteCoordinating {
+	func coordinateWritingItem(at destination: URL, accessor: (URL) -> Void) throws {
+		throw TestError.coordinationFailed
+	}
+}
+
+private enum TestError: Error {
+	case coordinationFailed
 }

--- a/MeshtasticTests/OTAFIXDriveWriterTests.swift
+++ b/MeshtasticTests/OTAFIXDriveWriterTests.swift
@@ -1,0 +1,38 @@
+//
+//  OTAFIXDriveWriterTests.swift
+//  MeshtasticTests
+//
+
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("OTAFIX drive writer")
+struct OTAFIXDriveWriterTests {
+
+	@Test func writesTheDownloadedImageAtTheSelectedDestination() throws {
+		let directory = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+		defer { try? FileManager.default.removeItem(at: directory) }
+
+		let destination = directory.appendingPathComponent("update-t1000_e_bootloader.uf2")
+		let image = Data([0x55, 0x46, 0x32])
+
+		try OTAFIXDriveWriter.write(image, to: destination)
+
+		#expect(try Data(contentsOf: destination) == image)
+	}
+
+	@Test func reportsAWriteErrorFromTheSelectedDestination() throws {
+		let directory = FileManager.default.temporaryDirectory
+			.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+		defer { try? FileManager.default.removeItem(at: directory) }
+
+		#expect(throws: Error.self) {
+			try OTAFIXDriveWriter.write(Data([0x55]), to: directory)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Coordinate bootloader-image writes to the security-scoped URL returned by the iOS Files picker.
- Preserve both file-coordination and destination-write errors for the existing user-facing failure state.
- Add focused coverage for successful writes and destination errors.

## Why

The bootloader flow could read `INFO_UF2.TXT` from a selected T1000-E DFU volume, then fail while saving the verified UF2 image to the same external drive. Apple requires `NSFileCoordinator` for reads and writes through document-picker URLs; the flow previously wrote directly with `Data.write(to:)`.

## Validation

- [x] `xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -destination 'platform=iOS Simulator,id=1C12F7AC-636D-4BE1-B075-0479A603EB02'` — 3,011 tests in 524 suites passed.\n- [x] `xcodebuild build -workspace Meshtastic.xcworkspace -scheme Meshtastic -destination 'platform=iOS Simulator,id=1C12F7AC-636D-4BE1-B075-0479A603EB02'` — succeeded.\n- [x] Focused regression tests cover a successful coordinated write and propagation of a write error.\n\n## Reporter evidence\n\nThe reporter selected the mounted T1000-E drive successfully; the app identified the board and selected `update-t1000_e_bootloader-0.9.2-OTAFIX2.3-BP1.5_nosd.uf2`, but then displayed a Files-provider error that the file could not be saved in the UUID-named selected folder. The supplied screenshot is intentionally not committed; attachment upload requires an authenticated GitHub browser session that is unavailable on this host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootloader upgrades to work more reliably with USB drives accessed through the system file provider.
  * Installation errors are now reported when the destination cannot be written.

* **Tests**
  * Added coverage for successful bootloader image transfers and invalid destination errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->