### PR TITLE
Log each step of the ESP32 OTA handoff

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -2097,6 +2097,9 @@ extension AccessoryManager {
 		} else {
 			throw AccessoryError.ioFailed("sendRebootOta: Unable to serialize admin packet")
 		}
+		// Log the packet id so a routing ack can be matched back to this request — the
+		// difference between the radio refusing the reboot and never hearing it.
+		Logger.services.info("📡 [ESP32 OTA] Reboot admin packet \(meshPacket.id) to \(meshPacket.to) from \(meshPacket.from)")
 		let messageDescription = "🚀 Sent Reboot OTA Admin Message to: \(toUser.longName ?? "Unknown".localized) from: \(fromUser.longName ?? "Unknown".localized)"
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 	}

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
@@ -78,6 +78,7 @@ struct ESP32BLEOTASheet: View {
 			rebootSuccessful = false
 		}
 		.onDisappear {
+			Logger.services.info("📡 [ESP32 BLE OTA] Sheet dismissed (otaInProgress=\(accessoryManager.otaInProgress))")
 			otaTask?.cancel()
 			otaTask = nil
 			if accessoryManager.otaInProgress {
@@ -89,6 +90,7 @@ struct ESP32BLEOTASheet: View {
 	/// Hand the radio back to the app: restart discovery and let auto-connect pick the device up
 	/// once it reboots into the new firmware.
 	private func releaseRadio() {
+		Logger.services.info("📡 [ESP32 BLE OTA] Releasing the radio, restarting discovery")
 		accessoryManager.otaInProgress = false
 		accessoryManager.userRequestedConnectionCancellation = false
 		accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
@@ -113,6 +115,7 @@ struct ESP32BLEOTASheet: View {
 					// otaInProgress — a disconnect arriving while this is still false tears this
 					// sheet down mid-update and leaves the device in OTA mode with nothing driving
 					// it. Stopping discovery here also keeps the teardown from re-arming it.
+					Logger.services.info("📡 [ESP32 BLE OTA] Step 1: claiming the radio (node \(deviceNum), peripheral \(peripheral?.identifier.uuidString ?? "nil", privacy: .private))")
 					accessoryManager.otaInProgress = true
 					accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = false
 					accessoryManager.stopDiscovery()
@@ -125,14 +128,18 @@ struct ESP32BLEOTASheet: View {
 					}.value
 					
 					// 2. Send the reboot command via existing connection
+					Logger.services.info("📡 [ESP32 BLE OTA] Step 2: sending reboot into OTA mode")
 					try await accessoryManager.sendRebootOta(fromUser: user, toUser: user, mode: .otaBle, otaHash: sha256Digest)
 					rebootSuccessful = true
+					Logger.services.info("📡 [ESP32 BLE OTA] Reboot command accepted")
 					
 					// Give some time for any final incoming notifications
 					try await Task.sleep(for: .seconds(1.0))
 
 					// 3. Disconnect app so the ViewModel can grab the new OTA-Mode advertisement
+					Logger.services.info("📡 [ESP32 BLE OTA] Step 3: disconnecting")
 					try await accessoryManager.disconnect()
+					Logger.services.info("📡 [ESP32 BLE OTA] Disconnected")
 
 					// 4. Wait briefly for device to reboot
 					try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
@@ -140,15 +147,25 @@ struct ESP32BLEOTASheet: View {
 				
 				// The sheet can be dismissed during either sleep above, which cancels this task
 				// and hands the radio back. Do not start a transfer after that.
-				guard !Task.isCancelled else { return }
+				guard !Task.isCancelled else {
+					Logger.services.info("📡 [ESP32 BLE OTA] Cancelled before the transfer — sheet was dismissed")
+					return
+				}
 
 				// 5. Start the OTA process. Discovery and auto-connect are restored when this
 				// sheet closes, not here: clearing the flag on completion lets the Firmware
 				// screen rebuild and dismiss the sheet before the result is read.
+				Logger.services.info("📡 [ESP32 BLE OTA] Step 4: starting the transfer")
 				await ota.startOTA(binURL: binFileURL, desiredPeripheral: peripheral?.identifier)
+				Logger.services.info("📡 [ESP32 BLE OTA] Transfer returned, status \(String(describing: ota.otaStatus), privacy: .public)")
 
+			} catch is CancellationError {
+				// Dismissing the sheet cancels this task mid-sleep, which arrives here as a
+				// thrown cancellation rather than the guard below. Not a failure.
+				Logger.services.info("📡 [ESP32 BLE OTA] Cancelled — sheet was dismissed")
+				releaseRadio()
 			} catch {
-				Logger.mesh.error("ESP32 BLE OTA Failed: \(error.localizedDescription)")
+				Logger.services.error("📡 [ESP32 BLE OTA] Failed: \(error.localizedDescription, privacy: .public)")
 				releaseRadio()
 			}
 		}

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/ESP32OTAIntroSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/ESP32OTAIntroSheet.swift
@@ -191,10 +191,12 @@ struct ESP32OTAIntroSheet: View {
 					#endif
 					return nil
 				}()
+				let _ = Logger.services.info("📡 [ESP32 OTA] Wi-Fi path, file \(binFileURL.lastPathComponent, privacy: .public)")
 				ESP32WifiOTASheet(binFileURL: binFileURL, host: theHost, onUpdateComplete: { dismiss() })
 					.environmentObject(accessoryManager)
 			}
 			.sheet(isPresented: $showBLEUpdater) {
+				let _ = Logger.services.info("📡 [ESP32 OTA] BLE path, file \(binFileURL.lastPathComponent, privacy: .public)")
 				ESP32BLEOTASheet(binFileURL: binFileURL, onUpdateComplete: { dismiss() })
 					.environmentObject(accessoryManager)
 			}
@@ -222,6 +224,7 @@ struct ESP32OTAIntroSheet: View {
 
 	private var OTAMode: SupportedOTAMode {
 		guard let connection = accessoryManager.activeConnection?.connection else {
+			Logger.services.info("📡 [ESP32 OTA] No active connection — no OTA path available")
 			return .none
 		}
 

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
@@ -82,6 +82,7 @@ struct ESP32WifiOTASheet: View {
 			alreadyRebooted = false
 		}
 		.onDisappear {
+			Logger.services.info("📡 [ESP32 WiFi OTA] Sheet dismissed (otaInProgress=\(accessoryManager.otaInProgress))")
 			otaTask?.cancel()
 			otaTask = nil
 			if accessoryManager.otaInProgress {
@@ -93,6 +94,7 @@ struct ESP32WifiOTASheet: View {
 	/// Hand the radio back to the app: let discovery and auto-connect pick the device up once it
 	/// reboots into the new firmware.
 	private func releaseRadio() {
+		Logger.services.info("📡 [ESP32 WiFi OTA] Releasing the radio, restarting discovery")
 		accessoryManager.otaInProgress = false
 		accessoryManager.userRequestedConnectionCancellation = false
 		accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
@@ -119,6 +121,7 @@ struct ESP32WifiOTASheet: View {
 						// Firmware screen keys its content off otaInProgress, so without this it
 						// swaps to the "please reconnect" placeholder and takes this sheet — and
 						// the update — down with it, leaving the device waiting in OTA mode.
+						Logger.services.info("📡 [ESP32 WiFi OTA] Step 1: claiming the radio (node \(deviceNum), host \(host, privacy: .private))")
 						accessoryManager.otaInProgress = true
 						accessoryManager.shouldAutomaticallyConnectToPreferredPeripheralAfterError = false
 
@@ -130,20 +133,29 @@ struct ESP32WifiOTASheet: View {
 						
 						Logger.services.debug("Requesting reboot for OTA with hash: \(sha256Digest as NSData)")
 						
+						Logger.services.info("📡 [ESP32 WiFi OTA] Step 2: sending reboot into OTA mode")
 						try await accessoryManager.sendRebootOta(fromUser: user, toUser: user, mode: .otaWifi, otaHash: sha256Digest)
+						Logger.services.info("📡 [ESP32 WiFi OTA] Reboot command accepted")
 						
 						// Give the packet a moment to send before disconnecting
 						try await Task.sleep(for: .seconds(0.5))
+						Logger.services.info("📡 [ESP32 WiFi OTA] Step 3: disconnecting")
 						try await accessoryManager.disconnect()
+						Logger.services.info("📡 [ESP32 WiFi OTA] Disconnected")
 						alreadyRebooted = true
 					}
 					
 					// The sheet can be dismissed while the reboot settles, which cancels this task
 					// and hands the radio back. Do not start a transfer after that.
-					guard !Task.isCancelled else { return }
+					guard !Task.isCancelled else {
+						Logger.services.info("📡 [ESP32 WiFi OTA] Cancelled before the transfer — sheet was dismissed")
+						return
+					}
 
 					// Begin the HTTP update
+					Logger.services.info("📡 [ESP32 WiFi OTA] Step 4: starting the transfer")
 					await ota.startUpdate(host: host, firmwareUrl: self.binFileURL)
+					Logger.services.info("📡 [ESP32 WiFi OTA] Transfer returned, state \(ota.otaState.rawValue, privacy: .public) error \(ota.errorMessage ?? "none", privacy: .public)")
 					
 					// Attempt to reconnect after update. The reconnect needs the gate open, but
 					// the sheet stays up: releaseRadio only restores discovery and auto-connect,
@@ -156,8 +168,13 @@ struct ESP32WifiOTASheet: View {
 						try await accessoryManager.connect(to: device, retries: 5)
 					}
 				}
+			} catch is CancellationError {
+				// Dismissing the sheet cancels this task mid-sleep, which arrives here as a
+				// thrown cancellation rather than the guard above. Not a failure.
+				Logger.services.info("📡 [ESP32 WiFi OTA] Cancelled — sheet was dismissed")
+				releaseRadio()
 			} catch {
-				Logger.mesh.error("ESP32 OTA Failed: \(error.localizedDescription)")
+				Logger.services.error("📡 [ESP32 WiFi OTA] Failed: \(error.localizedDescription, privacy: .public)")
 				releaseRadio()
 			}
 		}


### PR DESCRIPTION
## Summary

An ESP32 OTA that stalls left almost nothing in the log. The nRF DFU flow
names every handoff step; the two ESP32 flows named none of them, so an
attempt that failed part way through looked the same as one that never
started.

## What changed

- The intro sheet logs which path it picked (BLE or Wi-Fi) and the file.
- Both ESP32 sheets log each step: claiming the radio, the reboot command and
  the packet id it went out as, the disconnect, the transfer starting and what
  it returned, and any failure with its error.
- Both sheets log dismissal along with the flag that keeps the sheet alive
  during an update.
- Dismissal cancels the task mid-sleep, which arrives as a thrown
  cancellation rather than reaching the `Task.isCancelled` guard, so both
  paths name it instead of reporting a failure.

Device and network identifiers — the peripheral UUID and the Wi-Fi host — are
logged `private`. The rest is `public` so an exported log is readable. Node
numbers stay public, as they already are throughout the app: matching the
reboot packet to its routing ack is the point of these lines.

No behavior change beyond the cancellation logging.

## Testing

Built for iOS and installed on a device. Ran an ESP32 BLE OTA against a radio
with no update loader and read the whole sequence back in the in-app log
viewer, ending in the radio's refusal. Full suite passes.