### PR TITLE
Fix nRF DFU updates aborting when the radio reboots into DFU mode

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -393,6 +393,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	}
 	
 	func connectToPreferredDevice(device: Device? = nil) {
+		// A firmware update owns the radio: reconnecting mid-update fights the
+		// updater for the device while it is rebooting into its bootloader.
+		if otaInProgress { return }
 		if !self.isConnected && !self.isConnecting,
 		   let preferredDevice = device ?? self.devices.first(where: { $0.id.uuidString == UserDefaults.preferredPeripheralId }) {
 			Task {

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -19,6 +19,7 @@ import WebKit
 struct Firmware: View {
 	let node: NodeInfoEntity?
 
+	@EnvironmentObject private var accessoryManager: AccessoryManager
 	@Query private var hardwareResults: [DeviceHardwareEntity]
 	@State private var cachedHardware: DeviceHardwareEntity?
 	@State private var cachedNode: NodeInfoEntity?
@@ -95,8 +96,10 @@ struct Firmware: View {
 			in: records
 		)
 		if didReset, hardwareState.resolution == nil {
-			cachedNode = nil
-			cachedHardware = nil
+			if !accessoryManager.otaInProgress {
+				cachedNode = nil
+				cachedHardware = nil
+			}
 			return
 		}
 		cacheResolvedHardware(for: node)
@@ -115,6 +118,10 @@ struct Firmware: View {
 	}
 
 	private func resetHardwareCache() {
+		// An update disconnects the radio on purpose. Keep the cached content on
+		// screen through it, or the update sheet is torn down mid-flash and the
+		// device is left sitting in its bootloader.
+		if accessoryManager.otaInProgress { return }
 		cachedNode = nil
 		cachedHardware = nil
 		hardwareState.reset()

--- a/Meshtastic/Views/Settings/Firmware/NRF DFU/DFUModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/NRF DFU/DFUModel.swift
@@ -49,6 +49,7 @@ class DFUViewModel: NSObject, ObservableObject {
     func startDFU(peripheral: CBPeripheral, zipFileUrl: URL) {
         
         guard let firmware = try? DFUFirmware(urlToZipFile: zipFileUrl) else {
+			Logger.services.error("NRF DFU: could not read the firmware zip")
             self.state = .error("Invalid Zip File")
             return
         }
@@ -70,6 +71,7 @@ class DFUViewModel: NSObject, ObservableObject {
         
         // Start the process
         self.state = .uploading
+		Logger.services.info("NRF DFU: starting on \(peripheral.identifier.uuidString, privacy: .public)")
 		self.dfuController = initiator.with(firmware: firmware)
 			.start(target: peripheral)
     }

--- a/Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 struct NRFDFUSheet: View {
 	@Environment(\.dismiss) var dismiss
@@ -59,10 +60,19 @@ struct NRFDFUSheet: View {
 								case .idle:
 									Button("Begin Update") {
 										Task {
-											if let connection = accessoryManager.activeConnection?.connection as? BLEConnection {
-												let peripheral = await connection.peripheral
-												dfuViewModel.startDFU(peripheral: peripheral, zipFileUrl: firmwareToFlash)
+											guard let connection = accessoryManager.activeConnection?.connection as? BLEConnection else {
+												Logger.services.error("NRF DFU: no active BLE connection, cannot start")
+												return
 											}
+											let peripheral = await connection.peripheral
+											// The DFU library reboots the radio into the bootloader and
+											// reconnects to it on its own. Stop scanning and auto-connect
+											// first or the app grabs the device out from under it.
+											accessoryManager.otaInProgress = true
+											accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = false
+											accessoryManager.stopDiscovery()
+											Logger.services.info("NRF DFU: handing the radio to the DFU library")
+											dfuViewModel.startDFU(peripheral: peripheral, zipFileUrl: firmwareToFlash)
 										}
 									}
 									.controlSize(.large)
@@ -118,6 +128,21 @@ struct NRFDFUSheet: View {
 		}
 		.interactiveDismissDisabled(true)
 		.firmwareUpdateGame(isPresented: $showChirpyGame, status: gameStatus)
+		.onDisappear {
+			if accessoryManager.otaInProgress {
+				restoreDiscovery()
+			}
+		}
+	}
+
+	/// Give the radio back to the app once DFU is finished: restart discovery and
+	/// let auto-connect pick the device up when it reboots into the new firmware.
+	private func restoreDiscovery() {
+		Logger.services.info("NRF DFU: restoring discovery")
+		accessoryManager.otaInProgress = false
+		accessoryManager.userRequestedConnectionCancellation = false
+		accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
+		accessoryManager.startDiscovery()
 	}
 
 	private var gameStatus: FirmwareUpdateGameStatus {


### PR DESCRIPTION
## Summary

nRF firmware updates were stalling at "Enabling DFU Mode" and leaving the device sitting in its bootloader. Starting a DFU reboots the radio into the bootloader, which drops the Bluetooth connection, and the app did not survive that disconnect.

## What changed

The Firmware screen swapped itself for the "please reconnect" placeholder as soon as the connected node went away. That removed the view that owns the update sheet, which owns the DFU controller, so the update was aborted about a second after it started. The screen now holds its content while an update is running.

The app also kept scanning and auto-connecting during the update, so it raced the DFU library for the radio while the library was trying to reconnect to the bootloader. Discovery and auto-connect are now stopped before the radio is handed over, and `connectToPreferredDevice` refuses to run during any firmware update. Both are restored when the update sheet is closed rather than on completion, so the finished state stays on screen.

Each step of the handoff is logged now, including the case where the firmware zip can't be read, which previously failed silently.

## Testing

Flashed an nRF52 radio over BLE from an iPhone. Before this change the update hung and the screen dropped to "please reconnect" with the device left in its bootloader; after it, the update runs through and the sheet stays up. ESP32 BLE OTA already stopped discovery the same way and is unaffected.
