### PR TITLE
Claim the radio before the ESP32 OTA reboot command

### DIFF
--- a/Meshtastic.xcodeproj/project.pbxproj
+++ b/Meshtastic.xcodeproj/project.pbxproj
@@ -1536,7 +1536,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.21;
+				MARKETING_VERSION = 2.7.22;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1563,7 +1563,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.21;
+				MARKETING_VERSION = 2.7.22;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1588,7 +1588,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.21;
+				MARKETING_VERSION = 2.7.22;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1621,7 +1621,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.21;
+				MARKETING_VERSION = 2.7.22;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.Widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1656,7 +1656,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.21;
+				MARKETING_VERSION = 2.7.22;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1709,7 +1709,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.21;
+				MARKETING_VERSION = 2.7.22;
 				PRODUCT_BUNDLE_IDENTIFIER = gvh.MeshtasticClient.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1756,7 +1756,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.21;
+				MARKETING_VERSION = 2.7.22;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -1806,7 +1806,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.7.21;
+				MARKETING_VERSION = 2.7.22;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
@@ -26,6 +26,9 @@ struct ESP32BLEOTASheet: View {
 	var onUpdateComplete: (() -> Void)?
 
 	@State var peripheral: CBPeripheral?
+	/// Retained so dismissing the sheet cancels it. Without this the flow could resume after
+	/// cleanup had already handed the radio back and start a transfer against a reconnected node.
+	@State private var otaTask: Task<Void, Never>?
 	
 	var body: some View {
 		FirmwareOTAUpdateSheet(
@@ -60,6 +63,8 @@ struct ESP32BLEOTASheet: View {
 			}
 		}
 		.onDisappear {
+			otaTask?.cancel()
+			otaTask = nil
 			if accessoryManager.otaInProgress {
 				releaseRadio()
 			}
@@ -85,7 +90,7 @@ struct ESP32BLEOTASheet: View {
 			return
 		}
 		
-		Task {
+		otaTask = Task {
 			do {
 				if !rebootSuccessful {
 					// 0. Claim the radio before the reboot command goes out. The device reboots into
@@ -118,6 +123,10 @@ struct ESP32BLEOTASheet: View {
 					try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
 				}
 				
+				// The sheet can be dismissed during either sleep above, which cancels this task
+				// and hands the radio back. Do not start a transfer after that.
+				guard !Task.isCancelled else { return }
+
 				// 5. Start the OTA process. Discovery and auto-connect are restored when this
 				// sheet closes, not here: clearing the flag on completion lets the Firmware
 				// screen rebuild and dismiss the sheet before the result is read.

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
@@ -59,6 +59,20 @@ struct ESP32BLEOTASheet: View {
 				self.peripheral = await connection.peripheral
 			}
 		}
+		.onDisappear {
+			if accessoryManager.otaInProgress {
+				releaseRadio()
+			}
+		}
+	}
+
+	/// Hand the radio back to the app: restart discovery and let auto-connect pick the device up
+	/// once it reboots into the new firmware.
+	private func releaseRadio() {
+		accessoryManager.otaInProgress = false
+		accessoryManager.userRequestedConnectionCancellation = false
+		accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
+		accessoryManager.startDiscovery()
 	}
 	
 	// MARK: - Logic
@@ -74,6 +88,15 @@ struct ESP32BLEOTASheet: View {
 		Task {
 			do {
 				if !rebootSuccessful {
+					// 0. Claim the radio before the reboot command goes out. The device reboots into
+					// OTA mode as soon as it lands, and the Firmware screen keys its content off
+					// otaInProgress — a disconnect arriving while this is still false tears this
+					// sheet down mid-update and leaves the device in OTA mode with nothing driving
+					// it. Stopping discovery here also keeps the teardown from re-arming it.
+					accessoryManager.otaInProgress = true
+					accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = false
+					accessoryManager.stopDiscovery()
+
 					// 1. Move file reading/hashing to a detached task to avoid blocking Main Thread
 					let sha256Digest = try await Task.detached(priority: .userInitiated) {
 						let data = try Data(contentsOf: binFileURL)
@@ -90,27 +113,19 @@ struct ESP32BLEOTASheet: View {
 
 					// 3. Disconnect app so the ViewModel can grab the new OTA-Mode advertisement
 					try await accessoryManager.disconnect()
-					
-					// 4. Disable discovery to focus on the specific OTA device
-					accessoryManager.otaInProgress = true
-					accessoryManager.stopDiscovery()
-					
-					// 5. Wait briefly for device to reboot
+
+					// 4. Wait briefly for device to reboot
 					try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
 				}
 				
-				// 6. Set auto-reconnect preference
-				accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
-				
-				// 7. Start the OTA process
+				// 5. Start the OTA process. Discovery and auto-connect are restored when this
+				// sheet closes, not here: clearing the flag on completion lets the Firmware
+				// screen rebuild and dismiss the sheet before the result is read.
 				await ota.startOTA(binURL: binFileURL, desiredPeripheral: peripheral?.identifier)
-				
-				// 8. Cleanup / Restart discovery
-				accessoryManager.otaInProgress = false
-				accessoryManager.startDiscovery()
-				
+
 			} catch {
 				Logger.mesh.error("ESP32 BLE OTA Failed: \(error.localizedDescription)")
+				releaseRadio()
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
@@ -65,6 +65,20 @@ struct ESP32WifiOTASheet: View {
 				self.host = await connection.host.stringValue
 			}
 		}
+		.onDisappear {
+			if accessoryManager.otaInProgress {
+				releaseRadio()
+			}
+		}
+	}
+
+	/// Hand the radio back to the app: let discovery and auto-connect pick the device up once it
+	/// reboots into the new firmware.
+	private func releaseRadio() {
+		accessoryManager.otaInProgress = false
+		accessoryManager.userRequestedConnectionCancellation = false
+		accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
+		accessoryManager.startDiscovery()
 	}
 	
 	// MARK: - Logic
@@ -82,6 +96,14 @@ struct ESP32WifiOTASheet: View {
 					let device = accessoryManager.activeConnection?.device
 					
 					if !alreadyRebooted {
+						// Claim the radio before the reboot command goes out. The device reboots
+						// into OTA mode as soon as it lands and the connection drops with it; the
+						// Firmware screen keys its content off otaInProgress, so without this it
+						// swaps to the "please reconnect" placeholder and takes this sheet — and
+						// the update — down with it, leaving the device waiting in OTA mode.
+						accessoryManager.otaInProgress = true
+						accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = false
+
 						// Move heavy file reading/hashing off the Main Actor
 						let sha256Digest = try await Task.detached(priority: .userInitiated) {
 							let data = try Data(contentsOf: binFileURL)
@@ -101,14 +123,20 @@ struct ESP32WifiOTASheet: View {
 					// Begin the HTTP update
 					await ota.startUpdate(host: host, firmwareUrl: self.binFileURL)
 					
-					// Attempt to reconnect after update
+					// Attempt to reconnect after update. The reconnect needs the gate open, but
+					// the sheet stays up: releaseRadio only restores discovery and auto-connect,
+					// and the Firmware screen behind it rebuilds once the node is back.
 					if let device {
+						accessoryManager.otaInProgress = false
+						accessoryManager.userRequestedConnectionCancellation = false
+						accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
 						try await Task.sleep(for: .seconds(3))
 						try await accessoryManager.connect(to: device, retries: 5)
 					}
 				}
 			} catch {
 				Logger.mesh.error("ESP32 OTA Failed: \(error.localizedDescription)")
+				releaseRadio()
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
@@ -26,6 +26,9 @@ struct ESP32WifiOTASheet: View {
 	
 	@State var alreadyRebooted: Bool = false
 	@State var inRetryWorkflow = false
+	/// Retained so dismissing the sheet cancels it. Without this the flow could resume after
+	/// cleanup had already handed the radio back and start a transfer against a reconnected node.
+	@State private var otaTask: Task<Void, Never>?
 
 	init(binFileURL: URL, host: String? = nil, onUpdateComplete: (() -> Void)? = nil) {
 		self.onUpdateComplete = onUpdateComplete
@@ -66,6 +69,8 @@ struct ESP32WifiOTASheet: View {
 			}
 		}
 		.onDisappear {
+			otaTask?.cancel()
+			otaTask = nil
 			if accessoryManager.otaInProgress {
 				releaseRadio()
 			}
@@ -90,7 +95,7 @@ struct ESP32WifiOTASheet: View {
 			return
 		}
 		
-		Task {
+		otaTask = Task {
 			do {
 				if let host {
 					let device = accessoryManager.activeConnection?.device
@@ -120,6 +125,10 @@ struct ESP32WifiOTASheet: View {
 						alreadyRebooted = true
 					}
 					
+					// The sheet can be dismissed while the reboot settles, which cancels this task
+					// and hands the radio back. Do not start a transfer after that.
+					guard !Task.isCancelled else { return }
+
 					// Begin the HTTP update
 					await ota.startUpdate(host: host, firmwareUrl: self.binFileURL)
 					

--- a/project.yml
+++ b/project.yml
@@ -393,7 +393,7 @@ targets:
             - "$(inherited)"
             - "@executable_path/Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.21"
+          MARKETING_VERSION: "2.7.22"
           OTHER_LDFLAGS:
             - "-weak_framework"
             - "SwiftUI"
@@ -436,7 +436,7 @@ targets:
             - "$(inherited)"
             - "@executable_path/Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.21"
+          MARKETING_VERSION: "2.7.22"
           OTHER_LDFLAGS:
             - "-weak_framework"
             - "SwiftUI"
@@ -482,7 +482,7 @@ targets:
             - "@executable_path/Frameworks"
             - "@executable_path/../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.21"
+          MARKETING_VERSION: "2.7.22"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.Widgets"
           PRODUCT_NAME: "$(TARGET_NAME)"
           PROVISIONING_PROFILE_SPECIFIER: ""
@@ -511,7 +511,7 @@ targets:
             - "@executable_path/Frameworks"
             - "@executable_path/../../Frameworks"
           MACOSX_DEPLOYMENT_TARGET: "14.6"
-          MARKETING_VERSION: "2.7.21"
+          MARKETING_VERSION: "2.7.22"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.Widgets"
           PRODUCT_NAME: "$(TARGET_NAME)"
           PROVISIONING_PROFILE_SPECIFIER: ""
@@ -606,7 +606,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.21"
+          MARKETING_VERSION: "2.7.22"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.watchkitapp"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "watchos"
@@ -634,7 +634,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.21"
+          MARKETING_VERSION: "2.7.22"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient.watchkitapp"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "watchos"
@@ -695,7 +695,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.21"
+          MARKETING_VERSION: "2.7.22"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "appletvos"
@@ -714,7 +714,7 @@ targets:
           LD_RUNPATH_SEARCH_PATHS:
             - "$(inherited)"
             - "@executable_path/Frameworks"
-          MARKETING_VERSION: "2.7.21"
+          MARKETING_VERSION: "2.7.22"
           PRODUCT_BUNDLE_IDENTIFIER: "gvh.MeshtasticClient"
           PRODUCT_NAME: "$(TARGET_NAME)"
           SDKROOT: "appletvos"


### PR DESCRIPTION
## Summary

Reported on an Elecrow ThinkNode M9 (`thinknode_m9`, esp32-s3): the same failure #2384 fixed for nRF DFU, on the ESP32 BLE OTA path.

The flow set `otaInProgress` at step 4, after sending the reboot command at step 2 and disconnecting at step 3. The device reboots into OTA mode as soon as that command lands, so the connection can drop while the flag is still false. The Firmware screen keys its content off that flag, so it swapped itself for the "please reconnect" placeholder, which removed the view owning this sheet and aborted the update — leaving the device in OTA mode with nothing driving it.

## What changed

The flag, auto-connect suppression and discovery stop all happen before the reboot command goes out, so there is no window where a disconnect can arrive unclaimed. Stopping discovery first also prevents the disconnect teardown from re-arming it, which it previously did between steps 3 and 4.

Discovery and auto-connect are restored when the sheet closes rather than when the transfer returns. Clearing on completion let the Firmware screen rebuild and dismiss the sheet before the result could be read — the same reason #2384 restores on dismiss.

The failure path now restores too. The `catch` previously only logged, so a mid-flow error left discovery off and the flag set for the rest of the session.

## Testing

Built and installed on an iPhone. Awaiting a run on the reporting device — the M9 is the hardware that reproduced it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP32 Bluetooth OTA handoff reliability.
  * Prevented the OTA screen from closing unexpectedly when the device disconnects during reboot.
  * Restored connection discovery and automatic reconnection when the OTA screen closes or the process is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->