### PR TITLE
Offer nightly firmware builds next to stable and alpha

### DIFF
--- a/Meshtastic/API/MeshtasticAPI.swift
+++ b/Meshtastic/API/MeshtasticAPI.swift
@@ -16,6 +16,7 @@ import os
 enum ReleaseType: String {
 	case stable = "Stable"
 	case alpha = "Alpha"
+	case nightly = "Nightly"
 	case unlisted = "Unlisted"
 }
 
@@ -70,6 +71,16 @@ struct FirmwareRelease: Codable {
 		case zipURL = "zip_url"
 		case releaseNotes = "release_notes"
 	}
+}
+
+/// Points at the current nightly build. Nightly artifacts live in one fixed
+/// `firmware-nightly` directory that is overwritten each build, so this file is the
+/// only way to learn which version is sitting in there right now.
+struct NightlyFirmwareIndex: Codable {
+	let version: String
+	let id: String
+	let title: String
+	let commit: String?
 }
 
 private struct GitHubFirmwareRelease: Decodable {
@@ -171,6 +182,8 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 	static let imageURLPrefix = URL(string: "https://flasher.meshtastic.org/img/devices/")!
 	static let firmwareURLEndpoint = URL(string: "https://api.meshtastic.org/github/firmware/list")!
 	static let firmwareGitHubURLEndpoint = URL(string: "https://api.github.com/repos/meshtastic/firmware/releases?per_page=100")!
+	static let nightlyIndexEndpoint = URL(string: "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/firmware-nightly/index.json")!
+	static let nightlyReleaseNotesEndpoint = URL(string: "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/firmware-nightly/release_notes.md")!
 	static let eventFirmwareURLEndpoint = URL(string: "https://api.meshtastic.org/resource/eventFirmware")!
 
 	/// How long a completed device image + msh.to link pass stays fresh before another network pass
@@ -253,6 +266,7 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 		}
 		let stableVersions = Set(decodedFirmware.releases.stable.map { $0.id })
 		let alphaVersions = Set(decodedFirmware.releases.alpha.map { $0.id })
+		let nightlyRelease = await fetchNightlyRelease()
 
 		// All DB work on mainContext so @Query observers see changes
 		await MainActor.run {
@@ -264,6 +278,26 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 
 			for alphaRelease in decodedFirmware.releases.alpha {
 				self.processFirmware(release: alphaRelease, releaseType: .alpha, context: context)
+			}
+
+			if let nightlyRelease {
+				self.processFirmware(release: nightlyRelease, releaseType: .nightly, context: context)
+
+				// Only one nightly exists at a time — the host overwrites the directory — so
+				// drop yesterday's row. Skipped when the index could not be read, or a failed
+				// fetch would empty the tab.
+				let nightlyRaw = ReleaseType.nightly.rawValue
+				let currentNightly = [nightlyRelease.id]
+				let staleNightlyDescriptor = FetchDescriptor<FirmwareReleaseEntity>(
+					predicate: #Predicate {
+						$0.releaseType == nightlyRaw && !currentNightly.contains($0.versionId)
+					}
+				)
+				if let staleNightlies = try? context.fetch(staleNightlyDescriptor) {
+					for staleNightly in staleNightlies {
+						context.delete(staleNightly)
+					}
+				}
 			}
 
 			// Anything that's left in stableVersions and alphaVersions is no longer present in the API and should be deleted.
@@ -468,6 +502,28 @@ deviceEntity.architecture = device.architecture
 		return decoded
 	}
 	
+	/// Read the nightly pointer file. Best effort on purpose: no nightly, or an
+	/// unreachable one, must not fail the stable and alpha list refresh.
+	private func fetchNightlyRelease() async -> FirmwareRelease? {
+		do {
+			let data = try await Self.nightlyIndexEndpoint.data(timeout: 5.0)
+			let index = try JSONDecoder().decode(NightlyFirmwareIndex.self, from: data)
+			let notes = try? await Self.nightlyReleaseNotesEndpoint.data(timeout: 5.0)
+			let pageURL = index.commit.map { "https://github.com/meshtastic/firmware/commit/\($0)" }
+				?? "https://github.com/meshtastic/firmware/commits/master"
+			return FirmwareRelease(
+				id: index.id,
+				title: index.title,
+				pageURL: pageURL,
+				zipURL: "",
+				releaseNotes: notes.flatMap { String(data: $0, encoding: .utf8) }
+			)
+		} catch {
+			Logger.services.warning("Nightly firmware index unavailable: \(error.localizedDescription, privacy: .public)")
+			return nil
+		}
+	}
+
 	private func processFirmware(release: FirmwareRelease, releaseType: ReleaseType, context: ModelContext) {
 		let releaseId = release.id
 		var descriptor = FetchDescriptor<FirmwareReleaseEntity>(

--- a/Meshtastic/Model/Firmware/FirmwareFile.swift
+++ b/Meshtastic/Model/Firmware/FirmwareFile.swift
@@ -137,7 +137,11 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 		let fileNameVersion = versionId.hasPrefix("v") ? String(versionId.dropFirst()) : versionId
 		let fileName = "firmware-\(target)-\(fileNameVersion)\(firmwareType)"
 		self.localUrl = FirmwareFile.localFirmwareStorageURL.appendingPathComponent(fileName)
+		// Tagged releases get a directory per version; the nightly is one fixed directory
+		// that each build overwrites.
+		let directoryName = releaseType == .nightly ? "firmware-nightly" : "firmware-\(fileNameVersion)"
 		self.remoteUrlCandidates = Self.makeRemoteURLCandidates(
+			directoryName: directoryName,
 			target: target,
 			version: fileNameVersion,
 			firmwareType: firmwareType,
@@ -360,12 +364,13 @@ class FirmwareFile: ObservableObject, Hashable, Equatable {
 	}
 
 	private static func makeRemoteURLCandidates(
+		directoryName: String,
 		target: String,
 		version: String,
 		firmwareType: FirmwareType,
 		localeTags: [String]
 	) -> [URL] {
-		let directory = remoteFirmwareURLPrefix.appendingPathComponent("firmware-\(version)")
+		let directory = remoteFirmwareURLPrefix.appendingPathComponent(directoryName)
 		var fileNames: [String] = []
 		var seen = Set<String>()
 		func append(_ value: String) {

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -156,7 +156,7 @@ struct Firmware: View {
 private struct FirmwareContentView: View {
 	
 	private enum FirmwareTab {
-		case stable, alpha, downloaded
+		case stable, alpha, nightly, downloaded
 	}
 	
 	@EnvironmentObject var accessoryManager: AccessoryManager
@@ -265,6 +265,7 @@ private struct FirmwareContentView: View {
 				Picker("Firmware Version", selection: $firmwareSelection) {
 					Text("Stable").tag(FirmwareTab.stable)
 					Text("Alpha").tag(FirmwareTab.alpha)
+					Text("Nightly").tag(FirmwareTab.nightly)
 					Text("Downloaded").tag(FirmwareTab.downloaded)
 				}.pickerStyle(.segmented)
 				
@@ -347,6 +348,22 @@ private struct FirmwareContentView: View {
 			if let last = alphas.last, let notes = last.releaseNotes {
 				NavigationLink("Release Notes") {
 					FirmwareReleaseNotesView(markdown: notes, versionId: last.versionId)
+				}
+			}
+		case .nightly:
+			let nightlies = firmwareList.mostRecentFirmware(forReleaseType: .nightly)
+			if nightlies.isEmpty {
+				Text("No nightly build is available for this device right now.")
+			} else {
+				ForEach(nightlies, id: \.localUrl) { release in
+					FirmwareRow(firmwareFile: release) { type, url in
+						self.rowInstallation = RowInstallation(type: type, url: url)
+					}
+				}
+				if let last = nightlies.last, let notes = last.releaseNotes {
+					NavigationLink("Release Notes") {
+						FirmwareReleaseNotesView(markdown: notes, versionId: last.versionId)
+					}
 				}
 			}
 		case .downloaded:
@@ -610,6 +627,8 @@ private struct FirmwareRow: View {
 						FirmwareTagView("STABLE", color: Color.green)
 					case .alpha:
 						FirmwareTagView("ALPHA", color: Color.blue)
+					case .nightly:
+						FirmwareTagView("NIGHTLY", color: Color.purple)
 					case .unlisted:
 						FirmwareTagView("UNLISTED", color: Color.orange)
 					}

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -578,9 +578,11 @@ struct FirmwareHeroImage: View {
 }
 
 struct FirmwareTagView: View {
-	let text: String
+	// LocalizedStringKey, not String: a String argument reaches Text() already resolved,
+	// so the tag literals were never extracted for translation.
+	let text: LocalizedStringKey
 	let color: Color
-	init(_ text: String, color: Color = .black) {
+	init(_ text: LocalizedStringKey, color: Color = .black) {
 		self.text = text
 		self.color = color
 	}


### PR DESCRIPTION
## Summary

Adds a Nightly tab next to Stable and Alpha on the firmware screen.

Nightly builds are published to a fixed `firmware-nightly` directory that each build overwrites, with an `index.json` naming the version currently in it. That means no version list is needed — one small read gives the current nightly, and its artifacts follow the same `firmware-<target>-<version>` naming everything else uses.

## What changed

`ReleaseType` gains a nightly case, and the firmware list refresh reads the nightly index alongside the stable and alpha lists, feeding it through the same release path. The read is best effort: an unreachable or missing index leaves the rest of the list alone.

`FirmwareFile` resolves nightly artifacts to the fixed directory rather than a per-version one. Filenames still carry the version, so downloads, caching, and the Downloaded tab keep working, and yesterday's nightly on disk stays distinct from today's.

Only one nightly exists at a time, so a refresh that finds a newer one drops the previous row. That prune is skipped when the index could not be read, or a failed fetch would empty the tab.

Release notes come from the nightly's `release_notes.md` when it's there. The update notifier only looks at stable releases, so nightlies don't generate update prompts.

## Testing

Checked the URLs the app builds against the host: `index.json` returns version 2.8.0.52d5214, and the `.uf2`, `-ota.zip`, and rak4631 `.uf2` artifacts for that version all return 200 from `firmware-nightly/`. Installed on an iPhone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for nightly firmware releases.
  - Nightly builds now appear in the firmware selection interface with release notes when available.
  - Added clear messaging when nightly firmware is unavailable.
  - Nightly firmware downloads now use the correct remote location.
  - Automatically removes outdated nightly release entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->