### PR TITLE
Fix detection sensor notifications opening Direct Messages

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1952,10 +1952,13 @@ actor MeshPackets {
 								let dmUserNum = Int64(packet.from)
 								var dmNotification: Notification?
 								if newMessage.isEmoji == false {
+									let notificationPath = packet.decoded.portnum == PortNum.detectionSensorApp
+										? "meshtastic:///nodes?nodenum=\(dmUserNum)"
+										: "meshtastic:///messages?userNum=\(newMessage.fromUser?.num ?? 0)&messageId=\(newMessage.messageId)"
 									dmNotification = makeMessageNotification(
 										message: newMessage,
 										content: messageText!,
-										path: "meshtastic:///messages?userNum=\(newMessage.fromUser?.num ?? 0)&messageId=\(newMessage.messageId)",
+										path: notificationPath,
 										userNum: dmUserNum,
 										critical: critical
 									)

--- a/MeshtasticTests/SelfOriginatedMessageEchoTests.swift
+++ b/MeshtasticTests/SelfOriginatedMessageEchoTests.swift
@@ -78,6 +78,15 @@ struct SelfOriginatedMessageEchoTests {
 		return mp
 	}
 
+	@MainActor
+	private func makeMeshPackets(notificationRecorder: NotificationRecorder) async -> MeshPackets {
+		let mp = MeshPackets(modelContainer: sharedModelContainer)
+		await mp.replaceNotificationScheduler { @MainActor @Sendable notifications in
+			notificationRecorder.record(notifications)
+		}
+		return mp
+	}
+
 	// MARK: - Existing repro tests
 
 	/// The exact user-reported symptom: a broadcast we originated comes back from the radio and is
@@ -317,13 +326,13 @@ struct SelfOriginatedMessageEchoTests {
 	/// Detection-sensor packets are intentionally omitted from Direct Messages and live in the
 	/// sender node's Detection Sensor Log. When their notifications are enabled, opening one must
 	/// therefore select that node rather than navigating to an empty DM conversation.
-	@Test @MainActor func directDetectionSensor_notificationOpensSenderNode() async {
+	@Test @MainActor func directDetectionSensor_notificationOpensSenderNode() async throws {
 		let previousValue = UserDefaults.enableDetectionNotifications
 		UserDefaults.enableDetectionNotifications = true
 		defer { UserDefaults.enableDetectionNotifications = previousValue }
 
-		let notifications = MainActorBox<[MeshNotification]>([])
-		let mp = await makeMeshPackets(scheduledNotifications: notifications)
+		let notificationRecorder = NotificationRecorder()
+		let mp = await makeMeshPackets(notificationRecorder: notificationRecorder)
 		let id: Int64 = 0x00C0_0031
 
 		let ctx = ModelContext(sharedModelContainer)
@@ -339,7 +348,7 @@ struct SelfOriginatedMessageEchoTests {
 		receiver.num = connectedNode
 		receiver.longName = "Me"
 		receiver.shortName = "ME"
-		try? ctx.save()
+		try ctx.save()
 
 		await mp.textMessageAppPacket(
 			packet: detectionSensorPacket(id: UInt32(id), from: UInt32(peerNode), to: UInt32(connectedNode)),
@@ -348,8 +357,8 @@ struct SelfOriginatedMessageEchoTests {
 			appState: nil
 		)
 
-		try? await Task.sleep(for: .milliseconds(100))
-		#expect(notifications.value.first?.path == "meshtastic:///nodes?nodenum=\(peerNode)")
+		await notificationRecorder.waitForNextNotification()
+		#expect(notificationRecorder.notifications.first?.path == "meshtastic:///nodes?nodenum=\(peerNode)")
 	}
 
 	// MARK: - Self-originated DM
@@ -402,8 +411,8 @@ struct SelfOriginatedMessageEchoTests {
 	/// Uses a DM (not broadcast) so the notification path only needs fromUser + toUser,
 	/// avoiding the MyInfoEntity/channel setup the channel branch requires.
 	@Test @MainActor func normalPeerDM_isUnreadAndNotifies() async {
-		let notifications = MainActorBox<[MeshNotification]>([])
-		let mp = await makeMeshPackets(scheduledNotifications: notifications)
+		let notificationRecorder = NotificationRecorder()
+		let mp = await makeMeshPackets(notificationRecorder: notificationRecorder)
 		let id: Int64 = 0x00C0_0050
 		let noAppState: AppState? = nil
 
@@ -433,9 +442,9 @@ struct SelfOriginatedMessageEchoTests {
 		let stored = messages(withId: id)
 		#expect(stored.first?.read != true, "peer DM must land unread")
 
-		// Give the notification Task time to fire.
-		try? await Task.sleep(for: .milliseconds(100))
-		#expect(!notifications.value.isEmpty, "peer DM must schedule a notification")
+		await notificationRecorder.waitForNextNotification()
+		#expect(!notificationRecorder.notifications.isEmpty, "peer DM must schedule a notification")
+		#expect(notificationRecorder.notifications.first?.path == "meshtastic:///messages?userNum=\(peerNode)&messageId=\(id)")
 	}
 }
 

--- a/MeshtasticTests/SelfOriginatedMessageEchoTests.swift
+++ b/MeshtasticTests/SelfOriginatedMessageEchoTests.swift
@@ -314,6 +314,44 @@ struct SelfOriginatedMessageEchoTests {
 		#expect(stored.first?.read == true, "detection-sensor with notifications disabled must be read")
 	}
 
+	/// Detection-sensor packets are intentionally omitted from Direct Messages and live in the
+	/// sender node's Detection Sensor Log. When their notifications are enabled, opening one must
+	/// therefore select that node rather than navigating to an empty DM conversation.
+	@Test @MainActor func directDetectionSensor_notificationOpensSenderNode() async {
+		let previousValue = UserDefaults.enableDetectionNotifications
+		UserDefaults.enableDetectionNotifications = true
+		defer { UserDefaults.enableDetectionNotifications = previousValue }
+
+		let notifications = MainActorBox<[MeshNotification]>([])
+		let mp = await makeMeshPackets(scheduledNotifications: notifications)
+		let id: Int64 = 0x00C0_0031
+
+		let ctx = ModelContext(sharedModelContainer)
+		let sender = UserEntity()
+		ctx.insert(sender)
+		sender.num = peerNode
+		sender.longName = "Sensor"
+		sender.shortName = "SN"
+		sender.mute = false
+
+		let receiver = UserEntity()
+		ctx.insert(receiver)
+		receiver.num = connectedNode
+		receiver.longName = "Me"
+		receiver.shortName = "ME"
+		try? ctx.save()
+
+		await mp.textMessageAppPacket(
+			packet: detectionSensorPacket(id: UInt32(id), from: UInt32(peerNode), to: UInt32(connectedNode)),
+			wantRangeTestPackets: true,
+			connectedNode: connectedNode,
+			appState: nil
+		)
+
+		try? await Task.sleep(for: .milliseconds(100))
+		#expect(notifications.value.first?.path == "meshtastic:///nodes?nodenum=\(peerNode)")
+	}
+
 	// MARK: - Self-originated DM
 
 	/// A self-originated DM (not just broadcast) should schedule no notification.


### PR DESCRIPTION
## Summary
- Route direct detection-sensor notifications to the sender node detail instead of a Direct Messages conversation.
- Keep existing notification, mute, and normal-DM behavior unchanged.
- Add a packet-injection regression test for the notification deep link.

## Why
Detection-sensor packets are stored as port 10 messages and intentionally excluded from Direct Messages. Their enabled notifications previously opened a DM route with no visible message.

## Testing
- `xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -destination 'platform=macOS,arch=arm64,variant=Mac Catalyst,name=My Mac' CODE_SIGNING_ALLOWED=NO '-only-testing:MeshtasticTests/SelfOriginatedMessageEchoTests/directDetectionSensor_notificationOpensSenderNode()' '-only-testing:MeshtasticTests/SelfOriginatedMessageEchoTests/detectionSensorWithNotificationsDisabled_staysRead()' '-only-testing:MeshtasticTests/SelfOriginatedMessageEchoTests/normalPeerDM_isUnreadAndNotifies()'`\n  - 3 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detection-sensor message notifications now open the sender’s node details and Detection Sensor Log.
  * Other direct-message notifications continue opening the relevant conversation.

* **Bug Fixes**
  * Fixed detection-sensor notifications opening an empty direct-message conversation instead of the sender’s node view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->