### PR TITLE
Throttle the launch-time catalog and firmware-list refreshes

### DIFF
--- a/Meshtastic/API/MeshtasticAPI.swift
+++ b/Meshtastic/API/MeshtasticAPI.swift
@@ -184,12 +184,17 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 	static let firmwareGitHubURLEndpoint = URL(string: "https://api.github.com/repos/meshtastic/firmware/releases?per_page=100")!
 	static let nightlyIndexEndpoint = URL(string: "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/firmware-nightly/index.json")!
 
-	/// How long a launch-time API refresh stays fresh. Every cold launch used to pull the full
+	/// How long a launch-time API refresh stays fresh. Every process start used to pull the full
 	/// device catalog and firmware list, and neither endpoint sends `Cache-Control` or an `ETag`,
 	/// so nothing downstream could cache or revalidate them. Across every install that is most of
-	/// the API's egress, for data that changes a few times a week. Manual refreshes — pull to
-	/// refresh, a user-initiated connect — are never throttled.
-	static let launchRefreshInterval: TimeInterval = 60 * 60 * 6
+	/// the API's egress, for data that changes a few times a week. Background wakes count as
+	/// process starts, so this is deliberately long. Manual refreshes — pull to refresh, a
+	/// user-initiated connect — are never throttled.
+	static let launchRefreshInterval: TimeInterval = 60 * 60 * 72
+	/// The firmware screen refreshes on a shorter interval than launch: the user opened it on
+	/// purpose, and it is the one place where a board newer than the build needs to resolve by
+	/// name rather than fall back to another board sharing its hardware model.
+	static let screenRefreshInterval: TimeInterval = 60 * 60 * 6
 	/// Shared with the firmware screen's own refresh so the two don't each pull the catalog.
 	static let deviceCatalogRefreshKey = "firmware.hardwareCatalogRefreshedAt"
 

--- a/Meshtastic/API/MeshtasticAPI.swift
+++ b/Meshtastic/API/MeshtasticAPI.swift
@@ -183,6 +183,20 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 	static let firmwareURLEndpoint = URL(string: "https://api.meshtastic.org/github/firmware/list")!
 	static let firmwareGitHubURLEndpoint = URL(string: "https://api.github.com/repos/meshtastic/firmware/releases?per_page=100")!
 	static let nightlyIndexEndpoint = URL(string: "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/firmware-nightly/index.json")!
+
+	/// How long a launch-time API refresh stays fresh. Every cold launch used to pull the full
+	/// device catalog and firmware list, and neither endpoint sends `Cache-Control` or an `ETag`,
+	/// so nothing downstream could cache or revalidate them. Across every install that is most of
+	/// the API's egress, for data that changes a few times a week. Manual refreshes — pull to
+	/// refresh, a user-initiated connect — are never throttled.
+	static let launchRefreshInterval: TimeInterval = 60 * 60 * 6
+	/// Shared with the firmware screen's own refresh so the two don't each pull the catalog.
+	static let deviceCatalogRefreshKey = "firmware.hardwareCatalogRefreshedAt"
+
+	static func isStale(_ key: String, interval: TimeInterval = launchRefreshInterval) -> Bool {
+		guard let last = UserDefaults.standard.object(forKey: key) as? Date else { return true }
+		return Date().timeIntervalSince(last) > interval
+	}
 	static let nightlyReleaseNotesEndpoint = URL(string: "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/firmware-nightly/release_notes.md")!
 	static let eventFirmwareURLEndpoint = URL(string: "https://api.meshtastic.org/resource/eventFirmware")!
 
@@ -229,12 +243,22 @@ class MeshtasticAPI: ObservableObject, @unchecked Sendable {
 		Task.detached {
 			// Load bundled catalog first — instant display, no network needed.
 			try? await self.refreshBundledDevicesData()
-			try? await self.refreshFirmwareAPIData()
+			if UserDefaults.lastFirmwareAPIUpdate == .distantPast
+				|| abs(UserDefaults.lastFirmwareAPIUpdate.timeIntervalSinceNow) > Self.launchRefreshInterval {
+				try? await self.refreshFirmwareAPIData()
+			}
 			// Seed event-firmware branding from the bundle so it survives restarts offline.
 			await self.refreshBundledEventFirmwareData()
 			// Then silently update from the live API in the background.
-			Task.detached(priority: .utility) {
-				await self.refreshDevicesPreferringAPI()
+			if Self.isStale(Self.deviceCatalogRefreshKey) {
+				Task.detached(priority: .utility) {
+					await self.refreshDevicesPreferringAPI()
+				}
+			} else {
+				// Still resolve images and msh.to links from the bundle — that pass is local.
+				Task.detached(priority: .utility) {
+					await self.refreshDeviceImagesAndLinks()
+				}
 			}
 			Task.detached(priority: .utility) {
 				await self.refreshEventFirmwareAPIData()
@@ -398,6 +422,8 @@ deviceEntity.architecture = device.architecture
 		// PHASE 3: Images and msh.to links. This is the single image/link pass, driven by the
 		// live device list so hardware present only in the API still gets its images. It runs
 		// here, after the metadata upsert, so the device rows the images attach to already exist.
+		UserDefaults.standard.set(Date(), forKey: Self.deviceCatalogRefreshKey)
+
 		guard includeImages else { return }
 		await refreshDeviceImagesAndLinks(apiDevices: decodedDevices)
 	}

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -25,9 +25,6 @@ struct Firmware: View {
 	@State private var cachedNode: NodeInfoEntity?
 	@State private var hardwareState = FirmwareHardwareViewState()
 
-	private static let catalogRefreshKey = "firmware.hardwareCatalogRefreshedAt"
-	private static let catalogRefreshInterval: TimeInterval = 60 * 60 * 6
-
 	init(node: NodeInfoEntity?) {
 		self.node = node
 	}
@@ -76,13 +73,10 @@ struct Firmware: View {
 	/// resolve by their PlatformIO target instead of falling back to another board that
 	/// shares their hardware model. Metadata only — the image pass is not worth running here.
 	private func refreshCatalogIfNeeded() async {
-		let lastRefresh = UserDefaults.standard.object(forKey: Self.catalogRefreshKey) as? Date
-		if let lastRefresh, Date().timeIntervalSince(lastRefresh) < Self.catalogRefreshInterval {
-			return
-		}
+		guard MeshtasticAPI.isStale(MeshtasticAPI.deviceCatalogRefreshKey) else { return }
 		do {
+			// refreshDevicesAPIData stamps the shared timestamp on a successful fetch.
 			try await MeshtasticAPI.shared.refreshDevicesAPIData(includeImages: false)
-			UserDefaults.standard.set(Date(), forKey: Self.catalogRefreshKey)
 			resolveHardware()
 		} catch {
 			Logger.services.warning("Hardware catalog refresh failed: \(error.localizedDescription, privacy: .public)")

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -73,7 +73,10 @@ struct Firmware: View {
 	/// resolve by their PlatformIO target instead of falling back to another board that
 	/// shares their hardware model. Metadata only — the image pass is not worth running here.
 	private func refreshCatalogIfNeeded() async {
-		guard MeshtasticAPI.isStale(MeshtasticAPI.deviceCatalogRefreshKey) else { return }
+		guard MeshtasticAPI.isStale(
+			MeshtasticAPI.deviceCatalogRefreshKey,
+			interval: MeshtasticAPI.screenRefreshInterval
+		) else { return }
 		do {
 			// refreshDevicesAPIData stamps the shared timestamp on a successful fetch.
 			try await MeshtasticAPI.shared.refreshDevicesAPIData(includeImages: false)


### PR DESCRIPTION
## Summary

Railway traced most of api.meshtastic.org's egress to `/resource/deviceHardware` — 1.16 million requests in 24 hours from tens of thousands of clients, every one a full 200 with no caching. We were contributing: the app pulled the full device catalog and the firmware release list on every process start, unthrottled.

Neither endpoint sends `Cache-Control` or an `ETag`, so no client or CDN can cache or revalidate them. Until that changes on the API side, the only lever we have is asking less often, for data that changes a few times a week.

## What changed

Both launch-time refreshes are skipped when the last successful fetch is under 72 hours old. Background wakes count as process starts, so the interval is deliberately long. The device catalog and the firmware screen's own refresh share a single timestamp, stamped where the fetch actually succeeds, so they don't each pull the catalog. The screen keeps a shorter six-hour interval: the user opened it deliberately, and it's the one place a board newer than the build has to resolve by name.

When the catalog refresh is skipped, the bundle-only image and link pass still runs — that one is local and is what puts device images on screen offline.

Nothing user-initiated is throttled: pull to refresh, a user-initiated connect, and the update notifier's existing 24-hour staleness check all behave as before.

## Testing

Built for device. The throttle is a timestamp comparison with the first launch treated as stale, so a fresh install still fetches immediately. Payload sizes for reference: the catalog is 38,536 bytes raw and 4,059 gzipped; the firmware list is 157,357 raw and about 36,000 gzipped.
