### PR TITLE
Track remote configuration progress and retries for Android parity

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -200,7 +200,23 @@ extension AccessoryManager {
 		toRadio = ToRadio()
 		toRadio.packet = meshPacket
 
+		let operationID = RemoteAdminConfigTracker.currentOperationID
+		let enrolled = remoteAdminConfigTracker.registerPacket(
+			packetID: meshPacket.id,
+			targetNodeNum: Int64(meshPacket.to),
+			operationID: operationID
+		)
 		try await send(toRadio)
+		if enrolled, let operationID {
+			switch await remoteAdminConfigTracker.waitForPacket(packetID: meshPacket.id, operationID: operationID) {
+			case .succeeded:
+				break
+			case .failed(let message):
+				throw AccessoryError.ioFailed(message)
+			case .timedOut:
+				throw AccessoryError.timeout
+			}
+		}
 		if let adminDescription {
 			Logger.admin.debug("\(adminDescription, privacy: .public)")
 		}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -162,6 +162,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// back off repeats (see `shouldSurfaceFirmwareNotice`). In memory on purpose: after a
 	/// relaunch a standing notice alerts once more, which is the useful behaviour.
 	var firmwareNoticeHistory: [String: (count: Int, lastShown: Date)] = [:]
+	let remoteAdminConfigTracker = RemoteAdminConfigTracker()
+	@Published var remoteAdminConfigFeedback: (targetNodeNum: Int64, message: String)? = nil
 	/// Delay before the Nth repeat of the same notice may alert again.
 	static let firmwareNoticeBackoff: [TimeInterval] = [0, 300, 1_800, 7_200, 43_200]
 	/// A notice unseen for this long is forgotten, so it alerts immediately if it returns.
@@ -320,6 +322,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// monitor. True while sustained inbound mesh traffic is high enough to pause the map flyover.
 	@Published private(set) var isHighMeshTraffic = false
 	private var meshTrafficCancellable: AnyCancellable?
+	private var remoteAdminTrackerCancellable: AnyCancellable?
 
 	/// Packet count at the last periodic MeshPackets recycle (see `didReceive`). The ingest
 	/// actor's ModelContext registers every entity it inserts or faults and never lets go, so a
@@ -385,6 +388,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			.sink { [weak self] isHigh in
 				self?.isHighMeshTraffic = isHigh
 			}
+		remoteAdminTrackerCancellable = remoteAdminConfigTracker.objectWillChange
+			.sink { [weak self] _ in self?.objectWillChange.send() }
 	}
 
 	func transportForType(_ type: TransportType) -> Transport? {
@@ -587,6 +592,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	// If you are calling this in response to an error, then you should have
 	// exposed the error to the UI or handled the error prior to calling this.
 	func closeConnection() async throws {
+		failRemoteAdminConfigOperations(with: "The radio connection was closed before the remote node confirmed the configuration.")
 		guard !isClosingConnection else {
 			Logger.transport.debug("[AccessoryManager] closeConnection ignored while teardown is already in progress")
 			return
@@ -776,6 +782,31 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 	}
 
+	@discardableResult
+	func beginRemoteAdminConfigOperation(kind: RemoteAdminConfigOperationKind, targetNodeNum: Int64, section: String = "save") -> UUID? {
+		remoteAdminConfigTracker.begin(kind: kind, targetNodeNum: targetNodeNum, section: section)
+	}
+
+	func resolveRemoteAdminConfigPacket(packetID: UInt32, sourceNodeNum: Int64, result: RemoteAdminConfigOperationResult) {
+		guard let operationID = remoteAdminConfigTracker.resolveAdminResponse(packetID: packetID, sourceNodeNum: sourceNodeNum),
+			  let operation = remoteAdminConfigTracker.operations[operationID]
+		else { return }
+		if case .failed(let message) = result {
+			remoteAdminConfigFeedback = (operation.targetNodeNum, message)
+		}
+	}
+
+	func resolveRemoteAdminRoutingError(packetID: UInt32, reason: String) {
+		guard let operationID = remoteAdminConfigTracker.resolveRouting(packetID: packetID, sourceNodeNum: 0, reason: reason, isFailure: true),
+			  let operation = remoteAdminConfigTracker.operations[operationID]
+		else { return }
+		remoteAdminConfigFeedback = (operation.targetNodeNum, reason)
+	}
+
+	func failRemoteAdminConfigOperations(with message: String) {
+		remoteAdminConfigTracker.failAll(with: message)
+	}
+
 	func didReceive(_ event: ConnectionEvent) async {
 		let shouldIgnoreTransientEvent = isClosingConnection || userRequestedConnectionCancellation || activeConnection == nil
 
@@ -827,6 +858,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			updateDevice(deviceId: deviceId, key: \.rssi, value: rssi)
 			
 		case .error(let error), .errorWithoutReconnect(let error):
+			failRemoteAdminConfigOperations(with: "The radio connection was lost before the remote node confirmed the configuration.")
 			Task {
 				// Figure out if we'll reconnect
 				if case .errorWithoutReconnect = event {
@@ -856,6 +888,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			}
 			
 		case .disconnected:
+			failRemoteAdminConfigOperations(with: "The radio connection was lost before the remote node confirmed the configuration.")
 			guard !shouldIgnoreTransientEvent else {
 				Logger.transport.info("[Accessory] Ignoring disconnect event during teardown.")
 				return
@@ -943,6 +976,32 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 			// Dispatch based on packet contents.
 			if case let .decoded(data) = packet.payloadVariant {
+				let responseID = data.requestID != 0 ? data.requestID : data.replyID
+				if responseID != 0 {
+					if data.portnum == .adminApp,
+						let adminMessage = try? AdminMessage(serializedBytes: data.payload),
+						RemoteAdminConfigTracker.isAdminResponse(adminMessage) {
+						resolveRemoteAdminConfigPacket(
+							packetID: responseID,
+							sourceNodeNum: Int64(packet.from),
+							result: .succeeded
+						)
+					} else if data.portnum == .routingApp,
+						   let routing = try? Routing(serializedBytes: data.payload),
+						   case .errorReason(let reason)? = routing.variant {
+						if reason == .none {
+							remoteAdminConfigTracker.resolveRouting(
+								packetID: responseID,
+								sourceNodeNum: Int64(packet.from),
+								reason: nil,
+								isFailure: false)
+						} else {
+							resolveRemoteAdminRoutingError(
+								packetID: responseID,
+								reason: "Remote node rejected the request: \(reason)")
+						}
+					}
+				}
 				// Forward packets to discovery scan engine if active
 				if let engine = discoveryScanEngine, engine.isScanning {
 					engine.handleMeshPacket(packet, portNum: data.portnum)

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1218,31 +1218,31 @@ actor MeshPackets {
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getModuleConfigResponse(adminMessage.getModuleConfigResponse) {
 				let moduleConfig = adminMessage.getModuleConfigResponse
 				if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.ambientLighting(moduleConfig.ambientLighting) {
-					self.upsertAmbientLightingModuleConfigPacket(config: moduleConfig.ambientLighting, nodeNum: Int64(packet.from))
+					self.upsertAmbientLightingModuleConfigPacket(config: moduleConfig.ambientLighting, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.audio(moduleConfig.audio) {
-					self.upsertAudioModuleConfigPacket(config: moduleConfig.audio, nodeNum: Int64(packet.from))
+					self.upsertAudioModuleConfigPacket(config: moduleConfig.audio, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.cannedMessage(moduleConfig.cannedMessage) {
-					self.upsertCannedMessagesModuleConfigPacket(config: moduleConfig.cannedMessage, nodeNum: Int64(packet.from))
+					self.upsertCannedMessagesModuleConfigPacket(config: moduleConfig.cannedMessage, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.detectionSensor(moduleConfig.detectionSensor) {
-					self.upsertDetectionSensorModuleConfigPacket(config: moduleConfig.detectionSensor, nodeNum: Int64(packet.from))
+					self.upsertDetectionSensorModuleConfigPacket(config: moduleConfig.detectionSensor, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.externalNotification(moduleConfig.externalNotification) {
-					self.upsertExternalNotificationModuleConfigPacket(config: moduleConfig.externalNotification, nodeNum: Int64(packet.from))
+					self.upsertExternalNotificationModuleConfigPacket(config: moduleConfig.externalNotification, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.mqtt(moduleConfig.mqtt) {
-					self.upsertMqttModuleConfigPacket(config: moduleConfig.mqtt, nodeNum: Int64(packet.from))
+					self.upsertMqttModuleConfigPacket(config: moduleConfig.mqtt, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.rangeTest(moduleConfig.rangeTest) {
-					self.upsertRangeTestModuleConfigPacket(config: moduleConfig.rangeTest, nodeNum: Int64(packet.from))
+					self.upsertRangeTestModuleConfigPacket(config: moduleConfig.rangeTest, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.serial(moduleConfig.serial) {
-					self.upsertSerialModuleConfigPacket(config: moduleConfig.serial, nodeNum: Int64(packet.from))
+					self.upsertSerialModuleConfigPacket(config: moduleConfig.serial, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.storeForward(moduleConfig.storeForward) {
-					self.upsertStoreForwardModuleConfigPacket(config: moduleConfig.storeForward, nodeNum: Int64(packet.from))
+					self.upsertStoreForwardModuleConfigPacket(config: moduleConfig.storeForward, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.telemetry(moduleConfig.telemetry) {
-					self.upsertTelemetryModuleConfigPacket(config: moduleConfig.telemetry, nodeNum: Int64(packet.from))
+					self.upsertTelemetryModuleConfigPacket(config: moduleConfig.telemetry, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.tak(moduleConfig.tak) {
-					self.upsertTAKModuleConfigPacket(config: moduleConfig.tak, nodeNum: Int64(packet.from))
+					self.upsertTAKModuleConfigPacket(config: moduleConfig.tak, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.statusmessage(moduleConfig.statusmessage) {
-					self.upsertStatusMessageModuleConfigPacket(config: moduleConfig.statusmessage, nodeNum: Int64(packet.from))
+					self.upsertStatusMessageModuleConfigPacket(config: moduleConfig.statusmessage, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.trafficManagement(moduleConfig.trafficManagement) {
-					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from))
+					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				}
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getRingtoneResponse(adminMessage.getRingtoneResponse) {
 				if let rt = try? RTTTLConfig(serializedBytes: packet.decoded.payload) {

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -771,7 +771,7 @@ extension MeshPackets {
 		savePendingChanges()
 	}
 
-	func upsertBluetoothConfigPacket(config: Config.BluetoothConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertBluetoothConfigPacket(config: Config.BluetoothConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Bluetooth config received: %@".localized, String(nodeNum))
 		Logger.admin.info("📶 \(logString, privacy: .public)")
@@ -795,7 +795,7 @@ extension MeshPackets {
 					fetchedNode[0].bluetoothConfig?.mode = Int32(config.mode.rawValue)
 					fetchedNode[0].bluetoothConfig?.fixedPin = Int32(truncatingIfNeeded: config.fixedPin)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -810,7 +810,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertDeviceConfigPacket(config: Config.DeviceConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDeviceConfigPacket(config: Config.DeviceConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Device config received: %@".localized, String(nodeNum))
 		Logger.admin.info("📟 \(logString, privacy: .public)")
@@ -847,7 +847,7 @@ extension MeshPackets {
 					fetchedNode[0].deviceConfig?.isManaged = config.isManaged
 					fetchedNode[0].deviceConfig?.tzdef = config.tzdef
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -860,7 +860,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertDisplayConfigPacket(config: Config.DisplayConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDisplayConfigPacket(config: Config.DisplayConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Display config received: %@".localized, nodeNum.toHex())
 		Logger.data.info("🖥️ \(logString, privacy: .public)")
@@ -900,7 +900,7 @@ extension MeshPackets {
 					fetchedNode[0].displayConfig?.headingBold = config.headingBold
 					fetchedNode[0].displayConfig?.use12HClock = config.use12HClock
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -916,7 +916,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertLoRaConfigPacket(config: Config.LoRaConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertLoRaConfigPacket(config: Config.LoRaConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("LoRa config received: %@".localized, nodeNum.toHex())
 		Logger.data.info("📻 \(logString, privacy: .public)")
@@ -968,7 +968,7 @@ extension MeshPackets {
 					fetchedNode[0].loRaConfig?.okToMqtt = config.configOkToMqtt
 					fetchedNode[0].loRaConfig?.sx126xRxBoostedGain = config.sx126XRxBoostedGain
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -983,7 +983,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertNetworkConfigPacket(config: Config.NetworkConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertNetworkConfigPacket(config: Config.NetworkConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Network config received: %@".localized, String(nodeNum))
 		Logger.data.info("🌐 \(logString, privacy: .public)")
@@ -1025,7 +1025,7 @@ extension MeshPackets {
 					fetchedNode[0].networkConfig?.subnet = Int32(bitPattern: config.ipv4Config.subnet)
 					fetchedNode[0].networkConfig?.dns = Int32(bitPattern: config.ipv4Config.dns)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1040,7 +1040,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertPositionConfigPacket(config: Config.PositionConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPositionConfigPacket(config: Config.PositionConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Position config received: %@".localized, String(nodeNum))
 		Logger.data.info("🗺️ \(logString, privacy: .public)")
@@ -1084,7 +1084,7 @@ extension MeshPackets {
 					fetchedNode[0].positionConfig?.gpsUpdateInterval = Int32(truncatingIfNeeded: config.gpsUpdateInterval)
 					fetchedNode[0].positionConfig?.positionFlags = Int32(truncatingIfNeeded: config.positionFlags)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1099,7 +1099,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertPowerConfigPacket(config: Config.PowerConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPowerConfigPacket(config: Config.PowerConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		let logString = String.localizedStringWithFormat("Power config received: %@".localized, String(nodeNum))
 		Logger.data.info("🗺️ \(logString, privacy: .public)")
 		
@@ -1130,7 +1130,7 @@ extension MeshPackets {
 					fetchedNode[0].powerConfig?.onBatteryShutdownAfterSecs = Int32(truncatingIfNeeded: config.onBatteryShutdownAfterSecs)
 					fetchedNode[0].powerConfig?.waitBluetoothSecs = Int32(truncatingIfNeeded: config.waitBluetoothSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1155,7 +1155,7 @@ extension MeshPackets {
 		entity.adminKey3 = adminKeys.count > 2 ? adminKeys[2] : nil
 	}
 
-	func upsertSecurityConfigPacket(config: Config.SecurityConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertSecurityConfigPacket(config: Config.SecurityConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Security config received: @".localized, String(nodeNum))
 		Logger.data.info("🛡️ \(logString, privacy: .public)")
@@ -1189,7 +1189,7 @@ extension MeshPackets {
 					securityConfig.adminChannelEnabled = config.adminChannelEnabled
 					securityConfig.packetSignaturePolicy = Int32(config.packetSignaturePolicy.rawValue)
 				}
-				if sessionPasskey?.count != 0 {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1204,7 +1204,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertAudioModuleConfigPacket(config: ModuleConfig.AudioConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertAudioModuleConfigPacket(config: ModuleConfig.AudioConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Audio module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🔊 \(logString, privacy: .public)")
@@ -1235,7 +1235,7 @@ extension MeshPackets {
 					fetchedNode[0].audioConfig?.i2sDin = Int32(truncatingIfNeeded: config.i2SDin)
 					fetchedNode[0].audioConfig?.i2sSck = Int32(truncatingIfNeeded: config.i2SSck)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1250,7 +1250,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertAmbientLightingModuleConfigPacket(config: ModuleConfig.AmbientLightingConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertAmbientLightingModuleConfigPacket(config: ModuleConfig.AmbientLightingConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Ambient Lighting module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🏮 \(logString, privacy: .public)")
@@ -1285,7 +1285,7 @@ extension MeshPackets {
 					fetchedNode[0].ambientLightingConfig?.green = Int32(truncatingIfNeeded: config.green)
 					fetchedNode[0].ambientLightingConfig?.blue = Int32(truncatingIfNeeded: config.blue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1300,7 +1300,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertCannedMessagesModuleConfigPacket(config: ModuleConfig.CannedMessageConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertCannedMessagesModuleConfigPacket(config: ModuleConfig.CannedMessageConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Canned Message module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🥫 \(logString, privacy: .public)")
@@ -1340,7 +1340,7 @@ extension MeshPackets {
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventCcw = Int32(config.inputbrokerEventCcw.rawValue)
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventPress = Int32(config.inputbrokerEventPress.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1355,7 +1355,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertDetectionSensorModuleConfigPacket(config: ModuleConfig.DetectionSensorConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDetectionSensorModuleConfigPacket(config: ModuleConfig.DetectionSensorConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Detection Sensor module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🕵️ \(logString, privacy: .public)")
@@ -1389,7 +1389,7 @@ extension MeshPackets {
 					fetchedNode[0].detectionSensorConfig?.minimumBroadcastSecs = Int32(truncatingIfNeeded: config.minimumBroadcastSecs)
 					fetchedNode[0].detectionSensorConfig?.stateBroadcastSecs = Int32(truncatingIfNeeded: config.stateBroadcastSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1406,7 +1406,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertMeshBeaconModuleConfigPacket(config: ModuleConfig.MeshBeaconConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertMeshBeaconModuleConfigPacket(config: ModuleConfig.MeshBeaconConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Mesh Beacon module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📡 \(logString, privacy: .public)")
@@ -1448,7 +1448,7 @@ extension MeshPackets {
 					return newTarget
 				}
 
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1465,7 +1465,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertExternalNotificationModuleConfigPacket(config: ModuleConfig.ExternalNotificationConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertExternalNotificationModuleConfigPacket(config: ModuleConfig.ExternalNotificationConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("External Notification module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📣 \(logString, privacy: .public)")
@@ -1514,7 +1514,7 @@ extension MeshPackets {
 					fetchedNode[0].externalNotificationConfig?.nagTimeout = Int32(truncatingIfNeeded: config.nagTimeout)
 					fetchedNode[0].externalNotificationConfig?.useI2SAsBuzzer = config.useI2SAsBuzzer
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1529,7 +1529,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertNeighborInfoModuleConfigPacket(config: ModuleConfig.NeighborInfoConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertNeighborInfoModuleConfigPacket(config: ModuleConfig.NeighborInfoConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Neighbor Info config received: %@".localized, String(nodeNum))
 		Logger.data.info("🏘️ \(logString, privacy: .public)")
@@ -1552,7 +1552,7 @@ extension MeshPackets {
 					fetchedNode[0].neighborInfoConfig?.updateInterval = Int32(truncatingIfNeeded: config.updateInterval)
 					fetchedNode[0].neighborInfoConfig?.transmitOverLora = config.transmitOverLora
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1567,7 +1567,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertPaxCounterModuleConfigPacket(config: ModuleConfig.PaxcounterConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPaxCounterModuleConfigPacket(config: ModuleConfig.PaxcounterConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("PAX Counter config received: %@".localized, String(nodeNum))
 		Logger.data.info("🧑‍🤝‍🧑 \(logString, privacy: .public)")
@@ -1593,7 +1593,7 @@ extension MeshPackets {
 					fetchedNode[0].paxCounterConfig?.wifiThreshold = config.wifiThreshold
 					fetchedNode[0].paxCounterConfig?.bleThreshold = config.bleThreshold
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1608,7 +1608,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertRtttlConfigPacket(ringtone: String, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertRtttlConfigPacket(ringtone: String, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("RTTTL Ringtone config received: %@".localized, String(nodeNum))
 		Logger.data.info("⛰️ \(logString, privacy: .public)")
@@ -1628,7 +1628,7 @@ extension MeshPackets {
 				} else {
 					fetchedNode[0].rtttlConfig?.ringtone = ringtone
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1643,7 +1643,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertMqttModuleConfigPacket(config: ModuleConfig.MQTTConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertMqttModuleConfigPacket(config: ModuleConfig.MQTTConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("MQTT module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🌉 \(logString, privacy: .public)")
@@ -1687,7 +1687,7 @@ extension MeshPackets {
 					fetchedNode[0].mqttConfig?.mapPositionPrecision = Int32(truncatingIfNeeded: config.mapReportSettings.positionPrecision)
 					fetchedNode[0].mqttConfig?.mapPublishIntervalSecs = Int32(truncatingIfNeeded: config.mapReportSettings.publishIntervalSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1702,7 +1702,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertRangeTestModuleConfigPacket(config: ModuleConfig.RangeTestConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertRangeTestModuleConfigPacket(config: ModuleConfig.RangeTestConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Range Test module config received: %@".localized, String(nodeNum))
 		Logger.data.info("⛰️ \(logString, privacy: .public)")
@@ -1726,7 +1726,7 @@ extension MeshPackets {
 					fetchedNode[0].rangeTestConfig?.enabled = config.enabled
 					fetchedNode[0].rangeTestConfig?.save = config.save
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1741,7 +1741,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertSerialModuleConfigPacket(config: ModuleConfig.SerialConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertSerialModuleConfigPacket(config: ModuleConfig.SerialConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Serial module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🤖 \(logString, privacy: .public)")
@@ -1773,7 +1773,7 @@ extension MeshPackets {
 					fetchedNode[0].serialConfig?.timeout = Int32(truncatingIfNeeded: config.timeout)
 					fetchedNode[0].serialConfig?.mode = Int32(config.mode.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1789,7 +1789,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertStatusMessageModuleConfigPacket(config: ModuleConfig.StatusMessageConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertStatusMessageModuleConfigPacket(config: ModuleConfig.StatusMessageConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Status Message module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📬 \(logString, privacy: .public)")
@@ -1812,7 +1812,7 @@ extension MeshPackets {
 				// status too — displays prefer the live field and would otherwise show the
 				// old status until the next broadcast arrives.
 				fetchedNode[0].nodeStatus = config.nodeStatus.isEmpty ? nil : config.nodeStatus
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1858,7 +1858,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertStoreForwardModuleConfigPacket(config: ModuleConfig.StoreForwardConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertStoreForwardModuleConfigPacket(config: ModuleConfig.StoreForwardConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Store & Forward module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📬 \(logString, privacy: .public)")
@@ -1890,7 +1890,7 @@ extension MeshPackets {
 					// reflected after the first sync and the device-profile export keeps writing the old value.
 					fetchedNode[0].storeForwardConfig?.isRouter = config.isServer
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1905,7 +1905,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTelemetryModuleConfigPacket(config: ModuleConfig.TelemetryConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTelemetryModuleConfigPacket(config: ModuleConfig.TelemetryConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Telemetry module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📈 \(logString, privacy: .public)")
@@ -1945,7 +1945,7 @@ extension MeshPackets {
 					fetchedNode[0].telemetryConfig?.powerUpdateInterval = Int32(truncatingIfNeeded: config.powerUpdateInterval)
 					fetchedNode[0].telemetryConfig?.powerScreenEnabled = config.powerScreenEnabled
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1962,7 +1962,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTAKModuleConfigPacket(config: ModuleConfig.TAKConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTAKModuleConfigPacket(config: ModuleConfig.TAKConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("TAK module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🎯 \(logString, privacy: .public)")
@@ -1983,7 +1983,7 @@ extension MeshPackets {
 					fetchedNode[0].takConfig?.team = Int32(config.team.rawValue)
 					fetchedNode[0].takConfig?.role = Int32(config.role.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1998,7 +1998,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTrafficManagementModuleConfigPacket(config: ModuleConfig.TrafficManagementConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTrafficManagementModuleConfigPacket(config: ModuleConfig.TrafficManagementConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Traffic Management module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🚦 \(logString, privacy: .public)")
@@ -2037,7 +2037,7 @@ extension MeshPackets {
 				entity.rateLimitMaxPackets = Int32(truncatingIfNeeded: config.rateLimitMaxPackets)
 				entity.dropUnknownEnabled = dropUnknown
 				entity.unknownPacketThreshold = Int32(truncatingIfNeeded: config.unknownPacketThreshold)
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}

--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -27,7 +27,17 @@ struct BluetoothConfig: View {
 	}()
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Bluetooth", config: \.bluetoothConfig, node: node, onAppear: setBluetoothValues)
+			ConfigHeader(title: "Bluetooth", config: \.bluetoothConfig, node: node, onAppear: setBluetoothValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.bluetoothConfig == nil },
+				section: "Bluetooth",
+				request: accessoryManager.requestBluetoothConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -101,6 +101,7 @@ struct BluetoothConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.bluetoothConfig == nil },
+				section: "Bluetooth",
 				request: accessoryManager.requestBluetoothConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -8,6 +8,7 @@ struct ConfigHeader<T>: View {
 	let config: KeyPath<NodeInfoEntity, T?>
 	let node: NodeInfoEntity?
 	let onAppear: () -> Void
+	var onRetry: (() -> Void)? = nil
 
 	var body: some View {
 		let request = node.flatMap { accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .request, section: title) }
@@ -19,8 +20,10 @@ struct ConfigHeader<T>: View {
 				Text(result == .timedOut ? "No response was received from the remote node." : "The configuration request failed.")
 					.font(.callout)
 					.foregroundColor(.red)
-				Button("Retry") { onAppear() }
-					.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+				if let onRetry {
+					Button("Retry", action: onRetry)
+						.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+				}
 			}
 		} else if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			Text("There has been no response to a request for device metadata via PKC admin for this node.")

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -10,7 +10,19 @@ struct ConfigHeader<T>: View {
 	let onAppear: () -> Void
 
 	var body: some View {
-		if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
+		let request = node.flatMap { accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .request, section: title) }
+		if let request, !request.isFinished {
+			ProgressView("Requesting \(title) configuration…")
+				.font(.callout)
+		} else if let request, let result = request.result, result != .succeeded {
+			VStack(spacing: 8) {
+				Text(result == .timedOut ? "No response was received from the remote node." : "The configuration request failed.")
+					.font(.callout)
+					.foregroundColor(.red)
+				Button("Retry") { onAppear() }
+					.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+			}
+		} else if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			Text("There has been no response to a request for device metadata via PKC admin for this node.")
 				.font(.callout)
 				.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -42,18 +42,51 @@ func performConfigSave(
 	guard let deviceNum = accessoryManager.activeDeviceNum,
 		  let connectedNode = getNodeInfo(id: deviceNum, context: context),
 		  let fromUser = connectedNode.user,
-		  let toUser = node?.user
+		  let toUser = node?.user,
+		  let targetNode = node
 	else {
 		Logger.mesh.warning("⚠️ Cannot save config: missing connected node or user entities")
+		return
+	}
+	let operationID = targetNode.num == deviceNum
+		? nil
+		: accessoryManager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: targetNode.num)
+	if targetNode.num != deviceNum, operationID == nil {
+		accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "A configuration save is already in progress for this node. Please wait for it to finish.")
 		return
 	}
 
 	Task {
 		do {
-			try await save(fromUser, toUser)
-			hasChanges.wrappedValue = false
-			dismiss()
+			if let operationID {
+				try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+					try await save(fromUser, toUser)
+				}
+			} else {
+				try await save(fromUser, toUser)
+			}
+			if targetNode.num == deviceNum {
+				hasChanges.wrappedValue = false
+				dismiss()
+				return
+			}
+			guard let operationID else { return }
+			switch accessoryManager.remoteAdminConfigTracker.finish(operationID) {
+			case .succeeded:
+				hasChanges.wrappedValue = false
+				dismiss()
+			case .failed(let message):
+				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, message)
+				Logger.mesh.error("🚨 Config save rejected: \(message, privacy: .public)")
+			case .timedOut:
+				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "No confirmation was received from the remote node. Check that it is online and retry.")
+				Logger.mesh.error("🚨 Config save timed out")
+			}
 		} catch {
+			if let operationID {
+				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)
+			}
+			accessoryManager.remoteAdminConfigFeedback = (targetNode.num, error.localizedDescription)
 			Logger.mesh.error("🚨 Config save failed: \(error.localizedDescription)")
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -42,7 +42,16 @@ struct DeviceConfig: View {
 			}
 		} else {
 		Form {
-			ConfigHeader(title: "Device", config: \.deviceConfig, node: node, onAppear: setDeviceValues)
+			ConfigHeader(title: "Device", config: \.deviceConfig, node: node, onAppear: setDeviceValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.deviceConfig == nil },
+					section: "Device",
+					request: accessoryManager.requestDeviceConfig,
+					force: true)
+			})
 			
 			Section(header: Text("Options")) {
 				VStack(alignment: .leading) {
@@ -319,33 +328,13 @@ struct DeviceConfig: View {
 		} // end else
 		} // end Group
 		.onFirstAppear {
-			// Need to request a DeviceConfig from the remote node before allowing changes
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration {
-							/// 2.5 Administration with session passkey
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.deviceConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired device config requesting via PKI admin")
-										try await accessoryManager.requestDeviceConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.error("🚨 Device config request failed")
-									}
-								}
-							}
-						} else {
-							if node.deviceConfig == nil {
-								/// Legacy Administration
-								Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-							}
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.deviceConfig == nil },
+				section: "Device",
+				request: accessoryManager.requestDeviceConfig)
 		}
 		.onChange(of: deviceRole) { oldRole, newRole in
 			guard !isResetting else { return }

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -32,7 +32,17 @@ struct DisplayConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Display", config: \.displayConfig, node: node, onAppear: setDisplayValues)
+			ConfigHeader(title: "Display", config: \.displayConfig, node: node, onAppear: setDisplayValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.displayConfig == nil },
+				section: "Display",
+				request: accessoryManager.requestDisplayConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Device Screen")) {
 				

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -171,6 +171,7 @@ struct DisplayConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.displayConfig == nil },
+				section: "Display",
 				request: accessoryManager.requestDisplayConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -235,7 +235,17 @@ struct LoRaConfig: View {
 	/// See `body` — the Form and its chrome, split out for type-check time.
 	private var loRaForm: some View {
 		Form {
-			ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues)
+			ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.loRaConfig == nil },
+				section: "LoRa",
+				request: accessoryManager.requestLoRaConfig,
+				force: true
+			)
+		})
 
 			optionsSection
 

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -263,6 +263,7 @@ struct LoRaConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.loRaConfig == nil },
+				section: "LoRa",
 				request: accessoryManager.requestLoRaConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -24,7 +24,17 @@ struct AmbientLightingConfig: View {
 	@State private var components: Color.Resolved?
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Ambient Lighting", config: \.ambientLightingConfig, node: node, onAppear: setAmbientLightingConfigValue)
+			ConfigHeader(title: "Ambient Lighting", config: \.ambientLightingConfig, node: node, onAppear: setAmbientLightingConfigValue, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.ambientLightingConfig == nil },
+				section: "Ambient Lighting",
+				request: accessoryManager.requestAmbientLightingConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -87,6 +87,7 @@ struct AmbientLightingConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.ambientLightingConfig == nil },
+				section: "Ambient Lighting",
 				request: accessoryManager.requestAmbientLightingConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
@@ -156,6 +156,7 @@ struct AudioConfig: View {
 					context: context,
 					accessoryManager: accessoryManager,
 					configIsNil: { $0.audioConfig == nil },
+					section: "Audio",
 					request: accessoryManager.requestAudioModuleConfig
 				)
 			}

--- a/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
@@ -29,7 +29,18 @@ struct AudioConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				ConfigHeader(title: "Audio", config: \.audioConfig, node: node, onAppear: setAudioValues)
+				ConfigHeader(title: "Audio", config: \.audioConfig, node: node, onAppear: setAudioValues, onRetry: {
+			requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.audioConfig == nil },
+					section: "Audio",
+					request: accessoryManager.requestAudioModuleConfig
+				,
+				force: true
+			)
+		})
 
 				Section(header: Text("Options")) {
 					Toggle(isOn: $codec2Enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -221,6 +221,7 @@ struct CannedMessagesConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.cannedMessageConfig == nil },
+				section: "Canned messages",
 				request: accessoryManager.requestCannedMessagesModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -38,7 +38,17 @@ struct CannedMessagesConfig: View {
 	@State var messages = ""
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Canned messages", config: \.cannedMessageConfig, node: node, onAppear: setCannedMessagesValues)
+			ConfigHeader(title: "Canned messages", config: \.cannedMessageConfig, node: node, onAppear: setCannedMessagesValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.cannedMessageConfig == nil },
+				section: "Canned messages",
+				request: accessoryManager.requestCannedMessagesModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -183,6 +183,7 @@ struct DetectionSensorConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.detectionSensorConfig == nil },
+				section: "Detection Sensor",
 				request: accessoryManager.requestDetectionSensorModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -44,7 +44,17 @@ struct DetectionSensorConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Detection Sensor", config: \.detectionSensorConfig, node: node, onAppear: setDetectionSensorValues)
+			ConfigHeader(title: "Detection Sensor", config: \.detectionSensorConfig, node: node, onAppear: setDetectionSensorValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.detectionSensorConfig == nil },
+				section: "Detection Sensor",
+				request: accessoryManager.requestDetectionSensorModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -174,6 +174,7 @@ struct ExternalNotificationConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.externalNotificationConfig == nil },
+				section: "External notification",
 				request: accessoryManager.requestExternalNotificationModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -36,7 +36,17 @@ struct ExternalNotificationConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "External notification", config: \.externalNotificationConfig, node: node, onAppear: setExternalNotificationValues)
+			ConfigHeader(title: "External notification", config: \.externalNotificationConfig, node: node, onAppear: setExternalNotificationValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.externalNotificationConfig == nil },
+				section: "External notification",
+				request: accessoryManager.requestExternalNotificationModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -50,7 +50,17 @@ struct MQTTConfig: View {
 					}
 				}
 				
-				ConfigHeader(title: "MQTT", config: \.mqttConfig, node: node, onAppear: setMqttValues)
+				ConfigHeader(title: "MQTT", config: \.mqttConfig, node: node, onAppear: setMqttValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.mqttConfig == nil },
+				section: "MQTT",
+				request: accessoryManager.requestMqttModuleConfig,
+				force: true
+			)
+		})
 				
 				Section(header: Text("Options")) {
 					

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -353,6 +353,7 @@ struct MQTTConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.mqttConfig == nil },
+				section: "MQTT",
 				request: accessoryManager.requestMqttModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/NeighborInfoConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/NeighborInfoConfig.swift
@@ -22,7 +22,16 @@ struct NeighborInfoConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Neighbor Info", config: \.neighborInfoConfig, node: node, onAppear: setNeighborInfoValues)
+			ConfigHeader(title: "Neighbor Info", config: \.neighborInfoConfig, node: node, onAppear: setNeighborInfoValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.neighborInfoConfig == nil },
+					section: "Neighbor Info",
+					request: accessoryManager.requestNeighborInfoModuleConfig,
+					force: true)
+			})
 
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {
@@ -82,28 +91,13 @@ struct NeighborInfoConfig: View {
 			}
 		}
 		.onFirstAppear {
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration && node.num != connectedNode.num {
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.neighborInfoConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired neighbor info module config requesting via PKI admin")
-										try await accessoryManager.requestNeighborInfoModuleConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.info("🚨 Request for neighbor info module config failed")
-									}
-								}
-							}
-						} else {
-							Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.neighborInfoConfig == nil },
+				section: "Neighbor Info",
+				request: accessoryManager.requestNeighborInfoModuleConfig)
 		}
 		.onChange(of: enabled) { oldEnabled, newEnabled in
 			if oldEnabled != newEnabled && newEnabled != (node?.neighborInfoConfig?.enabled ?? false) { hasChanges = true }

--- a/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
@@ -24,7 +24,16 @@ struct PaxCounterConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "PAX Counter Config", config: \.powerConfig, node: node, onAppear: setPaxValues)
+			ConfigHeader(title: "PAX Counter Config", config: \.powerConfig, node: node, onAppear: setPaxValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.paxCounterConfig == nil },
+					section: "PAX Counter Config",
+					request: accessoryManager.requestPaxCounterModuleConfig,
+					force: true)
+			})
 			
 			Section {
 				Toggle(isOn: $enabled) {
@@ -108,31 +117,13 @@ struct PaxCounterConfig: View {
 			}
 		}
 		.onFirstAppear {
-			// Need to request a PaxCounterModuleConfig from the remote node before allowing changes
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration && node.num != connectedNode.num {
-							/// 2.5 Administration with session passkey
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.paxCounterConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired pax counter module config requesting via PKI admin")
-										try await accessoryManager.requestPaxCounterModuleConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.info("🚨 Request for pax counter module config failed")
-									}
-								}
-							}
-						} else {
-							/// Legacy Administration
-							Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.paxCounterConfig == nil },
+				section: "PAX Counter Config",
+				request: accessoryManager.requestPaxCounterModuleConfig)
 		}
 		.onChange(of: enabled) { oldEnabled, newEnabled in
 			if oldEnabled != newEnabled && newEnabled != (node?.paxCounterConfig?.enabled ?? false) { hasChanges = true }

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -37,7 +37,18 @@ struct RangeTestConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Range", config: \.rangeTestConfig, node: node, onAppear: setRangeTestValues)
+			ConfigHeader(title: "Range", config: \.rangeTestConfig, node: node, onAppear: setRangeTestValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.rangeTestConfig == nil },
+				section: "Range",
+				request: accessoryManager.requestRangeTestModuleConfig,
+				requestForConnectedNode: true,
+				force: true
+			)
+		})
 
 			if isPrimaryChannelPublic {
 				Section {

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -107,6 +107,7 @@ struct RangeTestConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.rangeTestConfig == nil },
+				section: "Range",
 				request: accessoryManager.requestRangeTestModuleConfig,
 				requestForConnectedNode: true
 			)

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -75,6 +75,7 @@ struct RtttlConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.rtttlConfig == nil },
+				section: "Ringtone",
 				request: accessoryManager.requestRtttlConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -21,7 +21,17 @@ struct RtttlConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Ringtone", config: \.rtttlConfig, node: node, onAppear: setRtttLConfigValue)
+			ConfigHeader(title: "Ringtone", config: \.rtttlConfig, node: node, onAppear: setRtttLConfigValue, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.rtttlConfig == nil },
+				section: "Ringtone",
+				request: accessoryManager.requestRtttlConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				HStack {

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -131,6 +131,7 @@ struct SerialConfig: View {
 					context: context,
 					accessoryManager: accessoryManager,
 					configIsNil: { $0.serialConfig == nil },
+					section: "Serial",
 					request: accessoryManager.requestSerialModuleConfig
 				)
 			}

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -31,7 +31,18 @@ struct SerialConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				ConfigHeader(title: "Serial", config: \.serialConfig, node: node, onAppear: setSerialValues)
+				ConfigHeader(title: "Serial", config: \.serialConfig, node: node, onAppear: setSerialValues, onRetry: {
+			requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.serialConfig == nil },
+					section: "Serial",
+					request: accessoryManager.requestSerialModuleConfig
+				,
+				force: true
+			)
+		})
 				
 				Section(header: Text("Options")) {
 					

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -31,7 +31,17 @@ struct StoreForwardConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Store & Forward", config: \.storeForwardConfig, node: node, onAppear: setStoreAndForwardValues)
+			ConfigHeader(title: "Store & Forward", config: \.storeForwardConfig, node: node, onAppear: setStoreAndForwardValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.storeForwardConfig == nil },
+				section: "Store & Forward",
+				request: accessoryManager.requestStoreAndForwardModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -132,6 +132,7 @@ struct StoreForwardConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.storeForwardConfig == nil },
+				section: "Store & Forward",
 				request: accessoryManager.requestStoreAndForwardModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
@@ -32,7 +32,17 @@ struct TAKModuleConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "TAK", config: \.takConfig, node: node, onAppear: setTAKValues)
+			ConfigHeader(title: "TAK", config: \.takConfig, node: node, onAppear: setTAKValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.takConfig == nil },
+				section: "TAK",
+				request: accessoryManager.requestTAKModuleConfig,
+				force: true
+			)
+		})
 
 			if accessoryManager.isConnected, node?.takConfig == nil {
 				Section {

--- a/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
@@ -132,6 +132,7 @@ struct TAKModuleConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.takConfig == nil },
+				section: "TAK",
 				request: accessoryManager.requestTAKModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -32,7 +32,17 @@ struct TelemetryConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Telemetry", config: \.telemetryConfig, node: node, onAppear: setTelemetryValues)
+			ConfigHeader(title: "Telemetry", config: \.telemetryConfig, node: node, onAppear: setTelemetryValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.telemetryConfig == nil },
+				section: "Telemetry",
+				request: accessoryManager.requestTelemetryModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Device Options")) {
 				if accessoryManager.checkIsVersionSupported(forVersion: "2.7.12") {

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -179,6 +179,7 @@ struct TelemetryConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.telemetryConfig == nil },
+				section: "Telemetry",
 				request: accessoryManager.requestTelemetryModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
@@ -34,7 +34,17 @@ struct TrafficManagementConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Traffic Management", config: \.trafficManagementConfig, node: node, onAppear: setTrafficManagementValues)
+			ConfigHeader(title: "Traffic Management", config: \.trafficManagementConfig, node: node, onAppear: setTrafficManagementValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.trafficManagementConfig == nil },
+				section: "Traffic Management",
+				request: accessoryManager.requestTrafficManagementModuleConfig,
+				force: true
+			)
+		})
 
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
@@ -178,6 +178,7 @@ struct TrafficManagementConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.trafficManagementConfig == nil },
+				section: "Traffic Management",
 				request: accessoryManager.requestTrafficManagementModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -35,7 +35,17 @@ struct NetworkConfig: View {
 	var body: some View {
 		let staticValid = staticConfigIsValid
 		Form {
-			ConfigHeader(title: "Network", config: \.networkConfig, node: node, onAppear: setNetworkValues)
+			ConfigHeader(title: "Network", config: \.networkConfig, node: node, onAppear: setNetworkValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.networkConfig == nil },
+				section: "Network",
+				request: accessoryManager.requestNetworkConfig,
+				force: true
+			)
+		})
 			
 			if let node {
 				if node.metadata?.hasWifi ?? false {

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -235,6 +235,7 @@ struct NetworkConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.networkConfig == nil },
+				section: "Network",
 				request: accessoryManager.requestNetworkConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -349,7 +349,17 @@ struct PositionConfig: View {
 	var body: some View {
 		
 		Form {
-			ConfigHeader(title: "Position", config: \.positionConfig, node: node, onAppear: setPositionValues)
+			ConfigHeader(title: "Position", config: \.positionConfig, node: node, onAppear: setPositionValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.positionConfig == nil },
+				section: "Position",
+				request: accessoryManager.requestPositionConfig,
+				force: true
+			)
+		})
 			positionPacketSection
 			deviceGPSSection
 			positionFlagsSection

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -395,6 +395,7 @@ struct PositionConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.positionConfig == nil },
+				section: "Position",
 				request: accessoryManager.requestPositionConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -28,7 +28,17 @@ struct PowerConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Power Config", config: \.powerConfig, node: node, onAppear: setPowerValues)
+			ConfigHeader(title: "Power Config", config: \.powerConfig, node: node, onAppear: setPowerValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.powerConfig == nil },
+				section: "Power Config",
+				request: accessoryManager.requestPowerConfig,
+				force: true
+			)
+		})
 
 			Section {
 				if let architecture, (architecture == .esp32 || architecture == .esp32S3) || (architecture == .nrf52840 && (node?.deviceConfig?.role ?? 0 == 5 || node?.deviceConfig?.role ?? 0 == 6)) {

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -133,6 +133,7 @@ struct PowerConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.powerConfig == nil },
+				section: "Power Config",
 				request: accessoryManager.requestPowerConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
+++ b/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
@@ -1,0 +1,144 @@
+//
+//  RemoteAdminConfigTracker.swift
+//  Meshtastic
+//
+
+import Combine
+import Foundation
+import MeshtasticProtobufs
+
+enum RemoteAdminConfigOperationKind: Equatable {
+	case request
+	case save
+}
+
+enum RemoteAdminConfigOperationResult: Equatable {
+	case succeeded
+	case failed(String)
+	case timedOut
+}
+
+struct RemoteAdminConfigOperation: Identifiable, Equatable {
+	let id: UUID
+	let sequence: UInt64
+	let kind: RemoteAdminConfigOperationKind
+	let targetNodeNum: Int64
+	let section: String
+	var pendingPacketIDs: Set<UInt32> = []
+	var result: RemoteAdminConfigOperationResult?
+
+	var isFinished: Bool { result != nil }
+}
+
+/// Tracks only explicitly enrolled remote-admin work. The operation token is carried through the
+/// async request/save closure with TaskLocal, so unrelated admin packets can never be enrolled by
+/// target-node coincidence.
+@MainActor
+final class RemoteAdminConfigTracker: ObservableObject {
+	@TaskLocal static var currentOperationID: UUID?
+
+	@Published private(set) var operations: [UUID: RemoteAdminConfigOperation] = [:]
+	private var nextSequence: UInt64 = 0
+
+	static func isAdminResponse(_ message: AdminMessage) -> Bool {
+		switch message.payloadVariant {
+		case .getChannelResponse, .getOwnerResponse, .getConfigResponse, .getModuleConfigResponse,
+				.getCannedMessageModuleMessagesResponse, .getDeviceMetadataResponse, .getRingtoneResponse,
+				.getDeviceConnectionStatusResponse, .getNodeRemoteHardwarePinsResponse, .getUiConfigResponse:
+			return true
+		default:
+			return false
+		}
+	}
+
+	@discardableResult
+	func begin(kind: RemoteAdminConfigOperationKind, targetNodeNum: Int64, section: String = "save") -> UUID? {
+		if operations.values.contains(where: {
+			$0.kind == kind && $0.targetNodeNum == targetNodeNum && $0.section == section && !$0.isFinished
+		}) { return nil }
+		nextSequence += 1
+		let id = UUID()
+		operations[id] = RemoteAdminConfigOperation(id: id, sequence: nextSequence, kind: kind, targetNodeNum: targetNodeNum, section: section)
+		return id
+	}
+
+	func registerPacket(packetID: UInt32, targetNodeNum: Int64, operationID: UUID?) -> Bool {
+		guard let operationID, var operation = operations[operationID], !operation.isFinished,
+			  operation.targetNodeNum == targetNodeNum else { return false }
+		operation.pendingPacketIDs.insert(packetID)
+		operations[operationID] = operation
+		return true
+	}
+
+	func resolveAdminResponse(packetID: UInt32, sourceNodeNum: Int64) -> UUID? {
+		guard let operation = operations.values.first(where: {
+			$0.pendingPacketIDs.contains(packetID) && $0.targetNodeNum == sourceNodeNum && !$0.isFinished
+		}) else { return nil }
+		return resolvePacket(packetID: packetID, operationID: operation.id, result: .succeeded)
+	}
+
+	func resolveRouting(packetID: UInt32, sourceNodeNum: Int64, reason: String?, isFailure: Bool) -> UUID? {
+		guard let operation = operations.values.first(where: { $0.pendingPacketIDs.contains(packetID) && !$0.isFinished }) else { return nil }
+		guard isFailure || (operation.kind == .save && operation.targetNodeNum == sourceNodeNum) else { return nil }
+		let result: RemoteAdminConfigOperationResult = isFailure ? .failed(reason ?? "Remote delivery failed") : .succeeded
+		return resolvePacket(packetID: packetID, operationID: operation.id, result: result)
+	}
+
+	private func resolvePacket(packetID: UInt32, operationID: UUID, result: RemoteAdminConfigOperationResult) -> UUID {
+		guard var operation = operations[operationID], !operation.isFinished else { return operationID }
+		operation.pendingPacketIDs.remove(packetID)
+		if case .failed = result { operation.result = result }
+		operations[operationID] = operation
+		return operationID
+	}
+
+	func waitForPacket(packetID: UInt32, operationID: UUID, timeout: Duration = .seconds(30)) async -> RemoteAdminConfigOperationResult {
+		let deadline = ContinuousClock.now + timeout
+		while !Task.isCancelled {
+			guard let operation = operations[operationID] else { return .failed("Operation cancelled") }
+			if let result = operation.result { return result }
+			if !operation.pendingPacketIDs.contains(packetID) { return .succeeded }
+			if ContinuousClock.now >= deadline {
+				self.timeout(operationID)
+				return .timedOut
+			}
+			try? await Task.sleep(for: .milliseconds(50))
+		}
+		fail(operationID, with: "Operation cancelled")
+		return .failed("Operation cancelled")
+	}
+
+	func timeout(_ operationID: UUID) {
+		guard var operation = operations[operationID], !operation.isFinished else { return }
+		operation.pendingPacketIDs.removeAll()
+		operation.result = .timedOut
+		operations[operationID] = operation
+	}
+
+	func finish(_ operationID: UUID) -> RemoteAdminConfigOperationResult {
+		guard var operation = operations[operationID], !operation.isFinished else { return operations[operationID]?.result ?? .failed("Operation cancelled") }
+		guard operation.pendingPacketIDs.isEmpty else { return .timedOut }
+		operation.result = .succeeded
+		operations[operationID] = operation
+		return .succeeded
+	}
+
+	func fail(_ operationID: UUID, with error: Error) {
+		fail(operationID, with: error.localizedDescription)
+	}
+
+	func fail(_ operationID: UUID, with message: String) {
+		guard var operation = operations[operationID], !operation.isFinished else { return }
+		operation.pendingPacketIDs.removeAll()
+		operation.result = .failed(message)
+		operations[operationID] = operation
+	}
+
+	func failAll(with message: String) {
+		for operationID in Array(operations.keys) { fail(operationID, with: message) }
+	}
+
+	func latest(for targetNodeNum: Int64, kind: RemoteAdminConfigOperationKind, section: String) -> RemoteAdminConfigOperation? {
+		operations.values.filter { $0.targetNodeNum == targetNodeNum && $0.kind == kind && $0.section == section }.max { $0.sequence < $1.sequence }
+	}
+}

--- a/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
+++ b/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
@@ -18,6 +18,7 @@ func requestRemoteConfig(
 	context: ModelContext,
 	accessoryManager: AccessoryManager,
 	configIsNil: @escaping (NodeInfoEntity) -> Bool,
+	section: String,
 	request: @escaping (_ fromUser: UserEntity, _ toUser: UserEntity) async throws -> Void,
 	requestForConnectedNode: Bool = false
 ) {
@@ -29,7 +30,9 @@ func requestRemoteConfig(
 	if requestForConnectedNode && node.num == deviceNum && configIsNil(node) {
 		Task {
 			do {
-				guard let fromUser = connectedNode.user, let toUser = node.user else { return }
+				guard let fromUser = connectedNode.user, let toUser = node.user else {
+					return
+				}
 				Logger.mesh.info("⚙️ Config missing for connected node, requesting")
 				try await request(fromUser, toUser)
 			} catch {
@@ -44,13 +47,24 @@ func requestRemoteConfig(
 	if UserDefaults.enableAdministration {
 		let expiration = node.sessionExpiration ?? Date()
 		if expiration < Date() || configIsNil(node) {
+			let operationID = accessoryManager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: node.num, section: section)
+			guard let operationID else { return }
 			Task {
 				do {
-					guard let fromUser = connectedNode.user, let toUser = node.user else { return }
+					guard let fromUser = connectedNode.user, let toUser = node.user else {
+						accessoryManager.remoteAdminConfigTracker.fail(operationID, with: AccessoryError.appError("Missing user identity"))
+						return
+					}
 					Logger.mesh.info("⚙️ Empty or expired config requesting via PKI admin")
+				try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
 					try await request(fromUser, toUser)
-				} catch {
-					Logger.mesh.error("🚨 Config request failed")
+				}
+				if case .failed(let message) = accessoryManager.remoteAdminConfigTracker.finish(operationID) {
+					accessoryManager.remoteAdminConfigFeedback = (node.num, message)
+				}
+			} catch {
+				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)
+				Logger.mesh.error("🚨 Config request failed")
 				}
 			}
 		}

--- a/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
+++ b/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
@@ -20,7 +20,8 @@ func requestRemoteConfig(
 	configIsNil: @escaping (NodeInfoEntity) -> Bool,
 	section: String,
 	request: @escaping (_ fromUser: UserEntity, _ toUser: UserEntity) async throws -> Void,
-	requestForConnectedNode: Bool = false
+	requestForConnectedNode: Bool = false,
+	force: Bool = false
 ) {
 	guard let deviceNum = accessoryManager.activeDeviceNum,
 		  let node,
@@ -46,7 +47,7 @@ func requestRemoteConfig(
 
 	if UserDefaults.enableAdministration {
 		let expiration = node.sessionExpiration ?? Date()
-		if expiration < Date() || configIsNil(node) {
+		if force || expiration < Date() || configIsNil(node) {
 			let operationID = accessoryManager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: node.num, section: section)
 			guard let operationID else { return }
 			Task {

--- a/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
+++ b/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
@@ -9,6 +9,24 @@ struct SaveConfigButton: View {
 	
 	var body: some View {
 		if accessoryManager.isConnected && hasChanges {
+			let feedback = node.map { accessoryManager.remoteAdminConfigFeedback?.targetNodeNum == $0.num ? accessoryManager.remoteAdminConfigFeedback?.message : nil } ?? nil
+			let remoteSaveInProgress = node.flatMap {
+				accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .save, section: "save")
+			}?.isFinished == false
+			if let feedback {
+				VStack(spacing: 8) {
+					Label(feedback, systemImage: "exclamationmark.triangle")
+						.foregroundColor(.red)
+					Button("Retry") {
+						accessoryManager.remoteAdminConfigFeedback = nil
+						onConfirmation()
+					}
+				}
+				.padding(.bottom)
+			} else if remoteSaveInProgress {
+				ProgressView("Saving…")
+					.padding(.bottom)
+			} else {
 			if #available(iOS 26.0, *) {
 				Button {
 					isPresentingSaveConfirm = true
@@ -54,6 +72,7 @@ struct SaveConfigButton: View {
 				} message: {
 					Text("After config values save the node will reboot.")
 				}
+			}
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -135,7 +135,17 @@ struct SecurityConfig: View {
 	/// See `body` — the Form and its chrome, split out for type-check time.
 	private var securityForm: some View {
 		Form {
-			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues)
+			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.securityConfig == nil },
+				section: "Security",
+				request: accessoryManager.requestSecurityConfig,
+				force: true
+			)
+		})
 			Text("Security Config Settings require a firmware version 2.5+")
 				.font(.title3)
 			packetAuthenticitySection

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -107,6 +107,7 @@ struct SecurityConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.securityConfig == nil },
+				section: "Security",
 				request: accessoryManager.requestSecurityConfig
 			)
 		}

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -126,6 +126,18 @@ struct NodeAdministrationTests {
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
+		#expect(node.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(node.sessionExpiration != nil)
+		let expiration = node.sessionExpiration
+		admin.sessionPasskey = Data()
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+		let emptyResponseNode = try fetchNode(num: num, in: container)
+		#expect(emptyResponseNode.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(emptyResponseNode.sessionExpiration == expiration)
+		await mesh.moduleConfig(config: moduleConfig, nodeNum: num, nodeLongName: "Remote Node")
+		let mirroredNode = try fetchNode(num: num, in: container)
+		#expect(mirroredNode.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(mirroredNode.sessionExpiration == expiration)
 	}
 
 	@Test func metadataResponseWithPasskeyMarksUnknownNode() async throws {
@@ -169,8 +181,7 @@ struct NodeAdministrationTests {
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(!node.hasBeenAdministered)
-		// The local download still stamps the (empty) passkey as before.
-		#expect(node.sessionPasskey == Data())
+		#expect(node.sessionPasskey == nil)
 	}
 
 	@Test func setConfigRequestWithPasskeyDoesNotMark() async throws {

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import Testing
+import SwiftData
 @testable import Meshtastic
 import MeshtasticProtobufs
 
@@ -134,6 +135,43 @@ struct RemoteAdminConfigTrackerTests {
 		let bluetooth = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Bluetooth"))
 		#expect(tracker.latest(for: 42, kind: .request, section: "Device")?.id == device)
 		#expect(tracker.latest(for: 42, kind: .request, section: "Bluetooth")?.id == bluetooth)
+	}
+
+	@Test func forcedRemoteConfigRetryDispatchesRequest() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let local = NodeInfoEntity(); local.num = 1; local.id = 1
+		let remote = NodeInfoEntity(); remote.num = 2; remote.id = 2
+		let from = UserEntity(); from.num = 1; from.userNode = local
+		let to = UserEntity(); to.num = 2; to.userNode = remote
+		local.user = from; remote.user = to
+		context.insert(local); context.insert(remote); context.insert(from); context.insert(to)
+		try context.save()
+
+		let manager = AccessoryManager(transports: [])
+		manager.context = context
+		manager.activeDeviceNum = 1
+		manager.updateState(.subscribed)
+		let previousAdministration = UserDefaults.enableAdministration
+		UserDefaults.enableAdministration = true
+		defer { UserDefaults.enableAdministration = previousAdministration }
+
+		var requests = 0
+		requestRemoteConfig(
+			node: remote,
+			context: context,
+			accessoryManager: manager,
+			configIsNil: { _ in false },
+			section: "Retry test",
+			request: { _, _ in requests += 1 },
+			force: true)
+		for _ in 0..<20 where requests == 0 {
+			try await Task.sleep(for: .milliseconds(10))
+		}
+		#expect(requests == 1)
 	}
 
 	@Test func managerPublishesNestedTrackerMutations() {

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Combine
+import Testing
+@testable import Meshtastic
+import MeshtasticProtobufs
+
+private actor RemoteAdminReceiveConnection: Connection {
+	let type: TransportType = .ble
+	var isConnected = true
+	func send(_ data: ToRadio) async throws {}
+	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
+	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {}
+	func drainPendingPackets() async throws {}
+	func startDrainPendingPackets() throws {}
+	func appDidEnterBackground() {}
+	func appDidBecomeActive() {}
+}
+
+@Suite("Remote admin configuration operation tracking")
+@MainActor
+struct RemoteAdminConfigTrackerTests {
+	private func makeManager(connection: RemoteAdminReceiveConnection) -> AccessoryManager {
+		let manager = AccessoryManager(transports: [])
+		let device = Device(id: UUID(), name: "Test Radio", transportType: .ble, identifier: "remote-admin-test", connectionState: .connected, num: 1)
+		manager.activeConnection = (device: device, connection: connection)
+		manager.activeDeviceNum = 1
+		manager.updateState(.subscribed)
+		return manager
+	}
+
+	@Test func encodedAdminResponseResolvesThroughReceivePath() async throws {
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+
+		var admin = AdminMessage()
+		admin.getModuleConfigResponse = ModuleConfig()
+		var data = DataMessage()
+		data.portnum = .adminApp
+		data.requestID = 100
+		data.payload = try admin.serializedData()
+		var packet = MeshPacket()
+		packet.from = 42
+		packet.to = 1
+		packet.decoded = data
+		var fromRadio = FromRadio()
+		fromRadio.packet = packet
+
+		await manager.didReceive(.data(fromRadio))
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+		#expect(manager.remoteAdminConfigTracker.finish(operationID) == .succeeded)
+	}
+	@Test func unrelatedPacketsCannotEnroll() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(!tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: nil))
+		#expect(tracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+	}
+
+	@Test func responseMustMatchPacketIDAndTarget() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+		#expect(tracker.resolveAdminResponse(packetID: 101, sourceNodeNum: 42) == nil)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 43) == nil)
+		#expect(tracker.operations[operationID]?.result == nil)
+	}
+
+	@Test func targetResponseSucceeds() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .request, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == operationID)
+		#expect(tracker.finish(operationID) == .succeeded)
+	}
+
+	@Test func routingFailurePropagatesByPacketID() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.resolveRouting(packetID: 100, sourceNodeNum: 99, reason: "No route", isFailure: true)
+		#expect(tracker.operations[operationID]?.result == .failed("No route"))
+	}
+
+	@Test func relaySuccessIsIgnoredUntilTargetConfirms() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 99, reason: nil, isFailure: false) == nil)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 42, reason: nil, isFailure: false) == operationID)
+	}
+
+	@Test func requestRequiresAdminResponseInsteadOfRoutingSuccess() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Ambient Lighting"))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 42, reason: nil, isFailure: false) == nil)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == operationID)
+	}
+
+	@Test func multiPacketOperationWaitsForEveryPacket() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.registerPacket(packetID: 200, targetNodeNum: 42, operationID: operationID)
+		tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42)
+		#expect(tracker.finish(operationID) == .timedOut)
+		tracker.resolveAdminResponse(packetID: 200, sourceNodeNum: 42)
+		#expect(tracker.finish(operationID) == .succeeded)
+	}
+
+	@Test func packetTimeoutIsRetainedAsTimeout() async throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(await tracker.waitForPacket(packetID: 100, operationID: operationID, timeout: .milliseconds(1)) == .timedOut)
+		#expect(tracker.operations[operationID]?.result == .timedOut)
+		#expect(tracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+	}
+
+	@Test func duplicateSaveIsBlockedAndRetryGetsNewSequence() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let first = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.begin(kind: .save, targetNodeNum: 42) == nil)
+		tracker.fail(first, with: "failed")
+		let retry = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.latest(for: 42, kind: .save, section: "save")?.id == retry)
+	}
+
+	@Test func requestStateIsScopedToConfigurationSection() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let device = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Device"))
+		let bluetooth = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Bluetooth"))
+		#expect(tracker.latest(for: 42, kind: .request, section: "Device")?.id == device)
+		#expect(tracker.latest(for: 42, kind: .request, section: "Bluetooth")?.id == bluetooth)
+	}
+
+	@Test func managerPublishesNestedTrackerMutations() {
+		let manager = AccessoryManager(transports: [])
+		var changeCount = 0
+		let cancellable = manager.objectWillChange.sink { _ in changeCount += 1 }
+		_ = manager.remoteAdminConfigTracker.begin(kind: .request, targetNodeNum: 42, section: "Device")
+		#expect(changeCount > 0)
+		cancellable.cancel()
+	}
+
+	@Test func disconnectInvalidatesPendingPacketsAndLateAck() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.failAll(with: "disconnected")
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == nil)
+		#expect(tracker.operations[operationID]?.result == .failed("disconnected"))
+	}
+}

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -45,6 +45,10 @@ The Remote Admin page stays inside node navigation: Back from a configuration se
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.
 
+### Remote configuration
+
+When you configure another node, Settings shows progress while the request or save is being confirmed by that node. A timeout or delivery error keeps your edits on screen and provides a **Retry** action, so you can check the node and try again without re-entering the values.
+
 ### LoRa
 
 LoRa settings control how your radio communicates on the mesh:


### PR DESCRIPTION
## What changed?

- Track each remote configuration request and save by target node, settings section, and packet ID.
- Keep request progress visible until the matching admin response arrives, and keep save progress visible until the matching routing ACK or error arrives.
- Show timeouts and routing failures in the settings screen with an in-place retry action instead of dismissing the editor as soon as the packet is queued.
- Fail outstanding operations when the radio disconnects, while ignoring unrelated ACKs and admin responses.
- Preserve the admin session when module responses arrive or cached configuration is updated, so a successful retry loads the editor without erasing its session.
- Update the Remote Administration documentation for the confirmed-save behavior.

This is PR 3 of the native Remote Admin parity stack tracked by #2410 and depends on #2409.

## Why did it change?

Remote configuration previously treated a successful local write to the transport as completion. That could dismiss an editor even when the remote node rejected the request, never received it, or failed to respond.

Android already keeps request IDs in a loading state, applies a 30-second timeout, distinguishes read responses from routing ACKs, and defers completion until the response appropriate to the operation arrives. See the pinned Android implementation in [request registration and timeout handling](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt#L1048-L1095) and [response completion handling](https://github.com/meshtastic/Meshtastic-Android/blob/5f1a4e58307d30a0a23c3e0b206562448b4ba00a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt#L1376-L1403). This change gives the Apple app the same user-visible completion semantics while retaining its native SwiftUI and transport architecture.

## How is this tested?

- Final combined stack: `xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -derivedDataPath /tmp/remote-admin-build -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:MeshtasticTests/RemoteAdminEntryTests -only-testing:MeshtasticTests/NodeAdministrationTests -only-testing:MeshtasticTests/RemoteAdminConfigTrackerTests -only-testing:MeshtasticTests/RemoteChannelsTests -only-testing:MeshtasticTests/RemoteAdminActionTransportTests -only-testing:MeshtasticTests/SettingsNodeSortTests -only-testing:MeshtasticTests/ChannelSetSaveTests` passed: **78 tests, 0 failures, 0 skips**.
- Tests cover packet/target correlation, pending saves until remote ACK, timeout, disconnect, unrelated responses, forced retry, and preservation of session keys during module responses and cache updates.
- Simulator with a localhost protocol fixture: suppressed a fresh MQTT response until the 30-second timeout, then restored responses and clicked Retry. Verified a new request ID, the matching response, initialized editor values, and the remote administration header without another session refresh. This controlled failure test uses a simulated radio.
- Real bench: MUZI (2.8.0) → TBEAM S3 (2.8.1) over RF, with the simulator connected through a serial/TCP bridge. A fresh MQTT module response retained the session and initialized values matching an independent serial read, without manually refreshing the session. The stack also passed eight channel reads and node/Settings Back navigation. Hardware destructive resets and channel writes were not performed.
- Full non-snapshot unit suite on the final combined stack: **2,968 passed, 0 failed, 6 skipped**. Ran `xcodebuild test-without-building -only-testing:MeshtasticTests` with the same 39 snapshot-suite exclusions as `.github/workflows/unit-tests.yml` and the simulator/build settings above. The six existing Keychain tests skipped because code signing was disabled (OSStatus -34018).

## Screenshots/Videos (when applicable)

The before image shows the previous Ambient Lighting feedback. The after sequence exercises MQTT timeout and retry using a controlled protocol fixture.

| Before: no-response message | After: timeout with Retry |
| --- | --- |
| <img width="280" alt="Previous configuration no-response feedback" src="https://github.com/user-attachments/assets/e8c1573e-0b4e-4776-b84f-24712739dd36" /> | <img width="280" alt="MQTT timeout with actionable Retry" src="https://github.com/user-attachments/assets/9f241086-cc3e-4cf0-8472-1cafcf768642" /> |

| Request pending | Retry succeeded and loaded remote values |
| --- | --- |
| <img width="280" alt="Configuration request remains pending" src="https://github.com/user-attachments/assets/169dc2ed-abff-49be-9d07-b7400b5daa30" /> | <img width="280" alt="Successful Retry retains the remote session and initializes the editor" src="https://github.com/user-attachments/assets/9efb318b-3e07-4947-b813-e83944afe080" /> |

Real RF request and response:

| Requesting TBEAM MQTT configuration | Remote values loaded with session intact |
| --- | --- |
| <img width="280" alt="Real RF module request pending" src="https://github.com/user-attachments/assets/af11ef33-c14b-41cf-8aee-cc5bac5e2c86" /> | <img width="280" alt="Real TBEAM response with preserved administration session" src="https://github.com/user-attachments/assets/7dec2f35-4639-4969-845b-c581aadb7849" /> |

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (see [copilot-instructions.md](../.github/copilot-instructions.md#in-app-documentation) for the view → doc page mapping). If no doc update is needed, add the **`skip-docs-check`** label.
- [x] I have tested the change to ensure that it works as intended.
