### PR TITLE
Add remote channels with the shared editor for Android parity

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -798,6 +798,9 @@ extension AccessoryManager {
 	public func saveChannel(channel: Channel, fromUser: UserEntity, toUser: UserEntity) async throws -> Int64 {
 		var adminPacket = AdminMessage()
 		adminPacket.setChannel = channel
+		if fromUser != toUser {
+			adminPacket.sessionPasskey = toUser.userNode?.sessionPasskey ?? Data()
+		}
 		var meshPacket: MeshPacket = MeshPacket()
 		meshPacket.to = UInt32(toUser.num)
 		meshPacket.from	= UInt32(fromUser.num)
@@ -815,6 +818,23 @@ extension AccessoryManager {
 		let messageDescription = "🛟 Saved Channel \(channel.index) for \(toUser.longName ?? "Unknown".localized)"
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 		return Int64(meshPacket.id)
+	}
+
+	/// Requests one channel from a remote admin target. The wire request is one based while
+	/// the response's Channel.index remains zero based.
+	public func requestRemoteChannel(index: Int32, fromUser: UserEntity, toUser: UserEntity) async throws -> UInt32 {
+		guard (0...7).contains(index) else {
+			throw AccessoryError.appError("Channel index must be between 0 and 7")
+		}
+		let sessionPasskey = toUser.userNode?.sessionPasskey ?? Data()
+		let packet = try RemoteChannelsPacketBuilder.getRequest(
+			index: index, from: UInt32(fromUser.num), to: UInt32(toUser.num), sessionPasskey: sessionPasskey
+		)
+		try await sendAdminMessageToRadio(
+			meshPacket: packet,
+			adminDescription: "🛟 Requested remote Channel \(index) for \(toUser.longName ?? "Unknown".localized)"
+		)
+		return packet.id
 	}
 
 	/// Join a mesh advertised by a beacon: set the primary channel to the offered channel (name +

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1193,7 +1193,17 @@ actor MeshPackets {
 					}
 				}
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getChannelResponse(adminMessage.getChannelResponse) {
-				channelPacket(channel: adminMessage.getChannelResponse, fromNum: Int64(packet.from))
+				// Remote Channels editing owns an in-memory target-scoped snapshot. Persisting a
+				// remote response through channelPacket would incorrectly attach it to MyInfo and
+				// overwrite the connected radio's local channel state.
+				if let connectedNodeNum, Int64(packet.from) == connectedNodeNum {
+					channelPacket(channel: adminMessage.getChannelResponse, fromNum: Int64(packet.from))
+				}
+				NotificationCenter.default.post(
+					name: .remoteChannelResponse,
+					object: nil,
+					userInfo: ["packet": packet, "response": adminMessage]
+				)
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getDeviceMetadataResponse(adminMessage.getDeviceMetadataResponse) {
 				deviceMetadataPacket(metadata: adminMessage.getDeviceMetadataResponse, fromNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getConfigResponse(adminMessage.getConfigResponse) {

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -506,7 +506,7 @@ private struct ChannelConfigSummaryRow: View {
 	}
 }
 
-private struct ChannelRow: View {
+struct ChannelRow: View {
 	let channel: ChannelEntity
 	let sharesLocation: Bool
 

--- a/Meshtastic/Views/Settings/RemoteChannels.swift
+++ b/Meshtastic/Views/Settings/RemoteChannels.swift
@@ -1,0 +1,423 @@
+import Foundation
+import MeshtasticProtobufs
+import SwiftUI
+
+enum RemoteChannelsPacketBuilder {
+    static func getRequest(index: Int32, from: UInt32, to: UInt32, sessionPasskey: Data, id: UInt32 = .random(in: 256...UInt32.max)) throws -> MeshPacket {
+        precondition((0...7).contains(index))
+        var admin = AdminMessage()
+        admin.getChannelRequest = UInt32(index + 1)
+        admin.sessionPasskey = sessionPasskey
+        var packet = MeshPacket()
+        packet.id = id
+        packet.from = from
+        packet.to = to
+        packet.priority = .reliable
+        packet.wantAck = true
+        var data = DataMessage()
+        data.payload = try admin.serializedData()
+        data.portnum = .adminApp
+        data.wantResponse = true
+        packet.decoded = data
+        return packet
+    }
+
+    static func matchesResponse(packet: MeshPacket, response: AdminMessage, requestID: UInt32, target: UInt32, index: Int32) -> Bool {
+        guard packet.from == target, packet.decoded.requestID == requestID else { return false }
+        guard case .getChannelResponse(let channel) = response.payloadVariant else { return false }
+        return channel.index == index
+    }
+}
+
+enum RemoteChannelsWriteResult: Equatable {
+    case success
+    case failure(index: Int32)
+}
+
+enum RemoteChannelsWritePlan {
+    static func execute(_ channels: [Channel], write: (Channel) async throws -> Void) async throws -> RemoteChannelsWriteResult {
+        for channel in channels.sorted(by: { $0.index < $1.index }) {
+            do {
+                try await write(channel)
+            } catch {
+                if error is CancellationError { throw error }
+                return .failure(index: Int32(channel.index))
+            }
+        }
+        return .success
+    }
+}
+
+enum RemoteChannelsReadPlan {
+    static func retry<T>(retries: Int, operation: () async throws -> T) async throws -> T {
+        var lastError: Error = AccessoryError.timeout
+        for attempt in 0...retries {
+            do { return try await operation() }
+			catch {
+				if error is CancellationError { throw error }
+				if case AccessoryError.disconnected = error { throw error }
+                lastError = error
+                if attempt == retries { throw lastError }
+            }
+        }
+        throw lastError
+    }
+}
+
+extension Foundation.Notification.Name {
+    static let remoteChannelResponse = Foundation.Notification.Name("Meshtastic.RemoteChannelResponse")
+}
+
+@MainActor
+protocol RemoteChannelsTransport {
+	var isConnected: Bool { get }
+	var connectedDeviceNum: Int64? { get }
+	var connectionID: ObjectIdentifier? { get }
+	var hasLiveSession: Bool { get }
+	var responseTimeout: Duration { get }
+	var sessionTimeout: Duration { get }
+	func refreshMetadata() async throws
+	func requestChannel(index: Int32) async throws -> UInt32
+	func saveChannel(_ channel: Channel) async throws
+}
+
+@MainActor
+final class AccessoryManagerRemoteChannelsTransport: RemoteChannelsTransport {
+	private let manager: AccessoryManager
+	private let fromUser: UserEntity
+	private let toUser: UserEntity
+
+	init(manager: AccessoryManager, fromUser: UserEntity, toUser: UserEntity) {
+		self.manager = manager
+		self.fromUser = fromUser
+		self.toUser = toUser
+	}
+
+	var isConnected: Bool { manager.isConnected }
+	var connectedDeviceNum: Int64? { manager.activeDeviceNum }
+	var connectionID: ObjectIdentifier? {
+		guard let connection = manager.activeConnection?.connection else { return nil }
+		return ObjectIdentifier(connection)
+	}
+	var hasLiveSession: Bool { toUser.userNode?.hasLiveAdminSession == true }
+	var responseTimeout: Duration { .seconds(30) }
+	var sessionTimeout: Duration { .seconds(30) }
+	func refreshMetadata() async throws { _ = try await manager.requestDeviceMetadata(fromUser: fromUser, toUser: toUser) }
+	func requestChannel(index: Int32) async throws -> UInt32 {
+		try await manager.requestRemoteChannel(index: index, fromUser: fromUser, toUser: toUser)
+	}
+	func saveChannel(_ channel: Channel) async throws {
+		_ = try await manager.saveChannel(channel: channel, fromUser: fromUser, toUser: toUser)
+	}
+}
+
+@MainActor
+final class RemoteChannelsCoordinator: ObservableObject {
+    @Published private(set) var channels: [Int32: Channel] = [:]
+    @Published private(set) var progress: Int = 0
+    @Published private(set) var isLoading = false
+    @Published private(set) var isSaving = false
+
+	private let transport: any RemoteChannelsTransport
+	private let sourceConnectionID: ObjectIdentifier?
+    private var responses: [(requestID: UInt32, target: UInt32, channel: Channel)] = []
+    private let sourceNum: Int64
+    private let targetNum: Int64
+
+	init(transport: any RemoteChannelsTransport, sourceNum: Int64, targetNum: Int64) {
+		self.transport = transport
+		self.sourceNum = sourceNum
+		self.targetNum = targetNum
+		self.sourceConnectionID = transport.connectionID
+    }
+
+    func receive(_ notification: Foundation.Notification) {
+        guard let packet = notification.userInfo?["packet"] as? MeshPacket,
+              let response = notification.userInfo?["response"] as? AdminMessage,
+              case .getChannelResponse(let channel) = response.payloadVariant,
+				packet.from == UInt32(targetNum), packet.to == UInt32(sourceNum) else { return }
+        responses.append((packet.decoded.requestID, packet.from, channel))
+    }
+
+    func load() async throws {
+        try validateConnection()
+        isLoading = true
+        progress = 0
+        defer { isLoading = false }
+        try await refreshSessionIfNeeded()
+        var loaded: [Int32: Channel] = [:]
+        for index in Int32(0)...Int32(7) {
+            try Task.checkCancellation()
+            try validateConnection()
+            let channel = try await read(index: index, retries: 1)
+            loaded[index] = channel
+            progress = Int(index) + 1
+        }
+        channels = loaded
+    }
+
+    func save(_ changed: [Channel]) async throws {
+        guard !isSaving else { return }
+        isSaving = true
+        defer { isSaving = false }
+        try Task.checkCancellation()
+        try validateConnection()
+        try await refreshSessionIfNeeded()
+		let result = try await RemoteChannelsWritePlan.execute(changed) { [weak self] channel in
+			guard let self else { throw AccessoryError.disconnected("Remote Channels was closed") }
+			try self.validateEditableChannel(channel)
+			var outgoing = channel
+			if outgoing.role == .disabled { outgoing.clearSettings() }
+			try Task.checkCancellation()
+			try self.validateConnection()
+			try await self.transport.saveChannel(outgoing)
+			let actual = try await self.read(index: Int32(outgoing.index), retries: 1)
+			guard self.matchesEditableChannel(actual, desired: outgoing) else {
+				throw AccessoryError.ioFailed("Remote channel \(channel.index) did not match the saved values")
+			}
+            self.channels[Int32(channel.index)] = actual
+        }
+        if case .failure(let index) = result {
+            throw AccessoryError.ioFailed("Remote channel \(index) was not confirmed")
+        }
+    }
+
+    private func read(index: Int32, retries: Int) async throws -> Channel {
+        try await RemoteChannelsReadPlan.retry(retries: retries) {
+                try Task.checkCancellation()
+                try self.validateConnection()
+				let requestID = try await transport.requestChannel(index: index)
+				let deadline = ContinuousClock.now + transport.responseTimeout
+                while ContinuousClock.now < deadline {
+                    try Task.checkCancellation()
+                    try self.validateConnection()
+					if let match = responses.firstIndex(where: { $0.requestID == requestID && $0.target == UInt32(targetNum) && $0.channel.index == index }) {
+                        return responses.remove(at: match).channel
+                    }
+                    try await Task.sleep(for: .milliseconds(50))
+                }
+                throw AccessoryError.timeout
+        }
+    }
+
+    private func refreshSessionIfNeeded() async throws {
+		// Remote Channels requires a live PKI administration session before any slot access.
+		guard !transport.hasLiveSession else { return }
+		try validateConnection()
+		try await transport.refreshMetadata()
+		let deadline = ContinuousClock.now + transport.sessionTimeout
+        while ContinuousClock.now < deadline {
+            try Task.checkCancellation()
+            try validateConnection()
+			if transport.hasLiveSession { return }
+            try await Task.sleep(for: .milliseconds(250))
+        }
+        throw AccessoryError.ioFailed("Remote admin session expired; refresh the node and try again")
+    }
+
+	private func validateConnection() throws {
+		guard transport.isConnected, transport.connectedDeviceNum == sourceNum,
+			  transport.connectionID == sourceConnectionID else {
+			throw AccessoryError.disconnected("The connected radio changed or disconnected")
+		}
+	}
+
+	private func validateEditableChannel(_ channel: Channel) throws {
+		guard (0...7).contains(channel.index) else { throw AccessoryError.appError("Channel index must be between 0 and 7") }
+		guard channel.index == 0 ? channel.role == .primary : channel.role != .primary else {
+			throw AccessoryError.appError("Only channel 0 can be primary")
+		}
+		guard channel.settings.name.utf8.count <= 11 else { throw AccessoryError.appError("Channel names must be 11 bytes or fewer") }
+		guard [0, 1, 16, 32].contains(channel.settings.psk.count) else { throw AccessoryError.appError("Channel key has an unsupported length") }
+	}
+
+	private func matchesEditableChannel(_ actual: Channel, desired: Channel) -> Bool {
+		guard actual.index == desired.index, actual.role == desired.role else { return false }
+		guard desired.role != .disabled else { return true }
+		return actual.settings.name == desired.settings.name &&
+			actual.settings.psk == desired.settings.psk &&
+			actual.settings.uplinkEnabled == desired.settings.uplinkEnabled &&
+			actual.settings.downlinkEnabled == desired.settings.downlinkEnabled &&
+			actual.settings.moduleSettings.positionPrecision == desired.settings.moduleSettings.positionPrecision &&
+			actual.settings.moduleSettings.isMuted == desired.settings.moduleSettings.isMuted
+	}
+	}
+
+struct RemoteChannels: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var accessoryManager: AccessoryManager
+    let node: NodeInfoEntity
+    let connectedNode: NodeInfoEntity
+    let fromUser: UserEntity
+    let toUser: UserEntity
+    @StateObject private var coordinator: RemoteChannelsCoordinator
+    @State private var selected: Channel?
+    @State private var errorMessage: String?
+
+    init(node: NodeInfoEntity, connectedNode: NodeInfoEntity, fromUser: UserEntity, toUser: UserEntity, accessoryManager: AccessoryManager) {
+        self.node = node
+        self.connectedNode = connectedNode
+        self.fromUser = fromUser
+        self.toUser = toUser
+		self.accessoryManager = accessoryManager
+		_coordinator = StateObject(wrappedValue: RemoteChannelsCoordinator(
+			transport: AccessoryManagerRemoteChannelsTransport(manager: accessoryManager, fromUser: fromUser, toUser: toUser),
+			sourceNum: fromUser.num, targetNum: toUser.num
+		))
+    }
+
+    var body: some View {
+        List {
+            if coordinator.isLoading {
+                ProgressView("Reading remote channels (\(coordinator.progress)/8)…")
+            }
+            ForEach(Int32(0)...Int32(7), id: \.self) { index in
+                if let channel = coordinator.channels[index] {
+                    Button {
+                        selected = channel
+                    } label: {
+                        HStack {
+                            Text(channel.settings.name.isEmpty ? "Channel \(index)" : channel.settings.name)
+                            Spacer()
+                            Text(channel.role == .primary ? "Primary" : channel.role == .disabled ? "Disabled" : "Secondary")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .navigationTitle("Remote Channels")
+        .task {
+            do { try await coordinator.load() }
+            catch { errorMessage = error.localizedDescription }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Retry") {
+                    Task {
+                        do { try await coordinator.load(); errorMessage = nil }
+                        catch { errorMessage = error.localizedDescription }
+                    }
+                }
+                .disabled(coordinator.isLoading || coordinator.isSaving)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .remoteChannelResponse).receive(on: RunLoop.main)) { coordinator.receive($0) }
+        .alert("Remote Channels", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: { Text(errorMessage ?? "") }
+        .sheet(isPresented: Binding(get: { selected != nil }, set: { if !$0 { selected = nil } })) {
+            if let channel = selected {
+                RemoteChannelEditor(channel: channel, isSaving: coordinator.isSaving) { edited in
+                    try await coordinator.save([edited])
+                    selected = nil
+                }
+            }
+        }
+    }
+}
+
+struct RemoteChannelsUnavailable: View {
+	let nodeName: String
+
+	var body: some View {
+		VStack(spacing: 12) {
+			Image(systemName: "lock.slash").font(.largeTitle).foregroundStyle(.secondary)
+			Text("Remote Channels Unavailable").font(.headline)
+			Text("\(nodeName) does not have a live PKI administration session. Refresh node administration and try again.")
+				.multilineTextAlignment(.center).foregroundStyle(.secondary)
+		}
+		.padding()
+		.navigationTitle("Remote Channels")
+	}
+}
+
+private struct RemoteChannelEditor: View {
+    @Environment(\.dismiss) private var dismiss
+    let channel: Channel
+    let isSaving: Bool
+    let onSave: (Channel) async throws -> Void
+    @State private var name: String
+    @State private var key: String
+    @State private var role: Channel.Role
+    @State private var uplink: Bool
+    @State private var downlink: Bool
+    @State private var precision: Int
+    @State private var muted: Bool
+    @State private var errorMessage: String?
+
+    init(channel: Channel, isSaving: Bool, onSave: @escaping (Channel) async throws -> Void) {
+        self.channel = channel
+        self.isSaving = isSaving
+        self.onSave = onSave
+        _name = State(initialValue: channel.settings.name)
+        _key = State(initialValue: channel.settings.psk.base64EncodedString())
+        _role = State(initialValue: channel.role)
+        _uplink = State(initialValue: channel.settings.uplinkEnabled)
+        _downlink = State(initialValue: channel.settings.downlinkEnabled)
+        _precision = State(initialValue: Int(channel.settings.moduleSettings.positionPrecision))
+        _muted = State(initialValue: channel.settings.moduleSettings.isMuted)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Name", text: $name)
+                    .onChange(of: name) { _, value in
+                        let compact = value.replacingOccurrences(of: " ", with: "")
+                        var limited = ""
+                        for scalar in compact.unicodeScalars {
+                            guard limited.utf8.count + String(scalar).utf8.count <= 11 else { break }
+                            limited.append(String(scalar))
+                        }
+                        name = limited
+                    }
+                TextField("Key (base64)", text: $key)
+                    .textSelection(.enabled)
+                Picker("Role", selection: $role) {
+                    if channel.index == 0 {
+                        Text("Primary").tag(Channel.Role.primary)
+                    } else {
+                        Text("Secondary").tag(Channel.Role.secondary)
+                        Text("Disabled").tag(Channel.Role.disabled)
+                    }
+                }
+                Toggle("MQTT Uplink Enabled", isOn: $uplink)
+                Toggle("MQTT Downlink Enabled", isOn: $downlink)
+                Toggle("Mute", isOn: $muted)
+                Stepper("Position Precision: \(precision)", value: $precision, in: 0...32)
+                if let errorMessage { Text(errorMessage).foregroundStyle(.red).font(.callout) }
+            }
+            .navigationTitle("Channel \(channel.index)")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isSaving ? "Saving…" : "Save") {
+                        guard name.utf8.count <= 11 else {
+                            errorMessage = "Channel names must be 11 bytes or fewer"
+                            return
+                        }
+                        guard let decodedKey = Data(base64Encoded: key), [0, 1, 16, 32].contains(decodedKey.count) else {
+                            errorMessage = "Key must be valid base64 with 0, 1, 16, or 32 bytes"
+                            return
+                        }
+                        var edited = channel
+                        edited.settings.name = name
+                        edited.settings.psk = decodedKey
+                        edited.role = role
+                        edited.settings.uplinkEnabled = uplink
+                        edited.settings.downlinkEnabled = downlink
+                        edited.settings.moduleSettings.positionPrecision = UInt32(precision)
+                        edited.settings.moduleSettings.isMuted = muted
+                        Task {
+                            do { try await onSave(edited) }
+                            catch { errorMessage = error.localizedDescription }
+                        }
+                    }
+                    .disabled(isSaving)
+                }
+            }
+        }
+    }
+}

--- a/Meshtastic/Views/Settings/RemoteChannels.swift
+++ b/Meshtastic/Views/Settings/RemoteChannels.swift
@@ -244,78 +244,156 @@ final class RemoteChannelsCoordinator: ObservableObject {
 	}
 
 struct RemoteChannels: View {
-    @Environment(\.dismiss) private var dismiss
-    @ObservedObject var accessoryManager: AccessoryManager
-    let node: NodeInfoEntity
-    let connectedNode: NodeInfoEntity
-    let fromUser: UserEntity
-    let toUser: UserEntity
-    @StateObject private var coordinator: RemoteChannelsCoordinator
-    @State private var selected: Channel?
-    @State private var errorMessage: String?
+	@ObservedObject var accessoryManager: AccessoryManager
+	let node: NodeInfoEntity
+	let connectedNode: NodeInfoEntity
+	let fromUser: UserEntity
+	let toUser: UserEntity
+	@StateObject private var coordinator: RemoteChannelsCoordinator
+	@State private var selected: Channel?
+	@State private var errorMessage: String?
+	@State private var editorErrorMessage: String?
+	@State private var channelIndex: Int32 = 0
+	@State private var channelName = ""
+	@State private var channelKeySize = 16
+	@State private var channelKey = "AQ=="
+	@State private var channelRole = 0
+	@State private var uplink = false
+	@State private var downlink = false
+	@State private var positionPrecision = 32.0
+	@State private var preciseLocation = true
+	@State private var positionsEnabled = true
+	@State private var hasChanges = false
+	@State private var hasValidKey = true
+	@State private var supportedVersion = true
 
-    init(node: NodeInfoEntity, connectedNode: NodeInfoEntity, fromUser: UserEntity, toUser: UserEntity, accessoryManager: AccessoryManager) {
-        self.node = node
-        self.connectedNode = connectedNode
-        self.fromUser = fromUser
-        self.toUser = toUser
+	init(node: NodeInfoEntity, connectedNode: NodeInfoEntity, fromUser: UserEntity, toUser: UserEntity, accessoryManager: AccessoryManager) {
+		self.node = node
+		self.connectedNode = connectedNode
+		self.fromUser = fromUser
+		self.toUser = toUser
 		self.accessoryManager = accessoryManager
 		_coordinator = StateObject(wrappedValue: RemoteChannelsCoordinator(
 			transport: AccessoryManagerRemoteChannelsTransport(manager: accessoryManager, fromUser: fromUser, toUser: toUser),
 			sourceNum: fromUser.num, targetNum: toUser.num
 		))
-    }
+	}
 
-    var body: some View {
-        List {
-            if coordinator.isLoading {
-                ProgressView("Reading remote channels (\(coordinator.progress)/8)…")
-            }
-            ForEach(Int32(0)...Int32(7), id: \.self) { index in
-                if let channel = coordinator.channels[index] {
-                    Button {
-                        selected = channel
-                    } label: {
-                        HStack {
-                            Text(channel.settings.name.isEmpty ? "Channel \(index)" : channel.settings.name)
-                            Spacer()
-                            Text(channel.role == .primary ? "Primary" : channel.role == .disabled ? "Disabled" : "Secondary")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-        }
-        .navigationTitle("Remote Channels")
-        .task {
-            do { try await coordinator.load() }
-            catch { errorMessage = error.localizedDescription }
-        }
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("Retry") {
-                    Task {
-                        do { try await coordinator.load(); errorMessage = nil }
-                        catch { errorMessage = error.localizedDescription }
-                    }
-                }
-                .disabled(coordinator.isLoading || coordinator.isSaving)
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .remoteChannelResponse).receive(on: RunLoop.main)) { coordinator.receive($0) }
-        .alert("Remote Channels", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
-            Button("OK", role: .cancel) { errorMessage = nil }
-        } message: { Text(errorMessage ?? "") }
-        .sheet(isPresented: Binding(get: { selected != nil }, set: { if !$0 { selected = nil } })) {
-            if let channel = selected {
-                RemoteChannelEditor(channel: channel, isSaving: coordinator.isSaving) { edited in
-                    try await coordinator.save([edited])
-                    selected = nil
-                }
-            }
-        }
-    }
+	private func select(_ channel: Channel) {
+		selected = channel
+		channelIndex = channel.index
+		channelRole = channel.index == 0 ? 1 : (channel.role == .primary ? 1 : channel.role == .secondary ? 2 : 0)
+		channelName = channel.settings.name
+		channelKey = channel.settings.psk.base64EncodedString()
+		channelKeySize = channel.settings.psk.isEmpty ? 0 : (channel.settings.psk == Data([1]) ? -1 : channel.settings.psk.count)
+		uplink = channel.settings.uplinkEnabled
+		downlink = channel.settings.downlinkEnabled
+		positionPrecision = Double(channel.settings.moduleSettings.positionPrecision)
+		positionsEnabled = positionPrecision > 0
+		preciseLocation = positionPrecision == 32
+		hasChanges = false
+		hasValidKey = true
+		editorErrorMessage = nil
+	}
+
+	private func displayEntity(_ channel: Channel) -> ChannelEntity {
+		let entity = ChannelEntity()
+		entity.index = channel.index
+		entity.id = channel.index
+		entity.role = channel.role == .primary ? 1 : channel.role == .secondary ? 2 : 0
+		entity.name = channel.settings.name
+		entity.psk = channel.settings.psk
+		entity.uplinkEnabled = channel.settings.uplinkEnabled
+		entity.downlinkEnabled = channel.settings.downlinkEnabled
+		entity.positionPrecision = Int32(channel.settings.moduleSettings.positionPrecision)
+		entity.mute = channel.settings.moduleSettings.isMuted
+		return entity
+	}
+
+	private func saveEditor() {
+		guard let original = selected else { return }
+		guard channelIndex == 0 ? channelRole == 1 : (channelRole == 0 || channelRole == 2) else {
+			editorErrorMessage = "Only slot 0 can be primary."
+			return
+		}
+		guard channelName.utf8.count <= 11 else {
+			editorErrorMessage = "Channel names must be 11 bytes or fewer"
+			return
+		}
+		guard let decodedKey = Data(base64Encoded: channelKey), [0, 1, 16, 32].contains(decodedKey.count) else {
+			editorErrorMessage = "Key must be valid base64 with 0, 1, 16, or 32 bytes"
+			return
+		}
+		var edited = original
+		edited.settings.name = channelName
+		edited.settings.psk = decodedKey
+		edited.role = ChannelRoles(rawValue: channelRole)?.protoEnumValue() ?? .disabled
+		edited.settings.uplinkEnabled = uplink
+		edited.settings.downlinkEnabled = downlink
+		edited.settings.moduleSettings.positionPrecision = UInt32(positionPrecision)
+		hasChanges = false
+		Task {
+			do {
+				try await coordinator.save([edited])
+				selected = nil
+			} catch {
+				editorErrorMessage = error.localizedDescription
+				hasChanges = true
+			}
+		}
+	}
+
+	var body: some View {
+		List {
+			if coordinator.isLoading {
+				ProgressView("Reading remote channels (\(coordinator.progress)/8)…")
+			}
+			ForEach(Int32(0)...Int32(7), id: \.self) { index in
+				if let channel = coordinator.channels[index] {
+					Button { select(channel) } label: {
+						ChannelRow(channel: displayEntity(channel), sharesLocation: channel.settings.moduleSettings.positionPrecision > 0)
+					}
+					.buttonStyle(.plain)
+				}
+			}
+		}
+		.navigationTitle("Channels")
+		.task {
+			do { try await coordinator.load() }
+			catch { errorMessage = error.localizedDescription }
+		}
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				Button("Retry") {
+					Task {
+						do { try await coordinator.load(); errorMessage = nil }
+						catch { errorMessage = error.localizedDescription }
+					}
+				}
+				.disabled(coordinator.isLoading || coordinator.isSaving)
+			}
+		}
+		.onReceive(NotificationCenter.default.publisher(for: .remoteChannelResponse).receive(on: RunLoop.main)) { coordinator.receive($0) }
+		.alert("Channels", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+			Button("OK", role: .cancel) { errorMessage = nil }
+		} message: { Text(errorMessage ?? "") }
+		.sheet(isPresented: Binding(get: { selected != nil }, set: { if !$0 { selected = nil } })) {
+			NavigationStack {
+				ChannelForm(channelIndex: $channelIndex, channelName: $channelName, channelKeySize: $channelKeySize, channelKey: $channelKey, channelRole: $channelRole, uplink: $uplink, downlink: $downlink, positionPrecision: $positionPrecision, preciseLocation: $preciseLocation, positionsEnabled: $positionsEnabled, hasChanges: $hasChanges, hasValidKey: $hasValidKey, supportedVersion: $supportedVersion)
+					.navigationTitle("Channel \(channelIndex)")
+					.toolbar {
+						ToolbarItem(placement: .cancellationAction) { Button("Cancel") { selected = nil } }
+						ToolbarItem(placement: .confirmationAction) {
+							Button(coordinator.isSaving ? "Saving…" : "Save", action: saveEditor)
+							.disabled(coordinator.isSaving || !hasValidKey)
+						}
+					}
+					.safeAreaInset(edge: .bottom) {
+						if let editorErrorMessage { Text(editorErrorMessage).foregroundStyle(.red).font(.callout).padding() }
+					}
+			}
+		}
+	}
 }
 
 struct RemoteChannelsUnavailable: View {
@@ -331,93 +409,4 @@ struct RemoteChannelsUnavailable: View {
 		.padding()
 		.navigationTitle("Remote Channels")
 	}
-}
-
-private struct RemoteChannelEditor: View {
-    @Environment(\.dismiss) private var dismiss
-    let channel: Channel
-    let isSaving: Bool
-    let onSave: (Channel) async throws -> Void
-    @State private var name: String
-    @State private var key: String
-    @State private var role: Channel.Role
-    @State private var uplink: Bool
-    @State private var downlink: Bool
-    @State private var precision: Int
-    @State private var muted: Bool
-    @State private var errorMessage: String?
-
-    init(channel: Channel, isSaving: Bool, onSave: @escaping (Channel) async throws -> Void) {
-        self.channel = channel
-        self.isSaving = isSaving
-        self.onSave = onSave
-        _name = State(initialValue: channel.settings.name)
-        _key = State(initialValue: channel.settings.psk.base64EncodedString())
-        _role = State(initialValue: channel.role)
-        _uplink = State(initialValue: channel.settings.uplinkEnabled)
-        _downlink = State(initialValue: channel.settings.downlinkEnabled)
-        _precision = State(initialValue: Int(channel.settings.moduleSettings.positionPrecision))
-        _muted = State(initialValue: channel.settings.moduleSettings.isMuted)
-    }
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                TextField("Name", text: $name)
-                    .onChange(of: name) { _, value in
-                        let compact = value.replacingOccurrences(of: " ", with: "")
-                        var limited = ""
-                        for scalar in compact.unicodeScalars {
-                            guard limited.utf8.count + String(scalar).utf8.count <= 11 else { break }
-                            limited.append(String(scalar))
-                        }
-                        name = limited
-                    }
-                TextField("Key (base64)", text: $key)
-                    .textSelection(.enabled)
-                Picker("Role", selection: $role) {
-                    if channel.index == 0 {
-                        Text("Primary").tag(Channel.Role.primary)
-                    } else {
-                        Text("Secondary").tag(Channel.Role.secondary)
-                        Text("Disabled").tag(Channel.Role.disabled)
-                    }
-                }
-                Toggle("MQTT Uplink Enabled", isOn: $uplink)
-                Toggle("MQTT Downlink Enabled", isOn: $downlink)
-                Toggle("Mute", isOn: $muted)
-                Stepper("Position Precision: \(precision)", value: $precision, in: 0...32)
-                if let errorMessage { Text(errorMessage).foregroundStyle(.red).font(.callout) }
-            }
-            .navigationTitle("Channel \(channel.index)")
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(isSaving ? "Saving…" : "Save") {
-                        guard name.utf8.count <= 11 else {
-                            errorMessage = "Channel names must be 11 bytes or fewer"
-                            return
-                        }
-                        guard let decodedKey = Data(base64Encoded: key), [0, 1, 16, 32].contains(decodedKey.count) else {
-                            errorMessage = "Key must be valid base64 with 0, 1, 16, or 32 bytes"
-                            return
-                        }
-                        var edited = channel
-                        edited.settings.name = name
-                        edited.settings.psk = decodedKey
-                        edited.role = role
-                        edited.settings.uplinkEnabled = uplink
-                        edited.settings.downlinkEnabled = downlink
-                        edited.settings.moduleSettings.positionPrecision = UInt32(precision)
-                        edited.settings.moduleSettings.isMuted = muted
-                        Task {
-                            do { try await onSave(edited) }
-                            catch { errorMessage = error.localizedDescription }
-                        }
-                    }
-                    .disabled(isSaving)
-                }
-            }
-        }
-    }
 }

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -275,7 +275,6 @@ struct Settings: View {
 					Image(systemName: "fibrechannel")
 				}
 			}
-			.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
 			settingsLink(value: .security) {
 				Label {
@@ -883,7 +882,15 @@ struct Settings: View {
 				case .lora:
 					LoRaConfig(node: configNode)
 				case .channels:
-					if let node = node {
+					if let targetNode = configNode, let connectedNode = node,
+						 targetNode.num != connectedNode.num,
+						 let fromUser = connectedNode.user, let toUser = targetNode.user {
+						if targetNode.sessionPasskey?.isEmpty == false {
+							RemoteChannels(node: targetNode, connectedNode: connectedNode, fromUser: fromUser, toUser: toUser, accessoryManager: accessoryManager)
+						} else {
+							RemoteChannelsUnavailable(nodeName: targetNode.user?.longName ?? "Selected node")
+						}
+					} else if let node = node {
 						Channels(node: node)
 					} else {
 						Text("Loading...")

--- a/MeshtasticTests/RemoteChannelsTests.swift
+++ b/MeshtasticTests/RemoteChannelsTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+import MeshtasticProtobufs
+@testable import Meshtastic
+
+@Suite("Remote Channels")
+struct RemoteChannelsTests {
+    @Test("channel read requests use one based wire indexes")
+    func channelReadRequestUsesOneBasedWireIndex() throws {
+        let packet = try RemoteChannelsPacketBuilder.getRequest(
+            index: 0, from: 0x1111, to: 0x2222, sessionPasskey: Data([1, 2, 3]), id: 42
+        )
+        let admin = try AdminMessage(serializedBytes: packet.decoded.payload)
+
+        #expect(admin.getChannelRequest == 1)
+        #expect(packet.to == 0x2222)
+        #expect(packet.from == 0x1111)
+        #expect(admin.sessionPasskey == Data([1, 2, 3]))
+        #expect(packet.decoded.wantResponse)
+    }
+
+    @Test("response matching isolates target and request index")
+    func responseMatchingIsTargetScoped() throws {
+        var channel = Channel()
+        channel.index = 3
+        var response = AdminMessage()
+        response.getChannelResponse = channel
+
+        var packet = MeshPacket()
+        packet.from = 0x2222
+        packet.to = 0x1111
+        packet.decoded.requestID = 99
+
+        #expect(RemoteChannelsPacketBuilder.matchesResponse(
+            packet: packet, response: response, requestID: 99, target: 0x2222, index: 3
+        ))
+        #expect(!RemoteChannelsPacketBuilder.matchesResponse(
+            packet: packet, response: response, requestID: 99, target: 0x3333, index: 3
+        ))
+        #expect(!RemoteChannelsPacketBuilder.matchesResponse(
+            packet: packet, response: response, requestID: 99, target: 0x2222, index: 2
+        ))
+    }
+
+    @Test("ordered writes stop at the first failure")
+    func orderedWritesStopAtFirstFailure() async throws {
+        let channels = [0, 1, 2].map { index in
+            var channel = Channel()
+            channel.index = Int32(index)
+            return channel
+        }
+        var attempted: [Int32] = []
+        let result = try await RemoteChannelsWritePlan.execute(channels) { channel in
+            attempted.append(channel.index)
+            if channel.index == 1 { throw AccessoryError.ioFailed("failed") }
+        }
+
+        #expect(attempted == [0, 1])
+        #expect(result == .failure(index: 1))
+    }
+
+    @Test("remote reads retry once and surface timeout when every attempt fails")
+    func remoteReadsRetryAndSurfaceTimeout() async {
+        var attempts = 0
+        let value = try? await RemoteChannelsReadPlan.retry(retries: 1) {
+            attempts += 1
+            if attempts == 1 { throw AccessoryError.timeout }
+            return "confirmed"
+        }
+        #expect(value == "confirmed")
+        #expect(attempts == 2)
+
+        let timedOut = try? await RemoteChannelsReadPlan.retry(retries: 1) {
+            throw AccessoryError.timeout
+        }
+        #expect(timedOut == nil)
+    }
+
+	@MainActor
+	@Test("coordinator confirms editable fields and stops after a mismatch")
+	func coordinatorReadbackMismatchStopsWrites() async throws {
+		let transport = TestRemoteChannelsTransport()
+		transport.session = true
+		var first = Channel(); first.index = 0; first.role = .primary; first.settings.name = "Before"
+		transport.channels[0] = first
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			var response = channel
+			if channel.index == 0 { response.settings.name = "Different" }
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: response))
+		}
+		var desired = first; desired.settings.name = "After"
+		await #expect(throws: AccessoryError.self) { try await coordinator.save([desired]) }
+		#expect(transport.saveCount == 1)
+	}
+
+	@MainActor
+	@Test("coordinator refreshes initial PKI session before loading")
+	func coordinatorRefreshesBeforeLoad() async throws {
+		let transport = TestRemoteChannelsTransport()
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: channel))
+		}
+		var primary = Channel(); primary.index = 0; primary.role = .primary; primary.settings.name = "Primary"; primary.settings.moduleSettings.isMuted = true
+		transport.channels[0] = primary
+		try await coordinator.load()
+		#expect(transport.refreshCount == 1)
+		#expect(coordinator.channels[0]?.role == .primary)
+		#expect(coordinator.channels[0]?.settings.name == "Primary")
+		#expect(coordinator.channels[0]?.settings.moduleSettings.isMuted == true)
+	}
+
+	@MainActor
+	@Test("coordinator reports a real no reply timeout")
+	func coordinatorNoReplyTimesOut() async {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		await #expect(throws: AccessoryError.self) { try await coordinator.load() }
+	}
+
+	@MainActor
+	@Test("coordinator aborts when the connected identity switches")
+	func coordinatorAbortsOnIdentitySwitch() async {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { _, _ in transport.switchConnection() }
+		await #expect(throws: AccessoryError.self) { try await coordinator.load() }
+	}
+
+	@MainActor
+	@Test("coordinator confirms a successful save with semantic fields")
+	func coordinatorConfirmsSuccessfulSave() async throws {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: channel))
+		}
+		var channel = Channel(); channel.index = 1; channel.role = .secondary
+		channel.settings.name = "Remote"; channel.settings.psk = Data(repeating: 7, count: 16)
+		channel.settings.uplinkEnabled = true; channel.settings.downlinkEnabled = true
+		channel.settings.moduleSettings.positionPrecision = 14; channel.settings.moduleSettings.isMuted = true
+		try await coordinator.save([channel])
+		#expect(transport.saveCount == 1)
+		#expect(coordinator.channels[1]?.settings.moduleSettings.isMuted == true)
+	}
+
+	@MainActor
+	@Test("disabled channel writes clear settings and invalid roles are rejected")
+	func disabledAndInvalidRoles() async throws {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: channel))
+		}
+		var disabled = Channel(); disabled.index = 1; disabled.role = .disabled; disabled.settings.name = "old"
+		try await coordinator.save([disabled])
+		#expect(transport.channels[1]?.hasSettings == false)
+		var primaryOnSecondary = Channel(); primaryOnSecondary.index = 1; primaryOnSecondary.role = .primary
+		await #expect(throws: AccessoryError.self) { try await coordinator.save([primaryOnSecondary]) }
+		var disabledPrimary = Channel(); disabledPrimary.index = 0; disabledPrimary.role = .disabled
+		await #expect(throws: AccessoryError.self) { try await coordinator.save([disabledPrimary]) }
+	}
+}
+
+private final class IdentityToken {}
+
+@MainActor
+private final class TestRemoteChannelsTransport: RemoteChannelsTransport {
+	var isConnected = true
+	var connectedDeviceNum: Int64? = 1
+	var identityToken = IdentityToken()
+	var connectionID: ObjectIdentifier? { ObjectIdentifier(identityToken) }
+	var session = false
+	var refreshCount = 0
+	var saveCount = 0
+	var channels: [Int32: Channel] = [:]
+	var onRequest: ((UInt32, Channel) -> Void)?
+	private var nextID: UInt32 = 100
+	var hasLiveSession: Bool { session }
+	func switchConnection() { identityToken = IdentityToken() }
+	var responseTimeout: Duration { .milliseconds(50) }
+	var sessionTimeout: Duration { .milliseconds(50) }
+
+	func refreshMetadata() async throws { refreshCount += 1; session = true }
+	func requestChannel(index: Int32) async throws -> UInt32 {
+		let id = nextID; nextID += 1
+		var channel = channels[index] ?? Channel()
+		channel.index = index
+		onRequest?(id, channel)
+		return id
+	}
+	func saveChannel(_ channel: Channel) async throws { saveCount += 1; channels[channel.index] = channel }
+
+	static func notification(id: UInt32, source: UInt32, destination: UInt32, channel: Channel) -> Foundation.Notification {
+		var response = AdminMessage(); response.getChannelResponse = channel
+		var packet = MeshPacket(); packet.from = source; packet.to = destination; packet.decoded.requestID = id
+		return Foundation.Notification(name: .remoteChannelResponse, object: nil, userInfo: ["packet": packet, "response": response])
+	}
+}

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -68,6 +68,8 @@ On firmware **2.8.0 or later**, the radio tells the app which modem presets are 
 
 Manage up to 8 channels (0–7). Channel 0 is the primary broadcast channel. Additional channels create isolated messaging groups with their own encryption keys.
 
+When a remote administered node is selected in Settings, Channels loads that node's eight slots through the connected radio. Remote edits are sent in slot order and confirmed by reading each slot back; progress and the first failed slot are shown in the screen. Remote channel responses stay scoped to the selected node and are not copied into the connected radio's local channel database.
+
 When sharing channels, the share screen shows a QR code and link, and — on iPhones with NFC hardware (iOS 18 or later) — a **Write to NFC Tag** button. Hold a writable NFC tag near the top of your iPhone to save the channel link to it, replacing any content the tag already held; tapping that tag on another phone opens the same add-or-replace channels flow the QR code does.
 
 ### Security


### PR DESCRIPTION
## What changed?

- Add a native Remote Channels screen for PKI-administered nodes, with sequential reads for all eight channel slots and progress, timeout, retry, and cancellation handling.
- Reuse the regular Settings channel list row (`ChannelRow`) and unchanged channel editor (`ChannelForm`) for remote channels, including name, key, role, MQTT flags, and position precision. Preserve other channel fields when saving enabled channels; disabling a slot clears its settings.
- Validate channel roles, UTF-8 name length, and key length before sending changes, then read each changed slot back and compare the editable fields before reporting success.
- Keep remote channel responses in a target-scoped in-memory snapshot so they cannot overwrite the connected radio's locally persisted channels.
- Abort reads and writes if the connection changes, including reconnecting to the same radio through a different connection.
- Update the Remote Administration documentation for remote channel editing.

This is PR 4 of the native Remote Admin parity stack tracked by #2410 and depends on #2413 (`codex/remote-admin-feedback`). Its base should remain that branch until the preceding layer lands.

## Why did it change?

The Apple app only exposed channel editing for the directly connected radio, leaving PKI-administered nodes without the channel workflow available on Android.

Android reads remote channel slots in sequence and advances the flow from each matching response. See the pinned [remote channel response chain](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt#L1270-L1297). Its native editor exposes the channel name, PSK, uplink/downlink flags, and position precision in [EditChannelDialog](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/component/EditChannelDialog.kt#L54-L145). This change brings that capability to Apple platforms while adding explicit readback confirmation and SwiftData isolation for the Apple app's persistence model.

## How is this tested?

- Final combined stack: `xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -derivedDataPath /tmp/remote-admin-build -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:MeshtasticTests/RemoteAdminEntryTests -only-testing:MeshtasticTests/NodeAdministrationTests -only-testing:MeshtasticTests/RemoteAdminConfigTrackerTests -only-testing:MeshtasticTests/RemoteChannelsTests -only-testing:MeshtasticTests/RemoteAdminActionTransportTests -only-testing:MeshtasticTests/SettingsNodeSortTests -only-testing:MeshtasticTests/ChannelSetSaveTests` passed: **78 tests, 0 failures, 0 skips**.
- Coverage includes response correlation, retry and timeout behavior, readback mismatch rejection, disabled-channel clearing, primary-slot validation, local database isolation, cancellation, and same-radio connection replacement.
- Real bench: iOS Simulator through a serial/TCP bridge to MUZI (2.8.0), administering TBEAM S3 over RF (2.8.1). Read all eight remote slots and opened the shared primary-channel editor. Values matched an independent serial snapshot, including name, role, position precision, and MQTT flags. Verified Back through Remote Settings to the originating node.
- The hardware run performed reads only; channel writes/readback, mismatch, and partial failures were verified by automated transport tests. The UI automation interface did not expose the editor’s Save button, so an end-to-end UI save was not exercised.
- Full non-snapshot unit suite on the final combined stack: **2,968 passed, 0 failed, 6 skipped**. Ran `xcodebuild test-without-building -only-testing:MeshtasticTests` with the same 39 snapshot-suite exclusions as `.github/workflows/unit-tests.yml` and the simulator/build settings above. The six existing Keychain tests skipped because code signing was disabled (OSStatus -34018).

## Screenshots/Videos (when applicable)

The before screenshot shows the original remote Settings entry using a seeded node. The after screenshots use the real TBEAM bench target and the same editor used by regular Settings.

| Before: remote Settings entry | After: remote channel list |
| --- | --- |
| <img width="280" alt="Original remote Settings entry" src="https://github.com/user-attachments/assets/ccf94902-8122-4fcc-849f-7d00e7eefbdb" /> | <img width="280" alt="All eight real remote channel slots" src="https://github.com/user-attachments/assets/06c6cc7b-6d70-45aa-824b-b3a60773a8d9" /> |

<img width="320" alt="The unchanged regular channel editor displaying the remote primary channel" src="https://github.com/user-attachments/assets/54f1bd36-3f3c-4d83-81c7-9d2e4a7bd62b" />

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
