### PR TITLE
Refresh the available radio list when a radio is renamed

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -726,14 +726,12 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		// Update the device in the devices array if it exists
 		if let index = devices.firstIndex(where: { $0.id == deviceId }) {
 			var device = devices[index]
-			device[keyPath: key] = value
 			if device[keyPath: key] != value {
 				// Update the @Published stuff for the UI
 				self.objectWillChange.send()
-				
-				if let index = devices.firstIndex(where: { $0.id == deviceId }) {
-					devices[index] = device
-				}
+
+				device[keyPath: key] = value
+				devices[index] = device
 			}
 		} else {
 			// Durring active connections, this discover list will be empty, so this is expected.

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -727,9 +727,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		if let index = devices.firstIndex(where: { $0.id == deviceId }) {
 			var device = devices[index]
 			if device[keyPath: key] != value {
-				// Update the @Published stuff for the UI
-				self.objectWillChange.send()
-
+				// No objectWillChange here: `devices` is @Published, so assigning to it
+				// notifies on its own. Sending as well invalidated twice per change.
 				device[keyPath: key] = value
 				devices[index] = device
 			}

--- a/MeshtasticTests/ConnectViewTests.swift
+++ b/MeshtasticTests/ConnectViewTests.swift
@@ -644,3 +644,19 @@ struct SignalStrengthIndicatorTests {
 		#expect(view.signalStrength == strength)
 	}
 }
+
+@Suite("AccessoryManager device updates")
+struct AccessoryManagerDeviceUpdateTests {
+	@MainActor
+	@Test func nameUpdateRefreshesAvailableDevices() {
+		let deviceID = UUID()
+		let manager = AccessoryManager(transports: [])
+		manager.devices = [
+			Device(id: deviceID, name: "Old Radio", transportType: .ble, identifier: deviceID.uuidString)
+		]
+
+		manager.updateDevice(deviceId: deviceID, key: \.name, value: "New Radio")
+
+		#expect(manager.devices.first?.name == "New Radio")
+	}
+}

--- a/MeshtasticTests/ConnectViewTests.swift
+++ b/MeshtasticTests/ConnectViewTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import SwiftData
 import SwiftUI
@@ -658,5 +659,27 @@ struct AccessoryManagerDeviceUpdateTests {
 		manager.updateDevice(deviceId: deviceID, key: \.name, value: "New Radio")
 
 		#expect(manager.devices.first?.name == "New Radio")
+	}
+
+	@MainActor
+	@Test func unchangedValueDoesNotRefreshTheUI() {
+		let deviceID = UUID()
+		let manager = AccessoryManager(transports: [])
+		manager.devices = [
+			Device(id: deviceID, name: "Same Radio", transportType: .ble, identifier: deviceID.uuidString)
+		]
+
+		var refreshes = 0
+		let cancellable = manager.objectWillChange.sink { _ in refreshes += 1 }
+		defer { cancellable.cancel() }
+
+		manager.updateDevice(deviceId: deviceID, key: \.name, value: "Same Radio")
+		#expect(refreshes == 0, "an unchanged value should not refresh the list")
+
+		manager.updateDevice(deviceId: deviceID, key: \.name, value: "Renamed Radio")
+		// Once, not twice: `devices` is @Published and notifies on assignment, so an
+		// explicit objectWillChange alongside it invalidated every observer twice.
+		#expect(refreshes == 1, "a changed value refreshes once")
+		#expect(manager.devices.first?.name == "Renamed Radio")
 	}
 }


### PR DESCRIPTION
## Summary

Renaming a radio left the old name in Available Radios. `updateDevice` assigned
the new value to its local copy and then compared that copy against the value
it had just assigned, so the check was always false: the array was never
written back and nothing told the UI to redraw. The active connection was
fine — the branch above it compares before assigning.

## What changed

The array branch compares first, then assigns and writes back, which is what
the branch above it already did.

It no longer sends `objectWillChange` by hand. `devices` is `@Published`, so
assigning to it notifies on its own, and doing both invalidated every observer
twice per change. The `activeConnection` branch keeps its send: that property
is a plain var and does not publish.

## Testing

Two tests: a rename reaches the devices array, and an unchanged value causes no
refresh while a changed one causes exactly one. The first fails without the
fix. Full suite passes.