### PR TITLE
Make swipe to disconnect read as destructive

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -252,7 +252,10 @@ struct Connect: View {
 									} label: {
 										Label("Disconnect", systemImage: "antenna.radiowaves.left.and.right.slash")
 									}
-									.disabled(!accessoryManager.allowDisconnect)
+									// Tinted explicitly: a destructive role alone leaves the swipe action
+									// the default gray here, and dropping the radio should read as
+									// destructive before the user commits to the swipe.
+									.tint(.red)
 								}
 							}
 							.contextMenu {
@@ -352,7 +355,7 @@ struct Connect: View {
 										} label: {
 											Label("Disconnect", systemImage: "antenna.radiowaves.left.and.right.slash")
 										}
-										.disabled(!accessoryManager.allowDisconnect)
+										.tint(.red)
 									}
 								}
 								


### PR DESCRIPTION
## Summary

Swiping a connected radio to disconnect showed a default gray action. Dropping the radio is destructive and should look like it before the user commits to the swipe.

## What changed

Both disconnect swipe actions on the Connect view are tinted red. They already carried `role: .destructive`, which sets the button's semantics but leaves the swipe action's background at the default here, so the tint is explicit.

Also drops a `.disabled(!accessoryManager.allowDisconnect)` on each: both sit inside `if accessoryManager.allowDisconnect`, so the modifier could never evaluate to true.

## Testing

Built for device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disconnect swipe actions now display with a red tint in relevant connection states.
  * Improved consistency of disconnect controls when disconnecting is restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->