### PR TITLE
No stacked pull requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,23 @@ Say what broke and what changed in ordinary words. No invented jargon,
 no dramatized debugging stories, no bold-lead bullet lists that read like
 marketing. Match how existing PRs in this repo are written (Summary /
 What changed / Testing). If there's nothing worth saying, say nothing.
+
+## Pull requests
+
+One change per pull request, based on `main`.
+
+Do not open stacked pull requests — a series where each one's base is the
+previous one's branch. They cannot be reviewed or merged independently: taking
+the third means taking the first two, the parts needing the most scrutiny sit
+furthest down the chain, and closing anything in the middle strands the rest.
+If a change only makes sense on top of another, wait for the first to merge and
+then open the second against `main`.
+
+Split work by what it does, not by how it was written. A bug fix that stands on
+its own goes in its own pull request, not at the bottom of a larger series.
+
+Keep a pull request small enough to review in one sitting. If it runs to
+thousands of lines across dozens of files, it is doing more than one thing.
+
+Describe the change in terms of what the app and the radio do. Parity with
+another client is a reason to want a change, not a description of one.


### PR DESCRIPTION
## Summary

We had a five PR stack land this week, each based on the previous one's
branch. It could not be reviewed or merged a piece at a time, and the one line
bug fix at the bottom of it had to wait on 2,500 lines above it.

## What changed

A Pull requests section in CLAUDE.md: one change per pull request, based on
`main`; no stacked series; a standalone bug fix goes in its own pull request
rather than at the bottom of a larger one; keep a pull request small enough to
review in one sitting; describe a change by what the app and the radio do
rather than by parity with another client.

## Testing

Documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added contribution guidelines for pull requests, including keeping changes focused, reviewable, and based on the main branch.
  - Clarified expectations for describing changes in terms of app and radio behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->