### PR TITLE
Disable the channel slots a replace does not fill

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -760,13 +760,24 @@ extension AccessoryManager {
 		}
 
 		let channelIndex = Int32(truncatingIfNeeded: channel.index)
-		let existing = canonicalValidUniqueChannels(from: myInfo.channels).first { $0.index == channelIndex }
+		// Every row at this index, not just the canonical one. Older app versions could leave
+		// duplicate rows for a slot, and `canonicalValidUniqueChannels` keeps one of them and
+		// hides the rest — so acting on that alone would leave a stale sibling behind. The
+		// wholesale clear this replaced used to take them with it.
+		let matches = myInfo.channels.filter { $0.index == channelIndex }
+		let existing = canonicalValidUniqueChannels(from: matches).first
 		if channel.role == .disabled {
-			if let existing {
-				context.delete(existing)
-				try context.save()
+			guard !matches.isEmpty else { return }
+			for row in matches {
+				context.delete(row)
 			}
+			try context.save()
 			return
+		}
+
+		// Keep the canonical row and drop any siblings, so a slot ends up with exactly one.
+		for row in matches where row !== existing {
+			context.delete(row)
 		}
 
 		let entity: ChannelEntity

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -543,6 +543,23 @@ extension AccessoryManager {
 		try await send(toRadio, debugDescription: logString)
 	}
 
+	/// Builds one channel write. Role comes from the slot: index 0 is the primary, the rest are
+	/// secondaries.
+	private func makeChannel(_ settings: ChannelSettings, at index: Int32) -> Channel {
+		var chan = Channel()
+		chan.role = (index == 0) ? .primary : .secondary
+		chan.settings = settings
+		chan.index = index
+		// Ensure moduleSettings is always explicitly set so the device stores a defined
+		// position_precision value. QR codes typically omit moduleSettings which causes the
+		// firmware to default to 32 (full precision), leaking exact GPS coordinates.
+		if !settings.hasModuleSettings {
+			chan.settings.moduleSettings.positionPrecision = 0
+			chan.settings.moduleSettings.isMuted = false
+		}
+		return chan
+	}
+
 	public func saveChannelSet(base64UrlString: String, addChannels: Bool = false, okToMQTT: Bool = false) async throws {
 		let channelLink = try MeshtasticChannelURL.parse(base64UrlString, defaultAddChannels: addChannels)
 		try await saveChannelSet(
@@ -612,26 +629,35 @@ extension AccessoryManager {
 			targetChannelIndexes = channelSet.settings.indices.map { Int32($0) }
 		}
 
+		// A replace has to say something about every slot, not just the ones it fills. The radio
+		// keeps a fixed array of 8 and a role per slot, so writing only 0..n-1 leaves whatever
+		// was in the rest still enabled — replace an 8 channel set with a 2 channel one and the
+		// old channels 2-7 keep running. Disabling the tail is what makes the import
+		// authoritative; the radio drops those slots on the reboot the LoRa config below
+		// triggers.
+		let plannedChannels: [Channel] = {
+			var planned = zip(channelSet.settings, targetChannelIndexes).map { cs, targetIndex in
+				makeChannel(cs, at: targetIndex)
+			}
+			guard !addChannels else { return planned }
+			let filled = Set(targetChannelIndexes)
+			for index in Int32(0)..<maxChannelSlots where !filled.contains(index) {
+				var disabled = Channel()
+				disabled.index = index
+				disabled.role = .disabled
+				planned.append(disabled)
+			}
+			return planned
+		}()
+
 		var deliveredChannels: [Channel] = []
-		for (cs, targetIndex) in zip(channelSet.settings, targetChannelIndexes) {
+		for chan in plannedChannels {
 			// Stop sending channels if the calling Task was cancelled. The channels already
 			// sent are fine inside a transaction (commit will persist them); skipping the rest
 			// lets the import engine exit promptly. The local-state upserts below are safe to
 			// skip: they mirror to Core Data and are rebuilt on the next connect/drain.
 			try Task.checkCancellation()
 
-			var chan = Channel()
-			chan.role = (targetIndex == 0) ? .primary : .secondary
-			chan.settings = cs
-			chan.index = targetIndex
-			// Ensure moduleSettings is always explicitly set so the device
-			// stores a defined position_precision value. QR codes typically
-			// omit moduleSettings which causes the firmware to default to 32
-			// (full precision), leaking exact GPS coordinates.
-			if !cs.hasModuleSettings {
-				chan.settings.moduleSettings.positionPrecision = 0
-				chan.settings.moduleSettings.isMuted = false
-			}
 			var adminPacket = AdminMessage()
 			adminPacket.setChannel = chan
 
@@ -688,11 +714,10 @@ extension AccessoryManager {
 			try await send(toRadio, debugDescription: logString)
 		}
 
-		// Mirror delivered channels locally only after channel and LoRa writes
-		// succeed, so a failed replace cannot wipe local state.
-		if !addChannels {
-			tryClearExistingChannels()
-		}
+		// Mirror delivered channels locally only after channel and LoRa writes succeed, so a
+		// failed replace cannot wipe local state. No wholesale clear first: every slot was
+		// written above, and applyLocalChannelMutation deletes the row for a disabled one, so
+		// the local set follows the radio slot by slot.
 		for chan in deliveredChannels {
 			do {
 				try applyLocalChannelMutation(chan, fromNum: deviceNum)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -718,6 +718,15 @@ extension AccessoryManager {
 		// failed replace cannot wipe local state. No wholesale clear first: every slot was
 		// written above, and applyLocalChannelMutation deletes the row for a disabled one, so
 		// the local set follows the radio slot by slot.
+		//
+		// Duplicate rows for one slot are the exception. Older app versions could leave them,
+		// and the mutation below only ever sees the canonical one, so a sibling would survive
+		// a replace that is meant to be authoritative — including on a slot just disabled.
+		// The wholesale clear this replaced took them with it. Drop them here, after the
+		// writes succeeded, so a failed replace still leaves local state alone.
+		if !addChannels {
+			removeDuplicateChannelRows(for: deviceNum)
+		}
 		for chan in deliveredChannels {
 			do {
 				try applyLocalChannelMutation(chan, fromNum: deviceNum)
@@ -748,6 +757,25 @@ extension AccessoryManager {
 
 	/// Mirrors a user-initiated channel write on the main context. Automatic refresh replacement
 	/// uses this same executor, so a QR/UI mutation cannot land between its baseline check and save.
+	/// Leaves one row per channel index, keeping the same row `canonicalValidUniqueChannels`
+	/// would pick so nothing visible changes.
+	private func removeDuplicateChannelRows(for deviceNum: Int64) {
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == deviceNum })
+		guard let myInfo = try? context.fetch(descriptor).first else { return }
+		let keep = Set(canonicalValidUniqueChannels(from: myInfo.channels).map { ObjectIdentifier($0) })
+		var removed = false
+		for row in myInfo.channels where !keep.contains(ObjectIdentifier(row)) {
+			context.delete(row)
+			removed = true
+		}
+		guard removed else { return }
+		do {
+			try context.save()
+		} catch {
+			Logger.data.error("💥 Could not remove duplicate channel rows: \(error.localizedDescription, privacy: .public)")
+		}
+	}
+
 	func applyLocalChannelMutation(_ channel: Channel, fromNum: Int64) throws {
 		guard channel.isInitialized && (channel.hasSettings || channel.role == .disabled) else { return }
 		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == fromNum })
@@ -760,24 +788,13 @@ extension AccessoryManager {
 		}
 
 		let channelIndex = Int32(truncatingIfNeeded: channel.index)
-		// Every row at this index, not just the canonical one. Older app versions could leave
-		// duplicate rows for a slot, and `canonicalValidUniqueChannels` keeps one of them and
-		// hides the rest — so acting on that alone would leave a stale sibling behind. The
-		// wholesale clear this replaced used to take them with it.
-		let matches = myInfo.channels.filter { $0.index == channelIndex }
-		let existing = canonicalValidUniqueChannels(from: matches).first
+		let existing = canonicalValidUniqueChannels(from: myInfo.channels).first { $0.index == channelIndex }
 		if channel.role == .disabled {
-			guard !matches.isEmpty else { return }
-			for row in matches {
-				context.delete(row)
+			if let existing {
+				context.delete(existing)
+				try context.save()
 			}
-			try context.save()
 			return
-		}
-
-		// Keep the canonical row and drop any siblings, so a slot ends up with exactly one.
-		for row in matches where row !== existing {
-			context.delete(row)
 		}
 
 		let entity: ChannelEntity

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -55,9 +55,12 @@ func validUniqueChannelIndexes(from channels: [ChannelEntity]) -> [Int32] {
 	canonicalValidUniqueChannels(from: channels).map(\.index)
 }
 
+/// Slots the radio keeps. It is a fixed array with a role per slot, not a list that grows.
+let maxChannelSlots: Int32 = 8
+
 func availableChannelIndexes(from channels: [ChannelEntity]) -> [Int32] {
 	let occupied = Set(validUniqueChannelIndexes(from: channels))
-	return (Int32(0)...Int32(7)).filter { !occupied.contains($0) }
+	return (Int32(0)..<maxChannelSlots).filter { !occupied.contains($0) }
 }
 
 func nextAvailableSecondaryChannelIndex(from channels: [ChannelEntity]) -> Int32? {

--- a/MeshtasticTests/ChannelSetSaveTests.swift
+++ b/MeshtasticTests/ChannelSetSaveTests.swift
@@ -51,6 +51,17 @@ actor MockChannelSetConnection: Connection {
 		}
 	}
 
+	/// Role written to each slot, in send order.
+	var sentChannelRoles: [(index: Int32, role: Channel.Role)] {
+		sentPackets.compactMap { toRadio in
+			guard case let .packet(meshPacket) = toRadio.payloadVariant,
+				  case let .decoded(dataMessage) = meshPacket.payloadVariant,
+				  let admin = try? AdminMessage(serializedBytes: dataMessage.payload),
+				  case let .setChannel(channel) = admin.payloadVariant else { return nil }
+			return (Int32(truncatingIfNeeded: channel.index), channel.role)
+		}
+	}
+
 	var sentChannelIndexes: [Int32] {
 		sentPackets.compactMap { toRadio in
 			guard case let .packet(meshPacket) = toRadio.payloadVariant,
@@ -199,6 +210,47 @@ struct ChannelSetSaveTests {
 		// Regression for the duplicated LoRa send block (#1682): the config must be sent once.
 		let count = await connection.loraConfigSendCount
 		#expect(count == 1)
+	}
+
+	@Test("A replace disables every slot it does not fill")
+	func testReplaceDisablesTrailingSlots() async throws {
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection)
+		let link = try makeChannelSetLink(channelNames: ["TestNet", "Second"])
+
+		try await manager.saveChannelSet(base64UrlString: link, addChannels: false, okToMQTT: false)
+
+		// The radio keeps a fixed array of 8 slots with a role each. Writing only the two the
+		// import fills would leave whatever was in slots 2-7 still enabled, so an 8 channel
+		// radio would keep running six channels the import never mentioned.
+		let roles = await connection.sentChannelRoles
+		#expect(roles.count == 8, "every slot is written, got \(roles.count)")
+		#expect(roles.first { $0.index == 0 }?.role == .primary)
+		#expect(roles.first { $0.index == 1 }?.role == .secondary)
+		for index in Int32(2)..<Int32(8) {
+			#expect(roles.first { $0.index == index }?.role == .disabled,
+					"slot \(index) should be disabled")
+		}
+	}
+
+	@Test("Appending channels leaves the other slots alone")
+	func testAppendDoesNotDisableAnything() async throws {
+		let deviceNum: Int64 = 123_456_799
+		try seedMyInfo(deviceNum: deviceNum, channels: [(0, "Primary"), (1, "Secondary")])
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection, deviceNum: deviceNum)
+		let link = try makeChannelSetLink(includeLoRaConfig: false, channelNames: ["Added"])
+
+		// Append sends no LoRa config, so the mock's post-wantConfig disconnect surfaces as an
+		// error — after the channel write.
+		await #expect(throws: (any Error).self) {
+			try await manager.saveChannelSet(base64UrlString: link, addChannels: true, okToMQTT: false)
+		}
+
+		// Append is not authoritative: it fills a free slot and says nothing about the rest.
+		let roles = await connection.sentChannelRoles
+		#expect(roles.allSatisfy { $0.role != .disabled }, "append must not disable a slot")
+		#expect(roles.map(\.index) == [2])
 	}
 
 	@Test("A malformed channel-set link throws instead of silently succeeding")

--- a/MeshtasticTests/ChannelSetSaveTests.swift
+++ b/MeshtasticTests/ChannelSetSaveTests.swift
@@ -148,6 +148,13 @@ struct ChannelSetSaveTests {
 		return manager
 	}
 
+	/// Every persisted row for a device, duplicates included.
+	private func channelRows(for deviceNum: Int64) throws -> [ChannelEntity] {
+		let context = PersistenceController.shared.context
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.myNodeNum == deviceNum })
+		return try context.fetch(descriptor).first?.channels.sorted { $0.index < $1.index } ?? []
+	}
+
 	private func seedMyInfo(deviceNum: Int64, channelName: String) throws {
 		try seedMyInfo(deviceNum: deviceNum, channels: [(0, channelName)])
 	}
@@ -231,6 +238,28 @@ struct ChannelSetSaveTests {
 			#expect(roles.first { $0.index == index }?.role == .disabled,
 					"slot \(index) should be disabled")
 		}
+	}
+
+	@Test("A replace clears duplicate rows left by older versions")
+	func testReplaceRemovesDuplicateRows() async throws {
+		// Duplicate rows for one slot are a supported legacy state — see the append test
+		// below. The wholesale clear this replace path used to do took them with it; acting
+		// only on the canonical row would leave the sibling behind, enabled and stale.
+		let deviceNum: Int64 = 123_456_801
+		try seedMyInfo(
+			deviceNum: deviceNum,
+			channels: [(0, "Legacy Primary"), (0, "Current Primary"), (1, "One"), (1, "One Again"), (2, "Two")]
+		)
+		let connection = MockChannelSetConnection()
+		let manager = makeManager(connection: connection, deviceNum: deviceNum)
+		let channelSet = makeChannelSet(channelNames: ["Replaced"])
+
+		try await manager.saveChannelSet(channelSet: channelSet, addChannels: false, okToMQTT: false)
+
+		let remaining = try channelRows(for: deviceNum)
+		#expect(remaining.count == 1, "one row for the one imported slot, got \(remaining.map { "\($0.index):\($0.name ?? "")" })")
+		#expect(remaining.first?.index == 0)
+		#expect(remaining.first?.name == "Replaced")
 	}
 
 	@Test("Appending channels leaves the other slots alone")


### PR DESCRIPTION
## Summary

The radio keeps eight channel slots with a role on each. A replace only wrote
the slots the import filled, so replacing an eight channel set with a two
channel one left the old channels 2-7 enabled. The app showed two channels and
the radio still had eight.

## What changed

A replace writes every slot: the imported settings where there are any,
disabled for the rest. The radio drops the disabled slots on the reboot the
LoRa config write already causes.

Append is unchanged. It fills a free slot and says nothing about the others.

Local state follows the writes slot by slot instead of being cleared first,
since a disabled write already deletes the row. Duplicate rows for one slot,
which older versions could leave, are cleared on the replace path after the
writes succeed — the mutation only sees one row per index, so a sibling would
otherwise survive a replace.

## Testing

Three tests: a replace writes all eight slots with the tail disabled, an
append writes only its own slot, and a replace over seeded duplicate rows
leaves one row per index. The last one fails without the fix. Full suite
passes.

Not tested against hardware. Worth importing a two channel QR in replace mode
onto a radio with several secondaries and confirming the extras are gone.