### PR TITLE
Bound the TestFlight notes at the previous release tag

### DIFF
--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -18,15 +18,37 @@ fi
 # Best effort — never fail the build over release notes.
 TESTFLIGHT_DIR="$CI_PRIMARY_REPOSITORY_PATH/TestFlight"
 mkdir -p "$TESTFLIGHT_DIR"
-# Xcode Cloud clones are shallow; deepen so the merge history is visible.
+# Xcode Cloud clones are shallow; deepen and fetch tags so the merge history and
+# the previous release tag are both visible.
 git -C "$CI_PRIMARY_REPOSITORY_PATH" fetch --deepen 50 --quiet 2>/dev/null || true
-# GitHub merge commits carry the PR title in the body. Take the last 10 merges,
-# first line of each body, drop empties/trailers, de-duplicate.
-NOTES=$(git -C "$CI_PRIMARY_REPOSITORY_PATH" log --merges -10 --pretty=format:"%b%n---" 2>/dev/null \
+git -C "$CI_PRIMARY_REPOSITORY_PATH" fetch --tags --quiet 2>/dev/null || true
+
+# Bound the notes at the previous release tag, so a build lists what is new in it
+# rather than a fixed count of merges that runs back through earlier releases.
+LAST_TAG=$(git -C "$CI_PRIMARY_REPOSITORY_PATH" describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null)
+# If this commit is itself tagged, the release has already been cut — measure from
+# the tag before it, or the range would be empty.
+if [ -n "$LAST_TAG" ] && \
+	[ "$(git -C "$CI_PRIMARY_REPOSITORY_PATH" rev-list -n1 "$LAST_TAG" 2>/dev/null)" = "$(git -C "$CI_PRIMARY_REPOSITORY_PATH" rev-parse HEAD 2>/dev/null)" ]; then
+	LAST_TAG=$(git -C "$CI_PRIMARY_REPOSITORY_PATH" describe --tags --abbrev=0 --match 'v[0-9]*' "$LAST_TAG^" 2>/dev/null)
+fi
+if [ -n "$LAST_TAG" ]; then
+	RANGE="$LAST_TAG..HEAD"
+	echo "WhatToTest range: $RANGE"
+else
+	RANGE=""
+	echo "WhatToTest: no release tag found, falling back to the last 10 merges."
+fi
+
+# GitHub merge commits carry the PR title in the body. Take the first line of each
+# body, drop empties/trailers and the version bump, de-duplicate.
+NOTES=$(git -C "$CI_PRIMARY_REPOSITORY_PATH" log --merges ${RANGE:--10} --pretty=format:"%b%n---" 2>/dev/null \
 	| awk '/^---$/{first=0; next} !first++ && NF && !/^Co-authored|^Signed-off/ {print "• " $0}' \
+	| grep -v -i '^• Bump version' \
 	| awk '!seen[$0]++' | head -12)
 if [ -z "$NOTES" ]; then
-	NOTES=$(git -C "$CI_PRIMARY_REPOSITORY_PATH" log -10 --no-merges --pretty=format:"• %s" 2>/dev/null)
+	NOTES=$(git -C "$CI_PRIMARY_REPOSITORY_PATH" log ${RANGE:--10} --no-merges --pretty=format:"• %s" 2>/dev/null \
+		| grep -v -i '^• Bump version' | head -12)
 fi
 if [ -n "$NOTES" ]; then
 	printf "Recent changes in this build:\n\n%s\n" "$NOTES" > "$TESTFLIGHT_DIR/WhatToTest.en-US.txt"


### PR DESCRIPTION
## Summary

TestFlight's "What to Test" for the 2.7.21 builds listed most of 2.7.20's changes as well. The notes were built from the last 10 merges regardless of which release they belonged to.

## What changed

The list now starts at the previous release tag, so a build only carries what is new in it. Xcode Cloud clones shallow and without tags, so the script fetches tags before looking one up. If the build commit is itself tagged — a build of the release commit — it steps back one tag, otherwise the range would be empty. The version bump PR is filtered out, since it is not something a tester can test. If no tag is found at all, the old behavior still applies.

## Testing

Ran the range logic against real history. From today's untagged main it produces the two changes that are actually new in 2.7.21. Detached at `v2.7.20` it steps back to `v2.7.19` and produces exactly 2.7.20's changes. `sh -n` passes on the script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * What’s New notes now cover all changes since the previous release tag.
  * Notes correctly handle tagged commits and fall back to recent changes when no release tag is available.

* **Bug Fixes**
  * Removed version-bump commits from generated release notes for cleaner, more relevant updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->