### PR TITLE
Fix Ambient Lighting target during remote administration

### DIFF
--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -781,7 +781,7 @@ struct Settings: View {
 				case .power:
 					PowerConfig(node: configNode)
 				case .ambientLighting:
-					AmbientLightingConfig(node: node)
+					AmbientLightingConfig(node: configNode)
 				case .audio:
 					AudioConfig(node: configNode)
 				case .cannedMessages:


### PR DESCRIPTION
## What changed?
Ambient Lighting now opens for the node selected in Settings, including a remote node.

## Why did it change?
This is part of bringing the iOS Remote Admin experience into parity with Android. Android retains the selected remote destination for configuration routes ([SettingsNavigation](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt#L198-L247)). This PR fixes the iOS-specific Ambient Lighting destination bug that breaks that behavior.
This destination passed the connected node while neighboring configuration destinations use `configNode`. Selecting a remote node could therefore show and save the connected radio’s Ambient Lighting configuration.

## How is this tested?
- iPhone 16 Pro simulator, iOS 18.6: `xcodebuild build-for-testing` passed.
- `xcodebuild test-without-building -only-testing:MeshtasticTests/SettingsNodeSortTests -only-testing:MeshtasticTests/ChannelSetSaveTests -parallel-testing-enabled NO`: 21 passed, zero failed.
- Repeated the Settings node-selection flow before and after the change. With U-District Solar selected, the old view displayed Capitol Hill Relay; the fixed view uses the remote configuration state.
- Independent code review completed. This one-line routing correction does not need a documentation change.

## Screenshots/Videos (when applicable)
Same existing seeded simulator fixture in both images. No radio writes were performed; the remote fixture has no returned Ambient Lighting configuration, so the fixed screen correctly waits for it.

| Before | After |
| --- | --- |
| <img width="300" src="https://github.com/user-attachments/assets/c33037ed-5d9e-4f72-a012-117fbf48d72b" alt="Incorrect connected-node configuration" /> | <img width="300" src="https://github.com/user-attachments/assets/e8c1573e-0b4e-4776-b84f-24712739dd36" alt="Selected remote-node configuration state" /> |

## Checklist
- [x] Code follows the project’s style.
- [x] Self-review and independent review completed.
- [x] Documentation impact checked; no user workflow changes.
- [x] Build, targeted tests, and simulator flow verified.
