### PR TITLE
Add remote Set Time and reset actions for Android parity

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -327,6 +327,30 @@ extension AccessoryManager {
 		let messageDescription = "🕛 Sent Set Time Admin Message to the connected node."
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 	}
+
+	public func sendTime(fromUser: UserEntity, toUser: UserEntity) async throws {
+		var adminPacket = AdminMessage()
+		adminPacket.setTimeOnly = UInt32(Date().timeIntervalSince1970)
+		if fromUser != toUser {
+			adminPacket.sessionPasskey = toUser.userNode?.sessionPasskey ?? Data()
+		}
+		var meshPacket: MeshPacket = MeshPacket()
+		meshPacket.to = UInt32(toUser.num)
+		meshPacket.from = UInt32(fromUser.num)
+		meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+		meshPacket.priority = MeshPacket.Priority.reliable
+		meshPacket.wantAck = true
+		var dataMessage = DataMessage()
+		if let serializedData: Data = try? adminPacket.serializedData() {
+			dataMessage.payload = serializedData
+			dataMessage.portnum = PortNum.adminApp
+			meshPacket.decoded = dataMessage
+		} else {
+			throw AccessoryError.ioFailed("sendTime(fromUser:toUser:): Unable to serialize admin packet")
+		}
+		let messageDescription = "🕛 Sent Set Time Admin Message to: \(toUser.longName ?? "Unknown".localized) from: \(fromUser.longName ?? "Unknown".localized)"
+		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+	}
 	
 	public func sendShutdown(fromUser: UserEntity, toUser: UserEntity) async throws {
 		var adminPacket = AdminMessage()

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -43,6 +43,12 @@ struct NodeDetail: View {
 	@EnvironmentObject var router: Router
 	@State private var showingShutdownConfirm: Bool = false
 	@State private var showingRebootConfirm: Bool = false
+	@State private var showingSetTimeConfirm: Bool = false
+	@State private var showingFactoryResetConfirm: Bool = false
+	@State private var showingNodeDBResetConfirm: Bool = false
+	@State private var isPerformingAdminAction: Bool = false
+	@State private var adminErrorMessage: String?
+	@State private var pendingAdminTarget: RemoteAdminActionTarget?
 	@State private var dateFormatRelative: Bool = true
 	@Bindable	var node: NodeInfoEntity
 	private let nodeNum: Int64
@@ -106,6 +112,15 @@ struct NodeDetail: View {
 			return nil
 		}
 		return (fromUser, toUser)
+	}
+	private var currentAdminTarget: RemoteAdminActionTarget? {
+		guard let radioNum = accessoryManager.activeDeviceNum,
+			  let connection = accessoryManager.activeConnection?.connection else { return nil }
+		return RemoteAdminActionTarget(
+			nodeNum: nodeNum,
+			name: currentUser?.displayLongName ?? "Unknown",
+			radioNum: radioNum,
+			connectionID: ObjectIdentifier(connection))
 	}
 	/// The status row opens the status message editor for the connected node, or for a remote
 	/// node we have successfully administered before. Firmware 2.8+ in both cases: the
@@ -976,8 +991,8 @@ struct NodeDetail: View {
 					"Are you sure?",
 					isPresented: $showingRebootConfirm
 				) {
-					Button("Reboot node?", role: .destructive) {
-						Task {
+						Button("Reboot node?", role: .destructive) {
+							Task {
 							guard let administrationUserPair else { return }
 							do {
 								try await accessoryManager.sendReboot(
@@ -991,7 +1006,149 @@ struct NodeDetail: View {
 					}
 				}
 				.disabled(administrationUserPair == nil)
+				Button {
+					pendingAdminTarget = currentAdminTarget
+					showingSetTimeConfirm = true
+				} label: {
+					Label("Set Time", systemImage: "clock")
 				}
+				.confirmationDialog(
+					"Set time on \(pendingAdminTarget?.name ?? "node")?",
+					isPresented: $showingSetTimeConfirm
+				) {
+					Button("Set time to now") {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendTime(fromUser: pair.fromUser, toUser: pair.toUser)
+							}
+							if let error { adminErrorMessage = "Set Time failed for \(target.name): \(error)" }
+						}
+					}
+				}
+				.disabled(administrationUserPair == nil || nodeNum == accessoryManager.activeDeviceNum || isPerformingAdminAction)
+				Button {
+					pendingAdminTarget = currentAdminTarget
+					showingFactoryResetConfirm = true
+				} label: {
+					Label("Factory Reset", systemImage: "arrowcounterclockwise")
+				}
+				.confirmationDialog(
+					"Factory reset \(pendingAdminTarget?.name ?? "node")?",
+					isPresented: $showingFactoryResetConfirm
+				) {
+					Button("Delete all config?", role: .destructive) {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser)
+							}
+							if let error { adminErrorMessage = "Factory Reset failed for \(target.name): \(error)" }
+						}
+					}
+					Button("Delete all config, keys and BLE bonds?", role: .destructive) {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser, resetDevice: true)
+							}
+							if let error { adminErrorMessage = "Factory Reset failed for \(target.name): \(error)" }
+						}
+					}
+				}
+				.disabled(administrationUserPair == nil || nodeNum == accessoryManager.activeDeviceNum || isPerformingAdminAction)
+				Button {
+					pendingAdminTarget = currentAdminTarget
+					showingNodeDBResetConfirm = true
+				} label: {
+					Label("NodeDB Reset", systemImage: "list.bullet.rectangle")
+				}
+				.confirmationDialog(
+					"Reset node database on \(pendingAdminTarget?.name ?? "node")?",
+					isPresented: $showingNodeDBResetConfirm
+				) {
+					Button("Reset node database, preserving favorites") {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: true)
+							}
+							if let error { adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)" }
+						}
+					}
+					Button("Reset node database and favorites?", role: .destructive) {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: false)
+							}
+							if let error { adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)" }
+						}
+					}
+				}
+				.disabled(administrationUserPair == nil || nodeNum == accessoryManager.activeDeviceNum || isPerformingAdminAction)
+				if isPerformingAdminAction {
+					HStack {
+						ProgressView()
+						Text("Sending command…")
+							.foregroundColor(.secondary)
+							.font(.caption)
+					}
+				}
+				}
+			}
+			.alert("Admin Action Failed", isPresented: Binding(
+				get: { adminErrorMessage != nil },
+				set: { if !$0 { adminErrorMessage = nil } }
+			)) {
+				Button("OK", role: .cancel) { adminErrorMessage = nil }
+			} message: {
+				Text(adminErrorMessage ?? "")
 			}
 		}
 	}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1014,7 +1014,8 @@ struct NodeDetail: View {
 				}
 				.confirmationDialog(
 					"Set time on \(pendingAdminTarget?.name ?? "node")?",
-					isPresented: $showingSetTimeConfirm
+					isPresented: $showingSetTimeConfirm,
+					titleVisibility: .visible
 				) {
 					Button("Set time to now") {
 						Task {
@@ -1044,7 +1045,8 @@ struct NodeDetail: View {
 				}
 				.confirmationDialog(
 					"Factory reset \(pendingAdminTarget?.name ?? "node")?",
-					isPresented: $showingFactoryResetConfirm
+					isPresented: $showingFactoryResetConfirm,
+					titleVisibility: .visible
 				) {
 					Button("Delete all config?", role: .destructive) {
 						Task {
@@ -1092,7 +1094,8 @@ struct NodeDetail: View {
 				}
 				.confirmationDialog(
 					"Reset node database on \(pendingAdminTarget?.name ?? "node")?",
-					isPresented: $showingNodeDBResetConfirm
+					isPresented: $showingNodeDBResetConfirm,
+					titleVisibility: .visible
 				) {
 					Button("Reset node database, preserving favorites") {
 						Task {
@@ -1213,9 +1216,7 @@ struct NodeDetail: View {
 			return
 		}
 		defer {
-			if remoteAdminAttemptID == attemptID {
-				remoteAdminAttemptID = nil
-			}
+			if remoteAdminAttemptID == attemptID { remoteAdminAttemptID = nil }
 		}
 		guard UserDefaults.enableAdministration else {
 			remoteAdminState = .failed(.requestFailed)

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminActionTarget.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminActionTarget.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct RemoteAdminActionTarget: Equatable {
+	let nodeNum: Int64
+	let name: String
+	let radioNum: Int64
+	let connectionID: ObjectIdentifier
+}
+
+@MainActor
+enum RemoteAdminActionGuard {
+	static func run(
+		target: RemoteAdminActionTarget,
+		activeRadioNum: @escaping @MainActor () -> Int64?,
+		activeConnectionID: @escaping @MainActor () -> ObjectIdentifier?,
+		isConnected: @escaping @MainActor () -> Bool,
+		hasLiveSession: @escaping @MainActor () -> Bool,
+		action: @escaping @MainActor () async throws -> Void
+	) async -> String? {
+		guard isConnected(), activeRadioNum() == target.radioNum,
+			  activeConnectionID() == target.connectionID else { return "Connection changed. Please try again." }
+		guard hasLiveSession() else { return "Session expired for \(target.name). Refresh device metadata first." }
+		do {
+			try await action()
+			return nil
+		} catch {
+			return error.localizedDescription
+		}
+	}
+}

--- a/MeshtasticTests/RemoteAdminActionsTests.swift
+++ b/MeshtasticTests/RemoteAdminActionsTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+import SwiftData
+import MeshtasticProtobufs
+@testable import Meshtastic
+
+private actor RemoteActionConnection: Connection {
+	let type: TransportType = .ble
+	var isConnected = true
+	private(set) var sent: [ToRadio] = []
+
+	func send(_ data: ToRadio) async throws { sent.append(data) }
+	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
+	func disconnect(withError: Error?, shouldReconnect: Bool) async throws { isConnected = false }
+	func drainPendingPackets() async throws {}
+	func startDrainPendingPackets() throws {}
+	func appDidEnterBackground() {}
+	func appDidBecomeActive() {}
+}
+
+@MainActor
+@Suite("Remote admin action transport", .serialized)
+struct RemoteAdminActionTransportTests {
+	private struct Fixture {
+		let manager: AccessoryManager
+		let connection: RemoteActionConnection
+		let from: UserEntity
+		let to: UserEntity
+		let container: ModelContainer
+	}
+
+	private func fixture() throws -> Fixture {
+		let container = try ModelContainer(for: Schema(MeshtasticSchema.allModels), configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+		let context = ModelContext(container)
+		let localNode = NodeInfoEntity(); localNode.num = 7; localNode.id = 7
+		let remoteNode = NodeInfoEntity(); remoteNode.num = 42; remoteNode.id = 42
+		remoteNode.sessionPasskey = Data([0xA5, 0x5A]); remoteNode.sessionExpiration = .now.addingTimeInterval(300)
+		let from = UserEntity(); from.num = 7; from.userNode = localNode
+		let to = UserEntity(); to.num = 42; to.userNode = remoteNode
+		context.insert(localNode); context.insert(remoteNode); context.insert(from); context.insert(to)
+		try context.save()
+		let connection = RemoteActionConnection()
+		let manager = AccessoryManager(transports: [])
+		manager.context = context
+		manager.activeConnection = (device: Device(id: UUID(), name: "Test", transportType: .ble, identifier: "test", connectionState: .connected), connection: connection)
+		manager.activeDeviceNum = 7
+		manager.updateState(.subscribed)
+		return Fixture(manager: manager, connection: connection, from: from, to: to, container: container)
+	}
+
+	private func guardTarget(connection: RemoteActionConnection, radio: Int64 = 7) -> RemoteAdminActionTarget {
+		RemoteAdminActionTarget(nodeNum: 42, name: "Target", radioNum: radio, connectionID: ObjectIdentifier(connection))
+	}
+
+	private func admin(from toRadio: ToRadio) throws -> (MeshPacket, AdminMessage) {
+		guard case .packet(let packet) = toRadio.payloadVariant else { throw AccessoryError.ioFailed("missing packet") }
+		return (packet, try AdminMessage(serializedBytes: packet.decoded.payload))
+	}
+
+	@Test func guardRejectsExpiredSessionWithoutSending() async {
+		let connection = RemoteActionConnection()
+		var sends = 0
+		let error = await RemoteAdminActionGuard.run(
+			target: guardTarget(connection: connection), activeRadioNum: { 7 },
+			activeConnectionID: { ObjectIdentifier(connection) }, isConnected: { true }, hasLiveSession: { false },
+			action: { sends += 1 }
+		)
+		#expect(error?.contains("Session expired") == true); #expect(sends == 0)
+	}
+
+	@Test func guardRejectsDifferentConnectionOnSameRadioWithoutSending() async {
+		let expected = RemoteActionConnection(); let active = RemoteActionConnection()
+		var sends = 0
+		let error = await RemoteAdminActionGuard.run(
+			target: guardTarget(connection: expected), activeRadioNum: { 7 },
+			activeConnectionID: { ObjectIdentifier(active) }, isConnected: { true }, hasLiveSession: { true },
+			action: { sends += 1 }
+		)
+		#expect(error?.contains("Connection changed") == true); #expect(sends == 0)
+	}
+
+	@Test func guardAllowsLiveMatchingConnectionExactlyOnce() async {
+		let connection = RemoteActionConnection(); var sends = 0
+		let error = await RemoteAdminActionGuard.run(
+			target: guardTarget(connection: connection), activeRadioNum: { 7 },
+			activeConnectionID: { ObjectIdentifier(connection) }, isConnected: { true }, hasLiveSession: { true },
+			action: { sends += 1 }
+		)
+		#expect(error == nil); #expect(sends == 1)
+	}
+
+	@Test func sendTimeUsesProductionTransportAndRemoteAuth() async throws {
+		let fixture = try fixture()
+		try await fixture.manager.sendTime(fromUser: fixture.from, toUser: fixture.to)
+		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
+		#expect(packet.from == 7); #expect(packet.to == 42); #expect(admin.sessionPasskey == Data([0xA5, 0x5A]))
+		#expect(admin.setTimeOnly > 0); #expect(packet.decoded.portnum == .adminApp)
+	}
+
+	@Test(arguments: [false, true]) func factoryResetModesReachRemote(resetDevice: Bool) async throws {
+		let fixture = try fixture()
+		try await fixture.manager.sendFactoryReset(fromUser: fixture.from, toUser: fixture.to, resetDevice: resetDevice)
+		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
+		#expect(packet.to == 42); #expect(admin.sessionPasskey == Data([0xA5, 0x5A]))
+		#expect(resetDevice ? admin.factoryResetDevice == 5 : admin.factoryResetConfig == 5)
+		#expect(resetDevice ? admin.factoryResetConfig == 0 : admin.factoryResetDevice == 0)
+	}
+
+	@Test(arguments: [false, true]) func nodeDBResetPreservesRequestedFavoriteMode(preserveFavorites: Bool) async throws {
+		let fixture = try fixture()
+		let context = ModelContext(fixture.container)
+		let local = try #require(try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 7 })).first)
+		local.favorite = true; try context.save()
+		try await fixture.manager.sendNodeDBReset(fromUser: fixture.from, toUser: fixture.to, preserveFavorites: preserveFavorites)
+		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
+		#expect(packet.to == 42); #expect(admin.nodedbReset == preserveFavorites)
+		let stillThere = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 7 })).first
+		#expect(stillThere?.favorite == true)
+		let targetStillTracked = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 42 })).first
+		#expect(targetStillTracked != nil)
+	}
+}

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -49,6 +49,8 @@ The Configure picker lists live nodes from the current node database, with favor
 
 When you configure another node, Settings shows progress while the request or save is being confirmed by that node. A timeout or delivery error keeps your edits on screen and provides a **Retry** action, so you can check the node and try again without re-entering the values.
 
+Remote **Set Time**, **Factory Reset**, and **NodeDB Reset** actions are sent only while the connected radio and live administration session still match the selected target. If the connection changes or the session expires, Settings stops the action and reports the failure rather than applying it to a stale target.
+
 ### LoRa
 
 LoRa settings control how your radio communicates on the mesh:


### PR DESCRIPTION
## What changed?

- Add native remote Set Time, Factory Reset, and NodeDB Reset actions to the node administration section.
- Preserve both reset choices: configuration-only or full factory reset, and NodeDB reset with or without favorites.
- Bind confirmation dialogs to an immutable target snapshot and verify the connected radio, concrete connection, target, and live PKI session immediately before sending.
- Use the existing production transport and authenticated admin packet path, including the remote session passkey.
- Keep local database clearing and reconnect side effects limited to resets of the directly connected radio.
- Show send progress and errors for local transport failures, expired sessions, disconnects, and changed targets. Completion means the command was sent; these actions do not yet wait for a remote acknowledgment.
- Update the Remote Administration documentation for the new actions.

This is PR 5 of the native Remote Admin parity stack tracked by #2410 and depends on #2411 (`codex/remote-admin-channels`). Its base should remain that branch until the preceding layer lands.

## Why did it change?

Android exposes time synchronization and reset operations for administered nodes through the same request-tracked admin flow used by other remote settings. The pinned Android implementation routes the actions in [RadioConfigViewModel](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt#L646-L699), and constructs their packet IDs and local-only reset side effects in [AdminActionsUseCase](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/AdminActionsUseCase.kt#L39-L122). This change provides the same remote administration capability in the Apple app and guards destructive confirmations against navigation or connection changes.

## How is this tested?

- Final combined stack: `xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -derivedDataPath /tmp/remote-admin-build -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:MeshtasticTests/RemoteAdminEntryTests -only-testing:MeshtasticTests/NodeAdministrationTests -only-testing:MeshtasticTests/RemoteAdminConfigTrackerTests -only-testing:MeshtasticTests/RemoteChannelsTests -only-testing:MeshtasticTests/RemoteAdminActionTransportTests -only-testing:MeshtasticTests/SettingsNodeSortTests -only-testing:MeshtasticTests/ChannelSetSaveTests` passed: **78 tests, 0 failures, 0 skips**.
- Coverage verifies the real production connection receives correctly addressed and authenticated Set Time, Factory Reset, and NodeDB Reset packets, including both reset variants. Guard tests cover disconnects, target changes, session expiry, and same-radio connection replacement.
- Real bench: iOS Simulator connected through a serial/TCP bridge to MUZI (firmware 2.8.0), administering TBEAM S3 over RF (2.8.1). An independent serial observer on TBEAM recorded the Set Time command from MUZI. An expired-session attempt was rejected in the app; refreshing the session allowed the command.
- Both reset confirmations named the remote TBEAM and were canceled. Destructive resets were verified with the capture transport, not executed on hardware. Channel and LoRa hashes were unchanged afterward.
- Full non-snapshot unit suite on the final combined stack: **2,968 passed, 0 failed, 6 skipped**. Ran `xcodebuild test-without-building -only-testing:MeshtasticTests` with the same 39 snapshot-suite exclusions as `.github/workflows/unit-tests.yml` and the simulator/build settings above. The six existing Keychain tests skipped because code signing was disabled (OSStatus -34018).

## Screenshots/Videos (when applicable)

The after screenshots use the real bench target. Both confirmations were canceled.

| Before | After |
| --- | --- |
| <img width="280" alt="Original remote administration actions" src="https://github.com/user-attachments/assets/dae4be4a-ffd6-4070-8530-65808cfd5b11" /> | <img width="280" alt="Remote administration actions on the real TBEAM" src="https://github.com/user-attachments/assets/9316f1f6-b7ff-4276-9e29-b4903ea660fb" /> |

| Factory Reset target | NodeDB Reset target |
| --- | --- |
| <img width="280" alt="Factory Reset confirmation naming the remote target" src="https://github.com/user-attachments/assets/d7d242eb-fc93-4c15-8cc9-1b999c59a9bd" /> | <img width="280" alt="NodeDB Reset confirmation naming the remote target" src="https://github.com/user-attachments/assets/54232078-e92b-4363-95af-6f2697815f76" /> |

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
