### PR TITLE
Open remote administration from node details for Android parity

### DIFF
--- a/Meshtastic/Model/NodeInfoEntity.swift
+++ b/Meshtastic/Model/NodeInfoEntity.swift
@@ -176,7 +176,7 @@ extension NodeInfoEntity {
 	/// session passkey inside the firmware's 5-minute session window. Empty-passkey stamps
 	/// (from the local config download and post-save mirrors) don't count.
 	var hasLiveAdminSession: Bool {
-		sessionPasskey?.isEmpty == false && (sessionExpiration ?? .distantPast) >= Date()
+		RemoteAdminSessionFreshness.isFresh(passkey: sessionPasskey, expiration: sessionExpiration)
 	}
 
 	/// Whether this node's own reported firmware supports the Status Message module (2.8+,

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -62,6 +62,10 @@ class Router: ObservableObject {
 	/// The currently selected node in the NavigationSplitView detail pane.
 	@Published var selectedNodeNum: Int64?
 
+	/// One-shot request consumed by Settings after a remote-admin entry point selects a node.
+	/// It remains pending while the Settings tab is lazy or its node snapshot is still loading.
+	@Published var settingsNodeNum: Int64?
+
 	// MARK: Node Object ID Cache
 
 	/// In-memory cache mapping node numbers to their SwiftData `PersistentIdentifier` for O(1) lookups.
@@ -189,6 +193,13 @@ class Router: ObservableObject {
 		Logger.services.info("🛣 [App] Direct route to node detail \(nodeNum, privacy: .public)")
 		selectedTab = .nodes
 		selectedNodeNum = nodeNum
+	}
+
+	func navigateToSettings(nodeNum: Int64) {
+		Logger.services.info("🛣 [App] Direct route to settings for node \(nodeNum, privacy: .public)")
+		settingsNodeNum = nodeNum
+		settingsPath = []
+		selectedTab = .settings
 	}
 
 	func popToRoot(tab: NavigationState.Tab) {

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -62,10 +62,6 @@ class Router: ObservableObject {
 	/// The currently selected node in the NavigationSplitView detail pane.
 	@Published var selectedNodeNum: Int64?
 
-	/// One-shot request consumed by Settings after a remote-admin entry point selects a node.
-	/// It remains pending while the Settings tab is lazy or its node snapshot is still loading.
-	@Published var settingsNodeNum: Int64?
-
 	// MARK: Node Object ID Cache
 
 	/// In-memory cache mapping node numbers to their SwiftData `PersistentIdentifier` for O(1) lookups.
@@ -193,13 +189,6 @@ class Router: ObservableObject {
 		Logger.services.info("🛣 [App] Direct route to node detail \(nodeNum, privacy: .public)")
 		selectedTab = .nodes
 		selectedNodeNum = nodeNum
-	}
-
-	func navigateToSettings(nodeNum: Int64) {
-		Logger.services.info("🛣 [App] Direct route to settings for node \(nodeNum, privacy: .public)")
-		settingsNodeNum = nodeNum
-		settingsPath = []
-		selectedTab = .settings
 	}
 
 	func popToRoot(tab: NavigationState.Tab) {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1024,6 +1024,7 @@ struct NodeDetail: View {
 	private func establishRemoteAdminSession() async {
 		guard let attemptID = remoteAdminAttemptID,
 			let radioNum = accessoryManager.activeDeviceNum,
+			let connection = accessoryManager.activeConnection?.connection,
 			nodeNum != radioNum else {
 			remoteAdminState = .failed(.targetChanged)
 			return
@@ -1036,10 +1037,12 @@ struct NodeDetail: View {
 			remoteAdminState = .failed(.disconnected)
 			return
 		}
+		let connectionID = ObjectIdentifier(connection)
 		let result = await RemoteAdminSessionOrchestrator.establish(
 			allowed: { UserDefaults.enableAdministration && accessoryManager.isConnected },
 			attemptIsCurrent: { [weak accessoryManager, weak node, weak router] in
 				accessoryManager?.activeDeviceNum == radioNum
+					&& accessoryManager?.activeConnection.map { ObjectIdentifier($0.connection) } == connectionID
 					&& node?.modelContext != nil && node?.isDeleted == false
 					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
 					&& self.remoteAdminAttemptID == attemptID
@@ -1057,6 +1060,7 @@ struct NodeDetail: View {
 					isConnected: { [weak accessoryManager] in
 						accessoryManager?.isConnected == true
 						&& accessoryManager?.activeDeviceNum == radioNum
+						&& accessoryManager?.activeConnection.map { ObjectIdentifier($0.connection) } == connectionID
 						&& self.remoteAdminAttemptID == attemptID
 					},
 					targetIsCurrent: { [weak node, weak router] in
@@ -1073,6 +1077,7 @@ struct NodeDetail: View {
 		guard UserDefaults.enableAdministration,
 			accessoryManager.isConnected,
 			accessoryManager.activeDeviceNum == radioNum,
+			accessoryManager.activeConnection.map({ ObjectIdentifier($0.connection) }) == connectionID,
 			node.modelContext != nil, !node.isDeleted,
 			remoteAdminAttemptID == attemptID else {
 			remoteAdminState = .failed(.targetChanged)

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -29,6 +29,7 @@ private struct NodeDetailLogAvailability {
 
 struct NodeDetail: View {
 	private let gridItemLayout = Array(repeating: GridItem(.flexible(), spacing: 10), count: 2)
+	private let nodeDetailScrollContentTopMargin: CGFloat = 0
 	private static let relativeFormatter: RelativeDateTimeFormatter = {
 		let formatter = RelativeDateTimeFormatter()
 		formatter.unitsStyle = .full
@@ -174,7 +175,7 @@ struct NodeDetail: View {
 							guard notification.object as? Int64 == nodeNum else { return }
 							refreshNodeSummary()
 						}
-						.contentMargins(.top, 0, for: .scrollContent)
+						.contentMargins(.top, nodeDetailScrollContentTopMargin, for: .scrollContent)
 						.task(id: remoteAdminAttemptID) {
 							guard remoteAdminAttemptID != nil else { return }
 							await establishRemoteAdminSession()

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -55,6 +55,8 @@ struct NodeDetail: View {
 	@State private var latestPowerMetrics: TelemetryEntity?
 	@State private var logAvailability = NodeDetailLogAvailability()
 	@State private var showingShareContactQR = false
+	@State private var remoteAdminState: RemoteAdminSessionState = .stale
+	@State private var remoteAdminAttemptID: UUID?
 
 	init(node: NodeInfoEntity, nodeNum: Int64, showMapLink: Bool = true) {
 		self.node = node
@@ -153,11 +155,29 @@ struct NodeDetail: View {
 						.onChange(of: node.lastHeard) {
 							refreshNodeSummary()
 						}
+						.onChange(of: accessoryManager.activeDeviceNum) { _, _ in
+							remoteAdminAttemptID = nil
+							if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
+							if !accessoryManager.isConnected {
+								remoteAdminState = .stale
+							}
+						}
+						.onChange(of: accessoryManager.isConnected) { _, connected in
+							if !connected {
+								remoteAdminAttemptID = nil
+								if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
+								remoteAdminState = .stale
+							}
+						}
 						.onReceive(NotificationCenter.default.publisher(for: .nodeLogAvailabilityDidChange)) { notification in
 							guard notification.object as? Int64 == nodeNum else { return }
 							refreshNodeSummary()
 						}
 						.contentMargins(.top, 0, for: .scrollContent)
+						.task(id: remoteAdminAttemptID) {
+							guard remoteAdminAttemptID != nil else { return }
+							await establishRemoteAdminSession()
+						}
 					.navigationTitle(String((currentUser?.displayLongName ?? "Unknown".localized).addingVariationSelectors))
 					.navigationBarTitleDisplayMode(.inline)
 					.id(displayNameRefresh)
@@ -867,11 +887,13 @@ struct NodeDetail: View {
 
 	@ViewBuilder
 	private var administrationSection: some View {
-		if let metadata = node.metadata,
-		   connectedNode != nil,
-		   accessoryManager.isConnected {
+		if connectedNode != nil, accessoryManager.isConnected {
 			Section("Administration") {
 				let administrationUserPair = self.administrationUserPair
+				if nodeNum != accessoryManager.activeDeviceNum {
+					remoteAdminEntry(administrationUserPair: administrationUserPair)
+				}
+				if let metadata = node.metadata {
 				if UserDefaults.enableAdministration {
 					Button {
 						Task {
@@ -946,8 +968,118 @@ struct NodeDetail: View {
 					}
 				}
 				.disabled(administrationUserPair == nil)
+				}
 			}
 		}
+	}
+
+	@ViewBuilder
+	private func remoteAdminEntry(administrationUserPair: (fromUser: UserEntity, toUser: UserEntity)?) -> some View {
+		let targetName = currentUser?.displayLongName ?? "Unknown".localized
+		switch remoteAdminState {
+		case .establishing:
+			HStack {
+				ProgressView()
+				Text("Establishing remote admin for \(targetName)")
+			}
+		case .active:
+			Button {
+				remoteAdminState = .establishing
+				remoteAdminAttemptID = UUID()
+			} label: {
+				Label("Remote Admin: \(targetName)", systemImage: "checkmark.shield")
+			}
+		case .failed(let result):
+			VStack(alignment: .leading) {
+				Button {
+					remoteAdminState = .establishing
+					remoteAdminAttemptID = UUID()
+				} label: {
+					Label("Retry Remote Admin for \(targetName)", systemImage: "arrow.clockwise")
+				}
+				Text("Remote admin failed: \(RemoteAdminSessionWaiter.description(for: result)).")
+					.font(.caption)
+					.foregroundStyle(.orange)
+			}
+			.disabled(administrationUserPair == nil || !UserDefaults.enableAdministration)
+		case .stale:
+			VStack(alignment: .leading) {
+				Button {
+					remoteAdminState = .establishing
+					remoteAdminAttemptID = UUID()
+				} label: {
+					Label("Remote Admin: \(targetName)", systemImage: "shield")
+				}
+				if !UserDefaults.enableAdministration {
+					Text("Enable Administration in App Settings to use remote admin.")
+						.font(.caption)
+						.foregroundStyle(.orange)
+				}
+			}
+			.disabled(administrationUserPair == nil || !UserDefaults.enableAdministration)
+		}
+	}
+
+	@MainActor
+	private func establishRemoteAdminSession() async {
+		guard let attemptID = remoteAdminAttemptID,
+			let radioNum = accessoryManager.activeDeviceNum,
+			nodeNum != radioNum else {
+			remoteAdminState = .failed(.targetChanged)
+			return
+		}
+		guard UserDefaults.enableAdministration else {
+			remoteAdminState = .failed(.requestFailed)
+			return
+		}
+		guard let administrationUserPair else {
+			remoteAdminState = .failed(.disconnected)
+			return
+		}
+		let result = await RemoteAdminSessionOrchestrator.establish(
+			allowed: { UserDefaults.enableAdministration && accessoryManager.isConnected },
+			attemptIsCurrent: { [weak accessoryManager, weak node, weak router] in
+				accessoryManager?.activeDeviceNum == radioNum
+					&& node?.modelContext != nil && node?.isDeleted == false
+					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
+					&& self.remoteAdminAttemptID == attemptID
+			},
+			fresh: { [weak node] in node?.hasLiveAdminSession == true },
+			request: {
+				_ = try await accessoryManager.requestDeviceMetadata(
+					fromUser: administrationUserPair.fromUser,
+					toUser: administrationUserPair.toUser
+				)
+			},
+			wait: {
+				await RemoteAdminSessionWaiter.wait(
+					isLive: { [weak node] in node?.hasLiveAdminSession == true },
+					isConnected: { [weak accessoryManager] in
+						accessoryManager?.isConnected == true
+						&& accessoryManager?.activeDeviceNum == radioNum
+						&& self.remoteAdminAttemptID == attemptID
+					},
+					targetIsCurrent: { [weak node, weak router] in
+						node?.modelContext != nil && node?.isDeleted == false
+						&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
+					}
+				)
+			}
+		)
+		guard result == .active else {
+			remoteAdminState = .failed(result)
+			return
+		}
+		guard UserDefaults.enableAdministration,
+			accessoryManager.isConnected,
+			accessoryManager.activeDeviceNum == radioNum,
+			node.modelContext != nil, !node.isDeleted,
+			remoteAdminAttemptID == attemptID else {
+			remoteAdminState = .failed(.targetChanged)
+			return
+		}
+		remoteAdminState = .active
+		router.navigateToSettings(nodeNum: nodeNum)
 	}
 
 	private func refreshNodeSummary() {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -57,6 +57,7 @@ struct NodeDetail: View {
 	@State private var showingShareContactQR = false
 	@State private var remoteAdminState: RemoteAdminSessionState = .stale
 	@State private var remoteAdminAttemptID: UUID?
+	@State private var remoteSettingsDestination: RemoteAdminSettingsDestination?
 
 	init(node: NodeInfoEntity, nodeNum: Int64, showMapLink: Bool = true) {
 		self.node = node
@@ -156,16 +157,16 @@ struct NodeDetail: View {
 							refreshNodeSummary()
 						}
 						.onChange(of: accessoryManager.activeDeviceNum) { _, _ in
+							remoteSettingsDestination = nil
 							remoteAdminAttemptID = nil
-							if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
 							if !accessoryManager.isConnected {
 								remoteAdminState = .stale
 							}
 						}
 						.onChange(of: accessoryManager.isConnected) { _, connected in
 							if !connected {
+								remoteSettingsDestination = nil
 								remoteAdminAttemptID = nil
-								if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
 								remoteAdminState = .stale
 							}
 						}
@@ -178,6 +179,27 @@ struct NodeDetail: View {
 							guard remoteAdminAttemptID != nil else { return }
 							await establishRemoteAdminSession()
 						}
+					.onChange(of: accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) }) { _, connectionID in
+						if let destination = remoteSettingsDestination, destination.connectionID != connectionID {
+							remoteSettingsDestination = nil
+						}
+					}
+					.navigationDestination(isPresented: Binding(
+						get: { remoteSettingsDestination != nil },
+						set: { if !$0 { remoteSettingsDestination = nil } }
+					)) {
+						if let destination = remoteSettingsDestination {
+							Settings(remoteNodeNum: destination.nodeNum)
+								.disabled(!destination.isCurrent(
+									radioNum: accessoryManager.activeDeviceNum,
+									connectionID: accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) },
+									isConnected: accessoryManager.isConnected))
+						}
+					}
+					.onChange(of: nodeNum) { _, _ in
+						remoteSettingsDestination = nil
+						remoteAdminAttemptID = nil
+					}
 					.navigationTitle(String((currentUser?.displayLongName ?? "Unknown".localized).addingVariationSelectors))
 					.navigationBarTitleDisplayMode(.inline)
 					.id(displayNameRefresh)
@@ -988,6 +1010,7 @@ struct NodeDetail: View {
 				remoteAdminAttemptID = UUID()
 			} label: {
 				Label("Remote Admin: \(targetName)", systemImage: "checkmark.shield")
+					.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 			}
 		case .failed(let result):
 			VStack(alignment: .leading) {
@@ -996,6 +1019,7 @@ struct NodeDetail: View {
 					remoteAdminAttemptID = UUID()
 				} label: {
 					Label("Retry Remote Admin for \(targetName)", systemImage: "arrow.clockwise")
+						.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 				}
 				Text("Remote admin failed: \(RemoteAdminSessionWaiter.description(for: result)).")
 					.font(.caption)
@@ -1009,6 +1033,7 @@ struct NodeDetail: View {
 					remoteAdminAttemptID = UUID()
 				} label: {
 					Label("Remote Admin: \(targetName)", systemImage: "shield")
+						.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 				}
 				if !UserDefaults.enableAdministration {
 					Text("Enable Administration in App Settings to use remote admin.")
@@ -1047,7 +1072,8 @@ struct NodeDetail: View {
 					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
 					&& self.remoteAdminAttemptID == attemptID
 			},
-			fresh: { [weak node] in node?.hasLiveAdminSession == true },
+			// Fetch to refresh the retained main-context node after the packet actor saves a session.
+			fresh: { getNodeInfo(id: nodeNum, context: context)?.hasLiveAdminSession == true },
 			request: {
 				_ = try await accessoryManager.requestDeviceMetadata(
 					fromUser: administrationUserPair.fromUser,
@@ -1056,7 +1082,7 @@ struct NodeDetail: View {
 			},
 			wait: {
 				await RemoteAdminSessionWaiter.wait(
-					isLive: { [weak node] in node?.hasLiveAdminSession == true },
+					isLive: { getNodeInfo(id: nodeNum, context: context)?.hasLiveAdminSession == true },
 					isConnected: { [weak accessoryManager] in
 						accessoryManager?.isConnected == true
 						&& accessoryManager?.activeDeviceNum == radioNum
@@ -1084,7 +1110,7 @@ struct NodeDetail: View {
 			return
 		}
 		remoteAdminState = .active
-		router.navigateToSettings(nodeNum: nodeNum)
+		remoteSettingsDestination = RemoteAdminSettingsDestination(nodeNum: nodeNum, radioNum: radioNum, connectionID: connectionID)
 	}
 
 	private func refreshNodeSummary() {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1054,6 +1054,11 @@ struct NodeDetail: View {
 			remoteAdminState = .failed(.targetChanged)
 			return
 		}
+		defer {
+			if remoteAdminAttemptID == attemptID {
+				remoteAdminAttemptID = nil
+			}
+		}
 		guard UserDefaults.enableAdministration else {
 			remoteAdminState = .failed(.requestFailed)
 			return

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+enum RemoteAdminSessionState: Equatable {
+	case stale
+	case establishing
+	case active
+	case failed(RemoteAdminSessionWaiter.Result)
+}
+
+enum RemoteAdminSessionFreshness {
+	static func isFresh(passkey: Data?, expiration: Date?, now: Date = Date()) -> Bool {
+		guard let passkey, !passkey.isEmpty, let expiration else { return false }
+		return expiration >= now
+	}
+}
+
+enum RemoteAdminSessionWaiter {
+	enum Result: Equatable {
+		case active
+		case timedOut
+		case disconnected
+		case targetChanged
+		case cancelled
+		case requestFailed
+	}
+
+	static func description(for result: Result) -> String {
+		switch result {
+		case .active: return "active"
+		case .timedOut: return "timed out"
+		case .disconnected: return "disconnected"
+		case .targetChanged: return "target changed"
+		case .cancelled: return "cancelled"
+		case .requestFailed: return "request failed"
+		}
+	}
+
+	@MainActor static func wait(
+		timeout: Duration = .seconds(30),
+		pollInterval: Duration = .milliseconds(200),
+		isLive: @escaping @MainActor () -> Bool,
+		isConnected: @escaping @MainActor () -> Bool,
+		targetIsCurrent: @escaping @MainActor () -> Bool,
+		sleep: @escaping @MainActor (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+	) async -> Result {
+		var elapsed = Duration.zero
+		while true {
+			if Task.isCancelled { return .cancelled }
+			if !isConnected() { return .disconnected }
+			if !targetIsCurrent() { return .targetChanged }
+			if isLive() { return .active }
+			if elapsed >= timeout { return .timedOut }
+			do {
+				let delay = min(pollInterval, timeout - elapsed)
+				try await sleep(delay)
+				elapsed += delay
+			} catch {
+				return .cancelled
+			}
+		}
+	}
+}
+
+enum RemoteAdminSessionOrchestrator {
+	@MainActor
+	static func establish(
+		allowed: @escaping @MainActor () -> Bool,
+		attemptIsCurrent: @escaping @MainActor () -> Bool,
+		fresh: @escaping @MainActor () -> Bool,
+		request: @escaping @MainActor () async throws -> Void,
+		wait: @escaping @MainActor () async -> RemoteAdminSessionWaiter.Result
+	) async -> RemoteAdminSessionWaiter.Result {
+		guard allowed() else { return .requestFailed }
+		guard !fresh() else { return .active }
+		guard attemptIsCurrent() else { return .targetChanged }
+		do {
+			try await request()
+		} catch is CancellationError {
+			return .cancelled
+		} catch {
+			return .requestFailed
+		}
+		guard attemptIsCurrent() else { return .targetChanged }
+		let result = await wait()
+		guard result == .active else { return result }
+		guard allowed() else { return .requestFailed }
+		guard attemptIsCurrent() else { return .targetChanged }
+		return .active
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -1,4 +1,13 @@
+//
+//  RemoteAdminSession.swift
+//  Meshtastic
+//
+//  Coordinates remote administration session state and confirmation waits.
+//
+
 import Foundation
+
+// MARK: - Session State
 
 enum RemoteAdminSessionState: Equatable {
 	case stale
@@ -7,12 +16,16 @@ enum RemoteAdminSessionState: Equatable {
 	case failed(RemoteAdminSessionWaiter.Result)
 }
 
+// MARK: - Session Freshness
+
 enum RemoteAdminSessionFreshness {
 	static func isFresh(passkey: Data?, expiration: Date?, now: Date = Date()) -> Bool {
 		guard let passkey, !passkey.isEmpty, let expiration else { return false }
 		return expiration >= now
 	}
 }
+
+// MARK: - Session Waiter
 
 enum RemoteAdminSessionWaiter {
 	enum Result: Equatable {
@@ -62,6 +75,8 @@ enum RemoteAdminSessionWaiter {
 	}
 }
 
+// MARK: - Session Orchestration
+
 enum RemoteAdminSessionOrchestrator {
 	@MainActor
 	static func establish(
@@ -89,6 +104,8 @@ enum RemoteAdminSessionOrchestrator {
 		return .active
 	}
 }
+
+// MARK: - Settings Destination
 
 struct RemoteAdminSettingsDestination {
 	let nodeNum: Int64

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -43,6 +43,7 @@ enum RemoteAdminSessionWaiter {
 		targetIsCurrent: @escaping @MainActor () -> Bool,
 		sleep: @escaping @MainActor (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
 	) async -> Result {
+		guard pollInterval > .zero else { return .timedOut }
 		var elapsed = Duration.zero
 		while true {
 			if Task.isCancelled { return .cancelled }
@@ -86,5 +87,15 @@ enum RemoteAdminSessionOrchestrator {
 		guard allowed() else { return .requestFailed }
 		guard attemptIsCurrent() else { return .targetChanged }
 		return .active
+	}
+}
+
+struct RemoteAdminSettingsDestination {
+	let nodeNum: Int64
+	let radioNum: Int64
+	let connectionID: ObjectIdentifier
+
+	func isCurrent(radioNum: Int64?, connectionID: ObjectIdentifier?, isConnected: Bool) -> Bool {
+		isConnected && radioNum == self.radioNum && connectionID == self.connectionID
 	}
 }

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -18,7 +18,7 @@ struct ConfigHeader<T>: View {
 		} else if node != nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			// Let users know what is going on if they are using remote admin and don't have the config yet
 			let expiration = node?.sessionExpiration ?? Date()
-			if node?[keyPath: config] == nil  || expiration < node?.sessionExpiration ?? Date() {
+			if node?[keyPath: config] == nil || expiration < Date() {
 				Text("\(title) config data was requested via PKC admin but no response has been returned from the remote node.")
 					.font(.callout)
 					.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -17,8 +17,7 @@ struct ConfigHeader<T>: View {
 
 		} else if node != nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			// Let users know what is going on if they are using remote admin and don't have the config yet
-			let expiration = node?.sessionExpiration ?? Date()
-			if node?[keyPath: config] == nil || expiration < Date() {
+			if node?[keyPath: config] == nil || node?.hasLiveAdminSession != true {
 				Text("\(title) config data was requested via PKC admin but no response has been returned from the remote node.")
 					.font(.callout)
 					.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -259,7 +259,7 @@ struct Settings: View {
 					.foregroundColor(.gray)
 			}
 
-			NavigationLink(value: SettingsNavigationState.lora) {
+			settingsLink(value: .lora) {
 				Label {
 					Text("LoRa")
 				} icon: {
@@ -268,7 +268,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.channels) {
+			settingsLink(value: .channels) {
 				Label {
 					Text("Channels")
 				} icon: {
@@ -277,7 +277,7 @@ struct Settings: View {
 			}
 			.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
-			NavigationLink(value: SettingsNavigationState.security) {
+			settingsLink(value: .security) {
 				Label {
 					Text("Security")
 				} icon: {
@@ -285,7 +285,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.shareQRCode) {
+			settingsLink(value: .shareQRCode) {
 				Label {
 					Text("Share QR Code")
 				} icon: {
@@ -298,7 +298,7 @@ struct Settings: View {
 
 	var deviceConfigurationSection: some View {
 		Section("Device Configuration") {
-			NavigationLink(value: SettingsNavigationState.user) {
+			settingsLink(value: .user) {
 				Label {
 					Text("User")
 				} icon: {
@@ -306,7 +306,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.bluetooth) {
+			settingsLink(value: .bluetooth) {
 				Label {
 					Text("Bluetooth")
 				} icon: {
@@ -314,7 +314,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.device) {
+			settingsLink(value: .device) {
 				Label {
 					Text("Device")
 				} icon: {
@@ -322,7 +322,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.display) {
+			settingsLink(value: .display) {
 				Label {
 					Text("Display")
 				} icon: {
@@ -330,7 +330,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.network) {
+			settingsLink(value: .network) {
 				Label {
 					Text("Network")
 				} icon: {
@@ -338,7 +338,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.position) {
+			settingsLink(value: .position) {
 				Label {
 					Text("Position")
 				} icon: {
@@ -346,7 +346,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.power) {
+			settingsLink(value: .power) {
 				Label {
 					Text("Power")
 				} icon: {
@@ -364,7 +364,7 @@ struct Settings: View {
 		let excludedModules = node?.excludedModules ?? 0
 		return Section {
 			if isModuleSupported(.ambientlightingConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.ambientLighting) {
+				settingsLink(value: .ambientLighting) {
 					Label {
 						Text("Ambient Lighting")
 					} icon: {
@@ -374,7 +374,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.audioConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.audio) {
+				settingsLink(value: .audio) {
 					Label {
 						Text("Audio")
 					} icon: {
@@ -384,7 +384,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.cannedmsgConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.cannedMessages) {
+				settingsLink(value: .cannedMessages) {
 					Label {
 						Text("Canned Messages")
 					} icon: {
@@ -394,7 +394,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.detectionsensorConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.detectionSensor) {
+				settingsLink(value: .detectionSensor) {
 					Label {
 						Text("Detection Sensor")
 					} icon: {
@@ -404,7 +404,7 @@ struct Settings: View {
 			}
 
 			if isMeshBeaconModuleSupported(node) {
-				NavigationLink(value: SettingsNavigationState.meshBeacon) {
+				settingsLink(value: .meshBeacon) {
 					Label {
 						Text("Mesh Beacon")
 					} icon: {
@@ -414,7 +414,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.extnotifConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.externalNotification) {
+				settingsLink(value: .externalNotification) {
 					Label {
 						Text("External Notification")
 					} icon: {
@@ -424,7 +424,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.mqttConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.mqtt) {
+				settingsLink(value: .mqtt) {
 					Label {
 						Text("MQTT")
 					} icon: {
@@ -434,7 +434,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.neighborinfoConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.neighborInfo) {
+				settingsLink(value: .neighborInfo) {
 					Label {
 						Text("Neighbor Info")
 					} icon: {
@@ -444,7 +444,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.rangetestConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.rangeTest) {
+				settingsLink(value: .rangeTest) {
 					Label {
 						Text("Range Test")
 					} icon: {
@@ -454,7 +454,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.paxcounterConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.paxCounter) {
+				settingsLink(value: .paxCounter) {
 					Label {
 						Text("PAX Counter")
 					} icon: {
@@ -464,7 +464,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.extnotifConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.ringtone) {
+				settingsLink(value: .ringtone) {
 					Label {
 						Text("Ringtone")
 					} icon: {
@@ -474,7 +474,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.serialConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.serial) {
+				settingsLink(value: .serial) {
 					Label {
 						Text("Serial")
 					} icon: {
@@ -484,7 +484,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.storeforwardConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.storeAndForward) {
+				settingsLink(value: .storeAndForward) {
 					Label {
 						Text("Store & Forward")
 					} icon: {
@@ -499,7 +499,7 @@ struct Settings: View {
 			// the top, and the in-app TAK Server controls (Enable, channel,
 			// mTLS certificates, data package export) below it. The TAK
 			// section at the bottom of this screen links to the same view.
-			NavigationLink(value: SettingsNavigationState.tak) {
+			settingsLink(value: .tak) {
 				Label {
 					Text("TAK Server")
 				} icon: {
@@ -508,7 +508,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.telemetryConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.telemetry) {
+				settingsLink(value: .telemetry) {
 					Label {
 						Text("Telemetry")
 					} icon: {
@@ -518,7 +518,7 @@ struct Settings: View {
 			}
 
 			if isTrafficManagementModuleSupported(node) {
-				NavigationLink(value: SettingsNavigationState.trafficManagement) {
+				settingsLink(value: .trafficManagement) {
 					Label {
 						Text("Traffic Management")
 					} icon: {
@@ -538,14 +538,14 @@ struct Settings: View {
 
 	var loggingSection: some View {
 		Section(header: Text("Logging")) {
-			NavigationLink(value: SettingsNavigationState.debugLogs) {
+			settingsLink(value: .debugLogs) {
 				Label {
 					Text("Logs")
 				} icon: {
 					Image(systemName: "scroll")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.traceRoutes) {
+			settingsLink(value: .traceRoutes) {
 				Label {
 					Text("Trace Routes")
 				} icon: {
@@ -557,28 +557,28 @@ struct Settings: View {
 
 	var developersSection: some View {
 		Section(header: Text("Developers")) {
-			NavigationLink(value: SettingsNavigationState.backupManagement) {
+			settingsLink(value: .backupManagement) {
 				Label {
 					Text("Backup Management")
 				} icon: {
 					Image(systemName: "externaldrive")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.coreDataBrowser) {
+			settingsLink(value: .coreDataBrowser) {
 				Label {
 					Text("Data Browser")
 				} icon: {
 					Image(systemName: "tablecells")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.deviceLinks) {
+			settingsLink(value: .deviceLinks) {
 				Label {
 					Text("Device Links")
 				} icon: {
 					Image(systemName: "link")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.appFiles) {
+			settingsLink(value: .appFiles) {
 				Label {
 					Text("App Files")
 				} icon: {
@@ -592,7 +592,7 @@ struct Settings: View {
 			#if !targetEnvironment(macCatalyst)
 			if #available(iOS 18, *) {
 				if NFCReader.isAvailable || accessoryManager.isConnected {
-					NavigationLink(value: SettingsNavigationState.tools) {
+					settingsLink(value: .tools) {
 						Label {
 							Text("Tools")
 						} icon: {
@@ -613,13 +613,26 @@ struct Settings: View {
 			// TAK — the Module Config link discovers the feature alongside
 			// other module configs, and the dedicated TAK section advertises
 			// the TAK Server functionality at a glance.
-			NavigationLink(value: SettingsNavigationState.tak) {
+			settingsLink(value: .tak) {
 				Label {
 					Text("TAK Server")
 				} icon: {
 					Image(systemName: "target")
 				}
 			}
+		}
+	}
+
+	@ViewBuilder
+	private func settingsLink<Label: View>(value: SettingsNavigationState, @ViewBuilder label: () -> Label) -> some View {
+		if remoteNodeNum != nil {
+			NavigationLink {
+				settingsDestination(value)
+			} label: {
+				label()
+			}
+		} else {
+			NavigationLink(value: value, label: label)
 		}
 	}
 
@@ -638,7 +651,7 @@ struct Settings: View {
 			let node = nodeSnapshot(for: preferredNodeNum)
 			List {
 				if remoteNodeNum == nil {
-				NavigationLink(value: SettingsNavigationState.about) {
+				settingsLink(value: .about) {
 					Label {
 						Text("About Meshtastic")
 					} icon: {
@@ -646,7 +659,7 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.helpDocs) {
+				settingsLink(value: .helpDocs) {
 					Label {
 						Text("Help & Documentation")
 					} icon: {
@@ -654,21 +667,21 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.appSettings) {
+				settingsLink(value: .appSettings) {
 					Label {
 						Text("App Settings")
 					} icon: {
 						Image(systemName: "gearshape")
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.localMeshDiscovery) {
+				settingsLink(value: .localMeshDiscovery) {
 					Label {
 						Text("Local Mesh Discovery")
 					} icon: {
 						Image(systemName: "antenna.radiowaves.left.and.right")
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.routes) {
+				settingsLink(value: .routes) {
 					Label {
 						Text("Routes")
 					} icon: {
@@ -676,7 +689,7 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.routeRecorder) {
+				settingsLink(value: .routeRecorder) {
 					Label {
 						Text("Route Recorder")
 					} icon: {
@@ -684,7 +697,7 @@ struct Settings: View {
 							.foregroundColor(.red)
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.firmwareUpdates) {
+				settingsLink(value: .firmwareUpdates) {
 					Label {
 						Text("Firmware Updates")
 					} icon: {
@@ -780,6 +793,82 @@ struct Settings: View {
 				}
 			}
 			.navigationDestination(for: SettingsNavigationState.self) { destination in
+				settingsDestination(destination)
+			}
+
+			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
+				// If the preferred node changes, then select the newly preferred node
+				// This should only happen during connect
+				preferredNodeNum = newConnectedNode
+				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
+			}
+			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
+				// If we are on this screen, haven't iniatialized the selection yet,
+				// And we transition, to connected, then initialize the selection
+				if isConnectedNow, self.selectedNode == 0 {
+					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
+					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
+				}
+			}
+			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
+				if remoteNodeNum != nil {
+					preferredNodeNum = Int(newDevice ?? 0)
+					selectedNode = 0
+					applyRemoteSettingsNode()
+					return
+				}
+				if newDevice == nil {
+					selectedNode = 0
+					preferredNodeNum = 0
+				} else if oldDevice != newDevice {
+					// Physical connection changed — any prior remote admin session is invalid
+					preferredNodeNum = Int(newDevice!)
+					selectedNode = Int(newDevice!)
+				}
+			}
+			.onAppear {
+				// If the selection hasn't be initialized yet, try to initalize it.
+				// If we are not fully connected yet, then setSelectedNode will
+				// not select the node and it will remain 0
+				refreshNodes()
+				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
+					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
+					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
+				}
+				applyRemoteSettingsNode()
+			}
+			.task(id: router.selectedTab) {
+				// Refresh the node snapshot on a gentle cadence, and only while Settings is
+				// the frontmost tab — the stale snapshot is invisible from other tabs, this
+				// task re-fires on every tab switch (so the guard comes first), and switching
+				// here restarts it for an immediate refresh.
+				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
+				refreshNodes()
+				while !Task.isCancelled {
+					do {
+						try await Task.sleep(for: .seconds(2))
+					} catch {
+						break
+					}
+					guard !Task.isCancelled else { break }
+					refreshNodes()
+				}
+			}
+			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
+			.toolbar {
+				if remoteNodeNum == nil {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
+					}
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	private func settingsDestination(_ destination: SettingsNavigationState) -> some View {
 				let node = liveNode(for: preferredNodeNum)
 				let configNode = liveNode(for: selectedNode)
 				switch destination {
@@ -874,76 +963,6 @@ struct Settings: View {
 				case .backupManagement:
 					BackupManagement()
 				}
-			}
-			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
-				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
-				// If the preferred node changes, then select the newly preferred node
-				// This should only happen during connect
-				preferredNodeNum = newConnectedNode
-				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
-			}
-			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
-				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
-				// If we are on this screen, haven't iniatialized the selection yet,
-				// And we transition, to connected, then initialize the selection
-				if isConnectedNow, self.selectedNode == 0 {
-					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
-					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
-				}
-			}
-			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
-				if remoteNodeNum != nil {
-					preferredNodeNum = Int(newDevice ?? 0)
-					selectedNode = 0
-					applyRemoteSettingsNode()
-					return
-				}
-				if newDevice == nil {
-					selectedNode = 0
-					preferredNodeNum = 0
-				} else if oldDevice != newDevice {
-					// Physical connection changed — any prior remote admin session is invalid
-					preferredNodeNum = Int(newDevice!)
-					selectedNode = Int(newDevice!)
-				}
-			}
-			.onAppear {
-				// If the selection hasn't be initialized yet, try to initalize it.
-				// If we are not fully connected yet, then setSelectedNode will
-				// not select the node and it will remain 0
-				refreshNodes()
-				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
-					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
-					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
-				}
-				applyRemoteSettingsNode()
-			}
-			.task(id: router.selectedTab) {
-				// Refresh the node snapshot on a gentle cadence, and only while Settings is
-				// the frontmost tab — the stale snapshot is invisible from other tabs, this
-				// task re-fires on every tab switch (so the guard comes first), and switching
-				// here restarts it for an immediate refresh.
-				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
-				refreshNodes()
-				while !Task.isCancelled {
-					do {
-						try await Task.sleep(for: .seconds(2))
-					} catch {
-						break
-					}
-					guard !Task.isCancelled else { break }
-					refreshNodes()
-				}
-			}
-			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
-			.toolbar {
-				if remoteNodeNum == nil {
-				ToolbarItem(placement: .topBarLeading) {
-					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
-					}
-				}
-			}
-		}
 	}
 
 	func setSelectedNode(to nodeNum: Int) {

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -102,6 +102,25 @@ struct SettingsNodeSnapshot: Identifiable, Equatable {
 }
 
 struct Settings: View {
+	static func remoteSettingsSelection(
+		requestedNodeNum: Int64?,
+		activeDeviceNum: Int64?,
+		availableNodeNums: Set<Int64>,
+		isConnected: Bool
+	) -> (preferredNodeNum: Int64, selectedNode: Int64)? {
+		guard let requestedNodeNum,
+			let activeDeviceNum,
+			availableNodeNums.contains(requestedNodeNum),
+			isConnected else { return nil }
+		return (activeDeviceNum, requestedNodeNum)
+	}
+
+	let remoteNodeNum: Int64?
+
+	init(remoteNodeNum: Int64? = nil) {
+		self.remoteNodeNum = remoteNodeNum
+	}
+
 	@Environment(\.modelContext) private var context
 	@Environment(\.colorScheme) private var colorScheme
 	@EnvironmentObject var accessoryManager: AccessoryManager
@@ -115,7 +134,7 @@ struct Settings: View {
 		let descriptor = FetchDescriptor<NodeInfoEntity>(sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)])
 		let refreshedNodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
 		nodes = refreshedNodes
-		applyPendingSettingsNode(availableNodes: refreshedNodes)
+		applyRemoteSettingsNode(availableNodes: refreshedNodes)
 	}
 
 	/// Nodes for the admin / configuration picker, ordered favorites-first while
@@ -179,7 +198,8 @@ struct Settings: View {
 	}
 
 	private func isMeshBeaconModuleSupported(_ node: SettingsNodeSnapshot?) -> Bool {
-		guard node != nil else { return false }
+		// Mesh Beacon currently has no remote read path.
+		guard let node, node.num == accessoryManager.activeDeviceNum else { return false }
 		return accessoryManager.checkIsVersionSupported(forVersion: "2.8.0")
 	}
 
@@ -604,11 +624,20 @@ struct Settings: View {
 	}
 
 	var body: some View {
-		NavigationStack(
-			path: $router.settingsPath
-		) {
+		if remoteNodeNum != nil {
+			settingsContent
+		} else {
+			NavigationStack(path: $router.settingsPath) {
+				settingsContent
+			}
+		}
+	}
+
+	@ViewBuilder
+	private var settingsContent: some View {
 			let node = nodeSnapshot(for: preferredNodeNum)
 			List {
+				if remoteNodeNum == nil {
 				NavigationLink(value: SettingsNavigationState.about) {
 					Label {
 						Text("About Meshtastic")
@@ -664,6 +693,8 @@ struct Settings: View {
 				}
 				.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
+				}
+
 				// A managed radio hides the configuration sections; say why instead of
 				// showing nothing (same message as Android).
 				if let node, node.isManaged, accessoryManager.isConnected {
@@ -676,7 +707,9 @@ struct Settings: View {
 				if let node, !node.isManaged {
 					if accessoryManager.isConnected {
 						Section("Configure") {
-							if node.canRemoteAdmin {
+							if let remoteNodeNum {
+								LabeledContent("Node", value: nodeSnapshot(for: Int(remoteNodeNum))?.userLongName ?? "Unknown")
+							} else if node.canRemoteAdmin {
 								Picker("Node", selection: $selectedNode) {
 									if selectedNode == 0 {
 										Text("Connect to a Node").tag(0)
@@ -740,8 +773,8 @@ struct Settings: View {
 					radioConfigurationSection
 					deviceConfigurationSection
 					moduleConfigurationSection
-					loggingSection
-					if showsDevelopersSection {
+					if remoteNodeNum == nil { loggingSection }
+					if remoteNodeNum == nil && showsDevelopersSection {
 					developersSection
 					}
 				}
@@ -843,12 +876,14 @@ struct Settings: View {
 				}
 			}
 			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
 				// If the preferred node changes, then select the newly preferred node
 				// This should only happen during connect
 				preferredNodeNum = newConnectedNode
 				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
 			}
 			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
 				// If we are on this screen, haven't iniatialized the selection yet,
 				// And we transition, to connected, then initialize the selection
 				if isConnectedNow, self.selectedNode == 0 {
@@ -857,6 +892,12 @@ struct Settings: View {
 				}
 			}
 			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
+				if remoteNodeNum != nil {
+					preferredNodeNum = Int(newDevice ?? 0)
+					selectedNode = 0
+					applyRemoteSettingsNode()
+					return
+				}
 				if newDevice == nil {
 					selectedNode = 0
 					preferredNodeNum = 0
@@ -871,21 +912,18 @@ struct Settings: View {
 				// If we are not fully connected yet, then setSelectedNode will
 				// not select the node and it will remain 0
 				refreshNodes()
-				if self.preferredNodeNum <= 0 {
+				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
 					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
 					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
 				}
-				applyPendingSettingsNode()
-			}
-			.onChange(of: router.settingsNodeNum) { _, _ in
-				applyPendingSettingsNode()
+				applyRemoteSettingsNode()
 			}
 			.task(id: router.selectedTab) {
 				// Refresh the node snapshot on a gentle cadence, and only while Settings is
 				// the frontmost tab — the stale snapshot is invisible from other tabs, this
 				// task re-fires on every tab switch (so the guard comes first), and switching
 				// here restarts it for an immediate refresh.
-				guard router.selectedTab == .settings else { return }
+				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
 				refreshNodes()
 				while !Task.isCancelled {
 					do {
@@ -897,8 +935,9 @@ struct Settings: View {
 					refreshNodes()
 				}
 			}
-			.navigationTitle("Settings")
+			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
 			.toolbar {
+				if remoteNodeNum == nil {
 				ToolbarItem(placement: .topBarLeading) {
 					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
 					}
@@ -922,13 +961,14 @@ struct Settings: View {
 		}
 	}
 
-	private func applyPendingSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
-		guard let requestedNodeNum = router.settingsNodeNum,
-			(availableNodes ?? sortedNodes).contains(where: { $0.num == requestedNodeNum }),
-			accessoryManager.isConnected else { return }
-		preferredNodeNum = Int(accessoryManager.activeDeviceNum ?? Int64(requestedNodeNum))
-		selectedNode = Int(requestedNodeNum)
-		router.settingsNodeNum = nil
+	private func applyRemoteSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
+		guard let selection = Self.remoteSettingsSelection(
+			requestedNodeNum: remoteNodeNum,
+			activeDeviceNum: accessoryManager.activeDeviceNum,
+			availableNodeNums: Set((availableNodes ?? sortedNodes).map(\.num)),
+			isConnected: accessoryManager.isConnected) else { return }
+		preferredNodeNum = Int(selection.preferredNodeNum)
+		selectedNode = Int(selection.selectedNode)
 	}
 
 	private func handleSelectedNodeChange(_ newValue: Int) {

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -113,7 +113,9 @@ struct Settings: View {
 
 	private func refreshNodes() {
 		let descriptor = FetchDescriptor<NodeInfoEntity>(sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)])
-		nodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
+		let refreshedNodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
+		nodes = refreshedNodes
+		applyPendingSettingsNode(availableNodes: refreshedNodes)
 	}
 
 	/// Nodes for the admin / configuration picker, ordered favorites-first while
@@ -873,6 +875,10 @@ struct Settings: View {
 					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
 					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
 				}
+				applyPendingSettingsNode()
+			}
+			.onChange(of: router.settingsNodeNum) { _, _ in
+				applyPendingSettingsNode()
 			}
 			.task(id: router.selectedTab) {
 				// Refresh the node snapshot on a gentle cadence, and only while Settings is
@@ -914,6 +920,15 @@ struct Settings: View {
 		} else {
 			self.selectedNode = Int(accessoryManager.isConnected ? nodeNum: 0)
 		}
+	}
+
+	private func applyPendingSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
+		guard let requestedNodeNum = router.settingsNodeNum,
+			(availableNodes ?? sortedNodes).contains(where: { $0.num == requestedNodeNum }),
+			accessoryManager.isConnected else { return }
+		preferredNodeNum = Int(accessoryManager.activeDeviceNum ?? Int64(requestedNodeNum))
+		selectedNode = Int(requestedNodeNum)
+		router.settingsNodeNum = nil
 	}
 
 	private func handleSelectedNodeChange(_ newValue: Int) {

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -87,6 +87,30 @@ struct NodeAdministrationTests {
 		#expect(node.sessionExpiration != nil)
 	}
 
+	@Test func refetchMakesReceivedSessionVisibleToRetainedNode() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x13AB34
+		try seedNode(num: num, in: container)
+		let mainContext = container.mainContext
+		let cachedNode = try #require(getNodeInfo(id: num, context: mainContext))
+		#expect(!cachedNode.hasLiveAdminSession)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0xA5, 0x5A])
+		var metadata = DeviceMetadata()
+		metadata.firmwareVersion = "2.8.0"
+		admin.getDeviceMetadataResponse = metadata
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .milliseconds(20),
+			isLive: { getNodeInfo(id: num, context: mainContext)?.hasLiveAdminSession == true },
+			isConnected: { true }, targetIsCurrent: { true })
+		#expect(result == .active)
+		#expect(cachedNode.hasLiveAdminSession)
+		#expect(cachedNode.metadata?.firmwareVersion == "2.8")
+	}
+
 	@Test func moduleConfigResponseWithPasskeyMarksAdministered() async throws {
 		let (mesh, container) = try freshMesh()
 		let num: Int64 = 0x22BB33

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -22,10 +22,12 @@ struct RemoteAdminEntryTests {
 
 	@Test @MainActor func orchestrator_staleSessionSendsAndWaits() async {
 		var sends = 0
+		var waits = 0
 		var fresh = false
-		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { fresh ? .active : .timedOut })
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { waits += 1; return fresh ? .active : .timedOut })
 		#expect(result == .active)
 		#expect(sends == 1)
+		#expect(waits == 1)
 	}
 
 	@Test @MainActor func orchestrator_identityChangeAfterSendCannotActivate() async {
@@ -96,7 +98,7 @@ struct RemoteAdminEntryTests {
 	@Test func sessionWaiter_stopsWhenConnectionDrops() async {
 		let result = await RemoteAdminSessionWaiter.wait(
 			timeout: .seconds(30),
-			pollInterval: .zero,
+			pollInterval: .milliseconds(1),
 			isLive: { false },
 			isConnected: { false },
 			targetIsCurrent: { true }
@@ -107,7 +109,7 @@ struct RemoteAdminEntryTests {
 	@Test func sessionWaiter_stopsWhenTargetChanges() async {
 		let result = await RemoteAdminSessionWaiter.wait(
 			timeout: .seconds(30),
-			pollInterval: .zero,
+			pollInterval: .milliseconds(1),
 			isLive: { false },
 			isConnected: { true },
 			targetIsCurrent: { false }
@@ -115,11 +117,38 @@ struct RemoteAdminEntryTests {
 		#expect(result == .targetChanged)
 	}
 
-	@Test @MainActor func routerStoresPendingSettingsNodeUntilSettingsAppears() {
-		let router = Router()
-		router.navigateToSettings(nodeNum: 42)
-		#expect(router.selectedTab == .settings)
-		#expect(router.settingsNodeNum == 42)
-		#expect(router.settingsPath.isEmpty)
+	@Test func sessionWaiter_rejectsNonPositivePollInterval() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { true }
+		)
+		#expect(result == .timedOut)
+	}
+
+	@Test @MainActor func remoteSettingsSelectionRequiresActiveDevice() {
+		#expect(Settings.remoteSettingsSelection(
+			requestedNodeNum: 42,
+			activeDeviceNum: nil,
+			availableNodeNums: [42],
+			isConnected: true
+		) == nil)
+		#expect(Settings.remoteSettingsSelection(
+			requestedNodeNum: 42,
+			activeDeviceNum: 7,
+			availableNodeNums: [42],
+			isConnected: true
+		)?.preferredNodeNum == 7)
+	}
+	@Test func remoteSettingsDestinationRejectsSourceReplacement() {
+		let connection = NSObject()
+		let replacement = NSObject()
+		let destination = RemoteAdminSettingsDestination(nodeNum: 42, radioNum: 7, connectionID: ObjectIdentifier(connection))
+		#expect(destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(connection), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 8, connectionID: ObjectIdentifier(connection), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(replacement), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(connection), isConnected: false))
 	}
 }

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -57,6 +57,22 @@ struct RemoteAdminEntryTests {
 		#expect(result == .requestFailed)
 	}
 
+	@Test @MainActor func sameRadioWithReplacementConnectionCannotActivate() async {
+		let initial = NSObject()
+		let replacement = NSObject()
+		let capturedID = ObjectIdentifier(initial)
+		var connectionID = capturedID
+		let radioNum = 42
+		let result = await RemoteAdminSessionOrchestrator.establish(
+			allowed: { true },
+			attemptIsCurrent: { radioNum == 42 && connectionID == capturedID },
+			fresh: { false },
+			request: { connectionID = ObjectIdentifier(replacement) },
+			wait: { .active }
+		)
+		#expect(result == .targetChanged)
+	}
+
 	@Test func sessionFreshness_requiresPasskeyAndFutureExpiration() {
 		let now = Date(timeIntervalSince1970: 100)
 		#expect(RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now.addingTimeInterval(1), now: now))

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Remote admin entry")
+struct RemoteAdminEntryTests {
+
+	@Test @MainActor func orchestrator_disabledSendsZero() async {
+		var sends = 0
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { false }, attemptIsCurrent: { true }, fresh: { false }, request: { sends += 1 }, wait: { .active })
+		#expect(result == .requestFailed)
+		#expect(sends == 0)
+	}
+
+	@Test @MainActor func orchestrator_freshSessionSendsZero() async {
+		var sends = 0
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { true }, request: { sends += 1 }, wait: { .active })
+		#expect(result == .active)
+		#expect(sends == 0)
+	}
+
+	@Test @MainActor func orchestrator_staleSessionSendsAndWaits() async {
+		var sends = 0
+		var fresh = false
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { fresh ? .active : .timedOut })
+		#expect(result == .active)
+		#expect(sends == 1)
+	}
+
+	@Test @MainActor func orchestrator_identityChangeAfterSendCannotActivate() async {
+		var current = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { current }, fresh: { false }, request: { current = false }, wait: { .active })
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func orchestrator_sendErrorIsRequestFailed() async {
+		struct SendError: Error {}
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { false }, request: { throw SendError() }, wait: { .active })
+		#expect(result == .requestFailed)
+	}
+
+	@Test @MainActor func orchestrator_cancelledSendDoesNotActivate() async {
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { false }, request: { throw CancellationError() }, wait: { .active })
+		#expect(result == .cancelled)
+	}
+
+	@Test @MainActor func orchestrator_postWaitIdentityChangeCannotActivate() async {
+		var current = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { current }, fresh: { false }, request: {}, wait: { current = false; return .active })
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func orchestrator_postWaitDisableCannotActivate() async {
+		var allowed = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { allowed }, attemptIsCurrent: { true }, fresh: { false }, request: {}, wait: { allowed = false; return .active })
+		#expect(result == .requestFailed)
+	}
+
+	@Test func sessionFreshness_requiresPasskeyAndFutureExpiration() {
+		let now = Date(timeIntervalSince1970: 100)
+		#expect(RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: nil, expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: Data(), expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now, now: now.addingTimeInterval(1)))
+	}
+
+	@Test func sessionWaiter_timesOutWhenResponseNeverArrives() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .milliseconds(1),
+			pollInterval: .milliseconds(1),
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { true },
+			sleep: { _ in }
+		)
+		#expect(result == .timedOut)
+	}
+
+	@Test func sessionWaiter_stopsWhenConnectionDrops() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { false },
+			targetIsCurrent: { true }
+		)
+		#expect(result == .disconnected)
+	}
+
+	@Test func sessionWaiter_stopsWhenTargetChanges() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { false }
+		)
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func routerStoresPendingSettingsNodeUntilSettingsAppears() {
+		let router = Router()
+		router.navigateToSettings(nodeNum: 42)
+		#expect(router.selectedTab == .settings)
+		#expect(router.settingsNodeNum == 42)
+		#expect(router.settingsPath.isEmpty)
+	}
+}

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -106,6 +106,12 @@ Long-press any node in the list to access quick actions:
 - **Ignore / Remove from ignored** — hide this node from normal views
 - **Remove** — remove the node from your local database
 
+## Remote Admin
+
+Remote Admin pushes a Settings page for that node within the Nodes navigation stack. Open a configuration section and use Back to return to the node’s Settings; use Back again to return to the node details. The target stays fixed while this page is open.
+
+On a node's detail screen, **Remote Admin** requires a connected radio and **Administration** enabled in App Settings. When the target has no live admin session, the app requests device metadata through the connected radio and waits for the session to become active before opening the target's configuration. If the request fails, the radio disconnects, the target changes, the request is cancelled, or the 30-second wait expires, the screen shows the reason and a **Retry Remote Admin** action. Retry after restoring the connection, selecting the intended target, or enabling Administration.
+
 ## Display Names
 
 You can give any node a local nickname that's shown throughout the app instead of its device long name — in the node list, node details, and messages. Set it from the node's long-press menu ("Display name") or from the **Name** row in Node Detail. The avatar circle always shows the node's actual short code, unaffected by the nickname.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -39,6 +39,8 @@ Radio configuration requires a connected node. Select your node from the **Confi
 
 From a node's detail screen, **Remote Admin** opens that node's configuration directly. If the app does not have a current admin session, it requests fresh device metadata first and shows the target name while the session is established. A disconnected radio, changed target, or 30-second timeout leaves the screen in an error state with a **Retry Remote Admin** action; Settings is opened only after the session becomes active.
 
+The Remote Admin page stays inside node navigation: Back from a configuration section returns to the remote Settings page, and Back from that page returns to the node. It does not switch to the app’s Settings tab.
+
 ### Node selection
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -35,6 +35,10 @@ Turning a toggle off suppresses only the alert — messages, reactions, waypoint
 
 Radio configuration requires a connected node. Select your node from the **Configure** section if you have multiple nodes.
 
+### Remote administration
+
+From a node's detail screen, **Remote Admin** opens that node's configuration directly. If the app does not have a current admin session, it requests fresh device metadata first and shows the target name while the session is established. A disconnected radio, changed target, or 30-second timeout leaves the screen in an error state with a **Retry Remote Admin** action; Settings is opened only after the session becomes active.
+
 ### Node selection
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.


### PR DESCRIPTION
## What changed?

Add **Remote Admin** to a remote node’s detail screen. Establish or reuse that node’s live admin session, then push its **Remote Settings** page inside the Nodes navigation stack. A section’s Back button returns to Remote Settings; Back from there returns to the originating node.

The remote page keeps its target fixed. Loading, timeout, and retry states name the node. Disconnects, connection replacement, target changes, and disabled Administration prevent stale navigation. Session checks refresh the main-context model after incoming packets save the passkey.

This is PR 2 of the native Remote Admin parity stack #2410, based on #2408.

## Why did it change?

This brings the direct Remote Admin entry flow into parity with Android: Android establishes or reuses the selected node’s session before opening Settings and reports timeout/disconnection instead of navigating ([NodeDetailViewModel](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt#L190-L221), [session use case](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/session/EnsureRemoteAdminSessionUseCase.kt#L110-L147)). Previously, remote configuration required switching tabs and finding the same node in the Settings picker.

## How is this tested?

- Final combined stack: `xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -derivedDataPath /tmp/remote-admin-build -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:MeshtasticTests/RemoteAdminEntryTests -only-testing:MeshtasticTests/NodeAdministrationTests -only-testing:MeshtasticTests/RemoteAdminConfigTrackerTests -only-testing:MeshtasticTests/RemoteChannelsTests -only-testing:MeshtasticTests/RemoteAdminActionTransportTests -only-testing:MeshtasticTests/SettingsNodeSortTests -only-testing:MeshtasticTests/ChannelSetSaveTests` passed: **78 tests, 0 failures, 0 skips**.
- Tests cover session freshness, timeout, cancellation, target/connection replacement, and session data saved from another model context.
- Real bench: iOS Simulator connected through a serial/TCP bridge to MUZI (firmware 2.8.0), administering TBEAM S3 over RF (2.8.1). Verified the session handshake and actual Back navigation: node → Remote Settings → Channels → editor → Channels → Remote Settings → same node. The app remained in Nodes throughout.
- Independent review completed; user documentation updated.
- Full non-snapshot unit suite on the final combined stack: **2,968 passed, 0 failed, 6 skipped**. Ran `xcodebuild test-without-building -only-testing:MeshtasticTests` with the same 39 snapshot-suite exclusions as `.github/workflows/unit-tests.yml` and the simulator/build settings above. The six existing Keychain tests skipped because code signing was disabled (OSStatus -34018).

## Screenshots/Videos (when applicable)

The before image uses a seeded node. The after images show the real bench target.

| Before | After: node entry | After: pushed Remote Settings |
| --- | --- | --- |
| <img width="260" alt="Original node administration section" src="https://github.com/user-attachments/assets/dae4be4a-ffd6-4070-8530-65808cfd5b11" /> | <img width="260" alt="Remote Admin on the node detail page" src="https://github.com/user-attachments/assets/31f06f49-3550-4b66-842f-f4cd372d6ab1" /> | <img width="260" alt="Node-specific Settings pushed in Nodes navigation" src="https://github.com/user-attachments/assets/2feedf99-5c7d-4725-a5b9-4a3fc1b64a81" /> |

| Back from Channels to Remote Settings | Back from Remote Settings to the same node |
| --- | --- |
| <img width="280" alt="Remote Settings after returning from Channels" src="https://github.com/user-attachments/assets/77417b40-ecc6-4438-9d53-59c85714d4a4" /> | <img width="280" alt="Back returned to Meshtastic c058" src="https://github.com/user-attachments/assets/75652dee-5910-4a89-b32b-0b0a7439a35c" /> |

## Checklist

- [x] Code follows the project’s style.
- [x] Self-review and independent review completed.
- [x] Non-obvious routing behavior documented in code.
- [x] User documentation updated.
- [x] Build, targeted tests, and simulator flow verified.
