### PR TITLE
Renumber the store when a radio's node number changes

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -256,13 +256,14 @@ extension AccessoryManager {
 
 		Logger.data.warning("💾 [Database] Connected to node \(incomingNodeNum.toHex(), privacy: .public) but the store belongs to \(nums.map { $0.toHex() }.joined(separator: ", "), privacy: .public) — backing up and resetting to prevent cross-device node bleed")
 
-		// Preserve the previous radio's data exactly like the switch flow would have.
+		// Preserve the previous radio's data exactly like the switch flow would have. Flush before
+		// copying the store files or the backup misses anything still waiting on a debounced save.
+		await MeshPackets.shared.flushDebouncedSaves()
 		if let previousNum = nums.first {
 			let previousName = devices.first(where: { $0.num == previousNum })?.longName
 			_ = await NodeBackupManager.shared.createBackup(forNode: previousNum, nodeName: previousName)
 		}
 
-		await MeshPackets.shared.flushDebouncedSaves()
 		let cleared = await MeshPackets.shared.clearDatabase(includeRoutes: false)
 		if !cleared {
 			// A half-cleared store must not receive this radio's dump (that IS the bleed).
@@ -281,10 +282,11 @@ extension AccessoryManager {
 	private func renumberStore(from oldNum: Int64, to newNum: Int64) async {
 		Logger.data.warning("💾 [Database] Node \(oldNum.toHex(), privacy: .public) now reports \(newNum.toHex(), privacy: .public) — same radio, renumbering the store")
 
-		// The backup is the safety net if the rewrite goes wrong.
+		// The backup is the safety net if the rewrite goes wrong, so flush first — it copies the
+		// store files, and anything still waiting on a debounced save would not be in them yet.
+		await MeshPackets.shared.flushDebouncedSaves()
 		let previousName = devices.first(where: { $0.num == oldNum })?.longName
 		_ = await NodeBackupManager.shared.createBackup(forNode: oldNum, nodeName: previousName)
-		await MeshPackets.shared.flushDebouncedSaves()
 
 		// Detail views bound to the old node have to unmount before its identity changes
 		// underneath them, the same reason the reset path pops first.

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -244,6 +244,16 @@ extension AccessoryManager {
 			return // The store already belongs to (or was restored for) this radio.
 		}
 
+		// Same radio, new number. A firmware upgrade to 2.8 changes the node number a radio
+		// reports, and everything the app stored is keyed to the old one. The MyInfo row records
+		// the peripheral it came from, so a match means this is that radio under a new number
+		// rather than a different radio — renumber the store instead of throwing it away.
+		if let connectedDeviceId = activeConnection?.device.id.uuidString,
+		   let sameRadio = myInfos.first(where: { $0.peripheralId == connectedDeviceId }) {
+			await renumberStore(from: sameRadio.myNodeNum, to: incomingNodeNum)
+			return
+		}
+
 		Logger.data.warning("💾 [Database] Connected to node \(incomingNodeNum.toHex(), privacy: .public) but the store belongs to \(nums.map { $0.toHex() }.joined(separator: ", "), privacy: .public) — backing up and resetting to prevent cross-device node bleed")
 
 		// Preserve the previous radio's data exactly like the switch flow would have.
@@ -263,6 +273,37 @@ extension AccessoryManager {
 		// Pops views, repoints the container (recreating the MeshPackets actor), and bumps
 		// databaseResetID so @Query views rebind before the new radio's data starts landing.
 		await resetDatabaseAfterClear()
+	}
+
+	/// Rewrites the store from the node number this radio used to report to the one it reports
+	/// now. Runs before any data for the new number is ingested, so what it rewrites is exactly
+	/// what the previous session left behind.
+	private func renumberStore(from oldNum: Int64, to newNum: Int64) async {
+		Logger.data.warning("💾 [Database] Node \(oldNum.toHex(), privacy: .public) now reports \(newNum.toHex(), privacy: .public) — same radio, renumbering the store")
+
+		// The backup is the safety net if the rewrite goes wrong.
+		let previousName = devices.first(where: { $0.num == oldNum })?.longName
+		_ = await NodeBackupManager.shared.createBackup(forNode: oldNum, nodeName: previousName)
+		await MeshPackets.shared.flushDebouncedSaves()
+
+		// Detail views bound to the old node have to unmount before its identity changes
+		// underneath them, the same reason the reset path pops first.
+		if let router = appState?.router {
+			router.popToRoot(tab: .messages)
+			router.popToRoot(tab: .nodes)
+			router.popToRoot(tab: .map)
+			router.popToRoot(tab: .settings)
+			await Task.yield()
+		}
+
+		guard NodeRenumber.apply(from: oldNum, to: newNum, in: context) else {
+			// Leave the store alone rather than half-renumbering it. The connect carries on and
+			// the radio arrives as a new node, which is what happened before this existed.
+			Logger.data.error("💾 [Database] Renumbering failed, leaving the store as it is")
+			return
+		}
+		UserDefaults.preferredPeripheralNum = Int(newNum)
+		appState?.databaseResetID = UUID()
 	}
 
 	/// When event firmware is detected (DEFCON, BURNING_MAN, OPEN_SAUCE, etc.),

--- a/Meshtastic/Persistence/NodeRenumber.swift
+++ b/Meshtastic/Persistence/NodeRenumber.swift
@@ -1,0 +1,104 @@
+//
+//  NodeRenumber.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 9/2/26.
+//
+
+import Foundation
+import SwiftData
+import OSLog
+
+/// Moves everything the app stored for one node number onto another.
+///
+/// A radio that upgrades to 2.8 comes back with a different node number. It is the same
+/// radio, and everything the app holds for it — messages, positions, telemetry, settings,
+/// trace routes — is keyed to the number it used to report. Without this the app sees a
+/// stranger where its own radio used to be.
+enum NodeRenumber {
+
+	/// Rewrites every reference to `oldNum` as `newNum`. Expects to run before any data for
+	/// `newNum` is ingested, and saves the context itself.
+	@discardableResult
+	static func apply(from oldNum: Int64, to newNum: Int64, in context: ModelContext) -> Bool {
+		guard oldNum != newNum, oldNum != 0, newNum != 0 else { return false }
+
+		foldExistingRows(from: oldNum, to: newNum, in: context)
+
+		// The node itself.
+		if let user = fetchUser(num: oldNum, in: context) {
+			user.num = newNum
+			user.userId = newNum.toHex()
+			user.numString = String(newNum)
+		}
+		if let node = fetchNode(num: oldNum, in: context) {
+			node.num = newNum
+			node.id = newNum
+		}
+		for myInfo in fetchAll(MyInfoEntity.self, in: context) where myInfo.myNodeNum == oldNum {
+			myInfo.myNodeNum = newNum
+		}
+
+		// Everything that stores a node number loose rather than as a relationship.
+		for route in fetchAll(TraceRouteEntity.self, in: context) {
+			if route.fromNum == oldNum { route.fromNum = newNum }
+			if route.toNum == oldNum { route.toNum = newNum }
+			for hop in route.hops where hop.num == oldNum { hop.num = newNum }
+			for snapshot in route.nodePositions where snapshot.num == oldNum { snapshot.num = newNum }
+		}
+		let relayed = (try? context.fetch(
+			FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.relayNode == oldNum })
+		)) ?? []
+		for message in relayed { message.relayNode = newNum }
+		for waypoint in fetchAll(WaypointEntity.self, in: context) {
+			if waypoint.createdBy == oldNum { waypoint.createdBy = newNum }
+			if waypoint.lastUpdatedBy == oldNum { waypoint.lastUpdatedBy = newNum }
+		}
+		for discovered in fetchAll(DiscoveredNodeEntity.self, in: context) where discovered.nodeNum == oldNum {
+			discovered.nodeNum = newNum
+		}
+		for beacon in fetchAll(DiscoveredBeaconEntity.self, in: context) where beacon.nodeNum == oldNum {
+			beacon.nodeNum = newNum
+		}
+
+		do {
+			try context.save()
+			Logger.data.info("💾 [Database] Renumbered \(oldNum.toHex(), privacy: .public) to \(newNum.toHex(), privacy: .public)")
+			return true
+		} catch {
+			Logger.data.error("💾 [Database] Renumbering \(oldNum.toHex(), privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+			return false
+		}
+	}
+
+	/// The app can hear a radio on the mesh before it connects to it, so the new number may
+	/// already have rows of its own. They have to go before the rewrite, because `num` is
+	/// unique — but their messages move to the surviving node first so none are orphaned.
+	private static func foldExistingRows(from oldNum: Int64, to newNum: Int64, in context: ModelContext) {
+		guard let keeper = fetchUser(num: oldNum, in: context) else { return }
+
+		if let duplicate = fetchUser(num: newNum, in: context), duplicate !== keeper {
+			for message in duplicate.sentMessages { message.fromUser = keeper }
+			for message in duplicate.receivedMessages { message.toUser = keeper }
+			context.delete(duplicate)
+		}
+		if let duplicateNode = fetchNode(num: newNum, in: context), duplicateNode !== keeper.userNode {
+			context.delete(duplicateNode)
+		}
+		try? context.save()
+	}
+
+	// MARK: - Fetch helpers
+
+	private static func fetchUser(num: Int64, in context: ModelContext) -> UserEntity? {
+		try? context.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == num })).first
+	}
+
+	private static func fetchNode(num: Int64, in context: ModelContext) -> NodeInfoEntity? {
+		try? context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })).first
+	}
+
+	private static func fetchAll<T: PersistentModel>(_ type: T.Type, in context: ModelContext) -> [T] {
+		(try? context.fetch(FetchDescriptor<T>())) ?? []
+	}
+}

--- a/Meshtastic/Persistence/NodeRenumber.swift
+++ b/Meshtastic/Persistence/NodeRenumber.swift
@@ -23,82 +23,91 @@ enum NodeRenumber {
 	static func apply(from oldNum: Int64, to newNum: Int64, in context: ModelContext) -> Bool {
 		guard oldNum != newNum, oldNum != 0, newNum != 0 else { return false }
 
-		foldExistingRows(from: oldNum, to: newNum, in: context)
-
-		// The node itself.
-		if let user = fetchUser(num: oldNum, in: context) {
-			user.num = newNum
-			user.userId = newNum.toHex()
-			user.numString = String(newNum)
-		}
-		if let node = fetchNode(num: oldNum, in: context) {
-			node.num = newNum
-			node.id = newNum
-		}
-		for myInfo in fetchAll(MyInfoEntity.self, in: context) where myInfo.myNodeNum == oldNum {
-			myInfo.myNodeNum = newNum
-		}
-
-		// Everything that stores a node number loose rather than as a relationship.
-		for route in fetchAll(TraceRouteEntity.self, in: context) {
-			if route.fromNum == oldNum { route.fromNum = newNum }
-			if route.toNum == oldNum { route.toNum = newNum }
-			for hop in route.hops where hop.num == oldNum { hop.num = newNum }
-			for snapshot in route.nodePositions where snapshot.num == oldNum { snapshot.num = newNum }
-		}
-		let relayed = (try? context.fetch(
-			FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.relayNode == oldNum })
-		)) ?? []
-		for message in relayed { message.relayNode = newNum }
-		for waypoint in fetchAll(WaypointEntity.self, in: context) {
-			if waypoint.createdBy == oldNum { waypoint.createdBy = newNum }
-			if waypoint.lastUpdatedBy == oldNum { waypoint.lastUpdatedBy = newNum }
-		}
-		for discovered in fetchAll(DiscoveredNodeEntity.self, in: context) where discovered.nodeNum == oldNum {
-			discovered.nodeNum = newNum
-		}
-		for beacon in fetchAll(DiscoveredBeaconEntity.self, in: context) where beacon.nodeNum == oldNum {
-			beacon.nodeNum = newNum
-		}
-
 		do {
+			try rewrite(from: oldNum, to: newNum, in: context)
 			try context.save()
 			Logger.data.info("💾 [Database] Renumbered \(oldNum.toHex(), privacy: .public) to \(newNum.toHex(), privacy: .public)")
 			return true
 		} catch {
+			// The whole rewrite lands in the one save above, so a failure anywhere — a fetch
+			// as much as the save — leaves the store on the old number instead of half moved.
+			// The rollback drops the edits still sitting unsaved in the context; without it the
+			// next unrelated save would commit them.
+			context.rollback()
 			Logger.data.error("💾 [Database] Renumbering \(oldNum.toHex(), privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
 			return false
 		}
 	}
 
-	/// The app can hear a radio on the mesh before it connects to it, so the new number may
-	/// already have rows of its own. They have to go before the rewrite, because `num` is
-	/// unique — but their messages move to the surviving node first so none are orphaned.
-	private static func foldExistingRows(from oldNum: Int64, to newNum: Int64, in context: ModelContext) {
-		guard let keeper = fetchUser(num: oldNum, in: context) else { return }
+	/// Stages every edit in the context without saving, so the caller can commit or discard
+	/// the whole rewrite at once.
+	private static func rewrite(from oldNum: Int64, to newNum: Int64, in context: ModelContext) throws {
+		try foldExistingRows(from: oldNum, to: newNum, in: context)
 
-		if let duplicate = fetchUser(num: newNum, in: context), duplicate !== keeper {
+		// The node itself.
+		if let user = try fetchUser(num: oldNum, in: context) {
+			user.num = newNum
+			user.userId = newNum.toHex()
+			user.numString = String(newNum)
+		}
+		if let node = try fetchNode(num: oldNum, in: context) {
+			node.num = newNum
+			node.id = newNum
+		}
+		for myInfo in try fetchAll(MyInfoEntity.self, in: context) where myInfo.myNodeNum == oldNum {
+			myInfo.myNodeNum = newNum
+		}
+
+		// Everything that stores a node number loose rather than as a relationship.
+		for route in try fetchAll(TraceRouteEntity.self, in: context) {
+			if route.fromNum == oldNum { route.fromNum = newNum }
+			if route.toNum == oldNum { route.toNum = newNum }
+			for hop in route.hops where hop.num == oldNum { hop.num = newNum }
+			for snapshot in route.nodePositions where snapshot.num == oldNum { snapshot.num = newNum }
+		}
+		let relayed = try context.fetch(
+			FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.relayNode == oldNum })
+		)
+		for message in relayed { message.relayNode = newNum }
+		for waypoint in try fetchAll(WaypointEntity.self, in: context) {
+			if waypoint.createdBy == oldNum { waypoint.createdBy = newNum }
+			if waypoint.lastUpdatedBy == oldNum { waypoint.lastUpdatedBy = newNum }
+		}
+		for discovered in try fetchAll(DiscoveredNodeEntity.self, in: context) where discovered.nodeNum == oldNum {
+			discovered.nodeNum = newNum
+		}
+		for beacon in try fetchAll(DiscoveredBeaconEntity.self, in: context) where beacon.nodeNum == oldNum {
+			beacon.nodeNum = newNum
+		}
+	}
+
+	/// The app can hear a radio on the mesh before it connects to it, so the new number may
+	/// already have rows of its own. They have to go, because `num` is unique — but their
+	/// messages move to the surviving node first so none are orphaned.
+	private static func foldExistingRows(from oldNum: Int64, to newNum: Int64, in context: ModelContext) throws {
+		guard let keeper = try fetchUser(num: oldNum, in: context) else { return }
+
+		if let duplicate = try fetchUser(num: newNum, in: context), duplicate !== keeper {
 			for message in duplicate.sentMessages { message.fromUser = keeper }
 			for message in duplicate.receivedMessages { message.toUser = keeper }
 			context.delete(duplicate)
 		}
-		if let duplicateNode = fetchNode(num: newNum, in: context), duplicateNode !== keeper.userNode {
+		if let duplicateNode = try fetchNode(num: newNum, in: context), duplicateNode !== keeper.userNode {
 			context.delete(duplicateNode)
 		}
-		try? context.save()
 	}
 
 	// MARK: - Fetch helpers
 
-	private static func fetchUser(num: Int64, in context: ModelContext) -> UserEntity? {
-		try? context.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == num })).first
+	private static func fetchUser(num: Int64, in context: ModelContext) throws -> UserEntity? {
+		try context.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == num })).first
 	}
 
-	private static func fetchNode(num: Int64, in context: ModelContext) -> NodeInfoEntity? {
-		try? context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })).first
+	private static func fetchNode(num: Int64, in context: ModelContext) throws -> NodeInfoEntity? {
+		try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == num })).first
 	}
 
-	private static func fetchAll<T: PersistentModel>(_ type: T.Type, in context: ModelContext) -> [T] {
-		(try? context.fetch(FetchDescriptor<T>())) ?? []
+	private static func fetchAll<T: PersistentModel>(_ type: T.Type, in context: ModelContext) throws -> [T] {
+		try context.fetch(FetchDescriptor<T>())
 	}
 }

--- a/MeshtasticTests/NodeRenumberTests.swift
+++ b/MeshtasticTests/NodeRenumberTests.swift
@@ -1,0 +1,182 @@
+//
+//  NodeRenumberTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/2/26.
+//
+
+import Testing
+import Foundation
+import SwiftData
+@testable import Meshtastic
+
+/// A radio that upgrades to 2.8 reports a different node number. Everything the app stored
+/// for it is keyed to the old one, so it all has to move.
+@Suite("Node renumber")
+@MainActor
+struct NodeRenumberTests {
+
+	private static let oldNum: Int64 = 0x0BAD_0001
+	private static let newNum: Int64 = 0x0BAD_0002
+
+	private func makeContext() -> ModelContext {
+		ModelContext(sharedModelContainer)
+	}
+
+	@Test("Everything keyed to the old number moves to the new one")
+	func rewritesEveryReference() throws {
+		let context = makeContext()
+		let old = Self.oldNum
+		let new = Self.newNum
+
+		let user = UserEntity()
+		user.num = old
+		user.userId = old.toHex()
+		user.longName = "Test Radio"
+		context.insert(user)
+
+		let node = NodeInfoEntity()
+		node.num = old
+		node.id = old
+		node.user = user
+		context.insert(node)
+
+		let myInfo = MyInfoEntity()
+		myInfo.myNodeNum = old
+		myInfo.peripheralId = "PERIPHERAL-1"
+		context.insert(myInfo)
+
+		let message = MessageEntity()
+		message.messageId = 90_001
+		message.messagePayload = "sent before the upgrade"
+		message.relayNode = old
+		message.fromUser = user
+		context.insert(message)
+
+		let route = TraceRouteEntity()
+		route.id = 90_002
+		route.fromNum = old
+		route.toNum = 42
+		context.insert(route)
+
+		let hop = TraceRouteHopEntity()
+		hop.num = old
+		hop.traceRoute = route
+		context.insert(hop)
+
+		let snapshot = TraceRouteNodePositionEntity()
+		snapshot.num = old
+		snapshot.traceRoute = route
+		context.insert(snapshot)
+
+		let waypoint = WaypointEntity()
+		waypoint.id = 90_003
+		waypoint.createdBy = old
+		waypoint.lastUpdatedBy = old
+		context.insert(waypoint)
+
+		try context.save()
+
+		#expect(NodeRenumber.apply(from: old, to: new, in: context))
+
+		#expect(user.num == new)
+		#expect(user.userId == new.toHex())
+		#expect(user.numString == String(new))
+		#expect(node.num == new)
+		#expect(node.id == new)
+		#expect(myInfo.myNodeNum == new)
+		#expect(message.relayNode == new)
+		#expect(route.fromNum == new)
+		#expect(route.toNum == 42, "an unrelated node number is left alone")
+		#expect(hop.num == new)
+		#expect(snapshot.num == new)
+		#expect(waypoint.createdBy == new)
+		#expect(waypoint.lastUpdatedBy == new)
+		// The node keeps its history rather than starting over.
+		#expect(user.sentMessages.contains { $0.messageId == 90_001 })
+
+		cleanUp(context)
+	}
+
+	@Test("Rows already stored under the new number are folded in, not orphaned")
+	func foldsRowsAlreadyUnderTheNewNumber() throws {
+		let context = makeContext()
+		let old = Self.oldNum + 0x10
+		let new = Self.newNum + 0x10
+
+		let keeper = UserEntity()
+		keeper.num = old
+		keeper.userId = old.toHex()
+		context.insert(keeper)
+
+		let keeperNode = NodeInfoEntity()
+		keeperNode.num = old
+		keeperNode.id = old
+		keeperNode.user = keeper
+		context.insert(keeperNode)
+
+		// The app heard the radio on the mesh under its new number before connecting to it.
+		let heardOnMesh = UserEntity()
+		heardOnMesh.num = new
+		heardOnMesh.userId = new.toHex()
+		context.insert(heardOnMesh)
+
+		let heardNode = NodeInfoEntity()
+		heardNode.num = new
+		heardNode.id = new
+		heardNode.user = heardOnMesh
+		context.insert(heardNode)
+
+		let recent = MessageEntity()
+		recent.messageId = 90_010
+		recent.messagePayload = "arrived after the upgrade"
+		recent.fromUser = heardOnMesh
+		context.insert(recent)
+
+		try context.save()
+
+		#expect(NodeRenumber.apply(from: old, to: new, in: context))
+
+		let users = try context.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == new }))
+		#expect(users.count == 1, "one node, not two")
+		let nodes = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == new }))
+		#expect(nodes.count == 1)
+
+		let survivor = try context.fetch(FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.messageId == 90_010 })).first
+		#expect(survivor != nil, "the message that arrived under the new number is kept")
+		#expect(survivor?.fromUser?.num == new)
+
+		cleanUp(context)
+	}
+
+	@Test("Refuses a no-op or a zero node number")
+	func refusesNonsense() {
+		let context = makeContext()
+		#expect(!NodeRenumber.apply(from: 5, to: 5, in: context))
+		#expect(!NodeRenumber.apply(from: 0, to: 5, in: context))
+		#expect(!NodeRenumber.apply(from: 5, to: 0, in: context))
+	}
+
+	/// The container is shared with every other suite, so leave nothing behind.
+	private func cleanUp(_ context: ModelContext) {
+		for user in (try? context.fetch(FetchDescriptor<UserEntity>())) ?? [] where user.num > 0x0BAD_0000 && user.num < 0x0BAE_0000 {
+			context.delete(user)
+		}
+		for node in (try? context.fetch(FetchDescriptor<NodeInfoEntity>())) ?? [] where node.num > 0x0BAD_0000 && node.num < 0x0BAE_0000 {
+			context.delete(node)
+		}
+		for myInfo in (try? context.fetch(FetchDescriptor<MyInfoEntity>())) ?? [] where myInfo.myNodeNum > 0x0BAD_0000 && myInfo.myNodeNum < 0x0BAE_0000 {
+			context.delete(myInfo)
+		}
+		for message in (try? context.fetch(FetchDescriptor<MessageEntity>())) ?? [] where message.messageId >= 90_000 && message.messageId < 91_000 {
+			context.delete(message)
+		}
+		for route in (try? context.fetch(FetchDescriptor<TraceRouteEntity>())) ?? [] where route.id >= 90_000 && route.id < 91_000 {
+			context.delete(route)
+		}
+		for waypoint in (try? context.fetch(FetchDescriptor<WaypointEntity>())) ?? [] where waypoint.id >= 90_000 && waypoint.id < 91_000 {
+			context.delete(waypoint)
+		}
+		try? context.save()
+	}
+}

--- a/MeshtasticTests/NodeRenumberTests.swift
+++ b/MeshtasticTests/NodeRenumberTests.swift
@@ -26,6 +26,7 @@ struct NodeRenumberTests {
 	@Test("Everything keyed to the old number moves to the new one")
 	func rewritesEveryReference() throws {
 		let context = makeContext()
+		defer { cleanUp(context) }
 		let old = Self.oldNum
 		let new = Self.newNum
 
@@ -75,6 +76,15 @@ struct NodeRenumberTests {
 		waypoint.lastUpdatedBy = old
 		context.insert(waypoint)
 
+		// Heard during a discovery scan, before the upgrade.
+		let discovered = DiscoveredNodeEntity()
+		discovered.nodeNum = old
+		context.insert(discovered)
+
+		let beacon = DiscoveredBeaconEntity()
+		beacon.nodeNum = old
+		context.insert(beacon)
+
 		try context.save()
 
 		#expect(NodeRenumber.apply(from: old, to: new, in: context))
@@ -92,21 +102,34 @@ struct NodeRenumberTests {
 		#expect(snapshot.num == new)
 		#expect(waypoint.createdBy == new)
 		#expect(waypoint.lastUpdatedBy == new)
+		#expect(discovered.nodeNum == new)
+		#expect(beacon.nodeNum == new)
 		// The node keeps its history rather than starting over.
 		#expect(user.sentMessages.contains { $0.messageId == 90_001 })
 
-		cleanUp(context)
+		// Read it back from a context that saw none of the edits, so this proves the rewrite
+		// was written to the store rather than just applied to instances in memory.
+		let fresh = makeContext()
+		let stored = try fresh.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == new }))
+		#expect(stored.count == 1)
+		#expect(stored.first?.longName == "Test Radio")
+		let storedRoute = try fresh.fetch(FetchDescriptor<TraceRouteEntity>(predicate: #Predicate { $0.id == 90_002 })).first
+		#expect(storedRoute?.fromNum == new)
+		let goneUnderOldNumber = try fresh.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == old }))
+		#expect(goneUnderOldNumber.isEmpty)
 	}
 
 	@Test("Rows already stored under the new number are folded in, not orphaned")
 	func foldsRowsAlreadyUnderTheNewNumber() throws {
 		let context = makeContext()
+		defer { cleanUp(context) }
 		let old = Self.oldNum + 0x10
 		let new = Self.newNum + 0x10
 
 		let keeper = UserEntity()
 		keeper.num = old
 		keeper.userId = old.toHex()
+		keeper.longName = "The Radio With The History"
 		context.insert(keeper)
 
 		let keeperNode = NodeInfoEntity()
@@ -119,6 +142,7 @@ struct NodeRenumberTests {
 		let heardOnMesh = UserEntity()
 		heardOnMesh.num = new
 		heardOnMesh.userId = new.toHex()
+		heardOnMesh.longName = "Heard On Mesh"
 		context.insert(heardOnMesh)
 
 		let heardNode = NodeInfoEntity()
@@ -133,40 +157,74 @@ struct NodeRenumberTests {
 		recent.fromUser = heardOnMesh
 		context.insert(recent)
 
+		let addressed = MessageEntity()
+		addressed.messageId = 90_011
+		addressed.messagePayload = "sent to it after the upgrade"
+		addressed.toUser = heardOnMesh
+		context.insert(addressed)
+
 		try context.save()
 
 		#expect(NodeRenumber.apply(from: old, to: new, in: context))
 
-		let users = try context.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == new }))
+		let fresh = makeContext()
+		let users = try fresh.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == new }))
 		#expect(users.count == 1, "one node, not two")
-		let nodes = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == new }))
+		#expect(users.first?.longName == "The Radio With The History", "the row with the history is the one that survives")
+		let nodes = try fresh.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == new }))
 		#expect(nodes.count == 1)
 
-		let survivor = try context.fetch(FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.messageId == 90_010 })).first
-		#expect(survivor != nil, "the message that arrived under the new number is kept")
-		#expect(survivor?.fromUser?.num == new)
+		let sent = try fresh.fetch(FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.messageId == 90_010 })).first
+		#expect(sent != nil, "the message that arrived under the new number is kept")
+		#expect(sent?.fromUser?.num == new)
+		#expect(sent?.fromUser?.longName == "The Radio With The History")
 
-		cleanUp(context)
+		let received = try fresh.fetch(FetchDescriptor<MessageEntity>(predicate: #Predicate { $0.messageId == 90_011 })).first
+		#expect(received != nil, "a message addressed to the new number is kept too")
+		#expect(received?.toUser?.num == new)
+		#expect(received?.toUser?.longName == "The Radio With The History")
 	}
 
 	@Test("Refuses a no-op or a zero node number")
-	func refusesNonsense() {
+	func refusesNonsense() throws {
 		let context = makeContext()
-		#expect(!NodeRenumber.apply(from: 5, to: 5, in: context))
-		#expect(!NodeRenumber.apply(from: 0, to: 5, in: context))
-		#expect(!NodeRenumber.apply(from: 5, to: 0, in: context))
+		defer { cleanUp(context) }
+
+		let user = UserEntity()
+		user.num = Self.oldNum + 0x20
+		user.userId = user.num.toHex()
+		context.insert(user)
+		try context.save()
+
+		let seeded = user.num
+		#expect(!NodeRenumber.apply(from: seeded, to: seeded, in: context))
+		#expect(!NodeRenumber.apply(from: 0, to: seeded, in: context))
+		#expect(!NodeRenumber.apply(from: seeded, to: 0, in: context))
+
+		// A refused call changes nothing.
+		#expect(user.num == seeded)
+		let fresh = makeContext()
+		let stored = try fresh.fetch(FetchDescriptor<UserEntity>(predicate: #Predicate { $0.num == seeded }))
+		#expect(stored.count == 1, "the seeded row is still there under its own number")
 	}
 
 	/// The container is shared with every other suite, so leave nothing behind.
 	private func cleanUp(_ context: ModelContext) {
-		for user in (try? context.fetch(FetchDescriptor<UserEntity>())) ?? [] where user.num > 0x0BAD_0000 && user.num < 0x0BAE_0000 {
+		let range: (Int64) -> Bool = { $0 > 0x0BAD_0000 && $0 < 0x0BAE_0000 }
+		for user in (try? context.fetch(FetchDescriptor<UserEntity>())) ?? [] where range(user.num) {
 			context.delete(user)
 		}
-		for node in (try? context.fetch(FetchDescriptor<NodeInfoEntity>())) ?? [] where node.num > 0x0BAD_0000 && node.num < 0x0BAE_0000 {
+		for node in (try? context.fetch(FetchDescriptor<NodeInfoEntity>())) ?? [] where range(node.num) {
 			context.delete(node)
 		}
-		for myInfo in (try? context.fetch(FetchDescriptor<MyInfoEntity>())) ?? [] where myInfo.myNodeNum > 0x0BAD_0000 && myInfo.myNodeNum < 0x0BAE_0000 {
+		for myInfo in (try? context.fetch(FetchDescriptor<MyInfoEntity>())) ?? [] where range(myInfo.myNodeNum) {
 			context.delete(myInfo)
+		}
+		for discovered in (try? context.fetch(FetchDescriptor<DiscoveredNodeEntity>())) ?? [] where range(discovered.nodeNum) {
+			context.delete(discovered)
+		}
+		for beacon in (try? context.fetch(FetchDescriptor<DiscoveredBeaconEntity>())) ?? [] where range(beacon.nodeNum) {
+			context.delete(beacon)
 		}
 		for message in (try? context.fetch(FetchDescriptor<MessageEntity>())) ?? [] where message.messageId >= 90_000 && message.messageId < 91_000 {
 			context.delete(message)


### PR DESCRIPTION
## Summary

A radio that upgrades to 2.8 comes back reporting a different node number. The
app saw a node number it had never met, decided the connect had landed on
another radio's database, and backed up and wiped the store. Everything held
for that radio — messages, positions, telemetry, settings, trace routes — was
keyed to the old number and had to be downloaded again.

## What changed

The MyInfo row records the peripheral it came from. A connect whose peripheral
matches the store is the same radio under a new number, not a different radio.
In that case the store is renumbered instead of reset, rewriting every
reference to the old number:

- the node and its user, including the `!hex` id
- MyInfo
- trace route endpoints, hops and position snapshots
- relay nodes on messages
- waypoint authorship
- discovered node and beacon records

The new number can already be in the store, because the app can hear a radio on
the mesh before it connects to it. Those rows are folded into the node being
renumbered, their messages moved across first, since the number is unique.

A backup is still taken before the rewrite, detail views are popped first so
nothing is bound to the old identity while it changes, and a store with no
peripheral recorded still falls back to the old backup-and-reset path. If the
rewrite fails the store is left alone and the radio arrives as a new node,
which is what happened before this existed.

## Testing

New tests cover the rewrite, the fold of rows already stored under the new
number, and the refusal of a no-op or zero number. Full suite passes.

Seen live: a device upgraded to 2.8 and the app wiped and rebuilt its database
on the next connect. That is the case this removes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a connected radio appears under a new node number.
  * Existing radio data is now preserved and reassigned instead of being unnecessarily backed up and reset.
  * Related messages, routes, waypoints, telemetry records, settings, and other references are migrated to the new node number.
  * Duplicate records are consolidated during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->