### PR TITLE
Stop saying Long Fast is the default preset

### DIFF
--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -359,7 +359,7 @@ struct LoRaConfig: View {
 						}
 					}
 					.fixedSize()
-					Text("Available modem presets, default is Long Fast.")
+					Text("Available modem presets.")
 						.foregroundColor(.gray)
 						.font(.callout)
 					// Long Fast stays selectable in the US, but its bandwidth is not

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -46,7 +46,7 @@ LoRa settings control how your radio communicates on the mesh:
 | Setting | Description |
 |---------|-------------|
 | Region | Your geographical region. **Must be set correctly** — using the wrong region is illegal and prevents communication with local nodes. The standard regions are always available; the amateur (ham) 2m / 70cm / 1.25m bands and the EU 866 / narrow bands require firmware **2.8.0 or later** and only appear when your connected radio supports them. |
-| Modem Preset | Speed/range trade-off. Most users should use Long Fast or Long Slow. On firmware 2.8+, the preset list is filtered to those that are legal for the selected region (see below). |
+| Modem Preset | Speed/range trade-off. Which preset to use depends on your region — on firmware 2.8+ the list is filtered to those legal there, and the recommended one differs by region (see below). |
 | Bandwidth | Available under **Advanced** when **Use Preset** is off. The protobuf default value of 0 is shown as its effective firmware value: 250 kHz in sub-GHz regions and 812.5 kHz in the 2.4 GHz region. Choices are filtered for the selected region and connected radio. If a stored nonzero bandwidth is unsupported, the app shows a warning and prevents saving until you select a supported value. |
 | Hop Limit | The number of times a message is repeated by other nodes. Higher values increase range but also mesh traffic. |
 | Frequency Slot | Fine-tune the exact frequency within your region. |


### PR DESCRIPTION
## Summary

The LoRa config screen said "Available modem presets, default is Long Fast."
That is no longer true, and the same screen contradicts it a few lines further
down: on firmware 2.8 the preset list is filtered to those legal in the
selected region, and choosing US moves a stock Long Fast node to Long Turbo
because Long Fast's bandwidth is not US compliant. On older firmware the list
is gated by what the firmware supports rather than by region, so there is no
single default there either.

## What changed

The hint under the picker now reads "Available modem presets." — the part that
is still true.

`docs/user/settings.md` carried the same claim in its Modem Preset row
("Most users should use Long Fast or Long Slow"), two lines above the
paragraph that describes the region filtering and the US behaviour. That row
now points at the region instead of naming a preset.

## Testing

Builds, full suite passes. Text and documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Shortened the caption beneath the modem preset selector in LoRa settings for a more concise presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->