### PR TITLE
Send a pairing failure through the error classifier

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -24,7 +24,16 @@ enum AccessoryError: Error, LocalizedError {
 	case eventStreamCancelled
 	case coreBluetoothError(CBError)
 	case coreBluetoothATTError(CBATTError)
+	/// The radio has thrown away the pairing this device still holds — a factory erase, a
+	/// reflash, or its Bluetooth settings being cleared. Nothing the app does fixes it; the
+	/// stale pairing has to be removed in Settings first.
+	case bondLost
 	
+	/// Said the same way whichever code the failure arrives under. iOS reports a stale
+	/// pairing as CBError 14, as CBError.encryptionTimedOut, or as a CBATTError about
+	/// authentication or encryption, and the advice is the same for all of them.
+	static let bondLostAdvice = "The radio has deleted its stored pairing information, but your device has not. To resolve this, you must forget the radio under Settings > Bluetooth to clear the old, now invalid, pairing information.".localized
+
 	var errorDescription: String? {
 		switch self {
 		case .discoveryFailed(let message):
@@ -53,11 +62,13 @@ enum AccessoryError: Error, LocalizedError {
 			case .peripheralDisconnected: // 7
 				return "The Bluetooth connection to the radio was disconnected, it will automatically reconnect to the preferred radio when it is powered back on or finishes rebooting.".localized
 			case .peerRemovedPairingInformation: // 14
-				return "The radio has deleted its stored pairing information, but your device has not. To resolve this, you must forget the radio under Settings > Bluetooth to clear the old, now invalid, pairing information.".localized
+				return Self.bondLostAdvice
 			default:
 				// Fallback for other CBError codes
 				return "A Bluetooth error occurred: \(cbError.localizedDescription)"
 			}
+		case .bondLost:
+			return Self.bondLostAdvice
 		case .coreBluetoothATTError(let attError):
 			// Map specific CBATTError values to a more user-friendly message
 			switch attError.code {
@@ -70,6 +81,19 @@ enum AccessoryError: Error, LocalizedError {
 				return "A Bluetooth Attribute Protocol error occurred: \(attError.localizedDescription)"
 			}
 		}
+	}
+}
+
+extension AccessoryError {
+	/// What to report when subscribing to notifications fails.
+	///
+	/// A radio that erased its pairing and a mistyped PIN arrive under the same Core
+	/// Bluetooth codes and need opposite advice — clear the pairing in Settings, or try the
+	/// PIN again. Having paired with this radio before is what separates them, so it has to
+	/// be decided here, while that is still known: tearing the connection down forgets it.
+	static func forNotifyFailure(_ error: Error, hadBond: Bool) -> Error {
+		guard hadBond, BLEConnection.isPairingFailure(error) else { return error }
+		return AccessoryError.bondLost
 	}
 }
 

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
@@ -428,24 +428,25 @@ extension BLEConnection {
 	func didUpdateNotificationState(characteristic: CBCharacteristic, error: Error?) {
 		if let error {
 			Logger.transport.error("🛜 [BLE] Notify state error for \(characteristic.meshtasticCharacteristicName, privacy: .public): \(error, privacy: .public)")
-			// A pairing/auth failure (wrong or cancelled PIN) surfaces here as a
-			// CBATTError. Treat it as a bond failure even if it lands on a non-gating
-			// characteristic (FROMRADIO/LOGRADIO) — encryption failures typically hit
-			// every subscription. A benign "notify not supported" error on those, by
-			// contrast, is ignored so it can't fail an otherwise-good connect.
-			if isAwaitingNotifyConfirmation
-				&& (pendingNotifyConfirmations.contains(characteristic.uuid) || Self.isPairingFailure(error)) {
-				// Which of these is a bond the radio threw away turns on whether we ever had
-				// one, and tearing the connection down forgets it — so decide first.
-				let reported = AccessoryError.forNotifyFailure(error, hadBond: UserDefaults.isPairedPeripheral(peripheral.identifier))
-				// Then hand it to the same classifier every other peripheral error goes
-				// through. It decides whether the error is worth reconnecting for — none of
-				// these are — tears the link down, forgets the stale pairing hint, and resumes
-				// the suspended connect with the error. Resuming the connect directly from
-				// here skipped all of that, and a connect step retries by default, so a
-				// pairing failure came back as "Too Many Retries" with the reason discarded.
-				Task { try? await self.handlePeripheralError(error: reported) }
-			}
+			guard case .endConnection = Self.notifyFailure(
+				error: error,
+				isAwaitingConfirmation: isAwaitingNotifyConfirmation,
+				gatesConnect: pendingNotifyConfirmations.contains(characteristic.uuid)
+			) else { return }
+
+			isAwaitingNotifyConfirmation = false
+			pendingNotifyConfirmations.removeAll()
+			let reported = Self.bondLostError(for: peripheral.identifier, error: error)
+			// Torn down while still waiting for the subscription means bonding did not
+			// complete, so the hint goes either way. `bondLostError` reads it first.
+			UserDefaults.forgetPairedPeripheral(peripheral.identifier)
+			// Then hand it to the same classifier every other peripheral error goes through.
+			// It decides whether the error is worth reconnecting for — none of these are —
+			// tears the link down, and resumes the suspended connect with the error.
+			// Resuming the connect directly from here skipped all of that, and a connect step
+			// retries by default, so a pairing failure came back as "Too Many Retries" with
+			// the reason discarded.
+			Task { try? await self.handlePeripheralError(error: reported) }
 			return
 		}
 
@@ -658,43 +659,86 @@ extension BLEConnection {
 	}
 	
 	func handlePeripheralError(error: Error) async throws {
-		/// Explicit retries for a few specific errors where we want to re-connect, all other errors should not reconnect automatically
-		var shouldReconnect = false
+		let shouldReconnect = Self.shouldReconnect(after: error)
+		logPeripheralError(error)
+
+		// Inform the active connection that there was an error and it should disconnect
+		try await self.disconnect(withError: error, shouldReconnect: shouldReconnect)
+	}
+
+	/// Whether an error is worth reconnecting for.
+	///
+	/// Three codes are: everything else is final. A pairing failure is one of the final
+	/// ones — the radio has thrown away a bond only the user can clear — and reconnecting on
+	/// it burns the connect step's retry budget and ends as "Too Many Retries" with the real
+	/// reason discarded. Pure so it can be tested without a peripheral.
+	static func shouldReconnect(after error: Error) -> Bool {
 		switch error {
 		case let attError as CBATTError:
-			 switch attError.code {
-			 case .insufficientResources:
-				 // The radio could not allocate a buffer for THIS write. The link is fine and the next
-				 // write usually succeeds, so reconnect rather than dropping the session. Observed on a
-				 // Heltec V4 (ESP32-S3/NimBLE): writes of 8-33B succeed while a 104B set_owner is rejected,
-				 // with an ATT MTU of 255 negotiated — so it is buffer exhaustion, not a size limit.
-				 Logger.transport.error("🛜 [BLEConnection] Radio out of buffers for this write (CBATTError \(attError.code.rawValue)); reconnecting rather than ending the session")
-				 shouldReconnect = true
-			 default:
-				 // All other CBATTErrors should not try and reconnect
-				 Logger.transport.error("🛜 [BLEConnection] Disconnected with CBATTError code: \(attError.code.rawValue) - \(attError.localizedDescription)")
-			 }
+			// The radio could not allocate a buffer for THIS write. The link is fine and the next
+			// write usually succeeds, so reconnect rather than dropping the session. Observed on a
+			// Heltec V4 (ESP32-S3/NimBLE): writes of 8-33B succeed while a 104B set_owner is rejected,
+			// with an ATT MTU of 255 negotiated — so it is buffer exhaustion, not a size limit.
+			return attError.code == .insufficientResources
 		case let cbError as CBError:
 			switch cbError.code {
-			case .connectionTimeout: // 6
-				// Happens when the node goes out of range or the shutdown or reset buttons are presses
-				// Should disconnect, show error, and retry when re-advertised
-				Logger.transport.error("🛜 [BLEConnection] Disconnected with CBError code: \(cbError.code.rawValue) - \(cbError.localizedDescription)")
-				shouldReconnect = true
-			case .peripheralDisconnected: // 7
-				// Happens when the node reboots or shuts down intentionally via the firmware or app
-				// Should disconnect, show error, and retry when re-advertised
-				Logger.transport.error("🛜 [BLEConnection] Disconnected with CBError code: \(cbError.code.rawValue) - \(cbError.localizedDescription)")
-				shouldReconnect = true
+			// Happens when the node goes out of range or the shutdown or reset buttons are pressed,
+			// and when it reboots or shuts down intentionally via the firmware or app. Disconnect,
+			// show the error, and retry when it advertises again.
+			case .connectionTimeout, .peripheralDisconnected: // 6, 7
+				return true
 			default:
-				Logger.transport.error("🛜 [BLEConnection] Disconnected with CBError code: \(cbError.code.rawValue) - \(cbError.localizedDescription)")
+				return false
 			}
+		default:
+			return false
+		}
+	}
+
+	/// What a notify-state error means for a connect still waiting on its subscription.
+	///
+	/// `.ignore` for a benign error on a characteristic the connect does not gate on — a
+	/// radio that does not support notifications on one of them must not fail an otherwise
+	/// good connect. A pairing failure counts wherever it lands, because an encryption
+	/// failure typically hits every subscription. Pure so it can be tested without a
+	/// peripheral.
+	enum NotifyFailure {
+		case ignore
+		case endConnection
+	}
+
+	static func notifyFailure(error: Error, isAwaitingConfirmation: Bool, gatesConnect: Bool) -> NotifyFailure {
+		guard isAwaitingConfirmation, gatesConnect || isPairingFailure(error) else { return .ignore }
+		return .endConnection
+	}
+
+	/// Reads the bond hint and clears it in one step, so the two cannot end up the wrong way
+	/// around: the answer depends on the hint that clearing destroys.
+	///
+	/// A radio that erased its pairing and a mistyped PIN arrive under the same Core
+	/// Bluetooth codes and need opposite advice — clear the pairing in Settings, or try the
+	/// PIN again. Having paired with this radio before is what separates them. Clearing the
+	/// hint also self-heals the connect timeout back to the long pairing window.
+	static func bondLostError(for peripheralID: UUID, error: Error) -> Error {
+		guard isPairingFailure(error) else { return error }
+		let hadBond = UserDefaults.isPairedPeripheral(peripheralID)
+		UserDefaults.forgetPairedPeripheral(peripheralID)
+		return hadBond ? AccessoryError.bondLost : error
+	}
+
+	private func logPeripheralError(_ error: Error) {
+		switch error {
+		case let attError as CBATTError:
+			if attError.code == .insufficientResources {
+				Logger.transport.error("🛜 [BLEConnection] Radio out of buffers for this write (CBATTError \(attError.code.rawValue)); reconnecting rather than ending the session")
+			} else {
+				Logger.transport.error("🛜 [BLEConnection] Disconnected with CBATTError code: \(attError.code.rawValue) - \(attError.localizedDescription)")
+			}
+		case let cbError as CBError:
+			Logger.transport.error("🛜 [BLEConnection] Disconnected with CBError code: \(cbError.code.rawValue) - \(cbError.localizedDescription)")
 		case let otherError:
 			Logger.transport.error("🛜 [BLEConnection] Disconnected with non CBError or CBATTError: \(otherError.localizedDescription)")
 		}
-		
-		// Inform the active connection that there was an error and it should disconnect
-		try await self.disconnect(withError: error, shouldReconnect: shouldReconnect)
 	}
 	
 	func appDidEnterBackground() {

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
@@ -435,10 +435,16 @@ extension BLEConnection {
 			// contrast, is ignored so it can't fail an otherwise-good connect.
 			if isAwaitingNotifyConfirmation
 				&& (pendingNotifyConfirmations.contains(characteristic.uuid) || Self.isPairingFailure(error)) {
-				isAwaitingNotifyConfirmation = false
-				pendingNotifyConfirmations.removeAll()
-				UserDefaults.forgetPairedPeripheral(peripheral.identifier)
-				self.continueConnectionProcess(throwing: error)
+				// Which of these is a bond the radio threw away turns on whether we ever had
+				// one, and tearing the connection down forgets it — so decide first.
+				let reported = AccessoryError.forNotifyFailure(error, hadBond: UserDefaults.isPairedPeripheral(peripheral.identifier))
+				// Then hand it to the same classifier every other peripheral error goes
+				// through. It decides whether the error is worth reconnecting for — none of
+				// these are — tears the link down, forgets the stale pairing hint, and resumes
+				// the suspended connect with the error. Resuming the connect directly from
+				// here skipped all of that, and a connect step retries by default, so a
+				// pairing failure came back as "Too Many Retries" with the reason discarded.
+				Task { try? await self.handlePeripheralError(error: reported) }
 			}
 			return
 		}

--- a/MeshtasticTests/BLEPairingHintTests.swift
+++ b/MeshtasticTests/BLEPairingHintTests.swift
@@ -111,43 +111,142 @@ struct BLEPairingFailureTests {
 	}
 }
 
-/// A factory-erased radio throws away the pairing this device still holds. The app has a
-/// message for it — forget the radio under Settings > Bluetooth — and the advice differs from
-/// the one for a mistyped PIN even though iOS reports both under the same codes.
-@Suite("Lost BLE bond")
-struct LostBondTests {
+/// A factory-erased radio throws away the pairing this device still holds. Reconnecting
+/// cannot fix it, so it must not be retried, and the advice differs from the one for a
+/// mistyped PIN even though iOS reports both under the same codes.
+///
+/// Serialized: these share the persisted `pairedPeripheralIds`, so they must not run in
+/// parallel with each other or with the hint suite above.
+@Suite("Lost BLE bond", .serialized)
+final class LostBondTests {
+
+	private let radio = UUID(uuidString: "00000000-0000-0000-0000-0000000000CC")!
+	private let originalPairedIds: [String]
+
+	init() {
+		originalPairedIds = UserDefaults.pairedPeripheralIds
+		UserDefaults.pairedPeripheralIds = []
+	}
+
+	deinit {
+		UserDefaults.pairedPeripheralIds = originalPairedIds
+	}
 
 	private func isBondLost(_ error: Error) -> Bool {
 		guard let accessoryError = error as? AccessoryError, case .bondLost = accessoryError else { return false }
 		return true
 	}
 
-	@Test func everyPairingCodeIsALostBondWhenWePairedBefore() {
-		let codes: [Error] = [
-			CBError(.peerRemovedPairingInformation),
-			CBError(.encryptionTimedOut),
-			CBATTError(.insufficientAuthentication),
-			CBATTError(.insufficientEncryption),
-			CBATTError(.insufficientAuthorization)
-		]
-		for code in codes {
-			#expect(isBondLost(AccessoryError.forNotifyFailure(code, hadBond: true)),
-					"\(code) should report a lost bond")
+	private static let pairingCodes: [Error] = [
+		CBError(.peerRemovedPairingInformation),
+		CBError(.encryptionTimedOut),
+		CBATTError(.insufficientAuthentication),
+		CBATTError(.insufficientEncryption),
+		CBATTError(.insufficientAuthorization)
+	]
+
+	// MARK: - Never retried
+
+	@Test func pairingFailuresAreNeverReconnected() {
+		// This is what stops the connect: `shouldReconnect == false` sends the error out as
+		// `errorWithoutReconnect`, which disables auto-reconnect and cancels the whole connect
+		// process instead of retrying it into "Too Many Retries".
+		for code in Self.pairingCodes {
+			#expect(BLEConnection.shouldReconnect(after: code) == false, "\(code) must not reconnect")
+		}
+		#expect(BLEConnection.shouldReconnect(after: AccessoryError.bondLost) == false)
+	}
+
+	@Test func theThreeRecoverableErrorsStillReconnect() {
+		#expect(BLEConnection.shouldReconnect(after: CBATTError(.insufficientResources)))
+		#expect(BLEConnection.shouldReconnect(after: CBError(.connectionTimeout)))
+		#expect(BLEConnection.shouldReconnect(after: CBError(.peripheralDisconnected)))
+	}
+
+	@Test func unrelatedErrorsDoNotReconnect() {
+		#expect(BLEConnection.shouldReconnect(after: CBATTError(.writeNotPermitted)) == false)
+		#expect(BLEConnection.shouldReconnect(after: NSError(domain: "com.example.test", code: 42)) == false)
+	}
+
+	// MARK: - Which advice
+
+	@Test func aRadioWePairedWithBeforeReportsALostBond() {
+		for code in Self.pairingCodes {
+			UserDefaults.rememberPairedPeripheral(radio)
+
+			let reported = BLEConnection.bondLostError(for: radio, error: code)
+
+			#expect(isBondLost(reported), "\(code) should report a lost bond")
+			// Read before clear, in one step: reversing them would answer from an already
+			// cleared hint and report the wrong advice.
+			#expect(UserDefaults.isPairedPeripheral(radio) == false,
+					"the stale pairing is forgotten, so the next attempt gets the long pairing window")
 		}
 	}
 
-	@Test func aFirstPairingAttemptIsNotALostBond() {
+	@Test func aFirstPairingAttemptKeepsItsOwnError() {
 		// Never paired with this radio: the same codes mean a wrong or cancelled PIN, which
 		// needs the opposite advice, so the original error has to survive.
-		let reported = AccessoryError.forNotifyFailure(CBATTError(.insufficientAuthentication), hadBond: false)
+		let reported = BLEConnection.bondLostError(for: radio, error: CBATTError(.insufficientAuthentication))
+
 		#expect(isBondLost(reported) == false)
 		#expect((reported as? CBATTError)?.code == .insufficientAuthentication)
 	}
 
-	@Test func benignNotifyErrorsPassThrough() {
-		let reported = AccessoryError.forNotifyFailure(CBATTError(.requestNotSupported), hadBond: true)
+	@Test func benignErrorsPassThroughAndKeepTheBond() {
+		UserDefaults.rememberPairedPeripheral(radio)
+
+		let reported = BLEConnection.bondLostError(for: radio, error: CBATTError(.requestNotSupported))
+
 		#expect(isBondLost(reported) == false)
 		#expect((reported as? CBATTError)?.code == .requestNotSupported)
+		#expect(UserDefaults.isPairedPeripheral(radio), "a benign error is not a bond failure")
+	}
+
+	// MARK: - Ignore or end the connection
+
+	@Test func aPairingFailureEndsTheConnectWhereverItLands() {
+		// An encryption failure typically hits every subscription, including ones the connect
+		// does not gate on.
+		for code in Self.pairingCodes {
+			let action = BLEConnection.notifyFailure(error: code, isAwaitingConfirmation: true, gatesConnect: false)
+			guard case .endConnection = action else {
+				Issue.record("\(code) should end the connect")
+				continue
+			}
+		}
+	}
+
+	@Test func abenignErrorOnANonGatingCharacteristicIsIgnored() {
+		// A radio that does not support notifications on FROMRADIO must not fail an
+		// otherwise-good connect.
+		let action = BLEConnection.notifyFailure(
+			error: CBATTError(.requestNotSupported), isAwaitingConfirmation: true, gatesConnect: false
+		)
+		guard case .ignore = action else {
+			Issue.record("a benign error off the gating path should be ignored")
+			return
+		}
+	}
+
+	@Test func aFailureOnTheGatingCharacteristicEndsTheConnect() {
+		let action = BLEConnection.notifyFailure(
+			error: CBATTError(.requestNotSupported), isAwaitingConfirmation: true, gatesConnect: true
+		)
+		guard case .endConnection = action else {
+			Issue.record("the connect waits on this subscription, so it cannot be ignored")
+			return
+		}
+	}
+
+	@Test func nothingHappensWhenTheConnectIsNotWaiting() {
+		let action = BLEConnection.notifyFailure(
+			error: CBError(.peerRemovedPairingInformation), isAwaitingConfirmation: false, gatesConnect: true
+		)
+		guard case .ignore = action else {
+			Issue.record("no connect in flight, nothing to end")
+			return
+		}
 	}
 
 	@Test func theMessageSaysHowToFixIt() {

--- a/MeshtasticTests/BLEPairingHintTests.swift
+++ b/MeshtasticTests/BLEPairingHintTests.swift
@@ -110,3 +110,50 @@ struct BLEPairingFailureTests {
 		#expect(BLEConnection.isPairingFailure(generic) == false)
 	}
 }
+
+/// A factory-erased radio throws away the pairing this device still holds. The app has a
+/// message for it — forget the radio under Settings > Bluetooth — and the advice differs from
+/// the one for a mistyped PIN even though iOS reports both under the same codes.
+@Suite("Lost BLE bond")
+struct LostBondTests {
+
+	private func isBondLost(_ error: Error) -> Bool {
+		guard let accessoryError = error as? AccessoryError, case .bondLost = accessoryError else { return false }
+		return true
+	}
+
+	@Test func everyPairingCodeIsALostBondWhenWePairedBefore() {
+		let codes: [Error] = [
+			CBError(.peerRemovedPairingInformation),
+			CBError(.encryptionTimedOut),
+			CBATTError(.insufficientAuthentication),
+			CBATTError(.insufficientEncryption),
+			CBATTError(.insufficientAuthorization)
+		]
+		for code in codes {
+			#expect(isBondLost(AccessoryError.forNotifyFailure(code, hadBond: true)),
+					"\(code) should report a lost bond")
+		}
+	}
+
+	@Test func aFirstPairingAttemptIsNotALostBond() {
+		// Never paired with this radio: the same codes mean a wrong or cancelled PIN, which
+		// needs the opposite advice, so the original error has to survive.
+		let reported = AccessoryError.forNotifyFailure(CBATTError(.insufficientAuthentication), hadBond: false)
+		#expect(isBondLost(reported) == false)
+		#expect((reported as? CBATTError)?.code == .insufficientAuthentication)
+	}
+
+	@Test func benignNotifyErrorsPassThrough() {
+		let reported = AccessoryError.forNotifyFailure(CBATTError(.requestNotSupported), hadBond: true)
+		#expect(isBondLost(reported) == false)
+		#expect((reported as? CBATTError)?.code == .requestNotSupported)
+	}
+
+	@Test func theMessageSaysHowToFixIt() {
+		let message = AccessoryError.bondLost.errorDescription ?? ""
+		#expect(message.contains("forget the radio"))
+		#expect(message == AccessoryError.coreBluetoothError(CBError(.peerRemovedPairingInformation)).errorDescription,
+				"however it arrives, it reads the same")
+	}
+}


### PR DESCRIPTION
## Summary

A factory-erased radio throws away the pairing this device still holds.
Reconnecting to it showed "Too Many Retries" instead of the message that says
to forget the radio under Settings > Bluetooth.

Peripheral errors go through one classifier — `handlePeripheralError` — that
decides whether an error is worth reconnecting for. It opts in three codes
(`insufficientResources`, `connectionTimeout`, `peripheralDisconnected`) and
treats everything else as final, which is why a lost pairing used to stop the
connect and report itself properly.

The notify-subscription failure added in #2057 resumed the suspended connect
with the raw error instead of going through that classifier. Connect steps
retry by default (`onFailure: .retryAll`), so the pairing failure restarted the
connect until the retry budget ran out and surfaced as
`AccessoryError.tooManyRetries`, discarding the real reason.

## What changed

Route the notify failure through the classifier like every other peripheral
error. It already does the rest: no reconnect for these codes, tear the link
down, forget the stale pairing hint, and resume the connect with the error —
all of which the direct continuation resume skipped.

The advice is also made right for the case that started this. iOS reports a
stale pairing under four codes, and the message was only wired to CBError 14;
the CBATTError ones said "check the BLE PIN carefully", which is what a radio
we have *never* paired with needs. The two are separated by whether pairing
with that peripheral ever worked, which the app already records — read before
the connection is torn down, since tearing it down forgets it.

No change to the pairing-sheet fix itself: the long pairing window and the
subscription confirmation gate are untouched.

## Testing

New tests cover all four codes reporting a lost bond when a bond existed, a
first pairing attempt keeping its original error, benign notify errors passing
through, and the message reading the same however it arrives. Full suite
passes, 3004 tests.

Still wants a live check: factory erase a radio and reconnect to it.