### PR TITLE
Don't offer direct messages to nodes we have no public key for

### DIFF
--- a/Meshtastic/Model/UserEntity.swift
+++ b/Meshtastic/Model/UserEntity.swift
@@ -37,6 +37,25 @@ final class UserEntity {
 
 	var userNode: NodeInfoEntity?
 
+	/// Whether a direct message to this contact can actually be delivered.
+	///
+	/// Two independent gates. `unmessagable` is the node saying it does not accept messages.
+	/// The public key is what the sending radio needs: firmware has generated a keypair since 2.5,
+	/// so a direct message takes the PKC path, and a radio with no key for the destination refuses
+	/// to send (`PKI_SEND_FAIL_PUBLIC_KEY`) rather than falling back to channel encryption. A node we
+	/// have only heard packets from has no key until its NodeInfo arrives, and cannot be messaged.
+	var canDirectMessage: Bool {
+		!unmessagable && !(publicKey?.isEmpty ?? true)
+	}
+
+	/// Whether to offer the Message shortcut for this contact.
+	///
+	/// `canDirectMessage` with an escape hatch: a contact we can no longer send to may still have a
+	/// thread worth reading. The contact list keeps those rows for the same reason.
+	var showsDirectMessageAction: Bool {
+		canDirectMessage || lastMessage != nil
+	}
+
 	init() {}
 }
 

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -25,7 +25,7 @@ struct UserList: View {
 		VStack {
 			FilteredUserList(withFilters: filters, node: $node, userSelection: $userSelection)
 			.sheet(isPresented: $editingFilters) {
-				NodeListFilter(filterTitle: "Contact Filters", filters: filters)
+				NodeListFilter(filterTitle: "Contact Filters", showsEncryptedFilter: false, filters: filters)
 			}
 			.sheet(isPresented: $showingHelp) {
 				DirectMessagesHelp()
@@ -505,16 +505,12 @@ fileprivate extension NodeFilterParameters {
 				return false
 			}
 		}
-		// Unmessagable filter
-		if user.unmessagable {
-			if user.lastMessage == nil { return false }
-		}
+		// Contacts we cannot direct message: the node says it is unmessagable, or we hold no public
+		// key and the radio would refuse to send. Keep any that already have a thread so existing
+		// conversations stay reachable.
+		if !user.showsDirectMessageAction { return false }
 		// Ignored
 		if user.userNode?.ignored == true { return false }
-		// Encrypted
-		if isPkiEncrypted {
-			if !user.pkiEncrypted { return false }
-		}
 		// Connected node
 		if user.numString == String(UserDefaults.preferredPeripheralNum) { return false }
 		return true

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -308,7 +308,7 @@ struct NodeDetail: View {
 					// Nodes we have only heard packets from have no key on file. Matches the yellow
 					// open lock the node list shows, rather than a green lock over an empty key.
 					Label {
-						VStack(alignment: .leading, spacing: 4) {
+						VStack(alignment: .leading) {
 							Text("No Public Key")
 							Text("This node has not shared a public key, so direct messages to it cannot be sent. Exchange User Info asks for one.")
 								.foregroundStyle(.secondary)

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -304,24 +304,41 @@ struct NodeDetail: View {
 				let publicKey = nodeNum == accessoryManager.activeDeviceNum
 				? node.securityConfig?.publicKey?.base64EncodedString() ?? ""
 				: user.publicKey?.base64EncodedString() ?? ""
-				HStack {
+				if publicKey.isEmpty {
+					// Nodes we have only heard packets from have no key on file. Matches the yellow
+					// open lock the node list shows, rather than a green lock over an empty key.
 					Label {
-						Text("Public Key")
+						VStack(alignment: .leading, spacing: 4) {
+							Text("No Public Key")
+							Text("This node has not shared a public key, so direct messages to it cannot be sent. Exchange User Info asks for one.")
+								.foregroundStyle(.secondary)
+								.font(.callout)
+						}
+						.accessibilityElement(children: .combine)
 					} icon: {
-						Image(systemName: "lock.fill")
-							.foregroundColor(.green)
+						Image(systemName: "lock.open.fill")
+							.foregroundColor(.yellow)
 					}
-					Spacer()
-					Button(action: {
-						UIPasteboard.general.string = publicKey
-					}) {
-						HStack {
-							Image(systemName: "key.horizontal.fill")
-							Text("Copy")
+				} else {
+					HStack {
+						Label {
+							Text("Public Key")
+						} icon: {
+							Image(systemName: "lock.fill")
+								.foregroundColor(.green)
+						}
+						Spacer()
+						Button(action: {
+							UIPasteboard.general.string = publicKey
+						}) {
+							HStack {
+								Image(systemName: "key.horizontal.fill")
+								Text("Copy")
+							}
 						}
 					}
+					.accessibilityElement(children: .combine)
 				}
-				.accessibilityElement(children: .combine)
 			}
 			if let metadata = node.metadata {
 				HStack {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -792,7 +792,7 @@ struct NodeDetail: View {
 					node: node
 				)
 				if accessoryManager.activeDeviceNum != nodeNum {
-					if !(currentUser?.unmessagable ?? true) {
+					if currentUser?.showsDirectMessageAction == true {
 						Button(action: {
 							if let url = URL(string: "meshtastic:///messages?userNum=\(nodeNum)") {
 								UIApplication.shared.open(url)

--- a/Meshtastic/Views/Nodes/Helpers/NodeListFilter.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListFilter.swift
@@ -12,6 +12,9 @@ struct NodeListFilter: View {
 	@Environment(\.dismiss) private var dismiss
 	@State var editMode = EditMode.active
 	var filterTitle = "Node Filters"
+	/// The contact list only ever shows contacts we can direct message, so filtering it by key
+	/// state would be a no-op. Node and map filters keep the toggle.
+	var showsEncryptedFilter = true
 	@ObservedObject var filters: NodeFilterParameters
 
 	var body: some View {
@@ -36,11 +39,13 @@ struct NodeListFilter: View {
 					.toggleStyle(.switch)
 					.listRowSeparator(.visible)
 
-					Toggle(isOn: $filters.isPkiEncrypted) {
-						Label("Encrypted", systemImage: "lock.fill")
+					if showsEncryptedFilter {
+						Toggle(isOn: $filters.isPkiEncrypted) {
+							Label("Encrypted", systemImage: "lock.fill")
+						}
+						.toggleStyle(.switch)
+						.listRowSeparator(.visible)
 					}
-					.toggleStyle(.switch)
-					.listRowSeparator(.visible)
 
 					Toggle(isOn: $filters.isFavorite) {
 						Label("Favorites", systemImage: "star.fill")

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -471,7 +471,7 @@ private struct FilteredNodeList: View {
 				NodeAlertsButton(context: context, node: node, user: user)
 			}
 			if connectedNode.num != node.num {
-				if !(node.user?.unmessagable ?? true) {
+				if node.user?.showsDirectMessageAction == true {
 					Button(action: {
 						if let url = URL(string: "meshtastic:///messages?userNum=\(node.num)") {
 							UIApplication.shared.open(url)

--- a/MeshtasticTests/UserEntityCanDirectMessageTests.swift
+++ b/MeshtasticTests/UserEntityCanDirectMessageTests.swift
@@ -1,0 +1,73 @@
+//
+//  UserEntityCanDirectMessageTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import Testing
+import Foundation
+@testable import Meshtastic
+
+/// Covers `UserEntity.canDirectMessage` — the gate behind the Message button in NodeDetail and the
+/// node list. Both signals have to pass: the node has to accept messages, and we need a public key
+/// for it or the sending radio refuses with `PKI_SEND_FAIL_PUBLIC_KEY`.
+@Suite("UserEntity.canDirectMessage")
+@MainActor
+struct UserEntityCanDirectMessageTests {
+
+	private let key = Data(repeating: 0x2B, count: 32)
+
+	private func user(key: Data?, unmessagable: Bool) -> UserEntity {
+		let user = UserEntity()
+		user.publicKey = key
+		user.unmessagable = unmessagable
+		return user
+	}
+
+	@Test("allows a messagable node with a key")
+	func allowsKeyedMessagableNode() {
+		#expect(user(key: key, unmessagable: false).canDirectMessage)
+	}
+
+	@Test("blocks a node that has no key on file")
+	func blocksNodeWithoutKey() {
+		#expect(!user(key: nil, unmessagable: false).canDirectMessage)
+	}
+
+	@Test("blocks a node whose stored key is empty rather than nil")
+	func blocksNodeWithEmptyKey() {
+		// Heard-but-never-introduced neighbors can land with a non-nil empty key; an empty key is
+		// no key as far as the radio is concerned.
+		#expect(!user(key: Data(), unmessagable: false).canDirectMessage)
+	}
+
+	@Test("blocks an unmessagable node even when a key is on file")
+	func blocksUnmessagableNode() {
+		#expect(!user(key: key, unmessagable: true).canDirectMessage)
+	}
+
+	@Test("blocks a node that is unmessagable and keyless")
+	func blocksUnmessagableKeylessNode() {
+		#expect(!user(key: nil, unmessagable: true).canDirectMessage)
+	}
+
+	@Test("still offers the Message shortcut when a thread already exists")
+	func keepsShortcutForExistingThread() {
+		let contact = user(key: nil, unmessagable: true)
+		contact.lastMessage = Date()
+
+		#expect(!contact.canDirectMessage)          // sending is still refused
+		#expect(contact.showsDirectMessageAction)   // but the thread stays reachable
+	}
+
+	@Test("hides the Message shortcut when there is no thread to open")
+	func hidesShortcutWithoutThread() {
+		#expect(!user(key: nil, unmessagable: false).showsDirectMessageAction)
+	}
+
+	@Test("offers the Message shortcut for a contact we can message")
+	func offersShortcutForMessagableContact() {
+		#expect(user(key: key, unmessagable: false).showsDirectMessageAction)
+	}
+}

--- a/docs/user/messages.md
+++ b/docs/user/messages.md
@@ -67,13 +67,18 @@ When you open or scan a Meshtastic channel link, review the listed channels and 
 | ![Favorites](../assets/screenshots/favorite.png) | **Favorites** — favorited contacts and nodes with recent messages appear at the top of the contact list. |
 | ![Long press](../assets/screenshots/longPress.png) | **Long Press Actions** — long press to favorite or mute the contact, or delete a conversation. |
 
+The contact list shows the contacts you can actually direct message. Nodes that report themselves as
+unmessagable, and nodes no public key has been received for, are left out — the radio would refuse to
+send to them. A contact you already have a conversation with stays in the list either way, so an
+existing thread is never hidden.
+
 ### Encryption
 
 ![Encryption legend](../assets/screenshots/lockLegend.png)
 
 | Icon | Meaning |
 |------|---------|
-| ![Shared Key](../assets/screenshots/lockOpen.png) | **Shared Key** — direct messages are using the shared key for the channel. |
+| ![No Public Key](../assets/screenshots/lockOpen.png) | **No Public Key** — no public key has been received for this node, so direct messages to it cannot be sent. Use **Exchange User Info** on the node to ask for one. |
 | ![Public Key Encryption](../assets/screenshots/lockClosed.png) | **Public Key Encryption** — direct messages use the public key infrastructure for encryption. Requires firmware 2.5 or later. |
 | ![PKI Mismatch](../assets/screenshots/keySlash.png) | **Public Key Mismatch** — the most recent public key for this node does not match the previously recorded key. Verify who you are messaging with by comparing public keys in person or over the phone. |
 

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -21,9 +21,14 @@ The Nodes tab shows every device your radio has heard on the mesh. Tap any node 
 
 | Icon | Meaning |
 |------|---------|
-| ![Shared Key](../assets/screenshots/lockOpen.png) | **Shared Key** — direct messages are using the shared key for the channel. |
+| ![No Public Key](../assets/screenshots/lockOpen.png) | **No Public Key** — no public key has been received for this node, so direct messages to it cannot be sent. Use **Exchange User Info** on the node to ask for one. |
 | ![Public Key Encryption](../assets/screenshots/lockClosed.png) | **Public Key Encryption** — direct messages use public key infrastructure. Requires firmware 2.5+. |
 | ![PKI Mismatch](../assets/screenshots/keySlash.png) | **Public Key Mismatch** — public key does not match the previously recorded key. Verify the contact out-of-band. |
+
+Every radio has generated a keypair since firmware 2.5, so direct messages use it. A radio with no
+public key for the destination refuses to send rather than falling back to the channel key, so a node
+showing the open lock cannot be messaged until its node info arrives. Node detail shows **No Public
+Key** in place of the public key row for those nodes, and they are left out of the contact list.
 
 ## Device Roles
 


### PR DESCRIPTION
## Summary

Every radio has had a keypair since 2.5, so a direct message takes the PKC path. If the sending radio has no public key for the destination it returns `PKI_SEND_FAIL_PUBLIC_KEY` and does not fall back to channel encryption, so the message never goes out. We were still offering those nodes in the contact list and showing a Message button for them.

This is common rather than rare. A node we have only heard packets from has no key until its NodeInfo arrives, and on one of my test radios most of its direct neighbors were in that state.

## What changed

- `UserEntity.canDirectMessage` is the shared rule: not unmessagable, and a public key on file. `showsDirectMessageAction` adds an escape hatch so a contact with an existing thread keeps its shortcut.
- Node detail and the node list gated the Message button on `unmessagable` alone. Both now use the shared rule.
- The contact list did the same thing for unmessagable nodes but still listed keyless ones. It now uses the shared rule too, keeping contacts that already have a thread.
- That makes the Encrypted filter a no-op on the contact list, so it is hidden there. The node list and map keep it.
- Node detail showed a green lock and a Copy button for nodes with no key, because `keyMatch` is true when there is nothing to compare, so Copy put an empty string on the pasteboard. Those nodes now get the yellow open lock the node list already uses, with a line saying why they cannot be messaged.

Exchange User Info is unchanged and still works on these nodes — `NODEINFO_APP` is exempt from PKC, so the request goes out without a key and is what fills the key in.

## Testing

- Built for the iOS Simulator.
- `UserEntity.canDirectMessage` (8 new tests), plus the existing `UserEntity.applyInboundPublicKey` and `NodeFilterParameters` suites — 36 tests, all passing.
- The behavior was traced from two real stores pulled off my phone, where a DM between two bench nodes failed in both directions: the sender refused with `PKI_SEND_FAIL_PUBLIC_KEY` in one direction, and in the other the message went out but the far end could not decrypt it without the sender's key, so it never acked.
- Run on device. Exchange User Info on a node we held no key for brought its NodeInfo in, the key filled, and the direct message then went through in both directions — the same pair that failed before.
- Also corrected `docs/user/nodes.md` and `docs/user/messages.md`, which described the open lock as "direct messages are using the shared key for the channel". There is no such fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Direct messaging actions now appear based on contact messaging eligibility and existing conversation history.
  - Node details clearly indicate when a public key is unavailable and explain that User Info exchange is required before sending direct messages.
  - Contact lists no longer display an encrypted-status filter that does not apply to them.
  - Public-key status remains visible for contacts that support direct messaging.

- **Bug Fixes**
  - Improved consistency of direct-message availability across contact lists, node details, and context menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
