### PR TITLE
Remove the share button beside the connection status indicator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,18 @@ thousands of lines across dozens of files, it is doing more than one thing.
 
 Describe the change in terms of what the app and the radio do. Parity with
 another client is a reason to want a change, not a description of one.
+
+## The connection status indicator
+
+`ConnectedDevice` is the small indicator in the top right of most screens: the
+radio's short name, the link icon, the MQTT icon and the RX/TX lights.
+
+It is full. Do not add controls to it, and do not add toolbar buttons beside it
+in `topBarTrailing`. The space is a status readout, not an action bar, and on a
+phone in the narrow width it is already close to overflowing — anything more
+either crowds the name or pushes the indicator off.
+
+New actions belong where the thing they act on lives: on the node's row or its
+detail screen, in a section on the relevant settings page, or in the Tools
+screen. If an action seems to need the top right of every screen, that is worth
+questioning rather than designing around.

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -178,15 +178,6 @@ struct NodeList: View {
 			ToolbarItem(placement: .topBarLeading) {
 				MeshtasticLogo()
 			}
-			if let connectedNode, ShareContactQR.canShareContact(for: connectedNode) {
-				ToolbarItem(placement: .topBarTrailing) {
-					Button {
-						shareContactNode = connectedNode
-					} label: {
-						Label("Share Connected Node", systemImage: "person.crop.circle.badge.plus")
-					}
-				}
-			}
 			ToolbarItem(placement: .topBarTrailing) {
 				ConnectedDevice(
 					deviceConnected: accessoryManager.isConnected,

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -170,10 +170,6 @@ Tap any node to see the full detail view with hardware info, signal metrics, env
 
 For messageable nodes, use **Actions > Share Contact QR** to show a Meshtastic contact link and QR code that another device can scan.
 
-### Share Connected Node
-
-When a radio is connected, a **Share Connected Node** button appears in the node list toolbar. It opens the same share sheet as **Share Contact QR**, pre-filled with your own node — a quick way to hand someone your contact without finding yourself in the list.
-
 ### Write a Contact to an NFC Tag
 
 On iPhones with NFC hardware (iOS 18 or later), the contact share sheet also offers **Write to NFC Tag**. Hold a writable NFC tag near the top of your iPhone and the contact link is saved to it, replacing whatever the tag held before. Anyone can then tap that tag with their phone to open the contact in Meshtastic — the tag carries exactly the same link the QR code encodes.


### PR DESCRIPTION
## Summary

A **Share Connected Node** button sat in the node list toolbar next to the
connection status indicator. That corner is a status readout — short name, link
icon, MQTT icon, RX/TX lights — and on a phone it is already close to
overflowing, so an action button there crowds the name.

## What changed

The toolbar button is gone. Sharing your own contact is unchanged everywhere
else: it is still on your node's row and its detail screen through **Share
Contact QR**, which is the same sheet the button opened. The sheet and its
binding stay, because the rows still use them.

`docs/user/nodes.md` loses the section describing the button.

CLAUDE.md gains a note that the indicator is full: no controls in it, no
toolbar buttons beside it, and where new actions should go instead.

## Testing

Builds, full suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the “Share Connected Node” action from the top toolbar. The toolbar now displays only the app logo and connection status.
  - Connection status remains a read-only indicator, with no additional controls presented alongside it.

- **Documentation**
  - Added guidance clarifying the intended placement of node-related actions in relevant screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->