### PR TITLE
Let people close a stuck firmware update

### DIFF
--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/AsyncCentral.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/AsyncCentral.swift
@@ -18,16 +18,26 @@ enum BLEError: Error, LocalizedError {
 
 	var errorDescription: String? {
 		switch self {
-		case .poweredOff: return "Bluetooth is not available."
-		case .scanTimeout: return "The device never advertised in OTA mode."
-		case .connectFailed: return "Could not connect to the device."
-		case .connectTimeout: return "Timed out connecting to the device."
-		case .serviceMissing: return "The device is not offering the OTA service."
-		case .characteristicMissing: return "The OTA service is missing a characteristic."
-		case .discoveryTimeout: return "Timed out reading the device's OTA service."
-		case .notifyTimeout: return "The device never confirmed the status channel."
-		case .writeTimeout: return "Timed out writing to the device."
-		case .disconnected: return "The device disconnected."
+		case .poweredOff:
+			return String(localized: "Bluetooth is not available.", comment: "OTA failed because Bluetooth is off or not permitted")
+		case .scanTimeout:
+			return String(localized: "The device never advertised in update mode.", comment: "OTA failed because the device never appeared in update mode")
+		case .connectFailed:
+			return String(localized: "Could not connect to the device.", comment: "OTA failed to connect to the device in update mode")
+		case .connectTimeout:
+			return String(localized: "Timed out connecting to the device.", comment: "OTA connection to the device in update mode timed out")
+		case .serviceMissing:
+			return String(localized: "The device is not offering the update service.", comment: "OTA failed because the device is missing the update service")
+		case .characteristicMissing:
+			return String(localized: "The update service is missing a characteristic.", comment: "OTA failed because the update service is incomplete")
+		case .discoveryTimeout:
+			return String(localized: "Timed out reading the device's update service.", comment: "OTA timed out discovering the update service")
+		case .notifyTimeout:
+			return String(localized: "The device never confirmed the status channel.", comment: "OTA timed out enabling status notifications")
+		case .writeTimeout:
+			return String(localized: "Timed out writing to the device.", comment: "OTA timed out writing to the device")
+		case .disconnected:
+			return String(localized: "The device disconnected.", comment: "OTA failed because the device disconnected")
 		}
 	}
 }
@@ -49,6 +59,9 @@ final class AsyncCentral: NSObject {
 	private var writeContinuation: CheckedContinuation<Void, Error>?
 	private var notificationStreams: [CBUUID: AsyncStream<Data>.Continuation] = [:]
 	private var desiredUUID: UUID?
+	/// The peripheral `connect` is waiting on, so a callback for a stale attempt to a
+	/// different device cannot answer the current wait.
+	private var connectingPeripheral: CBPeripheral?
 
 	override init() {
 		super.init()
@@ -57,6 +70,11 @@ final class AsyncCentral: NSObject {
 
 	func waitUntilPoweredOn(timeout: TimeInterval = 10) async throws {
 		if central.state == .poweredOn { return }
+		// A state that is already terminal produces no further callback, so waiting out the
+		// deadline only delays the same answer.
+		if [.poweredOff, .unauthorized, .unsupported].contains(central.state) {
+			throw BLEError.poweredOff
+		}
 		try await withDeadline(timeout, onExpiry: { self.finishPower(with: .failure(BLEError.poweredOff)) }) {
 			try await withCheckedThrowingContinuation { cont in
 				self.powerContinuation = cont
@@ -103,6 +121,7 @@ final class AsyncCentral: NSObject {
 	private func finishConnect(with result: Result<Void, Error>) {
 		guard let cont = connectContinuation else { return }
 		connectContinuation = nil
+		connectingPeripheral = nil
 		cont.resume(with: result)
 	}
 
@@ -168,12 +187,14 @@ extension AsyncCentral: CBCentralManagerDelegate, CBPeripheralDelegate {
 
 	nonisolated func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
 		MainActor.assumeIsolated {
+			guard peripheral.identifier == connectingPeripheral?.identifier else { return }
 			finishConnect(with: .success(()))
 		}
 	}
 
 	nonisolated func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
 		MainActor.assumeIsolated {
+			guard peripheral.identifier == connectingPeripheral?.identifier else { return }
 			finishConnect(with: .failure(error ?? BLEError.connectFailed))
 		}
 	}
@@ -241,9 +262,18 @@ extension AsyncCentral {
 	}
 
 	func connect(_ peripheral: CBPeripheral, timeout: TimeInterval = 10) async throws {
-		try await withDeadline(timeout, onExpiry: { self.finishConnect(with: .failure(BLEError.connectTimeout)) }) {
+		// Give up on the connection as well as the wait. Core Bluetooth keeps trying
+		// indefinitely otherwise, and a late didConnect would resume whatever wait is
+		// current by then.
+		let expire = { [weak self] in
+			guard let self else { return }
+			self.central.cancelPeripheralConnection(peripheral)
+			self.finishConnect(with: .failure(BLEError.connectTimeout))
+		}
+		try await withDeadline(timeout, onExpiry: expire) {
 			try await withCheckedThrowingContinuation { cont in
 				self.connectContinuation = cont
+				self.connectingPeripheral = peripheral
 				central.connect(peripheral, options: nil)
 			}
 		}

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/AsyncCentral.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/AsyncCentral.swift
@@ -12,10 +12,33 @@ private let meshtasticOTAServiceId = CBUUID(string: "4FAFC201-1FB5-459E-8FCC-C5C
 private let statusCharacteristicId = CBUUID(string: "62EC0272-3EC5-11EB-B378-0242AC130003")
 private let otaCharacteristicId    = CBUUID(string: "62EC0272-3EC5-11EB-B378-0242AC130005")
 
-enum BLEError: Error {
-	case poweredOff, scanTimeout, connectFailed, serviceMissing, characteristicMissing
+enum BLEError: Error, LocalizedError {
+	case poweredOff, scanTimeout, connectFailed, connectTimeout, serviceMissing, characteristicMissing
+	case discoveryTimeout, notifyTimeout, writeTimeout, disconnected
+
+	var errorDescription: String? {
+		switch self {
+		case .poweredOff: return "Bluetooth is not available."
+		case .scanTimeout: return "The device never advertised in OTA mode."
+		case .connectFailed: return "Could not connect to the device."
+		case .connectTimeout: return "Timed out connecting to the device."
+		case .serviceMissing: return "The device is not offering the OTA service."
+		case .characteristicMissing: return "The OTA service is missing a characteristic."
+		case .discoveryTimeout: return "Timed out reading the device's OTA service."
+		case .notifyTimeout: return "The device never confirmed the status channel."
+		case .writeTimeout: return "Timed out writing to the device."
+		case .disconnected: return "The device disconnected."
+		}
+	}
 }
 
+/// Core Bluetooth callbacks can simply never arrive: the radio reboots, the OTA
+/// advertisement never shows up, the connection drops between two delegate calls.
+/// Every wait in here therefore carries its own deadline. Racing the wait against a
+/// sleeping task is not enough — a checked continuation ignores cancellation, so the
+/// only thing that can end a wait is resuming the continuation the delegate would
+/// have resumed. That is what the `fail…` helpers below do.
+@MainActor
 final class AsyncCentral: NSObject {
 	private var central: CBCentralManager!
 	private var scanContinuation: CheckedContinuation<CBPeripheral, Error>?
@@ -26,137 +49,235 @@ final class AsyncCentral: NSObject {
 	private var writeContinuation: CheckedContinuation<Void, Error>?
 	private var notificationStreams: [CBUUID: AsyncStream<Data>.Continuation] = [:]
 	private var desiredUUID: UUID?
-	
+
 	override init() {
 		super.init()
 		central = CBCentralManager(delegate: self, queue: nil)
 	}
 
-	func waitUntilPoweredOn() async throws {
+	func waitUntilPoweredOn(timeout: TimeInterval = 10) async throws {
 		if central.state == .poweredOn { return }
-		try await withCheckedThrowingContinuation { cont in
-			self.powerContinuation = cont
+		try await withDeadline(timeout, onExpiry: { self.finishPower(with: .failure(BLEError.poweredOff)) }) {
+			try await withCheckedThrowingContinuation { cont in
+				self.powerContinuation = cont
+			}
 		}
 	}
 
 	private var powerContinuation: CheckedContinuation<Void, Error>?
+
+	// MARK: - Waiting
+
+	/// Runs `body`, and if it has not finished within `seconds`, calls `onExpiry` —
+	/// which is expected to resume whatever continuation `body` is waiting on.
+	private func withDeadline<T>(
+		_ seconds: TimeInterval,
+		onExpiry: @escaping @MainActor () -> Void,
+		body: () async throws -> T
+	) async throws -> T {
+		let timer = Task { @MainActor in
+			try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+			guard !Task.isCancelled else { return }
+			onExpiry()
+		}
+		defer { timer.cancel() }
+		return try await body()
+	}
+
+	// Each of these resumes at most once and clears the slot, so a delegate callback
+	// arriving after a deadline has already fired is a no-op instead of a crash.
+
+	private func finishPower(with result: Result<Void, Error>) {
+		guard let cont = powerContinuation else { return }
+		powerContinuation = nil
+		cont.resume(with: result)
+	}
+
+	private func finishScan(with result: Result<CBPeripheral, Error>) {
+		guard let cont = scanContinuation else { return }
+		scanContinuation = nil
+		central.stopScan()
+		cont.resume(with: result)
+	}
+
+	private func finishConnect(with result: Result<Void, Error>) {
+		guard let cont = connectContinuation else { return }
+		connectContinuation = nil
+		cont.resume(with: result)
+	}
+
+	private func finishServices(with result: Result<[CBService], Error>) {
+		guard let cont = serviceContinuation else { return }
+		serviceContinuation = nil
+		cont.resume(with: result)
+	}
+
+	private func finishCharacteristics(with result: Result<[CBCharacteristic], Error>) {
+		guard let cont = characteristicContinuation else { return }
+		characteristicContinuation = nil
+		cont.resume(with: result)
+	}
+
+	private func finishNotify(with result: Result<Void, Error>) {
+		guard let cont = notifyContinuation else { return }
+		notifyContinuation = nil
+		cont.resume(with: result)
+	}
+
+	private func finishWrite(with result: Result<Void, Error>) {
+		guard let cont = writeContinuation else { return }
+		writeContinuation = nil
+		cont.resume(with: result)
+	}
+
+	/// A drop ends every wait, not just the one the disconnect interrupted.
+	private func failAll(with error: Error) {
+		finishConnect(with: .failure(error))
+		finishServices(with: .failure(error))
+		finishCharacteristics(with: .failure(error))
+		finishNotify(with: .failure(error))
+		finishWrite(with: .failure(error))
+	}
 }
 
 extension AsyncCentral: CBCentralManagerDelegate, CBPeripheralDelegate {
-	func centralManagerDidUpdateState(_ central: CBCentralManager) {
-		if central.state == .poweredOn {
-			powerContinuation?.resume()
-			powerContinuation = nil
-		}
-	}
-
-	func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
-	                    advertisementData: [String: Any], rssi RSSI: NSNumber) {
-		scanContinuation?.resume(returning: peripheral)
-		scanContinuation = nil
-		central.stopScan()
-	}
-
-	func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-		connectContinuation?.resume()
-		connectContinuation = nil
-	}
-
-	func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
-		connectContinuation?.resume(throwing: error ?? BLEError.connectFailed)
-		connectContinuation = nil
-	}
-
-	func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-		if let error = error {
-			serviceContinuation?.resume(throwing: error)
-		} else if let desiredUUID {
-			if peripheral.identifier == desiredUUID {
-				serviceContinuation?.resume(returning: peripheral.services ?? [])
-				serviceContinuation = nil
+	nonisolated func centralManagerDidUpdateState(_ central: CBCentralManager) {
+		MainActor.assumeIsolated {
+			switch central.state {
+			case .poweredOn:
+				finishPower(with: .success(()))
+			case .poweredOff, .unauthorized, .unsupported:
+				// Nothing is coming. Waiting on the radio forever leaves the update
+				// screen with no way to end itself.
+				Logger.services.error("📡 [ESP32 BLE OTA] Bluetooth unavailable: \(String(describing: central.state), privacy: .public)")
+				finishPower(with: .failure(BLEError.poweredOff))
+				failAll(with: BLEError.poweredOff)
+				finishScan(with: .failure(BLEError.poweredOff))
+			default:
+				break
 			}
-		} else {
-			serviceContinuation?.resume(returning: peripheral.services ?? [])
-			serviceContinuation = nil
 		}
 	}
 
-	func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
-		if let error = error { characteristicContinuation?.resume(throwing: error) } else { characteristicContinuation?.resume(returning: service.characteristics ?? []) }
-		characteristicContinuation = nil
-	}
-
-	func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
-		if let error = error { notifyContinuation?.resume(throwing: error) } else { notifyContinuation?.resume() }
-		notifyContinuation = nil
-	}
-
-	func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-		guard error == nil, let data = characteristic.value else { return }
-		notificationStreams[characteristic.uuid]?.yield(data)
-	}
-
-	func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
-		if let error = error {
-			writeContinuation?.resume(throwing: error)
-		} else {
-			writeContinuation?.resume()
+	nonisolated func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
+	                                advertisementData: [String: Any], rssi RSSI: NSNumber) {
+		MainActor.assumeIsolated {
+			finishScan(with: .success(peripheral))
 		}
-		writeContinuation = nil
+	}
+
+	nonisolated func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+		MainActor.assumeIsolated {
+			finishConnect(with: .success(()))
+		}
+	}
+
+	nonisolated func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+		MainActor.assumeIsolated {
+			finishConnect(with: .failure(error ?? BLEError.connectFailed))
+		}
+	}
+
+	nonisolated func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+		MainActor.assumeIsolated {
+			Logger.services.info("📡 [ESP32 BLE OTA] Peripheral disconnected")
+			failAll(with: error ?? BLEError.disconnected)
+			for stream in notificationStreams.values { stream.finish() }
+			notificationStreams.removeAll()
+		}
+	}
+
+	nonisolated func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+		MainActor.assumeIsolated {
+			if let error {
+				finishServices(with: .failure(error))
+			} else if let desiredUUID, peripheral.identifier != desiredUUID {
+				return
+			} else {
+				finishServices(with: .success(peripheral.services ?? []))
+			}
+		}
+	}
+
+	nonisolated func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+		MainActor.assumeIsolated {
+			if let error {
+				finishCharacteristics(with: .failure(error))
+			} else {
+				finishCharacteristics(with: .success(service.characteristics ?? []))
+			}
+		}
+	}
+
+	nonisolated func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+		MainActor.assumeIsolated {
+			finishNotify(with: error.map { .failure($0) } ?? .success(()))
+		}
+	}
+
+	nonisolated func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+		MainActor.assumeIsolated {
+			guard error == nil, let data = characteristic.value else { return }
+			notificationStreams[characteristic.uuid]?.yield(data)
+		}
+	}
+
+	nonisolated func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+		MainActor.assumeIsolated {
+			finishWrite(with: error.map { .failure($0) } ?? .success(()))
+		}
 	}
 }
 
 extension AsyncCentral {
 	func scan(for service: CBUUID, desiredUUID: UUID? = nil, timeout: TimeInterval = 10) async throws -> CBPeripheral {
 		self.desiredUUID = desiredUUID
-		return try await withThrowingTaskGroup(of: CBPeripheral.self) { group in
-			group.addTask {
-				try await withCheckedThrowingContinuation { cont in
-					self.scanContinuation = cont
-					self.central.scanForPeripherals(withServices: [service], options: nil)
-				}
+		return try await withDeadline(timeout, onExpiry: { self.finishScan(with: .failure(BLEError.scanTimeout)) }) {
+			try await withCheckedThrowingContinuation { cont in
+				self.scanContinuation = cont
+				self.central.scanForPeripherals(withServices: [service], options: nil)
 			}
-			group.addTask {
-				try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-				throw BLEError.scanTimeout
-			}
-			let result = try await group.next()!
-			group.cancelAll()
-			self.central.stopScan()
-			return result
 		}
 	}
 
-	func connect(_ peripheral: CBPeripheral) async throws {
-		try await withCheckedThrowingContinuation { cont in
-			self.connectContinuation = cont
-			central.connect(peripheral, options: nil)
+	func connect(_ peripheral: CBPeripheral, timeout: TimeInterval = 10) async throws {
+		try await withDeadline(timeout, onExpiry: { self.finishConnect(with: .failure(BLEError.connectTimeout)) }) {
+			try await withCheckedThrowingContinuation { cont in
+				self.connectContinuation = cont
+				central.connect(peripheral, options: nil)
+			}
 		}
 	}
-	
+
 	func disconnect(_ peripheral: CBPeripheral) {
 		central.cancelPeripheralConnection(peripheral)
 	}
 
-	func discoverServices(_ uuids: [CBUUID], on peripheral: CBPeripheral) async throws -> [CBService] {
+	func discoverServices(_ uuids: [CBUUID], on peripheral: CBPeripheral, timeout: TimeInterval = 10) async throws -> [CBService] {
 		peripheral.delegate = self
-		peripheral.discoverServices(uuids)
-		return try await withCheckedThrowingContinuation { cont in
-			self.serviceContinuation = cont
+		return try await withDeadline(timeout, onExpiry: { self.finishServices(with: .failure(BLEError.discoveryTimeout)) }) {
+			try await withCheckedThrowingContinuation { cont in
+				self.serviceContinuation = cont
+				peripheral.discoverServices(uuids)
+			}
 		}
 	}
 
-	func discoverCharacteristics(_ uuids: [CBUUID], in service: CBService, on peripheral: CBPeripheral) async throws -> [CBCharacteristic] {
-		peripheral.discoverCharacteristics(uuids, for: service)
-		return try await withCheckedThrowingContinuation { cont in
-			self.characteristicContinuation = cont
+	func discoverCharacteristics(_ uuids: [CBUUID], in service: CBService, on peripheral: CBPeripheral, timeout: TimeInterval = 10) async throws -> [CBCharacteristic] {
+		try await withDeadline(timeout, onExpiry: { self.finishCharacteristics(with: .failure(BLEError.discoveryTimeout)) }) {
+			try await withCheckedThrowingContinuation { cont in
+				self.characteristicContinuation = cont
+				peripheral.discoverCharacteristics(uuids, for: service)
+			}
 		}
 	}
 
-	func setNotify(_ enabled: Bool, for characteristic: CBCharacteristic, on peripheral: CBPeripheral) async throws {
-		peripheral.setNotifyValue(enabled, for: characteristic)
-		try await withCheckedThrowingContinuation { cont in
-			self.notifyContinuation = cont
+	func setNotify(_ enabled: Bool, for characteristic: CBCharacteristic, on peripheral: CBPeripheral, timeout: TimeInterval = 5) async throws {
+		try await withDeadline(timeout, onExpiry: { self.finishNotify(with: .failure(BLEError.notifyTimeout)) }) {
+			try await withCheckedThrowingContinuation { cont in
+				self.notifyContinuation = cont
+				peripheral.setNotifyValue(enabled, for: characteristic)
+			}
 		}
 	}
 
@@ -166,14 +287,16 @@ extension AsyncCentral {
 		}
 	}
 
-	func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType, on peripheral: CBPeripheral) async throws {
-		if type == .withResponse {
+	func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType, on peripheral: CBPeripheral, timeout: TimeInterval = 10) async throws {
+		guard type == .withResponse else {
+			peripheral.writeValue(data, for: characteristic, type: type)
+			return
+		}
+		try await withDeadline(timeout, onExpiry: { self.finishWrite(with: .failure(BLEError.writeTimeout)) }) {
 			try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
 				self.writeContinuation = cont
 				peripheral.writeValue(data, for: characteristic, type: type)
 			}
-		} else {
-			peripheral.writeValue(data, for: characteristic, type: type)
 		}
 	}
 }

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
@@ -64,26 +64,18 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 			
 			name = peripheral.name ?? "unknown"
 			
-			// Connect with timeout (10s)
-			try await withTimeout(seconds: 10) {
-				try await self.ble.connect(peripheral)
-			}
+			try await ble.connect(peripheral, timeout: 10)
 			
 			otaStatus = .connected
 			self.statusMessage = "Discovering Services..."
 			
-			// Discover Services with timeout (10s)
-			let services = try await withTimeout(seconds: 10) {
-				try await self.ble.discoverServices([meshtasticOTAServiceId], on: peripheral)
-			}
+			let services = try await ble.discoverServices([meshtasticOTAServiceId], on: peripheral, timeout: 10)
 			guard let service = services.first(where: { $0.uuid == meshtasticOTAServiceId }) else { throw BLEError.serviceMissing }
 			
-			// Discover Characteristics with timeout (10s)
-			let chars = try await withTimeout(seconds: 10) {
-				try await self.ble.discoverCharacteristics([statusCharacteristicId, otaCharacteristicId],
-														   in: service,
-														   on: peripheral)
-			}
+			let chars = try await ble.discoverCharacteristics([statusCharacteristicId, otaCharacteristicId],
+															 in: service,
+															 on: peripheral,
+															 timeout: 10)
 			
 			guard
 				let statusChar = chars.first(where: { $0.uuid == statusCharacteristicId }),
@@ -91,10 +83,7 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 			else { throw BLEError.characteristicMissing }
 			
 			// --- 2. Setup Notification Stream ---
-			// Timeout for setting notify (usually fast, but good to be safe)
-			try await withTimeout(seconds: 5) {
-				try await self.ble.setNotify(true, for: statusChar, on: peripheral)
-			}
+			try await ble.setNotify(true, for: statusChar, on: peripheral, timeout: 5)
 			
 			let stream = ble.notifications(for: statusChar)
 			var iterator = stream.makeAsyncIterator()
@@ -161,6 +150,14 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 			let chunkSize = peripheral.maximumWriteValueLength(for: .withoutResponse)
 			
 			while offset < fileSize {
+				// Closing the sheet cancels the task that owns this transfer. Stop writing
+				// and drop the connection rather than flashing on into a screen that is gone.
+				if Task.isCancelled {
+					Logger.services.info("📡 [ESP32 BLE OTA] Transfer cancelled at \(offset) of \(fileSize) bytes")
+					ble.disconnect(peripheral)
+					throw CancellationError()
+				}
+
 				let endIndex = min(offset + chunkSize, fileSize)
 				let chunk = data.subdata(in: offset..<endIndex)
 				
@@ -239,6 +236,11 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 	}
 	
 	/// Executes an async operation with a strict timeout.
+	///
+	/// Only safe for operations that end when their task is cancelled — reading the
+	/// notification stream, for instance. A Core Bluetooth call waiting on a checked
+	/// continuation ignores cancellation, so racing it here would hang instead of
+	/// timing out; those calls carry their own deadlines in `AsyncCentral`.
 	/// - Parameters:
 	///   - seconds: The timeout duration.
 	///   - operation: The async closure to execute.

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
@@ -95,6 +95,10 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 			let peripheral = try await ble.scan(for: meshtasticOTAServiceId, timeout: 15.0)
 			
 			name = peripheral.name ?? "unknown"
+			// Every exit from here on leaves the device connected otherwise, including the
+			// failures: the device sits in update mode holding a link to an app that has
+			// given up on it.
+			defer { ble.disconnect(peripheral) }
 			
 			try await ble.connect(peripheral, timeout: 10)
 			
@@ -186,7 +190,6 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 				// and drop the connection rather than flashing on into a screen that is gone.
 				if Task.isCancelled {
 					Logger.services.info("📡 [ESP32 BLE OTA] Transfer cancelled at \(offset) of \(fileSize) bytes")
-					ble.disconnect(peripheral)
 					throw CancellationError()
 				}
 
@@ -248,7 +251,6 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 			if self.otaStatus != .completed {
 				throw BLEOTAFailure.unexpectedResponse("Stream ended without OK")
 			}
-			ble.disconnect(peripheral)
 		} catch {
 			self.otaStatus = .error
 			// The radio's own reason beats "the device never advertised in OTA mode", which is

--- a/Meshtastic/Views/Settings/Firmware/Helpers/FirmwareOTAUpdateSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/Helpers/FirmwareOTAUpdateSheet.swift
@@ -301,6 +301,9 @@ struct FirmwareOTASimulatorView: View {
 					resetToIdle()
 				},
 				onDismiss: {
+					// The simulation runs in an unstructured Task that would otherwise keep
+					// going after "Stop Update".
+					isLiveSimulating = false
 					dismiss()
 				},
 				gameTitle: selectedPreset.gameTitle

--- a/Meshtastic/Views/Settings/Firmware/Helpers/FirmwareOTAUpdateSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/Helpers/FirmwareOTAUpdateSheet.swift
@@ -52,6 +52,7 @@ struct FirmwareOTAUpdateSheet: View {
 	var gameTitle: String?
 
 	@State private var showChirpyGame = false
+	@State private var showStopConfirmation = false
 	@State private var tipIndex: Int = 0
 	private let tipTimer = Timer.publish(every: 8.0, on: .main, in: .common).autoconnect()
 
@@ -181,16 +182,39 @@ struct FirmwareOTAUpdateSheet: View {
 			.toolbar {
 				ToolbarItem(placement: .cancellationAction) {
 					Button {
-						onDismiss()
+						// Always a way out. An update can stall somewhere the app cannot
+						// recover from — the radio never advertises in OTA mode, say — and
+						// a disabled close button leaves force-quitting as the only exit.
+						if isDismissSafe {
+							onDismiss()
+						} else {
+							showStopConfirmation = true
+						}
 					} label: {
 						Image(systemName: "xmark")
 					}
 					.accessibilityLabel(String(localized: "Close", comment: "VoiceOver: dismiss this sheet"))
-					.disabled(!isDismissAllowed)
 				}
 			}
 		}
 		.interactiveDismissDisabled(true)
+		.confirmationDialog(
+			Text("Stop the update?", comment: "Title of the confirmation shown when closing an update in progress"),
+			isPresented: $showStopConfirmation,
+			titleVisibility: .visible
+		) {
+			Button(role: .destructive) {
+				onDismiss()
+			} label: {
+				Text("Stop Update", comment: "Button that abandons an update in progress")
+			}
+			Button(role: .cancel) { } label: {
+				Text("Keep Waiting", comment: "Button that returns to an update in progress")
+			}
+		} message: {
+			Text("The device stays in update mode until the update finishes or you power it off and on again.",
+				 comment: "Explains what happens to the device when an update is abandoned")
+		}
 		.firmwareUpdateGame(isPresented: $showChirpyGame, status: gameStatus)
 		.onReceive(tipTimer) { _ in
 			withAnimation(.easeInOut(duration: 0.35)) {
@@ -199,7 +223,8 @@ struct FirmwareOTAUpdateSheet: View {
 		}
 	}
 
-	private var isDismissAllowed: Bool {
+	/// States where nothing is under way, so closing needs no confirmation.
+	private var isDismissSafe: Bool {
 		[.idle, .completed, .error].contains(statusState)
 	}
 

--- a/Meshtastic/Views/Settings/Firmware/NRF DFU/DFUModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/NRF DFU/DFUModel.swift
@@ -30,6 +30,9 @@ class DFUViewModel: NSObject, ObservableObject {
     @Published var progress: Double = 0.0
     @Published var state: DFUUpdateState = .idle
     @Published var statusMessage: String = "Ready"
+	/// Set when the library confirms an abort. Handing the radio back to the app before
+	/// this lands restarts discovery while NordicDFU still owns the peripheral.
+	@Published private(set) var didAbort = false
 	@Published var rotatingMessage: String = ""
 	
 	var lastRotatingMessageUpdate = Date.distantPast
@@ -70,6 +73,7 @@ class DFUViewModel: NSObject, ObservableObject {
         initiator.logger = self // Optional: For debugging
         
         // Start the process
+        self.didAbort = false
         self.state = .uploading
 		Logger.services.info("NRF DFU: starting on \(peripheral.identifier.uuidString, privacy: .public)")
 		self.dfuController = initiator.with(firmware: firmware)
@@ -105,6 +109,7 @@ extension DFUViewModel: DFUServiceDelegate {
 			UIApplication.shared.isIdleTimerDisabled = false
 			self.state = .error("Aborted")
 			self.statusMessage = "Update Aborted"
+			self.didAbort = true
 		case .uploading:
 			self.state = .uploading
 			self.statusMessage = "Uploading..."

--- a/Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift
@@ -138,8 +138,7 @@ struct NRFDFUSheet: View {
 			titleVisibility: .visible
 		) {
 			Button(role: .destructive) {
-				dfuViewModel.abort()
-				dismiss()
+				Task { await stopUpdate() }
 			} label: {
 				Text("Stop Update", comment: "Button that abandons an update in progress")
 			}
@@ -156,6 +155,25 @@ struct NRFDFUSheet: View {
 				restoreDiscovery()
 			}
 		}
+	}
+
+	/// Abort, then wait for the library to confirm before handing the radio back: restarting
+	/// discovery while NordicDFU still owns the peripheral lets auto-connect grab it out from
+	/// under the abort. Bounded, because an abort that never confirms must not leave the app
+	/// unable to find the radio again.
+	private func stopUpdate() async {
+		dfuViewModel.abort()
+		let deadline = Date().addingTimeInterval(3)
+		while !dfuViewModel.didAbort && Date() < deadline {
+			try? await Task.sleep(for: .milliseconds(100))
+		}
+		if !dfuViewModel.didAbort {
+			Logger.services.error("NRF DFU: abort was not confirmed, handing the radio back anyway")
+		}
+		if accessoryManager.otaInProgress {
+			restoreDiscovery()
+		}
+		dismiss()
 	}
 
 	/// Give the radio back to the app once DFU is finished: restart discovery and

--- a/Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/NRF DFU/NRFDFUSheet.swift
@@ -14,6 +14,7 @@ struct NRFDFUSheet: View {
 	@State var showWarningAlert = true
 	@StateObject private var dfuViewModel = DFUViewModel()
 	@State private var showChirpyGame = false
+	@State private var showStopConfirmation = false
 	
 	let firmwareToFlash: URL
 	
@@ -113,7 +114,13 @@ struct NRFDFUSheet: View {
 		}
 		.overlay(alignment: .topLeading) {
 			Button {
-				dismiss()
+				// Always a way out. An update can stall somewhere the app cannot recover
+				// from, and a disabled close button leaves force-quitting as the only exit.
+				if [.starting, .uploading].contains(dfuViewModel.state) {
+					showStopConfirmation = true
+				} else {
+					dismiss()
+				}
 			} label: {
 				Image(systemName: "xmark.circle.fill")
 					.font(.title)
@@ -123,10 +130,26 @@ struct NRFDFUSheet: View {
 			.accessibilityLabel(String(localized: "Close", comment: "VoiceOver: dismiss this sheet"))
 			.buttonStyle(.plain)
 			.padding()
-			.disabled([.starting, .uploading].contains(dfuViewModel.state))
-			.opacity([.starting, .uploading].contains(dfuViewModel.state) ? 0.3 : 1.0)
 		}
 		.interactiveDismissDisabled(true)
+		.confirmationDialog(
+			Text("Stop the update?", comment: "Title of the confirmation shown when closing an update in progress"),
+			isPresented: $showStopConfirmation,
+			titleVisibility: .visible
+		) {
+			Button(role: .destructive) {
+				dfuViewModel.abort()
+				dismiss()
+			} label: {
+				Text("Stop Update", comment: "Button that abandons an update in progress")
+			}
+			Button(role: .cancel) { } label: {
+				Text("Keep Waiting", comment: "Button that returns to an update in progress")
+			}
+		} message: {
+			Text("The device stays in update mode until the update finishes or you power it off and on again.",
+				 comment: "Explains what happens to the device when an update is abandoned")
+		}
 		.firmwareUpdateGame(isPresented: $showChirpyGame, status: gameStatus)
 		.onDisappear {
 			if accessoryManager.otaInProgress {

--- a/MeshtasticTests/AsyncCentralDeadlineTests.swift
+++ b/MeshtasticTests/AsyncCentralDeadlineTests.swift
@@ -21,16 +21,21 @@ struct AsyncCentralDeadlineTests {
 
 	private static let otaServiceId = CBUUID(string: "4FAFC201-1FB5-459E-8FCC-C5C9C331914B")
 
-	@Test("Waiting for Bluetooth to power on ends on its own", .timeLimit(.minutes(1)))
+	@Test("Bluetooth being unavailable is reported at once, not after the deadline", .timeLimit(.minutes(1)))
 	func powerOnWaitEnds() async {
 		let central = AsyncCentral()
 		let start = Date()
+		var thrown: Error?
 		do {
-			try await central.waitUntilPoweredOn(timeout: 2)
+			try await central.waitUntilPoweredOn(timeout: 30)
 		} catch {
-			// Bluetooth being unavailable is the expected outcome here.
+			thrown = error
 		}
-		#expect(Date().timeIntervalSince(start) < 10)
+		let elapsed = Date().timeIntervalSince(start)
+		// The simulator has no Bluetooth, so the state is already terminal. A terminal state
+		// produces no further callback: waiting out the deadline only delays the same answer.
+		#expect(thrown as? BLEError == .poweredOff)
+		#expect(elapsed < 5, "reported after \(elapsed)s against a 30s deadline")
 	}
 
 	@Test("Scanning for a device in OTA mode ends on its own", .timeLimit(.minutes(1)))

--- a/MeshtasticTests/AsyncCentralDeadlineTests.swift
+++ b/MeshtasticTests/AsyncCentralDeadlineTests.swift
@@ -1,0 +1,51 @@
+//
+//  AsyncCentralDeadlineTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/2/26.
+//
+
+import Testing
+import Foundation
+import CoreBluetooth
+@testable import Meshtastic
+
+/// Every wait in the ESP32 BLE OTA path used to race a sleeping task against a Core
+/// Bluetooth callback. A checked continuation ignores cancellation, so when the
+/// deadline won, the task group waited forever on the operation it had just
+/// cancelled. Both calls below hung indefinitely before; they must now end on their
+/// own. The simulator has no Bluetooth, which is exactly the case that hung.
+@Suite("ESP32 BLE OTA deadlines")
+@MainActor
+struct AsyncCentralDeadlineTests {
+
+	private static let otaServiceId = CBUUID(string: "4FAFC201-1FB5-459E-8FCC-C5C9C331914B")
+
+	@Test("Waiting for Bluetooth to power on ends on its own", .timeLimit(.minutes(1)))
+	func powerOnWaitEnds() async {
+		let central = AsyncCentral()
+		let start = Date()
+		do {
+			try await central.waitUntilPoweredOn(timeout: 2)
+		} catch {
+			// Bluetooth being unavailable is the expected outcome here.
+		}
+		#expect(Date().timeIntervalSince(start) < 10)
+	}
+
+	@Test("Scanning for a device in OTA mode ends on its own", .timeLimit(.minutes(1)))
+	func scanEnds() async {
+		let central = AsyncCentral()
+		let start = Date()
+		var thrown: Error?
+		do {
+			_ = try await central.scan(for: Self.otaServiceId, timeout: 2)
+		} catch {
+			thrown = error
+		}
+		#expect(Date().timeIntervalSince(start) < 10)
+		// Bluetooth off in the simulator reports itself rather than running the full
+		// deadline; on a radio that never advertises this is .scanTimeout instead.
+		#expect(thrown is BLEError)
+	}
+}


### PR DESCRIPTION
## Summary

The close button on the firmware update sheets was disabled while an update
was running. An update that stalls could then only be escaped by force-quitting
the app. An ESP32 BLE update that never finds the device advertising in OTA
mode sits on "Connecting..." forever.

## What changed

The close button is always available. During an update it asks for
confirmation and says the device stays in update mode until the update
finishes or it is power cycled. Stopping cancels the transfer and drops the
connection instead of flashing on into a screen that is gone. Same treatment
on the nRF DFU sheet, which had the same disabled button.

Then the reason it hangs there. Every wait in the ESP32 BLE OTA path raced a
sleeping task against a Core Bluetooth callback inside a task group. A checked
continuation ignores cancellation, so when the deadline won, the group waited
forever on the operation it had just cancelled — none of those timeouts could
fire, including the 15 second scan timeout. Each wait now carries its own
deadline that resumes the continuation the delegate would have resumed.

Two more holes in the same file:

- Waiting for Bluetooth to power on had no deadline and only ever finished on
  success, so Bluetooth being off or denied hung in the same place. It now
  fails on those states.
- A disconnect ended no pending wait at all. It now ends all of them.

## Testing

Built for iOS and installed on a device.

New tests cover the two waits that hung: waiting for Bluetooth to power on and
scanning for the device in OTA mode both end on their own now. The simulator
has no Bluetooth, which is exactly the case that used to hang forever — before
this change those tests never returned.

Closing a stalled update and the confirmation still want a run against a real
ESP32 radio.

