### PR TITLE
Explain a refused firmware update instead of timing out on it

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -70,6 +70,15 @@ extension AccessoryManager {
 		// Always log, whether or not the user is alerted — Debug Logs stays complete.
 		Logger.services.error("⚠️ Client Notification: \(clientNotification.message, privacy: .private)")
 
+		// The radio answers an OTA request with one of these, and it is the only place it says
+		// why it would not start. Log it in the clear — it names a hardware capability, not
+		// anything about the user — and hand it to the update sheet, which otherwise sits there
+		// until it times out waiting for a device that never rebooted.
+		if clientNotification.message.contains("OTA") {
+			Logger.services.error("📡 [ESP32 OTA] Radio says: \(clientNotification.message, privacy: .public)")
+			NotificationCenter.default.post(name: .otaDeviceNotice, object: clientNotification.message)
+		}
+
 		let key = Self.noticeKey(for: clientNotification)
 		guard shouldSurfaceFirmwareNotice(key: key, isSecurity: Self.isSecurityNotice(clientNotification)) else {
 			Logger.services.debug("⏳ Firmware notification suppressed by backoff: \(key, privacy: .private)")

--- a/Meshtastic/AppState.swift
+++ b/Meshtastic/AppState.swift
@@ -22,6 +22,13 @@ extension NSNotification.Name {
 	/// (NSNotification.Name, not Notification.Name — the app defines its own
 	/// `Notification` model type which shadows Foundation's in some files.)
 	static let meshMessagesDidChange = NSNotification.Name("MeshMessagesDidChange")
+
+	/// Posted when the radio reports something about a firmware update it was asked to start.
+	/// The firmware answers an OTA request with a client notification saying what it did —
+	/// rebooting into update mode, or why it would not: no OTA loader, a loader that does not
+	/// do this transport, a bad hash. The update sheet shows it instead of waiting to time out
+	/// on a device that was never coming. The message is the notification object.
+	static let otaDeviceNotice = NSNotification.Name("OTADeviceNotice")
 }
 
 class AppState: ObservableObject {

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
@@ -65,6 +65,17 @@ struct ESP32BLEOTASheet: View {
 		.onReceive(NotificationCenter.default.publisher(for: .otaDeviceNotice)) { notice in
 			guard let message = notice.object as? String else { return }
 			ota.handleDeviceNotice(message)
+			guard ota.deviceRefusal != nil else { return }
+			// The radio is not going into update mode, so there is nothing left to wait for.
+			// Without this the transfer keeps scanning for a device that will never appear.
+			otaTask?.cancel()
+			otaTask = nil
+			// It refused, which means it did not reboot — whatever the reboot command
+			// returned. Retry has to ask again rather than transfer to a radio still running
+			// its normal firmware. Only cleared here: a refusal is the one case where we know
+			// the reboot did not happen, and a failure after a successful reboot must not
+			// re-send it, since by then the mesh connection is gone.
+			rebootSuccessful = false
 		}
 		.onDisappear {
 			otaTask?.cancel()

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTASheet.swift
@@ -62,6 +62,10 @@ struct ESP32BLEOTASheet: View {
 				self.peripheral = await connection.peripheral
 			}
 		}
+		.onReceive(NotificationCenter.default.publisher(for: .otaDeviceNotice)) { notice in
+			guard let message = notice.object as? String else { return }
+			ota.handleDeviceNotice(message)
+		}
 		.onDisappear {
 			otaTask?.cancel()
 			otaTask = nil

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
@@ -40,10 +40,26 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 	
 	// MARK: - User Actions
 	
+	/// What the radio said about the update it was asked to start. A refusal arrives while
+	/// the app is still waiting for the device to show up in OTA mode, and it is a far better
+	/// error than the timeout that would otherwise be reported.
+	@Published private(set) var deviceRefusal: String?
+
 	func retry() {
 		self.transferProgress = 0
 		self.statusMessage = ""
+		self.deviceRefusal = nil
 		self.otaStatus = .idle
+	}
+
+	/// The radio sends one of these on its way into update mode as well as when it refuses,
+	/// so only a message that is not about rebooting ends the update.
+	func handleDeviceNotice(_ message: String) {
+		guard otaStatus != .completed, otaStatus != .error else { return }
+		statusMessage = message
+		guard !message.localizedCaseInsensitiveContains("rebooting to") else { return }
+		deviceRefusal = message
+		otaStatus = .error
 	}
 	
 	func startOTA(binURL: URL, desiredPeripheral: UUID?) async {
@@ -53,6 +69,8 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 			UIApplication.shared.isIdleTimerDisabled = false
 		}
 		
+		deviceRefusal = nil
+
 		do {
 			// --- 1. Connection Phase ---
 			self.statusMessage = "Connecting..."
@@ -222,8 +240,10 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 			ble.disconnect(peripheral)
 		} catch {
 			self.otaStatus = .error
-			self.statusMessage = error.localizedDescription
-			Logger.services.error("OTA Failed: \(error.localizedDescription)")
+			// The radio's own reason beats "the device never advertised in OTA mode", which is
+			// only ever the symptom of it.
+			self.statusMessage = deviceRefusal ?? error.localizedDescription
+			Logger.services.error("OTA Failed: \(self.statusMessage, privacy: .public)")
 		}
 		
 		UIApplication.shared.isIdleTimerDisabled = false

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
@@ -56,9 +56,10 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 	/// so only a message that is not about rebooting ends the update.
 	func handleDeviceNotice(_ message: String) {
 		guard otaStatus != .completed, otaStatus != .error else { return }
-		statusMessage = message
+		let shown = OTARefusal.explanation(for: message) ?? message
+		statusMessage = shown
 		guard !message.localizedCaseInsensitiveContains("rebooting to") else { return }
-		deviceRefusal = message
+		deviceRefusal = shown
 		otaStatus = .error
 	}
 	

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/BLE/ESP32BLEOTAViewModel.swift
@@ -45,22 +45,34 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 	/// error than the timeout that would otherwise be reported.
 	@Published private(set) var deviceRefusal: String?
 
+	/// The last thing the radio said about this update, recognized or not. A message we
+	/// cannot classify does not end the update, but if the update then fails anyway the
+	/// radio's own words are a better error than the timeout.
+	private var lastDeviceNotice: String?
+
 	func retry() {
 		self.transferProgress = 0
 		self.statusMessage = ""
 		self.deviceRefusal = nil
+		self.lastDeviceNotice = nil
 		self.otaStatus = .idle
 	}
 
-	/// The radio sends one of these on its way into update mode as well as when it refuses,
-	/// so only a message that is not about rebooting ends the update.
 	func handleDeviceNotice(_ message: String) {
 		guard otaStatus != .completed, otaStatus != .error else { return }
-		let shown = OTARefusal.explanation(for: message) ?? message
-		statusMessage = shown
-		guard !message.localizedCaseInsensitiveContains("rebooting to") else { return }
-		deviceRefusal = shown
-		otaStatus = .error
+		lastDeviceNotice = message
+		switch OTARefusal.classify(message) {
+		case .refused(let explanation):
+			statusMessage = explanation
+			deviceRefusal = explanation
+			otaStatus = .error
+		case .progress(let text):
+			statusMessage = text
+		case nil:
+			// Not a sentence we know. Show it, but leave the update running: it may be
+			// unrelated, and firmware wording changes.
+			statusMessage = message
+		}
 	}
 	
 	func startOTA(binURL: URL, desiredPeripheral: UUID?) async {
@@ -71,6 +83,7 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 		}
 		
 		deviceRefusal = nil
+		lastDeviceNotice = nil
 
 		do {
 			// --- 1. Connection Phase ---
@@ -243,7 +256,7 @@ final class ESP32BLEOTAViewModel: ObservableObject {
 			self.otaStatus = .error
 			// The radio's own reason beats "the device never advertised in OTA mode", which is
 			// only ever the symptom of it.
-			self.statusMessage = deviceRefusal ?? error.localizedDescription
+			self.statusMessage = deviceRefusal ?? lastDeviceNotice ?? error.localizedDescription
 			Logger.services.error("OTA Failed: \(self.statusMessage, privacy: .public)")
 		}
 		

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
@@ -71,6 +71,15 @@ struct ESP32WifiOTASheet: View {
 		.onReceive(NotificationCenter.default.publisher(for: .otaDeviceNotice)) { notice in
 			guard let message = notice.object as? String else { return }
 			ota.handleDeviceNotice(message)
+			guard ota.deviceRefusal != nil else { return }
+			// The radio is not going into update mode, so there is nothing left to wait for.
+			otaTask?.cancel()
+			otaTask = nil
+			// It refused, which means it did not reboot — whatever the reboot command
+			// returned. Retry has to ask again rather than transfer to a radio still running
+			// its normal firmware. Only cleared here: a failure after a successful reboot
+			// must not re-send it, since by then the mesh connection is gone.
+			alreadyRebooted = false
 		}
 		.onDisappear {
 			otaTask?.cancel()

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTASheet.swift
@@ -68,6 +68,10 @@ struct ESP32WifiOTASheet: View {
 				self.host = await connection.host.stringValue
 			}
 		}
+		.onReceive(NotificationCenter.default.publisher(for: .otaDeviceNotice)) { notice in
+			guard let message = notice.object as? String else { return }
+			ota.handleDeviceNotice(message)
+		}
 		.onDisappear {
 			otaTask?.cancel()
 			otaTask = nil

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTAViewModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTAViewModel.swift
@@ -42,10 +42,11 @@ class ESP32WifiOTAViewModel: ObservableObject {
 	/// so only a message that is not about rebooting ends the update.
 	func handleDeviceNotice(_ message: String) {
 		guard otaState != .completed, otaState != .error else { return }
-		statusMessage = message
+		let shown = OTARefusal.explanation(for: message) ?? message
+		statusMessage = shown
 		guard !message.localizedCaseInsensitiveContains("rebooting to") else { return }
-		deviceRefusal = message
-		errorMessage = message
+		deviceRefusal = shown
+		errorMessage = shown
 		otaState = .error
 	}
 	

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTAViewModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTAViewModel.swift
@@ -30,24 +30,36 @@ class ESP32WifiOTAViewModel: ObservableObject {
 	/// better error than the timeout that would otherwise be reported.
 	@Published private(set) var deviceRefusal: String?
 
+	/// The last thing the radio said about this update, recognized or not. A message we
+	/// cannot classify does not end the update, but if the update then fails anyway the
+	/// radio's own words are a better error than the timeout.
+	private var lastDeviceNotice: String?
+
 	func retry() {
 		self.progress = 0
 		self.statusMessage = "Idle"
 		self.errorMessage = nil
 		self.deviceRefusal = nil
+		self.lastDeviceNotice = nil
 		self.otaState = .idle
 	}
 
-	/// The radio sends one of these on its way into update mode as well as when it refuses,
-	/// so only a message that is not about rebooting ends the update.
 	func handleDeviceNotice(_ message: String) {
 		guard otaState != .completed, otaState != .error else { return }
-		let shown = OTARefusal.explanation(for: message) ?? message
-		statusMessage = shown
-		guard !message.localizedCaseInsensitiveContains("rebooting to") else { return }
-		deviceRefusal = shown
-		errorMessage = shown
-		otaState = .error
+		lastDeviceNotice = message
+		switch OTARefusal.classify(message) {
+		case .refused(let explanation):
+			statusMessage = explanation
+			errorMessage = explanation
+			deviceRefusal = explanation
+			otaState = .error
+		case .progress(let text):
+			statusMessage = text
+		case nil:
+			// Not a sentence we know. Show it, but leave the update running: it may be
+			// unrelated, and firmware wording changes.
+			statusMessage = message
+		}
 	}
 	
 	func startUpdate(host: String? = nil, firmwareUrl: URL, password: String? = nil) async {
@@ -61,6 +73,7 @@ class ESP32WifiOTAViewModel: ObservableObject {
 		progress = 0.0
 		errorMessage = nil
 		deviceRefusal = nil
+		lastDeviceNotice = nil
 		statusMessage = "Starting..."
 		otaState = .waitingForConnection
 		
@@ -102,7 +115,7 @@ class ESP32WifiOTAViewModel: ObservableObject {
 			
 		} catch {
 			// The radio's own reason beats the timeout, which is only ever the symptom of it.
-			let reason = deviceRefusal ?? error.localizedDescription
+			let reason = deviceRefusal ?? lastDeviceNotice ?? error.localizedDescription
 			Logger.services.error("[ESP OTA] Error: \(reason, privacy: .public)")
 			errorMessage = reason
 			statusMessage = deviceRefusal ?? "Failed"

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTAViewModel.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/WiFi/ESP32WifiOTAViewModel.swift
@@ -25,11 +25,28 @@ class ESP32WifiOTAViewModel: ObservableObject {
 	
 	// MARK: - Public Interface
 	
+	/// What the radio said about the update it was asked to start. A refusal arrives while
+	/// the app is still waiting for the device to come up in update mode, and it is a far
+	/// better error than the timeout that would otherwise be reported.
+	@Published private(set) var deviceRefusal: String?
+
 	func retry() {
 		self.progress = 0
 		self.statusMessage = "Idle"
 		self.errorMessage = nil
+		self.deviceRefusal = nil
 		self.otaState = .idle
+	}
+
+	/// The radio sends one of these on its way into update mode as well as when it refuses,
+	/// so only a message that is not about rebooting ends the update.
+	func handleDeviceNotice(_ message: String) {
+		guard otaState != .completed, otaState != .error else { return }
+		statusMessage = message
+		guard !message.localizedCaseInsensitiveContains("rebooting to") else { return }
+		deviceRefusal = message
+		errorMessage = message
+		otaState = .error
 	}
 	
 	func startUpdate(host: String? = nil, firmwareUrl: URL, password: String? = nil) async {
@@ -42,6 +59,7 @@ class ESP32WifiOTAViewModel: ObservableObject {
 		
 		progress = 0.0
 		errorMessage = nil
+		deviceRefusal = nil
 		statusMessage = "Starting..."
 		otaState = .waitingForConnection
 		
@@ -82,9 +100,11 @@ class ESP32WifiOTAViewModel: ObservableObject {
 			Logger.services.info("[ESP OTA] Update Complete")
 			
 		} catch {
-			Logger.services.error("[ESP OTA] Error: \(error.localizedDescription)")
-			errorMessage = error.localizedDescription
-			statusMessage = "Failed"
+			// The radio's own reason beats the timeout, which is only ever the symptom of it.
+			let reason = deviceRefusal ?? error.localizedDescription
+			Logger.services.error("[ESP OTA] Error: \(reason, privacy: .public)")
+			errorMessage = reason
+			statusMessage = deviceRefusal ?? "Failed"
 			otaState = .error
 		}
 	}

--- a/Meshtastic/Views/Settings/Firmware/Helpers/OTARefusal.swift
+++ b/Meshtastic/Views/Settings/Firmware/Helpers/OTARefusal.swift
@@ -17,6 +17,30 @@ import Foundation
 /// device metadata reports it, which is why the app finds out by asking.
 enum OTARefusal {
 
+	/// What a message from the radio about an update means.
+	enum Notice {
+		/// The radio will not start the update, with the reason put in the app's own words.
+		case refused(String)
+		/// The radio is on its way into update mode.
+		case progress(String)
+	}
+
+	/// Classifies a client notification that mentions OTA.
+	///
+	/// nil for anything not recognized. These sentences come from firmware source rather
+	/// than a protocol, so an unrecognized one is shown to the user but is not treated as a
+	/// refusal — matching on the substring "OTA" alone would let an unrelated notification
+	/// end an update that is going fine.
+	static func classify(_ message: String) -> Notice? {
+		if message.localizedCaseInsensitiveContains("rebooting to") {
+			return .progress(message)
+		}
+		if let explanation = explanation(for: message) {
+			return .refused(explanation)
+		}
+		return nil
+	}
+
 	/// The app's version of a firmware refusal, or nil for a message it does not recognize —
 	/// in which case the radio's own wording is shown as-is. Matching is by substring: these
 	/// come from firmware source, not a protocol, so the exact sentences change over time.

--- a/Meshtastic/Views/Settings/Firmware/Helpers/OTARefusal.swift
+++ b/Meshtastic/Views/Settings/Firmware/Helpers/OTARefusal.swift
@@ -1,0 +1,49 @@
+//
+//  OTARefusal.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 9/2/26.
+//
+
+import Foundation
+
+/// Turns the firmware's reason for refusing an update into something useful to the person
+/// holding the radio.
+///
+/// An ESP32 updates over BLE or Wi-Fi by rebooting into a small loader app kept on its
+/// second app partition. The firmware checks for that loader before it reboots and refuses
+/// if it is missing or does not do the transport being asked for — a state only a USB flash
+/// can change, so the message needs to say that rather than name a partition. Nothing in
+/// device metadata reports it, which is why the app finds out by asking.
+enum OTARefusal {
+
+	/// The app's version of a firmware refusal, or nil for a message it does not recognize —
+	/// in which case the radio's own wording is shown as-is. Matching is by substring: these
+	/// come from firmware source, not a protocol, so the exact sentences change over time.
+	static func explanation(for message: String) -> String? {
+		let text = message.lowercased()
+
+		// "Cannot find OTA Loader partition." — the flash has no room set aside for a loader.
+		if text.contains("loader partition") {
+			return String(localized: "This device has no partition for an update loader, so it cannot update over Bluetooth or Wi-Fi. Use the Web Flasher over USB.", comment: "OTA refused: the device's flash has no OTA loader partition")
+		}
+		// "Device does have a valid OTA Loader." — the partition is there but empty. The
+		// firmware means "does not"; do not repeat the wording.
+		if text.contains("valid ota loader") {
+			return String(localized: "This device does not have an update loader installed, so it cannot update over Bluetooth or Wi-Fi. A full install with the Web Flasher over USB adds one.", comment: "OTA refused: the device has no OTA loader installed")
+		}
+		// "OTA Loader does not support BLE" / "WiFi"
+		if text.contains("does not support") {
+			return String(localized: "The update loader on this device does not support this connection. A full install with the Web Flasher over USB replaces it.", comment: "OTA refused: the installed OTA loader does not support this transport")
+		}
+		// "Cannot start OTA: Invalid `ota_hash` provided."
+		if text.contains("ota_hash") {
+			return String(localized: "The device rejected the checksum for this firmware file. Try downloading it again.", comment: "OTA refused: the device rejected the firmware hash")
+		}
+		// "Unable to switch to the OTA partition."
+		if text.contains("switch to the ota partition") {
+			return String(localized: "The device could not start its update loader. Use the Web Flasher over USB.", comment: "OTA refused: the device could not boot its OTA loader")
+		}
+		return nil
+	}
+}

--- a/MeshtasticTests/OTADeviceNoticeTests.swift
+++ b/MeshtasticTests/OTADeviceNoticeTests.swift
@@ -47,13 +47,31 @@ struct OTADeviceNoticeTests {
 		}
 	}
 
-	@Test("An unrecognized message is shown as the radio sent it")
-	func unknownMessagePassesThrough() {
-		#expect(OTARefusal.explanation(for: "Something new about OTA") == nil)
+	@Test("An unrecognized message is shown but does not end the update")
+	func unknownMessageDoesNotFailTheUpdate() {
+		// Matching "OTA" alone would let an unrelated notification fail an update that is
+		// going fine, and firmware wording changes, so only sentences we recognize are
+		// treated as a refusal.
+		#expect(OTARefusal.classify("Something new about OTA") == nil)
 		let model = ESP32BLEOTAViewModel()
 		model.handleDeviceNotice("Something new about OTA")
 		#expect(model.statusMessage == "Something new about OTA")
-		#expect(model.otaStatus == .error)
+		#expect(model.otaStatus != .error)
+		#expect(model.deviceRefusal == nil)
+	}
+
+	@Test("A refusal is what ends the update, on both transports")
+	func onlyRefusalsAreTerminal() {
+		for refusal in Self.refusals {
+			guard case .refused = OTARefusal.classify(refusal) else {
+				Issue.record("\(refusal) should classify as a refusal")
+				continue
+			}
+		}
+		guard case .progress = OTARefusal.classify("Rebooting to BLE OTA") else {
+			Issue.record("going into update mode is progress, not a refusal")
+			return
+		}
 	}
 
 	@Test("Going into update mode is not a failure")
@@ -86,11 +104,28 @@ struct OTADeviceNoticeTests {
 		}
 	}
 
-	@Test("Wi-Fi ignores a notice once the update already finished")
-	func wifiIgnoresAfterCompletion() {
+	@Test("A notice arriving after the update finished changes nothing")
+	func noticeAfterCompletionIsIgnored() {
 		let model = ESP32WifiOTAViewModel()
-		model.handleDeviceNotice("Rebooting to WiFi OTA")
-		model.retry()
-		#expect(model.otaState == .idle)
+		model.otaState = .completed
+		model.statusMessage = "Success! Rebooting..."
+
+		model.handleDeviceNotice("Cannot start OTA: Cannot find OTA Loader partition.")
+
+		#expect(model.otaState == .completed, "a finished update is not undone by a late notice")
+		#expect(model.statusMessage == "Success! Rebooting...")
+		#expect(model.errorMessage == nil)
+		#expect(model.deviceRefusal == nil)
+	}
+
+	@Test("A notice arriving after a failure does not replace the failure")
+	func noticeAfterFailureIsIgnored() {
+		let model = ESP32BLEOTAViewModel()
+		model.handleDeviceNotice("OTA Loader does not support BLE")
+		let firstReason = model.deviceRefusal
+
+		model.handleDeviceNotice("Cannot start OTA: Invalid `ota_hash` provided.")
+
+		#expect(model.deviceRefusal == firstReason, "the first reason is the real one")
 	}
 }

--- a/MeshtasticTests/OTADeviceNoticeTests.swift
+++ b/MeshtasticTests/OTADeviceNoticeTests.swift
@@ -1,0 +1,74 @@
+//
+//  OTADeviceNoticeTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/2/26.
+//
+
+import Testing
+import Foundation
+@testable import Meshtastic
+
+/// The firmware answers an OTA request with a client notification saying what it did — going
+/// into update mode, or why it would not. The update sheets show that instead of waiting to
+/// time out on a device that was never coming back.
+@Suite("OTA device notices")
+@MainActor
+struct OTADeviceNoticeTests {
+
+	private static let refusals = [
+		"Cannot start OTA: Invalid `ota_hash` provided.",
+		"Cannot start OTA: Cannot find OTA Loader partition.",
+		"Cannot start OTA: Device does have a valid OTA Loader.",
+		"OTA Loader does not support BLE",
+		"Unable to switch to the OTA partition."
+	]
+
+	@Test("A refusal ends the BLE update with the radio's own words")
+	func bleRefusal() {
+		for refusal in Self.refusals {
+			let model = ESP32BLEOTAViewModel()
+			model.handleDeviceNotice(refusal)
+			#expect(model.otaStatus == .error, "\(refusal) should end the update")
+			#expect(model.statusMessage == refusal)
+			#expect(model.deviceRefusal == refusal)
+		}
+	}
+
+	@Test("Going into update mode is not a failure")
+	func bleRebootNotice() {
+		let model = ESP32BLEOTAViewModel()
+		model.handleDeviceNotice("Rebooting to BLE OTA")
+		#expect(model.otaStatus != .error)
+		#expect(model.deviceRefusal == nil)
+		#expect(model.statusMessage == "Rebooting to BLE OTA")
+	}
+
+	@Test("Retry clears the refusal")
+	func bleRetryClears() {
+		let model = ESP32BLEOTAViewModel()
+		model.handleDeviceNotice("OTA Loader does not support BLE")
+		model.retry()
+		#expect(model.deviceRefusal == nil)
+		#expect(model.otaStatus == .idle)
+	}
+
+	@Test("A refusal ends the Wi-Fi update with the radio's own words")
+	func wifiRefusal() {
+		for refusal in Self.refusals {
+			let model = ESP32WifiOTAViewModel()
+			model.handleDeviceNotice(refusal)
+			#expect(model.otaState == .error, "\(refusal) should end the update")
+			#expect(model.errorMessage == refusal)
+			#expect(model.deviceRefusal == refusal)
+		}
+	}
+
+	@Test("Wi-Fi ignores a notice once the update already finished")
+	func wifiIgnoresAfterCompletion() {
+		let model = ESP32WifiOTAViewModel()
+		model.handleDeviceNotice("Rebooting to WiFi OTA")
+		model.retry()
+		#expect(model.otaState == .idle)
+	}
+}

--- a/MeshtasticTests/OTADeviceNoticeTests.swift
+++ b/MeshtasticTests/OTADeviceNoticeTests.swift
@@ -24,15 +24,36 @@ struct OTADeviceNoticeTests {
 		"Unable to switch to the OTA partition."
 	]
 
-	@Test("A refusal ends the BLE update with the radio's own words")
+	@Test("A refusal ends the BLE update and says what it means")
 	func bleRefusal() {
 		for refusal in Self.refusals {
 			let model = ESP32BLEOTAViewModel()
 			model.handleDeviceNotice(refusal)
 			#expect(model.otaStatus == .error, "\(refusal) should end the update")
-			#expect(model.statusMessage == refusal)
-			#expect(model.deviceRefusal == refusal)
+			#expect(model.deviceRefusal == model.statusMessage)
+			#expect(model.deviceRefusal == OTARefusal.explanation(for: refusal),
+					"\(refusal) should be explained, not repeated")
 		}
+	}
+
+	@Test("Every refusal the firmware can send is explained")
+	func everyRefusalIsExplained() {
+		for refusal in Self.refusals {
+			let explanation = OTARefusal.explanation(for: refusal)
+			#expect(explanation != nil, "no explanation for: \(refusal)")
+			// The firmware's own sentence for a missing loader reads as its opposite
+			// ("Device does have a valid OTA Loader"), so it must not be passed through.
+			#expect(explanation != refusal)
+		}
+	}
+
+	@Test("An unrecognized message is shown as the radio sent it")
+	func unknownMessagePassesThrough() {
+		#expect(OTARefusal.explanation(for: "Something new about OTA") == nil)
+		let model = ESP32BLEOTAViewModel()
+		model.handleDeviceNotice("Something new about OTA")
+		#expect(model.statusMessage == "Something new about OTA")
+		#expect(model.otaStatus == .error)
 	}
 
 	@Test("Going into update mode is not a failure")
@@ -48,6 +69,7 @@ struct OTADeviceNoticeTests {
 	func bleRetryClears() {
 		let model = ESP32BLEOTAViewModel()
 		model.handleDeviceNotice("OTA Loader does not support BLE")
+		#expect(model.deviceRefusal != nil)
 		model.retry()
 		#expect(model.deviceRefusal == nil)
 		#expect(model.otaStatus == .idle)
@@ -59,8 +81,8 @@ struct OTADeviceNoticeTests {
 			let model = ESP32WifiOTAViewModel()
 			model.handleDeviceNotice(refusal)
 			#expect(model.otaState == .error, "\(refusal) should end the update")
-			#expect(model.errorMessage == refusal)
-			#expect(model.deviceRefusal == refusal)
+			#expect(model.errorMessage == OTARefusal.explanation(for: refusal))
+			#expect(model.deviceRefusal == model.errorMessage)
 		}
 	}
 


### PR DESCRIPTION
## Summary

An ESP32 OTA that never starts reported "The device never advertised in OTA
mode" after a 15 second timeout. The radio had already said why, and the app
threw the message away.

An ESP32 updates over BLE or Wi-Fi by rebooting into a small loader app kept
on its second app partition. The firmware checks for that loader before it
reboots, and if it is missing or does not do the transport being asked for it
answers with a client notification and does not reboot at all — so the app was
waiting for something that was never going to happen. Nothing in device
metadata reports whether the loader is there, which is why asking is the only
way to find out.

## What changed

- OTA notices are logged in the clear. Every client notification was logged
  `private`, which is right for messages that can carry channel names but
  meant the one message explaining a failed update was unreadable in an
  exported log. These name a partition state.
- The notice is handed to the update sheet. A refusal ends the update
  immediately instead of after the timeout; the notice the firmware sends on
  its way into update mode shows as progress. Both the BLE and Wi-Fi sheets.
- The refusal is explained rather than repeated, because a missing loader is
  only fixable over USB and the firmware's message names a partition. It also
  reads as its own opposite — "Device does have a valid OTA Loader" is what it
  says when there isn't one. An unrecognized message is still shown as sent.

## Testing

New tests cover each refusal the firmware can send being explained and not
passed through, a refusal ending the update on both transports,
"Rebooting to …" not counting as a failure, retry clearing it, and an
unrecognized message passing through. Full suite passes, 3007 tests.

Found on a device whose flash has no update loader: it now says so instead of
timing out.