### PR TITLE
Cap the long name at what the radio will keep

### DIFF
--- a/Meshtastic/Helpers/NodeNameLimits.swift
+++ b/Meshtastic/Helpers/NodeNameLimits.swift
@@ -1,0 +1,33 @@
+//
+//  NodeNameLimits.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 9/4/26.
+//
+
+import Foundation
+
+/// How long a name the user can actually keep.
+///
+/// These are the nanopb buffer sizes minus the terminator, not the wire field sizes.
+/// `User.long_name` carries 39 bytes on the wire, but a 2.8 radio stores every node it hears
+/// in `NodeInfoLite`, whose `long_name` is 25 bytes including the terminator, and truncates
+/// anything longer on the way in. A longer name would come back shortened from every radio
+/// that stored it, including the user's own, so it is not worth letting them type it.
+enum NodeNameLimits {
+
+	/// Long name, in UTF-8 bytes.
+	static let longNameBytes = 24
+
+	/// Trims to `maxBytes` of UTF-8 without splitting a character. Counting bytes rather than
+	/// characters is the point: one emoji is four bytes, and the radio truncates by bytes.
+	static func trimmed(_ value: String, toBytes maxBytes: Int) -> String {
+		guard value.utf8.count > maxBytes else { return value }
+		var result = ""
+		for character in value {
+			guard result.utf8.count + String(character).utf8.count <= maxBytes else { break }
+			result.append(character)
+		}
+		return result
+	}
+}

--- a/Meshtastic/Helpers/NodeNameLimits.swift
+++ b/Meshtastic/Helpers/NodeNameLimits.swift
@@ -16,8 +16,20 @@ import Foundation
 /// that stored it, including the user's own, so it is not worth letting them type it.
 enum NodeNameLimits {
 
-	/// Long name, in UTF-8 bytes.
+	/// Long name on 2.8 and later, in UTF-8 bytes: `NodeInfoLite.long_name` is 25 including
+	/// the terminator.
 	static let longNameBytes = 24
+
+	/// Long name before 2.8, in UTF-8 bytes. Those radios store peers in `UserLite`, whose
+	/// `long_name` is 40 including the terminator, so nothing is truncated until 2.8.
+	static let legacyLongNameBytes = 39
+
+	/// The limit for the radio being edited. A 2.8 radio truncates on store; an older one
+	/// keeps the wire length. Note this is about the radio holding the name — a 2.8 node that
+	/// hears an older one still stores only 24 of it.
+	static func longNameBytes(storesCompactNames: Bool) -> Int {
+		storesCompactNames ? longNameBytes : legacyLongNameBytes
+	}
 
 	/// Trims to `maxBytes` of UTF-8 without splitting a character. Counting bytes rather than
 	/// characters is the point: one emoji is four bytes, and the radio truncates by bytes.

--- a/Meshtastic/Views/Settings/UserConfig.swift
+++ b/Meshtastic/Views/Settings/UserConfig.swift
@@ -79,17 +79,14 @@ struct UserConfig: View {
 							Label("Long Name", systemImage: "person.crop.rectangle.fill")
 							TextField("Long Name", text: $longName)
 								.onChange(of: longName) {
-									var newValue = longName.withoutVariationSelectors
-									while newValue.utf8.count > 36 {
-										newValue = String(newValue.dropLast())
-									}
-									longName = newValue
+									let newValue = longName.withoutVariationSelectors
+									longName = NodeNameLimits.trimmed(newValue, toBytes: NodeNameLimits.longNameBytes)
 									if longName.contains("📵") {
 										isUnmessagable = true
 									}
 								}
 						}
-						Text("Long Name can be up to 36 bytes long.")
+						Text("Long Name can be up to 24 bytes long.")
 							.foregroundColor(.gray)
 							.font(.callout)
 					}

--- a/Meshtastic/Views/Settings/UserConfig.swift
+++ b/Meshtastic/Views/Settings/UserConfig.swift
@@ -35,8 +35,18 @@ struct UserConfig: View {
 	@FocusState var focusedField: Field?
 	
 	public var minimumVersion = "2.6.9"
+	/// From this version a radio stores peers in `NodeInfoLite`, which holds 24 bytes of long
+	/// name rather than 39.
+	private let minimumCompactNameVersion = "2.8.0"
 	let floatFormatter = frequencyOverrideFormatter
 	
+	/// Bytes the radio being edited will keep of a long name.
+	private var longNameLimit: Int {
+		NodeNameLimits.longNameBytes(
+			storesCompactNames: accessoryManager.checkIsVersionSupported(forVersion: minimumCompactNameVersion)
+		)
+	}
+
 	var body: some View {
 		
 		Form {
@@ -77,16 +87,25 @@ struct UserConfig: View {
 					VStack(alignment: .leading) {
 						HStack {
 							Label("Long Name", systemImage: "person.crop.rectangle.fill")
-							TextField("Long Name", text: $longName)
-								.onChange(of: longName) {
-									let newValue = longName.withoutVariationSelectors
-									longName = NodeNameLimits.trimmed(newValue, toBytes: NodeNameLimits.longNameBytes)
-									if longName.contains("📵") {
-										isUnmessagable = true
-									}
+							// Limit through the binding, not onChange: onAppear assigns the stored
+							// name straight to the state, and trimming there would shorten a name
+							// the radio is perfectly happy with and mark the form dirty before the
+							// user has touched anything.
+							TextField("Long Name", text: Binding(
+								get: { longName },
+								set: { typed in
+									longName = NodeNameLimits.trimmed(
+										typed.withoutVariationSelectors, toBytes: longNameLimit
+									)
 								}
+							))
+							.onChange(of: longName) {
+								if longName.contains("📵") {
+									isUnmessagable = true
+								}
+							}
 						}
-						Text("Long Name can be up to 24 bytes long.")
+						Text("Long Name can be up to \(longNameLimit) bytes long.")
 							.foregroundColor(.gray)
 							.font(.callout)
 					}

--- a/MeshtasticTests/NodeNameLimitsTests.swift
+++ b/MeshtasticTests/NodeNameLimitsTests.swift
@@ -1,0 +1,61 @@
+//
+//  NodeNameLimitsTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/4/26.
+//
+
+import Testing
+import Foundation
+@testable import Meshtastic
+
+/// 2.8 radios store every node they hear in `NodeInfoLite`, whose `long_name` is 25 bytes
+/// including the terminator. A name longer than 24 bytes is truncated on the way in, so the
+/// app must not let one be typed — it would come back shortened from the user's own radio.
+@Suite("Node name limits")
+struct NodeNameLimitsTests {
+
+	@Test("Long name is capped at what a 2.8 radio will store")
+	func longNameCap() {
+		#expect(NodeNameLimits.longNameBytes == 24)
+	}
+
+	@Test("A name at the limit is left alone")
+	func atTheLimit() {
+		let name = String(repeating: "a", count: 24)
+		#expect(NodeNameLimits.trimmed(name, toBytes: 24) == name)
+	}
+
+	@Test("A name over the limit is trimmed to it")
+	func overTheLimit() {
+		let trimmed = NodeNameLimits.trimmed(String(repeating: "a", count: 40), toBytes: 24)
+		#expect(trimmed.utf8.count == 24)
+	}
+
+	@Test("Trimming counts bytes, not characters")
+	func countsBytes() {
+		// Each of these is 4 UTF-8 bytes, so six fit and the seventh does not.
+		let trimmed = NodeNameLimits.trimmed(String(repeating: "🛰", count: 10), toBytes: 24)
+		#expect(trimmed.utf8.count == 24)
+		#expect(trimmed.count == 6)
+	}
+
+	@Test("A character is never split at the boundary")
+	func neverSplitsACharacter() {
+		// 22 bytes of ASCII plus a 4-byte emoji would be 26; the emoji has to go whole.
+		let name = String(repeating: "a", count: 22) + "🛰"
+		let trimmed = NodeNameLimits.trimmed(name, toBytes: 24)
+		#expect(trimmed == String(repeating: "a", count: 22))
+		#expect(trimmed.utf8.count == 22, "stops short rather than emitting a partial character")
+	}
+
+	@Test("A Ham name always fits")
+	func hamNameFits() {
+		// Call sign 7 + "//" + descriptive name 14 = 23, inside the long name limit.
+		let composed = HamName(
+			callSign: String(repeating: "W", count: HamName.maxCallSignBytes),
+			longName: String(repeating: "n", count: HamName.maxLongNameBytes)
+		).composed
+		#expect(composed.utf8.count <= NodeNameLimits.longNameBytes)
+	}
+}

--- a/MeshtasticTests/NodeNameLimitsTests.swift
+++ b/MeshtasticTests/NodeNameLimitsTests.swift
@@ -42,9 +42,12 @@ struct NodeNameLimitsTests {
 		#expect(NodeNameLimits.trimmed(name, toBytes: 24) == name)
 	}
 
-	@Test("A name over the limit is trimmed to it")
+	@Test("A name over the limit keeps its first 24 bytes")
 	func overTheLimit() {
-		let trimmed = NodeNameLimits.trimmed(String(repeating: "a", count: 40), toBytes: 24)
+		// Assert the retained prefix, not just the length: trimming the wrong end, or
+		// returning any 24 bytes at all, would pass a count-only check.
+		let trimmed = NodeNameLimits.trimmed("abcdefghijklmnopqrstuvwxyz0123456789", toBytes: 24)
+		#expect(trimmed == "abcdefghijklmnopqrstuvwx")
 		#expect(trimmed.utf8.count == 24)
 	}
 

--- a/MeshtasticTests/NodeNameLimitsTests.swift
+++ b/MeshtasticTests/NodeNameLimitsTests.swift
@@ -20,6 +20,22 @@ struct NodeNameLimitsTests {
 		#expect(NodeNameLimits.longNameBytes == 24)
 	}
 
+	@Test("Older radios keep the wire length")
+	func legacyCap() {
+		// Before 2.8 a radio stores peers in UserLite, whose long_name is 40 including the
+		// terminator, so nothing was truncated.
+		#expect(NodeNameLimits.legacyLongNameBytes == 39)
+		#expect(NodeNameLimits.longNameBytes(storesCompactNames: false) == 39)
+		#expect(NodeNameLimits.longNameBytes(storesCompactNames: true) == 24)
+	}
+
+	@Test("A name that fits an older radio is not trimmed for it")
+	func legacyNameSurvives() {
+		let name = String(repeating: "a", count: 30)
+		#expect(NodeNameLimits.trimmed(name, toBytes: NodeNameLimits.longNameBytes(storesCompactNames: false)) == name)
+		#expect(NodeNameLimits.trimmed(name, toBytes: NodeNameLimits.longNameBytes(storesCompactNames: true)).utf8.count == 24)
+	}
+
 	@Test("A name at the limit is left alone")
 	func atTheLimit() {
 		let name = String(repeating: "a", count: 24)

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -86,6 +86,22 @@ On hardened lockdown-firmware radios, this page also shows a **Lockdown** sectio
 
 Set your Long Name (display name) and Short Name (4-character/emoji identifier shown in the node circle).
 
+Both limits are counted in UTF-8 bytes rather than characters, because that is
+how the radio stores them: an emoji is four bytes, so four emoji fill the short
+name exactly. Typing past the limit stops rather than cutting a character in
+half.
+
+How long a Long Name can be depends on the radio. Firmware 2.8 and later keeps
+24 bytes of it — those radios store every node they hear in a slimmer record to
+save memory, and truncate anything longer as it arrives. Older firmware keeps
+39. The hint under the field shows whichever applies to the radio you are
+connected to.
+
+A name you already have is left alone, even if it is longer than the radio you
+are now connected to would keep. Note that a 2.8 radio hearing an older one
+still stores only 24 bytes of its name, so a longer name is shortened by
+everyone else's radio even when your own keeps it.
+
 ### Bluetooth
 
 BLE radio settings including PIN mode and power saving. Changes apply on next radio restart.


### PR DESCRIPTION
## Summary

The Long Name field allowed 36 bytes. A 2.8 radio stores every node it hears in
`NodeInfoLite`, whose `long_name` is `max_size:25` — 24 usable bytes plus the
terminator — and truncates anything longer on the way in. So a name between 25
and 36 bytes was accepted here and came back shortened from every 2.8 radio
that stored it.

The protobufs say it directly, in `deviceonly.options`:

> Flattened user fields. long_name was 40 on UserLite; trimmed to 25 here so
> the slim header gives back ~15 B/node of RAM. Names that exceeded 24 chars on
> the wire (max 40) get truncated on store, with `sanitizeUtf8` cleaning up
> partial multi-byte sequences at the boundary.

That landed in `65400a2`, "2.8: Refactor NodeInfoLite structure and add legacy
support for migration".

## What changed

The limit follows the connected radio's firmware: 24 bytes on 2.8 and later,
39 below, since older radios store peers in `UserLite` and keep the full wire
length. The help text shows whichever applies.

The trim happens in the field's binding rather than in `onChange`. `onAppear`
assigns the stored name straight to the state and `onChange` fires for that
too, so opening the screen with a longer name shortened it on the spot and set
`hasChanges`, before the user had touched anything. Now only typed input is
limited and an existing name is left alone.

The limit and the trim live in `NodeNameLimits` so the numbers are stated once
and covered by tests rather than sitting as literals in a view.

Trimming counts UTF-8 bytes rather than characters and will not split one — an
emoji is four bytes and the radio truncates by bytes, so a name of six emoji is
exactly full at 24.

Unchanged: the wire field, `User.long_name`, still carries 39 usable bytes.
Short Name already enforced 4 bytes, the same `max_size` minus terminator
convention. Ham names already fit — call sign 7 plus `//` plus descriptive name
14 is 23 — and there is a test pinning that.

## Worth knowing

The version gate is about the radio holding the name. A 2.8 node that hears an
older one still stores only 24 bytes of its name, so a longer name on a pre-2.8
radio is still cut by any 2.8 peer that sees it.

## Testing

Nine tests: both caps and the version selection, a name at the limit, a name
over it, byte counting rather than character counting, never splitting a
character at the boundary, a name that fits an older radio surviving untrimmed,
and a maximum-length Ham name still fitting. Full suite passes, 3033 tests.