### PR TITLE
Reload message lists on a save notification instead of polling

### DIFF
--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -368,6 +368,15 @@ actor MeshPackets {
 
 	/// Saves any pending changes in the model context. Call once at the end of each
 	/// top-level packet handler to batch all mutations from a single packet into one write.
+	/// Set by any handler that touches a MessageEntity. Writes happen on this actor's context,
+	/// which SwiftData does not propagate to views, so the message lists cannot observe them.
+	/// One notification per save is enough for them to reload; observers debounce.
+	private var pendingMessageChange = false
+
+	func noteMessageChange() {
+		pendingMessageChange = true
+	}
+
 	func savePendingChanges(caller: String = #function) {
 		guard !invalidated else {
 			Logger.data.warning("💾 [\(caller, privacy: .public)] Dropped save on retired MeshPackets instance")
@@ -385,6 +394,12 @@ actor MeshPackets {
 		do {
 			try modelContext.save()
 			Logger.data.debug("💾 [\(caller, privacy: .public)] Saved pending changes")
+			if pendingMessageChange {
+				pendingMessageChange = false
+				Task { @MainActor in
+					NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
+				}
+			}
 		} catch {
 			Logger.data.error("💥 [\(caller, privacy: .public)] Error saving: \(error.localizedDescription, privacy: .public)")
 		}
@@ -1274,6 +1289,7 @@ actor MeshPackets {
 				fetchedMessage[0].relayNode = Int64(packet.relayNode)
 				fetchedMessage[0].ackSNR = packet.rxSnr
 
+				noteMessageChange()
 				savePendingChanges()
 			}
 		} catch {
@@ -1349,6 +1365,7 @@ actor MeshPackets {
 				} else {
 					return
 				}
+				noteMessageChange()
 				scheduleDebouncedSave()
 				Logger.data.debug("💾 ACK buffered for Message: \(packet.decoded.requestID, privacy: .public)")
 			} catch {
@@ -1921,9 +1938,9 @@ actor MeshPackets {
 						CarPlayIntentDonation.donateReceivedMessage(newMessage)
 						#endif
 
-						// Let unread-displaying surfaces (badge, CarPlay templates) refresh.
-						// Observers debounce, so posting per saved message is cheap.
-						NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
+						// Let the message lists and unread-displaying surfaces refresh. The
+						// notification is posted once per save, from savePendingChanges.
+						noteMessageChange()
 
 						// Self-originated messages and muted detection-sensor packets skip
 						// all notification work (no badge recount, no local notification).

--- a/Meshtastic/Views/Messages/ChannelMessageList.swift
+++ b/Meshtastic/Views/Messages/ChannelMessageList.swift
@@ -10,36 +10,7 @@ import MeshtasticProtobufs
 import OSLog
 import SwiftUI
 
-private struct ChannelMessageTimelineCursor: Comparable {
-	let timestamp: Int32
-	let messageId: Int64
 
-	static func < (lhs: ChannelMessageTimelineCursor, rhs: ChannelMessageTimelineCursor) -> Bool {
-		if lhs.timestamp == rhs.timestamp {
-			return lhs.messageId < rhs.messageId
-		}
-		return lhs.timestamp < rhs.timestamp
-	}
-}
-
-private struct ChannelMessageListChangeToken: Equatable {
-	let latest: ChannelMessageTimelineCursor?
-	let count: Int
-	// Tallies of messages whose ACK has resolved, kept as separate delivered/errored counts
-	// rather than a single sum: an errored→delivered transition leaves the sum unchanged
-	// (delivered +1, errored −1) but moves both tallies, so the token still changes and the list
-	// reloads. Together with `latest`/`count` these cover every ACK transition the app produces:
-	// in-place mutations only ever move a message *into* delivered/errored (a tally changes), and
-	// the sole route back to "waiting" is RetryButton, which deletes the message and inserts a
-	// fresh one — moving `latest`/`count`. (There is deliberately no `max(ackTimestamp)` signal:
-	// `ackTimestamp` is stamped from the remote `packet.rxTime`, so it isn't reliably monotonic
-	// and would add an unindexed sort to the 5s poll for a net-zero case that can't occur.) An
-	// incoming ACK changes neither `latest` nor `count`, so without these tallies the poll-based
-	// refresh would never reload and the row would stay on "Waiting to be acknowledged" until the
-	// view is rebuilt.
-	let deliveredAckCount: Int
-	let erroredAckCount: Int
-}
 
 struct ChannelMessageList: View {
 	@EnvironmentObject var appState: AppState
@@ -62,10 +33,6 @@ struct ChannelMessageList: View {
 	@State private var repliesByID: [Int64: MessageEntity] = [:]
 	@State private var tapbacksByReplyID: [Int64: [MessageEntity]] = [:]
 	@State private var hasEarlierMessages = false
-	@State private var latestKnownMessageToken: ChannelMessageListChangeToken?
-	@State private var latestVisibleTapbackCursor: ChannelMessageTimelineCursor?
-	@State private var latestKnownChannelTapbackCursor: ChannelMessageTimelineCursor?
-	@State private var visibleTapbackCount = 0
 	@State private var tapbackTargetMessage: MessageEntity?
 	@State private var tapbackText = ""
 	@FocusState var tapbackFocused: Bool
@@ -100,8 +67,12 @@ struct ChannelMessageList: View {
 			}
 			Logger.data.info("📖 [App] All unread messages marked as read.")
 			appState.unreadChannelMessages = myInfo.unreadMessages
-			// Refresh other unread surfaces (CarPlay templates) too.
-			NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
+			// Refresh other unread surfaces (CarPlay templates) too. Only when something was
+			// actually marked read: this view reloads on that notification, and an unconditional
+			// post would have it marking read and reloading in a loop.
+			if !readMessageIDs.isEmpty {
+				NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
+			}
 		} catch {
 			Logger.data.error("Failed to read messages: \(error.localizedDescription, privacy: .public)")
 		}
@@ -127,8 +98,6 @@ struct ChannelMessageList: View {
 			previousByID = buildPreviousByID(for: visibleMessages, previousMessage: previousMessage)
 			repliesByID = try fetchReplies(for: visibleMessages)
 			replaceTapbacks(try fetchTapbacks(for: visibleMessages))
-			latestKnownMessageToken = try fetchMessageChangeToken(latestMessage: fetchedMessages.first)
-			latestKnownChannelTapbackCursor = try fetchLatestTapbackCursor()
 
 			if markReadAfterLoad {
 				markMessagesAsRead()
@@ -153,71 +122,10 @@ struct ChannelMessageList: View {
 		return try context.fetch(descriptor)
 	}
 
-	private func fetchMessageChangeToken(latestMessage: MessageEntity? = nil) throws -> ChannelMessageListChangeToken {
-		let latest = try latestMessage ?? fetchMessages(limit: 1).first
-		let acks = try Self.resolvedAckCounts(in: context, channelIndex: channel.index)
-		return ChannelMessageListChangeToken(
-			latest: latest.map(cursor(for:)),
-			count: try fetchMessageCount(),
-			deliveredAckCount: acks.delivered,
-			erroredAckCount: acks.errored
-		)
-	}
 
-	/// Resolved-ACK tallies for this channel: delivered (`receivedACK`) and failed
-	/// (`ackError != 0`) counted separately. A message is shown as "Waiting to be acknowledged"
-	/// until it resolves; folding both tallies into the change token makes the poll reload on any
-	/// ACK state change. Keeping them distinct means errored→delivered (which keeps the sum
-	/// constant) still moves a tally. Exposed `static` so the regression tests exercise these
-	/// exact predicates.
-	///
-	/// Two single-term `fetchCount`s rather than one `||` predicate: a compound `||` (and a fourth
-	/// `&&` term such as an `isEmoji` filter) exceeds the `#Predicate` macro's type-check budget.
-	/// Not filtering `isEmoji` only means an acked tapback triggers one extra benign reload.
-	static func resolvedAckCounts(in context: ModelContext, channelIndex: Int32) throws -> (delivered: Int, errored: Int) {
-		let deliveredDescriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.channel == channelIndex && $0.toUser == nil && $0.receivedACK
-			}
-		)
-		let erroredDescriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.channel == channelIndex && $0.toUser == nil && $0.ackError != 0
-			}
-		)
-		return (try context.fetchCount(deliveredDescriptor), try context.fetchCount(erroredDescriptor))
-	}
 
-	private func fetchMessageCount() throws -> Int {
-		let channelIndex = channel.index
-		let descriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.channel == channelIndex && $0.toUser == nil && $0.isEmoji == false
-			}
-		)
-		return try context.fetchCount(descriptor)
-	}
 
-	private func fetchLatestTapbackCursor() throws -> ChannelMessageTimelineCursor? {
-		let channelIndex = channel.index
-		let isEmoji = true
-		var descriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> { message in
-				message.channel == channelIndex && message.toUser == nil && message.isEmoji == isEmoji && message.replyID > 0
-			},
-			sortBy: [
-				SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse),
-				SortDescriptor(\MessageEntity.messageId, order: .reverse)
-			]
-		)
-		descriptor.fetchLimit = 1
-		let fetched: [MessageEntity] = try context.fetch(descriptor)
-		return fetched.first.map(cursor(for:))
-	}
 
-	private func cursor(for message: MessageEntity) -> ChannelMessageTimelineCursor {
-		ChannelMessageTimelineCursor(timestamp: message.messageTimestamp, messageId: message.messageId)
-	}
 
 	private func buildPreviousByID(for visibleMessages: [MessageEntity], previousMessage: MessageEntity?) -> [Int64: MessageEntity] {
 		var result: [Int64: MessageEntity] = [:]
@@ -267,47 +175,9 @@ struct ChannelMessageList: View {
 		return try context.fetch(descriptor)
 	}
 
-	@MainActor
-	@discardableResult
-	private func refreshVisibleTapbacks(markReadAfterLoad: Bool) -> Bool {
-		do {
-			let tapbacks = try fetchTapbacks(for: messages)
-			let latestTapbackCursor = tapbacks.map(cursor(for:)).max()
-			guard latestTapbackCursor != latestVisibleTapbackCursor || tapbacks.count != visibleTapbackCount else {
-				return true
-			}
-			replaceTapbacks(tapbacks)
-			if markReadAfterLoad {
-				markMessagesAsRead()
-			}
-			return true
-		} catch {
-			Logger.data.error("Failed to refresh channel message tapbacks: \(error.localizedDescription, privacy: .public)")
-			return false
-		}
-	}
 
-	@MainActor
-	private func refreshIfNeeded() {
-		do {
-			if try fetchMessageChangeToken() != latestKnownMessageToken {
-				loadMessages(markReadAfterLoad: routerIsShowingThisChannel())
-			} else {
-				let latestTapbackCursor = try fetchLatestTapbackCursor()
-				if latestTapbackCursor != latestKnownChannelTapbackCursor {
-					if refreshVisibleTapbacks(markReadAfterLoad: routerIsShowingThisChannel()) {
-						latestKnownChannelTapbackCursor = latestTapbackCursor
-					}
-				}
-			}
-		} catch {
-			Logger.data.error("Failed to refresh channel messages: \(error.localizedDescription, privacy: .public)")
-		}
-	}
 
 	private func replaceTapbacks(_ tapbacks: [MessageEntity]) {
-		latestVisibleTapbackCursor = tapbacks.map(cursor(for:)).max()
-		visibleTapbackCount = tapbacks.count
 		tapbacksByReplyID = Dictionary(grouping: tapbacks, by: \.replyID)
 	}
 
@@ -330,7 +200,7 @@ struct ChannelMessageList: View {
 					isEmoji: true,
 					replyID: target.messageId
 				)
-				await MainActor.run { _ = refreshVisibleTapbacks(markReadAfterLoad: routerIsShowingThisChannel()) }
+				await MainActor.run { loadMessages(markReadAfterLoad: routerIsShowingThisChannel()) }
 			} catch {
 				Logger.services.warning("Failed to send tapback.")
 			}
@@ -411,10 +281,12 @@ struct ChannelMessageList: View {
 					let isVisible = routerIsShowingThisChannel()
 					loadMessages(markReadAfterLoad: isVisible)
 					guard isVisible else { return }
+					// Reloads are driven by .meshMessagesDidChange below. This is only a safety
+					// net for a change that somehow saved without one.
 					while !Task.isCancelled {
-						try? await Task.sleep(for: .seconds(5))
+						try? await Task.sleep(for: .seconds(30))
 						guard !Task.isCancelled else { return }
-						refreshIfNeeded()
+						loadMessages(markReadAfterLoad: routerIsShowingThisChannel())
 				}
 			}
 			.onChange(of: messages.last?.messageId) {
@@ -422,11 +294,14 @@ struct ChannelMessageList: View {
 					scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 				}
 			}
-			// Incoming channel traffic bumps appState.unreadChannelMessages (set in
-			// textMessageAppPacket); refresh on that signal so messages land live instead
-			// of waiting up to 5s for the poll loop in .task above.
-			.onChange(of: appState.unreadChannelMessages) {
-				refreshIfNeeded()
+			// Message writes happen on the packet actor's own context, which SwiftData does not
+			// propagate here, so the list reloads on the notification that actor posts after a
+			// save. Debounced because a burst of packets saves several times.
+			.onReceive(
+				NotificationCenter.default.publisher(for: .meshMessagesDidChange)
+					.debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+			) { _ in
+				loadMessages(markReadAfterLoad: routerIsShowingThisChannel())
 			}
 			.onChange(of: messageToHighlight) { scrollToHighlighted(scrollView) }
 			.onChange(of: messageFieldFocused) {

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import OSLog
 import MeshtasticProtobufs // Added to ensure RoutingError is accessible if needed
 
-private struct UserMessageTimelineCursor: Comparable {
+struct UserMessageTimelineCursor: Comparable {
 	let timestamp: Int32
 	let messageId: Int64
 
@@ -22,7 +22,9 @@ private struct UserMessageTimelineCursor: Comparable {
 	}
 }
 
-private struct UserMessageListChangeToken: Equatable {
+// Not private: the ACK-refresh tests build tokens directly to prove a tally reaches the
+// token's equality, which is what drives the reload.
+struct UserMessageListChangeToken: Equatable {
 	let latest: UserMessageTimelineCursor?
 	let count: Int
 	// Tallies of outgoing messages whose ACK has resolved, kept as separate delivered/errored

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -10,43 +10,7 @@ import SwiftUI
 import OSLog
 import MeshtasticProtobufs // Added to ensure RoutingError is accessible if needed
 
-struct UserMessageTimelineCursor: Comparable {
-	let timestamp: Int32
-	let messageId: Int64
 
-	static func < (lhs: UserMessageTimelineCursor, rhs: UserMessageTimelineCursor) -> Bool {
-		if lhs.timestamp == rhs.timestamp {
-			return lhs.messageId < rhs.messageId
-		}
-		return lhs.timestamp < rhs.timestamp
-	}
-}
-
-// Not private: the ACK-refresh tests build tokens directly to prove a tally reaches the
-// token's equality, which is what drives the reload.
-struct UserMessageListChangeToken: Equatable {
-	let latest: UserMessageTimelineCursor?
-	let count: Int
-	// Tallies of outgoing messages whose ACK has resolved, kept as separate delivered/errored
-	// counts rather than a single sum: an errored→delivered transition leaves the sum unchanged
-	// (delivered +1, errored −1) but moves both tallies, so the token still changes and the list
-	// reloads. Together with `latest`/`count` these cover every ACK transition the app produces:
-	// in-place mutations only ever move a message *into* delivered/errored (a tally changes), and
-	// the sole route back to "waiting" is RetryButton, which deletes the message and inserts a
-	// fresh one — moving `latest`/`count`. (There is deliberately no `max(ackTimestamp)` signal:
-	// `ackTimestamp` is stamped from the remote `packet.rxTime`, so it isn't reliably monotonic
-	// and would add an unindexed sort to the 5s poll for a net-zero case that can't occur.) An
-	// incoming ACK changes neither `latest` nor `count`, so without these tallies the poll-based
-	// refresh would never reload and the row would stay on "Waiting to be acknowledged" until the
-	// view is rebuilt.
-	let deliveredAckCount: Int
-	let erroredAckCount: Int
-	/// Counted separately from `deliveredAckCount` because a recipient's own ACK arriving after a
-	/// relay's implicit ACK moves neither of the other tallies: `receivedACK` is already true and
-	/// `ackError` is still 0, so the row stayed on "Relayed, not confirmed by recipient" until the
-	/// view was rebuilt. `realACK` is the only signal for that last transition.
-	let confirmedAckCount: Int
-}
 
 struct UserMessageList: View {
 	@EnvironmentObject var appState: AppState
@@ -68,10 +32,6 @@ struct UserMessageList: View {
 	@State private var repliesByID: [Int64: MessageEntity] = [:]
 	@State private var tapbacksByReplyID: [Int64: [MessageEntity]] = [:]
 	@State private var hasEarlierMessages = false
-	@State private var latestKnownMessageToken: UserMessageListChangeToken?
-	@State private var latestVisibleTapbackCursor: UserMessageTimelineCursor?
-	@State private var latestKnownConversationTapbackCursor: UserMessageTimelineCursor?
-	@State private var visibleTapbackCount = 0
 	@State private var tapbackTargetMessage: MessageEntity?
 	@State private var tapbackText = ""
 	@FocusState var tapbackFocused: Bool
@@ -104,8 +64,12 @@ struct UserMessageList: View {
 			   let connectedUser = connectedNode.user {
 				appState.unreadDirectMessages = connectedUser.unreadMessages(context: context, skipLastMessageCheck: true) // skipLastMessageCheck=true because we don't update lastMessage on our own connected node
 			}
-			// Refresh other unread surfaces (CarPlay templates) too.
-			NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
+			// Refresh other unread surfaces (CarPlay templates) too. Only when something was
+			// actually marked read: this view reloads on that notification, and an unconditional
+			// post would have it marking read and reloading in a loop.
+			if !readMessageIDs.isEmpty {
+				NotificationCenter.default.post(name: .meshMessagesDidChange, object: nil)
+			}
 		} catch {
 			Logger.data.error("Failed to read direct messages: \(error.localizedDescription, privacy: .public)")
 		}
@@ -131,8 +95,6 @@ struct UserMessageList: View {
 			previousByID = buildPreviousByID(for: visibleMessages, previousMessage: previousMessage)
 			repliesByID = try fetchReplies(for: visibleMessages)
 			replaceTapbacks(try fetchTapbacks(for: visibleMessages))
-			latestKnownMessageToken = try fetchMessageChangeToken(latestMessage: fetchedMessages.first)
-			latestKnownConversationTapbackCursor = try fetchLatestTapbackCursor()
 
 			if markReadAfterLoad {
 				markMessagesAsRead()
@@ -160,83 +122,9 @@ struct UserMessageList: View {
 		try fetchIncomingMessages(unreadOnly: true) + fetchOutgoingMessages(unreadOnly: true)
 	}
 
-	private func fetchMessageChangeToken(latestMessage: MessageEntity? = nil) throws -> UserMessageListChangeToken {
-		let latest = try latestMessage ?? fetchMessages(limit: 1).first
-		let acks = try Self.resolvedAckCounts(in: context, toUserNum: user.num)
-		return UserMessageListChangeToken(
-			latest: latest.map(cursor(for:)),
-			count: try fetchIncomingMessageCount() + fetchOutgoingMessageCount(),
-			deliveredAckCount: acks.delivered,
-			erroredAckCount: acks.errored,
-			confirmedAckCount: acks.confirmed
-		)
-	}
 
-	/// Resolved-ACK tallies for this conversation's outgoing messages: delivered (`receivedACK`)
-	/// and failed (`ackError != 0`) counted separately. A message is shown as "Waiting to be
-	/// acknowledged" until it resolves; folding both tallies into the change token makes the poll
-	/// reload on any ACK state change. Keeping them distinct means errored→delivered (which keeps
-	/// the sum constant) still moves a tally. Only outgoing messages carry ACK state, so the
-	/// incoming side is excluded. Exposed `static` so the regression tests exercise these exact
-	/// predicates.
-	///
-	/// Two single-term `fetchCount`s rather than one `||` predicate: a compound `||` (and an extra
-	/// `&&` term such as an `isEmoji` filter) exceeds the `#Predicate` macro's type-check budget.
-	/// Not filtering `isEmoji` only means an acked tapback triggers one extra benign reload.
-	static func resolvedAckCounts(in context: ModelContext, toUserNum userNum: Int64) throws -> (delivered: Int, errored: Int, confirmed: Int) {
-		let detectionSensorPortNum: Int32 = 10
-		let deliveredDescriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.toUser?.num == userNum
-				&& $0.admin == false && $0.portNum != detectionSensorPortNum
-				&& $0.receivedACK
-			}
-		)
-		let erroredDescriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.toUser?.num == userNum
-				&& $0.admin == false && $0.portNum != detectionSensorPortNum
-				&& $0.ackError != 0
-			}
-		)
-		let confirmedDescriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.toUser?.num == userNum
-				&& $0.admin == false && $0.portNum != detectionSensorPortNum
-				&& $0.realACK
-			}
-		)
-		return (
-			try context.fetchCount(deliveredDescriptor),
-			try context.fetchCount(erroredDescriptor),
-			try context.fetchCount(confirmedDescriptor)
-		)
-	}
 
-	private func fetchIncomingMessageCount() throws -> Int {
-		let userNum = user.num
-		let detectionSensorPortNum: Int32 = 10
-		let descriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.fromUser?.num == userNum
-				&& $0.toUser != nil
-				&& $0.isEmoji == false && $0.admin == false && $0.portNum != detectionSensorPortNum
-			}
-		)
-		return try context.fetchCount(descriptor)
-	}
 
-	private func fetchOutgoingMessageCount() throws -> Int {
-		let userNum = user.num
-		let detectionSensorPortNum: Int32 = 10
-		let descriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.toUser?.num == userNum
-				&& $0.isEmoji == false && $0.admin == false && $0.portNum != detectionSensorPortNum
-			}
-		)
-		return try context.fetchCount(descriptor)
-	}
 
 	private func fetchIncomingMessages(limit: Int? = nil, unreadOnly: Bool) throws -> [MessageEntity] {
 		let userNum = user.num
@@ -279,43 +167,9 @@ struct UserMessageList: View {
 		return try context.fetch(descriptor)
 	}
 
-	private func fetchLatestTapbackCursor() throws -> UserMessageTimelineCursor? {
-		try [fetchLatestIncomingTapbackCursor(), fetchLatestOutgoingTapbackCursor()].compactMap { $0 }.max()
-	}
 
-	private func fetchLatestIncomingTapbackCursor() throws -> UserMessageTimelineCursor? {
-		let userNum = user.num
-		var descriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.fromUser?.num == userNum && $0.toUser != nil && $0.isEmoji == true && $0.replyID > 0
-			},
-			sortBy: [
-				SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse),
-				SortDescriptor(\MessageEntity.messageId, order: .reverse)
-			]
-		)
-		descriptor.fetchLimit = 1
-		return try context.fetch(descriptor).first.map(cursor(for:))
-	}
 
-	private func fetchLatestOutgoingTapbackCursor() throws -> UserMessageTimelineCursor? {
-		let userNum = user.num
-		var descriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.toUser?.num == userNum && $0.isEmoji == true && $0.replyID > 0
-			},
-			sortBy: [
-				SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse),
-				SortDescriptor(\MessageEntity.messageId, order: .reverse)
-			]
-		)
-		descriptor.fetchLimit = 1
-		return try context.fetch(descriptor).first.map(cursor(for:))
-	}
 
-	private func cursor(for message: MessageEntity) -> UserMessageTimelineCursor {
-		UserMessageTimelineCursor(timestamp: message.messageTimestamp, messageId: message.messageId)
-	}
 
 	private func buildPreviousByID(for visibleMessages: [MessageEntity], previousMessage: MessageEntity?) -> [Int64: MessageEntity] {
 		var result: [Int64: MessageEntity] = [:]
@@ -362,47 +216,9 @@ struct UserMessageList: View {
 		return try context.fetch(descriptor)
 	}
 
-	@MainActor
-	@discardableResult
-	private func refreshVisibleTapbacks(markReadAfterLoad: Bool) -> Bool {
-		do {
-			let tapbacks = try fetchTapbacks(for: messages)
-			let latestTapbackCursor = tapbacks.map(cursor(for:)).max()
-			guard latestTapbackCursor != latestVisibleTapbackCursor || tapbacks.count != visibleTapbackCount else {
-				return true
-			}
-			replaceTapbacks(tapbacks)
-			if markReadAfterLoad {
-				markMessagesAsRead()
-			}
-			return true
-		} catch {
-			Logger.data.error("Failed to refresh direct message tapbacks: \(error.localizedDescription, privacy: .public)")
-			return false
-		}
-	}
 
-	@MainActor
-	private func refreshIfNeeded() {
-		do {
-			if try fetchMessageChangeToken() != latestKnownMessageToken {
-				loadMessages(markReadAfterLoad: routerIsShowingThisUser())
-			} else {
-				let latestTapbackCursor = try fetchLatestTapbackCursor()
-				if latestTapbackCursor != latestKnownConversationTapbackCursor {
-					if refreshVisibleTapbacks(markReadAfterLoad: routerIsShowingThisUser()) {
-						latestKnownConversationTapbackCursor = latestTapbackCursor
-					}
-				}
-			}
-		} catch {
-			Logger.data.error("Failed to refresh direct messages: \(error.localizedDescription, privacy: .public)")
-		}
-	}
 
 	private func replaceTapbacks(_ tapbacks: [MessageEntity]) {
-		latestVisibleTapbackCursor = tapbacks.map(cursor(for:)).max()
-		visibleTapbackCount = tapbacks.count
 		tapbacksByReplyID = Dictionary(grouping: tapbacks, by: \.replyID)
 	}
 
@@ -425,7 +241,7 @@ struct UserMessageList: View {
 					isEmoji: true,
 					replyID: target.messageId
 				)
-				await MainActor.run { _ = refreshVisibleTapbacks(markReadAfterLoad: routerIsShowingThisUser()) }
+				await MainActor.run { loadMessages(markReadAfterLoad: routerIsShowingThisUser()) }
 			} catch {
 				Logger.services.warning("Failed to send tapback.")
 			}
@@ -504,10 +320,12 @@ struct UserMessageList: View {
 					let isVisible = routerIsShowingThisUser()
 					loadMessages(markReadAfterLoad: isVisible)
 					guard isVisible else { return }
+					// Reloads are driven by .meshMessagesDidChange below. This is only a safety
+					// net for a change that somehow saved without one.
 					while !Task.isCancelled {
-						try? await Task.sleep(for: .seconds(5))
+						try? await Task.sleep(for: .seconds(30))
 						guard !Task.isCancelled else { return }
-						refreshIfNeeded()
+						loadMessages(markReadAfterLoad: routerIsShowingThisUser())
 					}
 				}
 				.onChange(of: messages.last?.messageId) {
@@ -515,10 +333,14 @@ struct UserMessageList: View {
 						scrollView.scrollTo("bottomAnchor", anchor: .bottom)
 					}
 				}
-				// Incoming DM traffic bumps appState.unreadDirectMessages; refresh on that
-				// signal so messages land live instead of waiting up to 5s for the poll.
-				.onChange(of: appState.unreadDirectMessages) {
-					refreshIfNeeded()
+				// Message writes happen on the packet actor's own context, which SwiftData does
+				// not propagate here, so the list reloads on the notification that actor posts
+				// after a save. Debounced because a burst of packets saves several times.
+				.onReceive(
+					NotificationCenter.default.publisher(for: .meshMessagesDidChange)
+						.debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+				) { _ in
+					loadMessages(markReadAfterLoad: routerIsShowingThisUser())
 				}
 				.onChange(of: messageToHighlight) { scrollToHighlighted(scrollView) }
 				.onChange(of: messageFieldFocused) {

--- a/Meshtastic/Views/Messages/UserMessageList.swift
+++ b/Meshtastic/Views/Messages/UserMessageList.swift
@@ -39,6 +39,11 @@ private struct UserMessageListChangeToken: Equatable {
 	// view is rebuilt.
 	let deliveredAckCount: Int
 	let erroredAckCount: Int
+	/// Counted separately from `deliveredAckCount` because a recipient's own ACK arriving after a
+	/// relay's implicit ACK moves neither of the other tallies: `receivedACK` is already true and
+	/// `ackError` is still 0, so the row stayed on "Relayed, not confirmed by recipient" until the
+	/// view was rebuilt. `realACK` is the only signal for that last transition.
+	let confirmedAckCount: Int
 }
 
 struct UserMessageList: View {
@@ -160,7 +165,8 @@ struct UserMessageList: View {
 			latest: latest.map(cursor(for:)),
 			count: try fetchIncomingMessageCount() + fetchOutgoingMessageCount(),
 			deliveredAckCount: acks.delivered,
-			erroredAckCount: acks.errored
+			erroredAckCount: acks.errored,
+			confirmedAckCount: acks.confirmed
 		)
 	}
 
@@ -175,7 +181,7 @@ struct UserMessageList: View {
 	/// Two single-term `fetchCount`s rather than one `||` predicate: a compound `||` (and an extra
 	/// `&&` term such as an `isEmoji` filter) exceeds the `#Predicate` macro's type-check budget.
 	/// Not filtering `isEmoji` only means an acked tapback triggers one extra benign reload.
-	static func resolvedAckCounts(in context: ModelContext, toUserNum userNum: Int64) throws -> (delivered: Int, errored: Int) {
+	static func resolvedAckCounts(in context: ModelContext, toUserNum userNum: Int64) throws -> (delivered: Int, errored: Int, confirmed: Int) {
 		let detectionSensorPortNum: Int32 = 10
 		let deliveredDescriptor = FetchDescriptor<MessageEntity>(
 			predicate: #Predicate<MessageEntity> {
@@ -191,7 +197,18 @@ struct UserMessageList: View {
 				&& $0.ackError != 0
 			}
 		)
-		return (try context.fetchCount(deliveredDescriptor), try context.fetchCount(erroredDescriptor))
+		let confirmedDescriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.toUser?.num == userNum
+				&& $0.admin == false && $0.portNum != detectionSensorPortNum
+				&& $0.realACK
+			}
+		)
+		return (
+			try context.fetchCount(deliveredDescriptor),
+			try context.fetchCount(erroredDescriptor),
+			try context.fetchCount(confirmedDescriptor)
+		)
 	}
 
 	private func fetchIncomingMessageCount() throws -> Int {

--- a/MeshtasticTests/MessageAckStatusRefreshTests.swift
+++ b/MeshtasticTests/MessageAckStatusRefreshTests.swift
@@ -279,6 +279,25 @@ struct MessageAckStatusRefreshTests {
 		#expect(confirmed.delivered == 1 && confirmed.errored == 0 && confirmed.confirmed == 1)
 		#expect(relayed.delivered == confirmed.delivered && relayed.errored == confirmed.errored)
 		#expect(relayed != confirmed)
+
+		// The tallies feed a change token, and it is the token's equality that decides whether the
+		// list reloads. Assert the transition there too: with only the delivered and errored
+		// counts the two tokens are identical, which is exactly why the row used to keep its old
+		// text until the view was rebuilt.
+		let cursor = UserMessageTimelineCursor(timestamp: 0, messageId: msg.messageId)
+		let before = UserMessageListChangeToken(
+			latest: cursor, count: 1,
+			deliveredAckCount: relayed.delivered,
+			erroredAckCount: relayed.errored,
+			confirmedAckCount: relayed.confirmed
+		)
+		let after = UserMessageListChangeToken(
+			latest: cursor, count: 1,
+			deliveredAckCount: confirmed.delivered,
+			erroredAckCount: confirmed.errored,
+			confirmedAckCount: confirmed.confirmed
+		)
+		#expect(before != after)
 	}
 
 	@Test func directMessageRoutingError_movesResolvedCount() throws {

--- a/MeshtasticTests/MessageAckStatusRefreshTests.swift
+++ b/MeshtasticTests/MessageAckStatusRefreshTests.swift
@@ -36,22 +36,7 @@ struct MessageAckStatusRefreshTests {
 
 	// MARK: - Channel-message mirrors of ChannelMessageList
 
-	/// Total resolved (delivered + errored) count via the *production* helper, so the tests
-	/// exercise the real predicates rather than a hand-mirrored copy that could silently drift.
-	private func resolvedChannelCount(_ channelIndex: Int32) throws -> Int {
-		let acks = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
-		return acks.delivered + acks.errored
-	}
 
-	/// Mirrors `ChannelMessageList.fetchMessageCount()` (the legacy token's `count`).
-	private func totalChannelCount(_ channelIndex: Int32) throws -> Int {
-		let descriptor = FetchDescriptor<MessageEntity>(
-			predicate: #Predicate<MessageEntity> {
-				$0.channel == channelIndex && $0.toUser == nil && $0.isEmoji == false
-			}
-		)
-		return try context.fetchCount(descriptor)
-	}
 
 	/// Mirrors the legacy token's `latest` cursor: newest message by (timestamp, messageId).
 	private func latestChannelCursor(_ channelIndex: Int32) throws -> Cursor? {
@@ -85,117 +70,13 @@ struct MessageAckStatusRefreshTests {
 
 	// MARK: - Channel tests
 
-	@Test func channelAck_movesResolvedCount_butNotLegacyToken() throws {
-		let channelIndex: Int32 = 7_701
-		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_100_001)
 
-		// Baseline: a sent-but-unacknowledged message is "Waiting…".
-		#expect(try resolvedChannelCount(channelIndex) == 0)
-		let baselineTotal = try totalChannelCount(channelIndex)
-		let baselineCursor = try latestChannelCursor(channelIndex)
-		#expect(baselineTotal == 1)
 
-		// An incoming ACK flips `receivedACK` on the existing row.
-		msg.receivedACK = true
-		try context.save()
 
-		// New signal moves → the list reloads and the row updates to "Acknowledged".
-		#expect(try resolvedChannelCount(channelIndex) == 1)
-		// Legacy token signals are blind to the ACK — this is exactly why the bug existed.
-		#expect(try totalChannelCount(channelIndex) == baselineTotal)
-		#expect(try latestChannelCursor(channelIndex) == baselineCursor)
-	}
 
-	@Test func channelErroredThenDelivered_movesToken() throws {
-		// A message that resolves to an error and is then delivered keeps the *summed* resolved
-		// count constant (delivered +1, errored −1). Tracking the tallies separately means a tally
-		// still moves, so the token changes and the row updates from the error to "Acknowledged".
-		let channelIndex: Int32 = 7_705
-		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_500_001)
-
-		msg.ackError = Int32(RoutingError.maxRetransmit.rawValue)
-		try context.save()
-		let errored = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
-		#expect(errored.delivered == 0 && errored.errored == 1)
-
-		// A later success packet flips ackError→0 and receivedACK→true.
-		msg.ackError = 0
-		msg.receivedACK = true
-		try context.save()
-		let delivered = try ChannelMessageList.resolvedAckCounts(in: context, channelIndex: channelIndex)
-
-		#expect(delivered.delivered == 1 && delivered.errored == 0)
-		// The summed count would be blind to this transition; the separate tallies are not.
-		#expect(errored.delivered + errored.errored == delivered.delivered + delivered.errored)
-		#expect(errored != delivered)
-	}
-
-	@Test func channelRetry_movesLatestCursorWhenTallyNetsZero() throws {
-		// The net-zero-tally concern (two messages making offsetting same-type ACK transitions in
-		// one poll window) can only arise via RetryButton, which is the sole route back to
-		// "waiting" — and it *deletes* the failed message and *inserts* a fresh one rather than
-		// mutating in place. So even when the errored tally nets to zero, the brand-new message
-		// becomes the newest row and moves the legacy `latest` cursor, changing the token. This is
-		// why a separate ackTimestamp signal isn't needed.
-		let channelIndex: Int32 = 7_706
-		let msgA = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_600_001, timestamp: 1_700_000_000)
-		let msgB = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_600_002, timestamp: 1_700_000_010)
-		msgB.ackError = Int32(RoutingError.maxRetransmit.rawValue)
-		try context.save()
-		let erroredBefore = try resolvedChannelCount(channelIndex)
-		let cursorBefore = try latestChannelCursor(channelIndex)
-		#expect(erroredBefore == 1)
-
-		// A resolves to errored (+1). B is retried: the failed row is deleted and a new waiting row
-		// is sent (newest timestamp). Errored tally nets to zero (A +1, B −1 via deletion)…
-		msgA.ackError = Int32(RoutingError.maxRetransmit.rawValue)
-		context.delete(msgB)
-		try insertChannelMessage(channelIndex: channelIndex, messageId: 970_600_003, timestamp: 1_700_000_020)
-		try context.save()
-
-		#expect(try resolvedChannelCount(channelIndex) == erroredBefore)
-		// …but the freshly-sent retry message is now the newest, so the `latest` cursor moved.
-		#expect(try latestChannelCursor(channelIndex) != cursorBefore)
-	}
-
-	@Test func channelRoutingError_movesResolvedCount() throws {
-		let channelIndex: Int32 = 7_702
-		let msg = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_200_001)
-		#expect(try resolvedChannelCount(channelIndex) == 0)
-
-		// A failed delivery resolves via a non-zero routing error (receivedACK stays false).
-		msg.ackError = Int32(RoutingError.maxRetransmit.rawValue)
-		try context.save()
-
-		#expect(msg.ackError != 0)
-		#expect(try resolvedChannelCount(channelIndex) == 1)
-	}
-
-	@Test func incomingChannelMessage_isNotCountedAsResolved() throws {
-		let channelIndex: Int32 = 7_704
-		// An incoming broadcast from another node. Incoming channel messages are never
-		// self-acknowledged — the device doesn't ACK its own received traffic — so receivedACK
-		// stays false and ackError stays 0, which is the genuine state under test. (The channel
-		// change-token predicate is intentionally sender-agnostic, so the guarantee is "unresolved
-		// rows don't count", not "incoming rows are filtered out".)
-		let sender = try makeUser(num: 0x2017_00AA)
-		let incoming = try insertChannelMessage(channelIndex: channelIndex, messageId: 970_400_001)
-		incoming.fromUser = sender
-		try context.save()
-
-		#expect(incoming.receivedACK == false && incoming.ackError == 0)
-		#expect(try totalChannelCount(channelIndex) == 1)
-		#expect(try resolvedChannelCount(channelIndex) == 0)
-	}
 
 	// MARK: - Direct-message mirrors of UserMessageList
 
-	/// Total resolved (delivered + errored) count via the *production* helper, so the tests
-	/// exercise the real predicates rather than a hand-mirrored copy that could silently drift.
-	private func resolvedDirectCount(userNum: Int64) throws -> Int {
-		let acks = try UserMessageList.resolvedAckCounts(in: context, toUserNum: userNum)
-		return acks.delivered + acks.errored
-	}
 
 	private func makeUser(num: Int64) throws -> UserEntity {
 		let user = UserEntity()
@@ -223,105 +104,10 @@ struct MessageAckStatusRefreshTests {
 
 	// MARK: - Direct-message tests
 
-	@Test func directMessageAck_movesResolvedCount() throws {
-		let user = try makeUser(num: 0x2017_0001)
-		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_001)
-		#expect(try resolvedDirectCount(userNum: user.num) == 0)
 
-		msg.receivedACK = true
-		try context.save()
 
-		#expect(try resolvedDirectCount(userNum: user.num) == 1)
-	}
 
-	@Test func directMessageErroredThenDelivered_movesToken() throws {
-		// DM path: error then delivery leaves the summed count unchanged, but a separate tally
-		// still moves so the change token differs and the conversation reloads. (The net-zero
-		// offsetting case is covered by the same retry-deletes-and-reinserts mechanism asserted in
-		// channelRetry_movesLatestCursorWhenTallyNetsZero — it is identical for both lists.)
-		let user = try makeUser(num: 0x2017_0004)
-		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_004)
 
-		msg.ackError = Int32(RoutingError.noResponse.rawValue)
-		try context.save()
-		let errored = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
-		#expect(errored.delivered == 0 && errored.errored == 1)
-
-		msg.ackError = 0
-		msg.receivedACK = true
-		try context.save()
-		let delivered = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
-
-		#expect(delivered.delivered == 1 && delivered.errored == 0)
-		#expect(errored.delivered + errored.errored == delivered.delivered + delivered.errored)
-		#expect(errored != delivered)
-	}
-
-	/// A relay's implicit ACK resolves the message first (`receivedACK`), and the recipient's own
-	/// ACK arrives after it (`realACK`). That second transition moves neither the delivered nor the
-	/// errored tally, so without a `realACK` tally the row stayed on "Relayed, not confirmed by
-	/// recipient" until the view was rebuilt — the reported "status only updates after leaving and
-	/// re-entering the conversation".
-	@Test func directMessageRealAck_movesConfirmedCountAfterImplicitAck() throws {
-		let user = try makeUser(num: 0x2017_0009)
-		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_009)
-
-		// Implicit ACK from a relay: resolved, but not confirmed by the recipient.
-		msg.receivedACK = true
-		try context.save()
-		let relayed = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
-		#expect(relayed.delivered == 1 && relayed.errored == 0 && relayed.confirmed == 0)
-
-		// The recipient's own ACK. Neither of the original tallies can see this.
-		msg.realACK = true
-		try context.save()
-		let confirmed = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
-		#expect(confirmed.delivered == 1 && confirmed.errored == 0 && confirmed.confirmed == 1)
-		#expect(relayed.delivered == confirmed.delivered && relayed.errored == confirmed.errored)
-		#expect(relayed != confirmed)
-
-		// The tallies feed a change token, and it is the token's equality that decides whether the
-		// list reloads. Assert the transition there too: with only the delivered and errored
-		// counts the two tokens are identical, which is exactly why the row used to keep its old
-		// text until the view was rebuilt.
-		let cursor = UserMessageTimelineCursor(timestamp: 0, messageId: msg.messageId)
-		let before = UserMessageListChangeToken(
-			latest: cursor, count: 1,
-			deliveredAckCount: relayed.delivered,
-			erroredAckCount: relayed.errored,
-			confirmedAckCount: relayed.confirmed
-		)
-		let after = UserMessageListChangeToken(
-			latest: cursor, count: 1,
-			deliveredAckCount: confirmed.delivered,
-			erroredAckCount: confirmed.errored,
-			confirmedAckCount: confirmed.confirmed
-		)
-		#expect(before != after)
-	}
-
-	@Test func directMessageRoutingError_movesResolvedCount() throws {
-		let user = try makeUser(num: 0x2017_0002)
-		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_002)
-		#expect(try resolvedDirectCount(userNum: user.num) == 0)
-
-		msg.ackError = Int32(RoutingError.noResponse.rawValue)
-		try context.save()
-
-		#expect(try resolvedDirectCount(userNum: user.num) == 1)
-	}
-
-	@Test func detectionSensorDirectMessage_isExcludedFromResolvedCount() throws {
-		let user = try makeUser(num: 0x2017_0003)
-		// Detection-sensor messages don't surface an ACK status row, so they must not
-		// drive the conversation's refresh signal even once acknowledged.
-		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_003, portNum: 10)
-
-		msg.receivedACK = true
-		try context.save()
-
-		#expect(try resolvedDirectCount(userNum: user.num) == 0)
-	}
 
 	// MARK: - Message delivery status wording
 

--- a/MeshtasticTests/MessageAckStatusRefreshTests.swift
+++ b/MeshtasticTests/MessageAckStatusRefreshTests.swift
@@ -257,6 +257,30 @@ struct MessageAckStatusRefreshTests {
 		#expect(errored != delivered)
 	}
 
+	/// A relay's implicit ACK resolves the message first (`receivedACK`), and the recipient's own
+	/// ACK arrives after it (`realACK`). That second transition moves neither the delivered nor the
+	/// errored tally, so without a `realACK` tally the row stayed on "Relayed, not confirmed by
+	/// recipient" until the view was rebuilt — the reported "status only updates after leaving and
+	/// re-entering the conversation".
+	@Test func directMessageRealAck_movesConfirmedCountAfterImplicitAck() throws {
+		let user = try makeUser(num: 0x2017_0009)
+		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_009)
+
+		// Implicit ACK from a relay: resolved, but not confirmed by the recipient.
+		msg.receivedACK = true
+		try context.save()
+		let relayed = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
+		#expect(relayed.delivered == 1 && relayed.errored == 0 && relayed.confirmed == 0)
+
+		// The recipient's own ACK. Neither of the original tallies can see this.
+		msg.realACK = true
+		try context.save()
+		let confirmed = try UserMessageList.resolvedAckCounts(in: context, toUserNum: user.num)
+		#expect(confirmed.delivered == 1 && confirmed.errored == 0 && confirmed.confirmed == 1)
+		#expect(relayed.delivered == confirmed.delivered && relayed.errored == confirmed.errored)
+		#expect(relayed != confirmed)
+	}
+
 	@Test func directMessageRoutingError_movesResolvedCount() throws {
 		let user = try makeUser(num: 0x2017_0002)
 		let msg = try insertOutgoingDirectMessage(to: user, messageId: 971_000_002)


### PR DESCRIPTION
## Summary

Reported in #2380: a direct message's status doesn't update until you leave the conversation and come back.

The first commit fixed the symptom by adding a third ACK tally. The rest of the branch removes the machinery that made the bug possible.

## Why it happened

Message writes happen on the packet actor's own context. SwiftData does not propagate those to views, so neither list could observe them. Both polled every five seconds and compared a change token to decide whether to reload.

A token has to be cheap, so it could only hold counts — and that means every mutable field that affects a row needs its own tally in it. New message was a cursor, delivered was `receivedACK`, errored was `ackError`. `realACK` had none, so when the recipient's own ACK arrived after a relay's implicit one, nothing in the token moved and the row kept saying "Relayed, not confirmed by recipient" until the view was rebuilt.

That is a design where forgetting a field is invisible, and this was the second time it bit: the comment above the tallies exists because the errored-to-delivered transition had the same problem.

## What changed

Every write on that actor already funnels through `savePendingChanges`. A handler that touches a message now marks a flag, and that one function posts a single notification per save. Both lists reload on it, debounced, and the poll drops to 30 seconds as a safety net.

Removed: two change-token structs, two timeline-cursor structs, the ACK tallies and their fetch descriptors, the message-count fetches, the tapback cursor fetches, and the partial-refresh path — in both lists. 558 lines out, 58 in.

Marking messages read no longer posts unconditionally. The lists now reload on that notification, so a pass that marked nothing would have looped.

## Testing

Full suite passes, 3,000 tests in 523 suites. The eight `MessageDeliveryStatus` tests still cover what each ACK state renders.

Ten tests went with the machinery they exercised — they asserted tallies and token transitions for code that no longer exists. That is a real reduction in coverage of change detection, traded for there being much less to get wrong: one notification, posted from the single place every write already passes through, instead of a token that had to enumerate every field.

Verified on hardware before the refactor that the refresh path itself fires: sending a DM from a simulator on TCP to a real radio, the row read "Sending…" four seconds after send and had updated itself by twelve, without leaving the screen.
