### PR TITLE
Name the screens reported to RUM

### DIFF
--- a/Meshtastic/Extensions/Logger+DataDog.swift
+++ b/Meshtastic/Extensions/Logger+DataDog.swift
@@ -9,6 +9,7 @@ import Foundation
 import os.log
 import DatadogRUM
 import DatadogLogs
+import SwiftUI
 
 enum DataDogLoggableAction {
 	// Add more cases as new loggable actions are required.
@@ -90,4 +91,22 @@ struct DatadogLogger {
 
 extension os.Logger {
 	static let datadog = DatadogLogger(subsystem: "datadog", category: "🐶 DataDog")
+}
+
+extension View {
+	/// Names this screen for RUM, so crashes and hangs that happen on it are filed under it.
+	///
+	/// Automatic SwiftUI view tracking names a view by reflecting the hosting controller's
+	/// type. The app root is type-erased, so it resolved to the first concrete view type it
+	/// found in the root `Group`'s branches — `FirmwareUpdateGameDemoHost`, which is
+	/// DEBUG-only and cannot be on screen in a release build. Everything happening at the
+	/// root was filed under that name, and the rest landed on
+	/// `NavigationStackHostingController<AnyView>`, so nothing could be attributed to a
+	/// screen at all.
+	///
+	/// A name set here wins: an error is attributed to the innermost view that has started.
+	/// Keep the names stable — renaming one splits that screen's history in Error Tracking.
+	func trackScreen(_ name: String) -> some View {
+		trackRUMView(name: name)
+	}
 }

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -232,7 +232,14 @@ struct MeshtasticAppleApp: App {
 			if Self.isRunningTests {
 				Color.clear
 			} else if Self.isChirpyOTADemo {
+				// Kept out of the release build's view type on purpose, not just behind a flag
+				// that is false there: the automatic RUM view naming reflects over these
+				// branches, and this type — which can never be on screen in release — was
+				// being reported as the view for everything that happened at the app root.
+				// See `trackScreen`.
+				#if DEBUG
 				FirmwareUpdateGameDemoHost()
+				#endif
 			} else if appState.isDatabaseResetting {
 				// Unmount the WHOLE SwiftData-bound tree — including the `.modelContainer`
 				// modifier in mainAppContent — while a node switch clears the store. The

--- a/Meshtastic/Router/NavigationState.swift
+++ b/Meshtastic/Router/NavigationState.swift
@@ -95,6 +95,19 @@ struct NavigationState: Hashable {
 		case map
 		case settings
 		case connect
+
+		/// Screen name reported to RUM. Written out rather than derived from the raw value:
+		/// these names are the grouping key for a screen's crashes and hangs, so they need to
+		/// survive a rename of the case.
+		var screenName: String {
+			switch self {
+			case .messages: return "Messages"
+			case .nodes: return "Nodes"
+			case .map: return "Map"
+			case .settings: return "Settings"
+			case .connect: return "Connect"
+			}
+		}
 	}
 
 	var selectedTab: Tab = .connect

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -238,25 +238,30 @@ struct ContentView: View {
 						unreadChannelMessages: $appState.unreadChannelMessages,
 						unreadDirectMessages: $appState.unreadDirectMessages
 					)
+					.trackScreen(NavigationState.Tab.messages.screenName)
 				}
 				.badge(appState.totalUnreadMessages)
 
 				Tab("Nodes", image: "custom.mesh.radio", value: NavigationState.Tab.nodes) {
 					NodeList()
+						.trackScreen(NavigationState.Tab.nodes.screenName)
 				}
 
 				Tab("Map", systemImage: "map", value: NavigationState.Tab.map) {
 					MeshMapMK(router: appState.router)
+						.trackScreen(NavigationState.Tab.map.screenName)
 				}
 
 				Tab("Settings", systemImage: "gear", value: NavigationState.Tab.settings) {
 					Settings()
+						.trackScreen(NavigationState.Tab.settings.screenName)
 				}
 
 				Tab("Connect", systemImage: "link", value: NavigationState.Tab.connect) {
 					Connect(
 						router: appState.router
 					)
+					.trackScreen(NavigationState.Tab.connect.screenName)
 				}
 			}
 		} else {
@@ -319,10 +324,11 @@ struct ContentView: View {
 				unreadChannelMessages: $appState.unreadChannelMessages,
 				unreadDirectMessages: $appState.unreadDirectMessages
 			)
-		case .nodes: NodeList()
-		case .map: MeshMapMK(router: appState.router)
-		case .settings: Settings()
-		case .connect: Connect(router: appState.router)
+			.trackScreen(tab.value.screenName)
+		case .nodes: NodeList().trackScreen(tab.value.screenName)
+		case .map: MeshMapMK(router: appState.router).trackScreen(tab.value.screenName)
+		case .settings: Settings().trackScreen(tab.value.screenName)
+		case .connect: Connect(router: appState.router).trackScreen(tab.value.screenName)
 		}
 	}
 

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -137,8 +137,10 @@ struct Messages: View {
 				Group {
 					if let myInfo = node?.myInfo, let channelSelection {
 						ChannelMessageList(myInfo: myInfo, channel: channelSelection)
+							.trackScreen("Channel Messages")
 					} else if let userSelection {
 						UserMessageList(user: userSelection)
+							.trackScreen("Direct Messages")
 					} else if case .channels = router.messagesSection {
 						Text("Select a channel")
 					} else if case .directMessages = router.messagesSection {
@@ -148,6 +150,7 @@ struct Messages: View {
 				.navigationDestination(for: Int64.self) { nodeNum in
 					if let node = getNodeInfo(id: nodeNum, context: context) {
 						NodeDetail(node: node, nodeNum: nodeNum)
+							.trackScreen("Node Detail")
 					}
 				}
 			}

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -482,6 +482,7 @@ struct MeshMapMK: View {
 					if let node = getNodeInfo(id: selection.id, context: context) {
 						NavigationStack {
 							NodeDetail(node: node, nodeNum: selection.id, showMapLink: false)
+								.trackScreen("Node Detail")
 						}
 						#if targetEnvironment(macCatalyst)
 							.overlay(alignment: .topLeading) {

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -48,6 +48,7 @@ struct NodeList: View {
 						LocalStatsLog(node: node)
 					} else {
 						NodeDetail(node: node, nodeNum: selectedNum)
+							.trackScreen("Node Detail")
 					}
 				} else {
 					ContentUnavailableView("Select a Node", systemImage: "flipphone")


### PR DESCRIPTION
## Summary

Crashes and hangs cannot be attributed to a screen today. The automatic
SwiftUI view naming reflects over the hosting controller's type, and for this
app it mostly returns things that are not screens.

The top view names in a recent 25-minute window of release traffic:

| View name | Views |
|---|---|
| `NavigationStackHostingController<AnyView>` | 6,234 |
| `FirmwareUpdateGameDemoHost` | 3,439 |
| `AppSettings` | 753 |
| `ApplicationLaunch` | 382 |
| `AutoTracked_HostingController_Fallback` | 326 |

`FirmwareUpdateGameDemoHost` is `#if DEBUG` and gated behind
`--chirpy-ota-demo`, so it cannot be on screen in a release build at all —
everything happening at the app root was filed under it. Further down the list
are `PresentationOptionsPreferenceKey`, `TextAlignment`, `Never`,
`_FrameLayout` and `_PaddingLayout`, none of which are screens either.

## What changed

- The five tab roots are named explicitly, from a `screenName` on
  `NavigationState.Tab` so the iOS 18 and iOS 17 tab paths cannot drift apart.
- The three screens the top crash and hang signatures point at are named at
  their call sites: Node Detail, Direct Messages, Channel Messages.
- A `trackScreen(_:)` helper lives with the rest of the Datadog wiring, so
  views do not import the SDK.
- The Chirpy demo host is kept out of the release build's view *type*, not
  just behind a flag that is false there.

A name set this way takes precedence, because an error is attributed to the
innermost view that started.

## What this does not do

It does not name every screen. Pushed screens without a name still land on
`NavigationStackHostingController<AnyView>`. Turning the automatic predicate
off entirely would remove the junk names but leave those screens with no view
at all, so that is a separate decision.

## Testing

Full suite passes, 3025 tests.

Verified end to end against the `local` env, which DEBUG builds report to.
Drove the app through every tab in the simulator and read the names back out
of RUM: `Nodes`, `Connect`, `Messages`, `Map`, `Settings` and
`Direct Messages` all arrived.

`Node Detail` and `Channel Messages` are unverified: the driver's node-detail
step landed on the Messages screen instead of navigating, so NodeDetail never
rendered. Their placement is the same pattern as the verified ones.
`FirmwareUpdateGameDemoHost` still appears in a DEBUG run, which is what the
fence implies — it is release builds that can no longer produce it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added screen-view tracking across the app’s main tabs and key detail screens.
  * Screen names are now reported consistently for messages, nodes, maps, settings, connections, and node details.
  * Release builds no longer include the OTA demo view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->