### PR TITLE
Track remote configuration progress and retries for Android parity

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -200,7 +200,23 @@ extension AccessoryManager {
 		toRadio = ToRadio()
 		toRadio.packet = meshPacket
 
+		let operationID = RemoteAdminConfigTracker.currentOperationID
+		let enrolled = remoteAdminConfigTracker.registerPacket(
+			packetID: meshPacket.id,
+			targetNodeNum: Int64(meshPacket.to),
+			operationID: operationID
+		)
 		try await send(toRadio)
+		if enrolled, let operationID {
+			switch await remoteAdminConfigTracker.waitForPacket(packetID: meshPacket.id, operationID: operationID) {
+			case .succeeded:
+				break
+			case .failed(let message):
+				throw AccessoryError.ioFailed(message)
+			case .timedOut:
+				throw AccessoryError.timeout
+			}
+		}
 		if let adminDescription {
 			Logger.admin.debug("\(adminDescription, privacy: .public)")
 		}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -206,6 +206,9 @@ extension AccessoryManager {
 			targetNodeNum: Int64(meshPacket.to),
 			operationID: operationID
 		)
+		if operationID != nil && !enrolled {
+			throw AccessoryError.ioFailed("Remote admin operation is no longer active.")
+		}
 		try await send(toRadio)
 		if enrolled, let operationID {
 			switch await remoteAdminConfigTracker.waitForPacket(packetID: meshPacket.id, operationID: operationID) {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -163,7 +163,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// relaunch a standing notice alerts once more, which is the useful behaviour.
 	var firmwareNoticeHistory: [String: (count: Int, lastShown: Date)] = [:]
 	let remoteAdminConfigTracker = RemoteAdminConfigTracker()
-	@Published var remoteAdminConfigFeedback: (targetNodeNum: Int64, message: String)? = nil
+	@Published var remoteAdminConfigFeedback: RemoteAdminConfigFeedback?
 	/// Delay before the Nth repeat of the same notice may alert again.
 	static let firmwareNoticeBackoff: [TimeInterval] = [0, 300, 1_800, 7_200, 43_200]
 	/// A notice unseen for this long is forgotten, so it alerts immediately if it returns.
@@ -838,12 +838,20 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		remoteAdminConfigTracker.begin(kind: kind, targetNodeNum: targetNodeNum, section: section)
 	}
 
+	func remoteAdminConfigFeedback(for targetNodeNum: Int64, kind: RemoteAdminConfigOperationKind) -> String? {
+		guard let feedback = remoteAdminConfigFeedback,
+			  feedback.targetNodeNum == targetNodeNum,
+			  feedback.kind == kind else { return nil }
+		return feedback.message
+	}
+
 	func resolveRemoteAdminConfigPacket(packetID: UInt32, sourceNodeNum: Int64, result: RemoteAdminConfigOperationResult) {
 		guard let operationID = remoteAdminConfigTracker.resolveAdminResponse(packetID: packetID, sourceNodeNum: sourceNodeNum),
 			  let operation = remoteAdminConfigTracker.operations[operationID]
 		else { return }
 		if case .failed(let message) = result {
-			remoteAdminConfigFeedback = (operation.targetNodeNum, message)
+			remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+				targetNodeNum: operation.targetNodeNum, kind: operation.kind, message: message)
 		}
 	}
 
@@ -857,7 +865,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		if reason == .adminBadSessionKey {
 			invalidateRemoteAdminSession(for: operation.targetNodeNum)
 		}
-		remoteAdminConfigFeedback = (operation.targetNodeNum, message)
+		remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+			targetNodeNum: operation.targetNodeNum, kind: operation.kind, message: message)
 	}
 
 	func failRemoteAdminConfigOperations(with message: String) {
@@ -1035,7 +1044,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 			// Dispatch based on packet contents.
 			if case let .decoded(data) = packet.payloadVariant {
-				let responseID = data.requestID != 0 ? data.requestID : data.replyID
+				let responseID = data.requestID
 				if responseID != 0 {
 					if data.portnum == .adminApp,
 						let adminMessage = try? AdminMessage(serializedBytes: data.payload),

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -622,6 +622,25 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 	}
 
+	/// A routing rejection invalidates only the remote node whose session was rejected.
+	/// The local transport and sessions for other remote nodes remain usable.
+	@discardableResult
+	func invalidateRemoteAdminSession(for targetNodeNum: Int64) -> Bool {
+		let descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == targetNodeNum })
+		guard let node = try? context.fetch(descriptor).first,
+			  node.sessionPasskey != nil || node.sessionExpiration != nil else { return false }
+
+		node.sessionPasskey = nil
+		node.sessionExpiration = nil
+		do {
+			try context.save()
+			return true
+		} catch {
+			Logger.data.error("💥 [AccessoryManager] Failed to clear remote admin session for node \(targetNodeNum, privacy: .public): \(error.localizedDescription, privacy: .public)")
+			return false
+		}
+	}
+
 	func closeConnection() async throws {
 		failRemoteAdminConfigOperations(with: "The radio connection was closed before the remote node confirmed the configuration.")
 		guard !isClosingConnection else {
@@ -828,11 +847,17 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 	}
 
-	func resolveRemoteAdminRoutingError(packetID: UInt32, reason: String) {
-		guard let operationID = remoteAdminConfigTracker.resolveRouting(packetID: packetID, sourceNodeNum: 0, reason: reason, isFailure: true),
+	func resolveRemoteAdminRoutingError(packetID: UInt32, reason: Routing.Error) {
+		let message = "Remote node rejected the request: \(reason)"
+		guard let operationID = remoteAdminConfigTracker.resolveRouting(packetID: packetID, sourceNodeNum: 0, reason: message, isFailure: true),
 			  let operation = remoteAdminConfigTracker.operations[operationID]
 		else { return }
-		remoteAdminConfigFeedback = (operation.targetNodeNum, reason)
+		// A rejected passkey must not be retried. Other routing errors do not prove that
+		// the cached authorization material itself is invalid.
+		if reason == .adminBadSessionKey {
+			invalidateRemoteAdminSession(for: operation.targetNodeNum)
+		}
+		remoteAdminConfigFeedback = (operation.targetNodeNum, message)
 	}
 
 	func failRemoteAdminConfigOperations(with message: String) {
@@ -1032,7 +1057,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 						} else {
 							resolveRemoteAdminRoutingError(
 								packetID: responseID,
-								reason: "Remote node rejected the request: \(reason)")
+								reason: reason)
 						}
 					}
 				}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -162,6 +162,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// back off repeats (see `shouldSurfaceFirmwareNotice`). In memory on purpose: after a
 	/// relaunch a standing notice alerts once more, which is the useful behaviour.
 	var firmwareNoticeHistory: [String: (count: Int, lastShown: Date)] = [:]
+	let remoteAdminConfigTracker = RemoteAdminConfigTracker()
+	@Published var remoteAdminConfigFeedback: (targetNodeNum: Int64, message: String)? = nil
 	/// Delay before the Nth repeat of the same notice may alert again.
 	static let firmwareNoticeBackoff: [TimeInterval] = [0, 300, 1_800, 7_200, 43_200]
 	/// A notice unseen for this long is forgotten, so it alerts immediately if it returns.
@@ -328,6 +330,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// monitor. True while sustained inbound mesh traffic is high enough to pause the map flyover.
 	@Published private(set) var isHighMeshTraffic = false
 	private var meshTrafficCancellable: AnyCancellable?
+	private var remoteAdminTrackerCancellable: AnyCancellable?
 
 	/// Packet count at the last periodic MeshPackets recycle (see `didReceive`). The ingest
 	/// actor's ModelContext registers every entity it inserts or faults and never lets go, so a
@@ -393,6 +396,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			.sink { [weak self] isHigh in
 				self?.isHighMeshTraffic = isHigh
 			}
+		remoteAdminTrackerCancellable = remoteAdminConfigTracker.objectWillChange
+			.sink { [weak self] _ in self?.objectWillChange.send() }
 	}
 
 	func transportForType(_ type: TransportType) -> Transport? {
@@ -595,6 +600,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	// If you are calling this in response to an error, then you should have
 	// exposed the error to the UI or handled the error prior to calling this.
 	func closeConnection() async throws {
+		failRemoteAdminConfigOperations(with: "The radio connection was closed before the remote node confirmed the configuration.")
 		guard !isClosingConnection else {
 			Logger.transport.debug("[AccessoryManager] closeConnection ignored while teardown is already in progress")
 			return
@@ -782,6 +788,31 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 	}
 
+	@discardableResult
+	func beginRemoteAdminConfigOperation(kind: RemoteAdminConfigOperationKind, targetNodeNum: Int64, section: String = "save") -> UUID? {
+		remoteAdminConfigTracker.begin(kind: kind, targetNodeNum: targetNodeNum, section: section)
+	}
+
+	func resolveRemoteAdminConfigPacket(packetID: UInt32, sourceNodeNum: Int64, result: RemoteAdminConfigOperationResult) {
+		guard let operationID = remoteAdminConfigTracker.resolveAdminResponse(packetID: packetID, sourceNodeNum: sourceNodeNum),
+			  let operation = remoteAdminConfigTracker.operations[operationID]
+		else { return }
+		if case .failed(let message) = result {
+			remoteAdminConfigFeedback = (operation.targetNodeNum, message)
+		}
+	}
+
+	func resolveRemoteAdminRoutingError(packetID: UInt32, reason: String) {
+		guard let operationID = remoteAdminConfigTracker.resolveRouting(packetID: packetID, sourceNodeNum: 0, reason: reason, isFailure: true),
+			  let operation = remoteAdminConfigTracker.operations[operationID]
+		else { return }
+		remoteAdminConfigFeedback = (operation.targetNodeNum, reason)
+	}
+
+	func failRemoteAdminConfigOperations(with message: String) {
+		remoteAdminConfigTracker.failAll(with: message)
+	}
+
 	func didReceive(_ event: ConnectionEvent) async {
 		let shouldIgnoreTransientEvent = isClosingConnection || userRequestedConnectionCancellation || activeConnection == nil
 
@@ -833,6 +864,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			updateDevice(deviceId: deviceId, key: \.rssi, value: rssi)
 			
 		case .error(let error), .errorWithoutReconnect(let error):
+			failRemoteAdminConfigOperations(with: "The radio connection was lost before the remote node confirmed the configuration.")
 			Task {
 				// Figure out if we'll reconnect
 				if case .errorWithoutReconnect = event {
@@ -864,6 +896,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			}
 			
 		case .disconnected:
+			failRemoteAdminConfigOperations(with: "The radio connection was lost before the remote node confirmed the configuration.")
 			guard !shouldIgnoreTransientEvent else {
 				Logger.transport.info("[Accessory] Ignoring disconnect event during teardown.")
 				return
@@ -951,6 +984,32 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 			// Dispatch based on packet contents.
 			if case let .decoded(data) = packet.payloadVariant {
+				let responseID = data.requestID != 0 ? data.requestID : data.replyID
+				if responseID != 0 {
+					if data.portnum == .adminApp,
+						let adminMessage = try? AdminMessage(serializedBytes: data.payload),
+						RemoteAdminConfigTracker.isAdminResponse(adminMessage) {
+						resolveRemoteAdminConfigPacket(
+							packetID: responseID,
+							sourceNodeNum: Int64(packet.from),
+							result: .succeeded
+						)
+					} else if data.portnum == .routingApp,
+						   let routing = try? Routing(serializedBytes: data.payload),
+						   case .errorReason(let reason)? = routing.variant {
+						if reason == .none {
+							remoteAdminConfigTracker.resolveRouting(
+								packetID: responseID,
+								sourceNodeNum: Int64(packet.from),
+								reason: nil,
+								isFailure: false)
+						} else {
+							resolveRemoteAdminRoutingError(
+								packetID: responseID,
+								reason: "Remote node rejected the request: \(reason)")
+						}
+					}
+				}
 				// Forward packets to discovery scan engine if active
 				if let engine = discoveryScanEngine, engine.isScanning {
 					engine.handleMeshPacket(packet, portNum: data.portnum)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -599,6 +599,29 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	// Fully tears down a connection and sets up the AccessoryManager for the next.
 	// If you are calling this in response to an error, then you should have
 	// exposed the error to the UI or handled the error prior to calling this.
+	/// Clears every cached remote-admin authorization before the next transport can be used.
+	/// Session passkeys are scoped to the local transport session; retaining one across a
+	/// disconnect would let a reconnect reuse authorization established by the previous link.
+	@discardableResult
+	func invalidateRemoteAdminSessions() -> Int {
+		do {
+			let nodes = try context.fetch(FetchDescriptor<NodeInfoEntity>())
+			var invalidated = 0
+			for node in nodes where node.sessionPasskey != nil || node.sessionExpiration != nil {
+				node.sessionPasskey = nil
+				node.sessionExpiration = nil
+				invalidated += 1
+			}
+			if invalidated > 0 {
+				try context.save()
+			}
+			return invalidated
+		} catch {
+			Logger.data.error("💥 [AccessoryManager] Failed to clear remote admin sessions: \(error.localizedDescription, privacy: .public)")
+			return 0
+		}
+	}
+
 	func closeConnection() async throws {
 		failRemoteAdminConfigOperations(with: "The radio connection was closed before the remote node confirmed the configuration.")
 		guard !isClosingConnection else {
@@ -618,6 +641,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 		self.activeDeviceNum = nil
 		self.firmwareUpdateRequired = false
+		// A remote-admin session is authorized by the local transport that established it.
+		// Clear all cached passkeys before a replacement/reconnect can observe them as fresh.
+		invalidateRemoteAdminSessions()
 		if let refresh = activeAutomaticConfigRefresh {
 			automaticConfigRefreshTask?.cancel()
 			await finishAutomaticConfigRefresh(owner: refresh.owner, error: CancellationError())

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1261,9 +1261,10 @@ actor MeshPackets {
 					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				}
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getRingtoneResponse(adminMessage.getRingtoneResponse) {
-				if let rt = try? RTTTLConfig(serializedBytes: packet.decoded.payload) {
-					self.upsertRtttlConfigPacket(ringtone: rt.ringtone, nodeNum: Int64(packet.from))
-				}
+				self.upsertRtttlConfigPacket(
+					ringtone: adminMessage.getRingtoneResponse,
+					nodeNum: Int64(packet.from),
+					sessionPasskey: adminMessage.sessionPasskey)
 			} else {
 				Logger.admin.error("🕸️ MESH PACKET received Admin App UNHANDLED \((try? packet.decoded.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
 			}

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1234,31 +1234,31 @@ actor MeshPackets {
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getModuleConfigResponse(adminMessage.getModuleConfigResponse) {
 				let moduleConfig = adminMessage.getModuleConfigResponse
 				if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.ambientLighting(moduleConfig.ambientLighting) {
-					self.upsertAmbientLightingModuleConfigPacket(config: moduleConfig.ambientLighting, nodeNum: Int64(packet.from))
+					self.upsertAmbientLightingModuleConfigPacket(config: moduleConfig.ambientLighting, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.audio(moduleConfig.audio) {
-					self.upsertAudioModuleConfigPacket(config: moduleConfig.audio, nodeNum: Int64(packet.from))
+					self.upsertAudioModuleConfigPacket(config: moduleConfig.audio, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.cannedMessage(moduleConfig.cannedMessage) {
-					self.upsertCannedMessagesModuleConfigPacket(config: moduleConfig.cannedMessage, nodeNum: Int64(packet.from))
+					self.upsertCannedMessagesModuleConfigPacket(config: moduleConfig.cannedMessage, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.detectionSensor(moduleConfig.detectionSensor) {
-					self.upsertDetectionSensorModuleConfigPacket(config: moduleConfig.detectionSensor, nodeNum: Int64(packet.from))
+					self.upsertDetectionSensorModuleConfigPacket(config: moduleConfig.detectionSensor, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.externalNotification(moduleConfig.externalNotification) {
-					self.upsertExternalNotificationModuleConfigPacket(config: moduleConfig.externalNotification, nodeNum: Int64(packet.from))
+					self.upsertExternalNotificationModuleConfigPacket(config: moduleConfig.externalNotification, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.mqtt(moduleConfig.mqtt) {
-					self.upsertMqttModuleConfigPacket(config: moduleConfig.mqtt, nodeNum: Int64(packet.from))
+					self.upsertMqttModuleConfigPacket(config: moduleConfig.mqtt, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.rangeTest(moduleConfig.rangeTest) {
-					self.upsertRangeTestModuleConfigPacket(config: moduleConfig.rangeTest, nodeNum: Int64(packet.from))
+					self.upsertRangeTestModuleConfigPacket(config: moduleConfig.rangeTest, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.serial(moduleConfig.serial) {
-					self.upsertSerialModuleConfigPacket(config: moduleConfig.serial, nodeNum: Int64(packet.from))
+					self.upsertSerialModuleConfigPacket(config: moduleConfig.serial, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.storeForward(moduleConfig.storeForward) {
-					self.upsertStoreForwardModuleConfigPacket(config: moduleConfig.storeForward, nodeNum: Int64(packet.from))
+					self.upsertStoreForwardModuleConfigPacket(config: moduleConfig.storeForward, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.telemetry(moduleConfig.telemetry) {
-					self.upsertTelemetryModuleConfigPacket(config: moduleConfig.telemetry, nodeNum: Int64(packet.from))
+					self.upsertTelemetryModuleConfigPacket(config: moduleConfig.telemetry, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.tak(moduleConfig.tak) {
-					self.upsertTAKModuleConfigPacket(config: moduleConfig.tak, nodeNum: Int64(packet.from))
+					self.upsertTAKModuleConfigPacket(config: moduleConfig.tak, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.statusmessage(moduleConfig.statusmessage) {
-					self.upsertStatusMessageModuleConfigPacket(config: moduleConfig.statusmessage, nodeNum: Int64(packet.from))
+					self.upsertStatusMessageModuleConfigPacket(config: moduleConfig.statusmessage, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.trafficManagement(moduleConfig.trafficManagement) {
-					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from))
+					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				}
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getRingtoneResponse(adminMessage.getRingtoneResponse) {
 				if let rt = try? RTTTLConfig(serializedBytes: packet.decoded.payload) {

--- a/Meshtastic/Model/NodeInfoEntity.swift
+++ b/Meshtastic/Model/NodeInfoEntity.swift
@@ -180,7 +180,7 @@ extension NodeInfoEntity {
 	/// session passkey inside the firmware's 5-minute session window. Empty-passkey stamps
 	/// (from the local config download and post-save mirrors) don't count.
 	var hasLiveAdminSession: Bool {
-		sessionPasskey?.isEmpty == false && (sessionExpiration ?? .distantPast) >= Date()
+		RemoteAdminSessionFreshness.isFresh(passkey: sessionPasskey, expiration: sessionExpiration)
 	}
 
 	/// Whether this node's own reported firmware supports the Status Message module (2.8+,

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -771,7 +771,7 @@ extension MeshPackets {
 		savePendingChanges()
 	}
 
-	func upsertBluetoothConfigPacket(config: Config.BluetoothConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertBluetoothConfigPacket(config: Config.BluetoothConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Bluetooth config received: %@".localized, String(nodeNum))
 		Logger.admin.info("📶 \(logString, privacy: .public)")
@@ -795,7 +795,7 @@ extension MeshPackets {
 					fetchedNode[0].bluetoothConfig?.mode = Int32(config.mode.rawValue)
 					fetchedNode[0].bluetoothConfig?.fixedPin = Int32(truncatingIfNeeded: config.fixedPin)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -810,7 +810,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertDeviceConfigPacket(config: Config.DeviceConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDeviceConfigPacket(config: Config.DeviceConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Device config received: %@".localized, String(nodeNum))
 		Logger.admin.info("📟 \(logString, privacy: .public)")
@@ -847,7 +847,7 @@ extension MeshPackets {
 					fetchedNode[0].deviceConfig?.isManaged = config.isManaged
 					fetchedNode[0].deviceConfig?.tzdef = config.tzdef
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -860,7 +860,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertDisplayConfigPacket(config: Config.DisplayConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDisplayConfigPacket(config: Config.DisplayConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Display config received: %@".localized, nodeNum.toHex())
 		Logger.data.info("🖥️ \(logString, privacy: .public)")
@@ -900,7 +900,7 @@ extension MeshPackets {
 					fetchedNode[0].displayConfig?.headingBold = config.headingBold
 					fetchedNode[0].displayConfig?.use12HClock = config.use12HClock
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -916,7 +916,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertLoRaConfigPacket(config: Config.LoRaConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertLoRaConfigPacket(config: Config.LoRaConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("LoRa config received: %@".localized, nodeNum.toHex())
 		Logger.data.info("📻 \(logString, privacy: .public)")
@@ -968,7 +968,7 @@ extension MeshPackets {
 					fetchedNode[0].loRaConfig?.okToMqtt = config.configOkToMqtt
 					fetchedNode[0].loRaConfig?.sx126xRxBoostedGain = config.sx126XRxBoostedGain
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -983,7 +983,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertNetworkConfigPacket(config: Config.NetworkConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertNetworkConfigPacket(config: Config.NetworkConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Network config received: %@".localized, String(nodeNum))
 		Logger.data.info("🌐 \(logString, privacy: .public)")
@@ -1025,7 +1025,7 @@ extension MeshPackets {
 					fetchedNode[0].networkConfig?.subnet = Int32(bitPattern: config.ipv4Config.subnet)
 					fetchedNode[0].networkConfig?.dns = Int32(bitPattern: config.ipv4Config.dns)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1040,7 +1040,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertPositionConfigPacket(config: Config.PositionConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPositionConfigPacket(config: Config.PositionConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Position config received: %@".localized, String(nodeNum))
 		Logger.data.info("🗺️ \(logString, privacy: .public)")
@@ -1084,7 +1084,7 @@ extension MeshPackets {
 					fetchedNode[0].positionConfig?.gpsUpdateInterval = Int32(truncatingIfNeeded: config.gpsUpdateInterval)
 					fetchedNode[0].positionConfig?.positionFlags = Int32(truncatingIfNeeded: config.positionFlags)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1099,7 +1099,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertPowerConfigPacket(config: Config.PowerConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPowerConfigPacket(config: Config.PowerConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		let logString = String.localizedStringWithFormat("Power config received: %@".localized, String(nodeNum))
 		Logger.data.info("🗺️ \(logString, privacy: .public)")
 		
@@ -1130,7 +1130,7 @@ extension MeshPackets {
 					fetchedNode[0].powerConfig?.onBatteryShutdownAfterSecs = Int32(truncatingIfNeeded: config.onBatteryShutdownAfterSecs)
 					fetchedNode[0].powerConfig?.waitBluetoothSecs = Int32(truncatingIfNeeded: config.waitBluetoothSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1155,7 +1155,7 @@ extension MeshPackets {
 		entity.adminKey3 = adminKeys.count > 2 ? adminKeys[2] : nil
 	}
 
-	func upsertSecurityConfigPacket(config: Config.SecurityConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertSecurityConfigPacket(config: Config.SecurityConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Security config received: @".localized, String(nodeNum))
 		Logger.data.info("🛡️ \(logString, privacy: .public)")
@@ -1189,7 +1189,7 @@ extension MeshPackets {
 					securityConfig.adminChannelEnabled = config.adminChannelEnabled
 					securityConfig.packetSignaturePolicy = Int32(config.packetSignaturePolicy.rawValue)
 				}
-				if sessionPasskey?.count != 0 {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1204,7 +1204,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertAudioModuleConfigPacket(config: ModuleConfig.AudioConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertAudioModuleConfigPacket(config: ModuleConfig.AudioConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Audio module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🔊 \(logString, privacy: .public)")
@@ -1235,7 +1235,7 @@ extension MeshPackets {
 					fetchedNode[0].audioConfig?.i2sDin = Int32(truncatingIfNeeded: config.i2SDin)
 					fetchedNode[0].audioConfig?.i2sSck = Int32(truncatingIfNeeded: config.i2SSck)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1250,7 +1250,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertAmbientLightingModuleConfigPacket(config: ModuleConfig.AmbientLightingConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertAmbientLightingModuleConfigPacket(config: ModuleConfig.AmbientLightingConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Ambient Lighting module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🏮 \(logString, privacy: .public)")
@@ -1285,7 +1285,7 @@ extension MeshPackets {
 					fetchedNode[0].ambientLightingConfig?.green = Int32(truncatingIfNeeded: config.green)
 					fetchedNode[0].ambientLightingConfig?.blue = Int32(truncatingIfNeeded: config.blue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1300,7 +1300,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertCannedMessagesModuleConfigPacket(config: ModuleConfig.CannedMessageConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertCannedMessagesModuleConfigPacket(config: ModuleConfig.CannedMessageConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Canned Message module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🥫 \(logString, privacy: .public)")
@@ -1340,7 +1340,7 @@ extension MeshPackets {
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventCcw = Int32(config.inputbrokerEventCcw.rawValue)
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventPress = Int32(config.inputbrokerEventPress.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1355,7 +1355,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertDetectionSensorModuleConfigPacket(config: ModuleConfig.DetectionSensorConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDetectionSensorModuleConfigPacket(config: ModuleConfig.DetectionSensorConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Detection Sensor module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🕵️ \(logString, privacy: .public)")
@@ -1389,7 +1389,7 @@ extension MeshPackets {
 					fetchedNode[0].detectionSensorConfig?.minimumBroadcastSecs = Int32(truncatingIfNeeded: config.minimumBroadcastSecs)
 					fetchedNode[0].detectionSensorConfig?.stateBroadcastSecs = Int32(truncatingIfNeeded: config.stateBroadcastSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1406,7 +1406,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertMeshBeaconModuleConfigPacket(config: ModuleConfig.MeshBeaconConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertMeshBeaconModuleConfigPacket(config: ModuleConfig.MeshBeaconConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Mesh Beacon module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📡 \(logString, privacy: .public)")
@@ -1448,7 +1448,7 @@ extension MeshPackets {
 					return newTarget
 				}
 
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1465,7 +1465,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertExternalNotificationModuleConfigPacket(config: ModuleConfig.ExternalNotificationConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertExternalNotificationModuleConfigPacket(config: ModuleConfig.ExternalNotificationConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("External Notification module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📣 \(logString, privacy: .public)")
@@ -1514,7 +1514,7 @@ extension MeshPackets {
 					fetchedNode[0].externalNotificationConfig?.nagTimeout = Int32(truncatingIfNeeded: config.nagTimeout)
 					fetchedNode[0].externalNotificationConfig?.useI2SAsBuzzer = config.useI2SAsBuzzer
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1529,7 +1529,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertNeighborInfoModuleConfigPacket(config: ModuleConfig.NeighborInfoConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertNeighborInfoModuleConfigPacket(config: ModuleConfig.NeighborInfoConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Neighbor Info config received: %@".localized, String(nodeNum))
 		Logger.data.info("🏘️ \(logString, privacy: .public)")
@@ -1552,7 +1552,7 @@ extension MeshPackets {
 					fetchedNode[0].neighborInfoConfig?.updateInterval = Int32(truncatingIfNeeded: config.updateInterval)
 					fetchedNode[0].neighborInfoConfig?.transmitOverLora = config.transmitOverLora
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1567,7 +1567,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertPaxCounterModuleConfigPacket(config: ModuleConfig.PaxcounterConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPaxCounterModuleConfigPacket(config: ModuleConfig.PaxcounterConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("PAX Counter config received: %@".localized, String(nodeNum))
 		Logger.data.info("🧑‍🤝‍🧑 \(logString, privacy: .public)")
@@ -1593,7 +1593,7 @@ extension MeshPackets {
 					fetchedNode[0].paxCounterConfig?.wifiThreshold = config.wifiThreshold
 					fetchedNode[0].paxCounterConfig?.bleThreshold = config.bleThreshold
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1608,7 +1608,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertRtttlConfigPacket(ringtone: String, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertRtttlConfigPacket(ringtone: String, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("RTTTL Ringtone config received: %@".localized, String(nodeNum))
 		Logger.data.info("⛰️ \(logString, privacy: .public)")
@@ -1628,7 +1628,7 @@ extension MeshPackets {
 				} else {
 					fetchedNode[0].rtttlConfig?.ringtone = ringtone
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1643,7 +1643,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertMqttModuleConfigPacket(config: ModuleConfig.MQTTConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertMqttModuleConfigPacket(config: ModuleConfig.MQTTConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("MQTT module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🌉 \(logString, privacy: .public)")
@@ -1687,7 +1687,7 @@ extension MeshPackets {
 					fetchedNode[0].mqttConfig?.mapPositionPrecision = Int32(truncatingIfNeeded: config.mapReportSettings.positionPrecision)
 					fetchedNode[0].mqttConfig?.mapPublishIntervalSecs = Int32(truncatingIfNeeded: config.mapReportSettings.publishIntervalSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1702,7 +1702,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertRangeTestModuleConfigPacket(config: ModuleConfig.RangeTestConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertRangeTestModuleConfigPacket(config: ModuleConfig.RangeTestConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Range Test module config received: %@".localized, String(nodeNum))
 		Logger.data.info("⛰️ \(logString, privacy: .public)")
@@ -1726,7 +1726,7 @@ extension MeshPackets {
 					fetchedNode[0].rangeTestConfig?.enabled = config.enabled
 					fetchedNode[0].rangeTestConfig?.save = config.save
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1741,7 +1741,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertSerialModuleConfigPacket(config: ModuleConfig.SerialConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertSerialModuleConfigPacket(config: ModuleConfig.SerialConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Serial module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🤖 \(logString, privacy: .public)")
@@ -1773,7 +1773,7 @@ extension MeshPackets {
 					fetchedNode[0].serialConfig?.timeout = Int32(truncatingIfNeeded: config.timeout)
 					fetchedNode[0].serialConfig?.mode = Int32(config.mode.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1789,7 +1789,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertStatusMessageModuleConfigPacket(config: ModuleConfig.StatusMessageConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertStatusMessageModuleConfigPacket(config: ModuleConfig.StatusMessageConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Status Message module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📬 \(logString, privacy: .public)")
@@ -1812,7 +1812,7 @@ extension MeshPackets {
 				// status too — displays prefer the live field and would otherwise show the
 				// old status until the next broadcast arrives.
 				fetchedNode[0].nodeStatus = config.nodeStatus.isEmpty ? nil : config.nodeStatus
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1858,7 +1858,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertStoreForwardModuleConfigPacket(config: ModuleConfig.StoreForwardConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertStoreForwardModuleConfigPacket(config: ModuleConfig.StoreForwardConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Store & Forward module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📬 \(logString, privacy: .public)")
@@ -1890,7 +1890,7 @@ extension MeshPackets {
 					// reflected after the first sync and the device-profile export keeps writing the old value.
 					fetchedNode[0].storeForwardConfig?.isRouter = config.isServer
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1905,7 +1905,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTelemetryModuleConfigPacket(config: ModuleConfig.TelemetryConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTelemetryModuleConfigPacket(config: ModuleConfig.TelemetryConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Telemetry module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📈 \(logString, privacy: .public)")
@@ -1945,7 +1945,7 @@ extension MeshPackets {
 					fetchedNode[0].telemetryConfig?.powerUpdateInterval = Int32(truncatingIfNeeded: config.powerUpdateInterval)
 					fetchedNode[0].telemetryConfig?.powerScreenEnabled = config.powerScreenEnabled
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1962,7 +1962,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTAKModuleConfigPacket(config: ModuleConfig.TAKConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTAKModuleConfigPacket(config: ModuleConfig.TAKConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("TAK module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🎯 \(logString, privacy: .public)")
@@ -1983,7 +1983,7 @@ extension MeshPackets {
 					fetchedNode[0].takConfig?.team = Int32(config.team.rawValue)
 					fetchedNode[0].takConfig?.role = Int32(config.role.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1998,7 +1998,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTrafficManagementModuleConfigPacket(config: ModuleConfig.TrafficManagementConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTrafficManagementModuleConfigPacket(config: ModuleConfig.TrafficManagementConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Traffic Management module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🚦 \(logString, privacy: .public)")
@@ -2037,7 +2037,7 @@ extension MeshPackets {
 				entity.rateLimitMaxPackets = Int32(truncatingIfNeeded: config.rateLimitMaxPackets)
 				entity.dropUnknownEnabled = dropUnknown
 				entity.unknownPacketThreshold = Int32(truncatingIfNeeded: config.unknownPacketThreshold)
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -62,6 +62,10 @@ class Router: ObservableObject {
 	/// The currently selected node in the NavigationSplitView detail pane.
 	@Published var selectedNodeNum: Int64?
 
+	/// One-shot request consumed by Settings after a remote-admin entry point selects a node.
+	/// It remains pending while the Settings tab is lazy or its node snapshot is still loading.
+	@Published var settingsNodeNum: Int64?
+
 	// MARK: Node Object ID Cache
 
 	/// In-memory cache mapping node numbers to their SwiftData `PersistentIdentifier` for O(1) lookups.
@@ -189,6 +193,13 @@ class Router: ObservableObject {
 		Logger.services.info("🛣 [App] Direct route to node detail \(nodeNum, privacy: .public)")
 		selectedTab = .nodes
 		selectedNodeNum = nodeNum
+	}
+
+	func navigateToSettings(nodeNum: Int64) {
+		Logger.services.info("🛣 [App] Direct route to settings for node \(nodeNum, privacy: .public)")
+		settingsNodeNum = nodeNum
+		settingsPath = []
+		selectedTab = .settings
 	}
 
 	func popToRoot(tab: NavigationState.Tab) {

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -62,10 +62,6 @@ class Router: ObservableObject {
 	/// The currently selected node in the NavigationSplitView detail pane.
 	@Published var selectedNodeNum: Int64?
 
-	/// One-shot request consumed by Settings after a remote-admin entry point selects a node.
-	/// It remains pending while the Settings tab is lazy or its node snapshot is still loading.
-	@Published var settingsNodeNum: Int64?
-
 	// MARK: Node Object ID Cache
 
 	/// In-memory cache mapping node numbers to their SwiftData `PersistentIdentifier` for O(1) lookups.
@@ -193,13 +189,6 @@ class Router: ObservableObject {
 		Logger.services.info("🛣 [App] Direct route to node detail \(nodeNum, privacy: .public)")
 		selectedTab = .nodes
 		selectedNodeNum = nodeNum
-	}
-
-	func navigateToSettings(nodeNum: Int64) {
-		Logger.services.info("🛣 [App] Direct route to settings for node \(nodeNum, privacy: .public)")
-		settingsNodeNum = nodeNum
-		settingsPath = []
-		selectedTab = .settings
 	}
 
 	func popToRoot(tab: NavigationState.Tab) {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -68,6 +68,8 @@ struct NodeDetail: View {
 	@State private var latestPowerMetrics: TelemetryEntity?
 	@State private var logAvailability = NodeDetailLogAvailability()
 	@State private var showingShareContactQR = false
+	@State private var remoteAdminState: RemoteAdminSessionState = .stale
+	@State private var remoteAdminAttemptID: UUID?
 
 	init(node: NodeInfoEntity, nodeNum: Int64, showMapLink: Bool = true) {
 		self.node = node
@@ -166,11 +168,29 @@ struct NodeDetail: View {
 						.onChange(of: node.lastHeard) {
 							refreshNodeSummary()
 						}
+						.onChange(of: accessoryManager.activeDeviceNum) { _, _ in
+							remoteAdminAttemptID = nil
+							if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
+							if !accessoryManager.isConnected {
+								remoteAdminState = .stale
+							}
+						}
+						.onChange(of: accessoryManager.isConnected) { _, connected in
+							if !connected {
+								remoteAdminAttemptID = nil
+								if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
+								remoteAdminState = .stale
+							}
+						}
 						.onReceive(NotificationCenter.default.publisher(for: .nodeLogAvailabilityDidChange)) { notification in
 							guard notification.object as? Int64 == nodeNum else { return }
 							refreshNodeSummary()
 						}
 						.contentMargins(.top, 0, for: .scrollContent)
+						.task(id: remoteAdminAttemptID) {
+							guard remoteAdminAttemptID != nil else { return }
+							await establishRemoteAdminSession()
+						}
 					.navigationTitle(String((currentUser?.displayLongName ?? "Unknown".localized).addingVariationSelectors))
 					.navigationBarTitleDisplayMode(.inline)
 					.id(displayNameRefresh)
@@ -906,11 +926,13 @@ struct NodeDetail: View {
 
 	@ViewBuilder
 	private var administrationSection: some View {
-		if let metadata = node.metadata,
-		   connectedNode != nil,
-		   accessoryManager.isConnected {
+		if connectedNode != nil, accessoryManager.isConnected {
 			Section("Administration") {
 				let administrationUserPair = self.administrationUserPair
+				if nodeNum != accessoryManager.activeDeviceNum {
+					remoteAdminEntry(administrationUserPair: administrationUserPair)
+				}
+				if let metadata = node.metadata {
 				if UserDefaults.enableAdministration {
 					Button {
 						Task {
@@ -985,8 +1007,118 @@ struct NodeDetail: View {
 					}
 				}
 				.disabled(administrationUserPair == nil)
+				}
 			}
 		}
+	}
+
+	@ViewBuilder
+	private func remoteAdminEntry(administrationUserPair: (fromUser: UserEntity, toUser: UserEntity)?) -> some View {
+		let targetName = currentUser?.displayLongName ?? "Unknown".localized
+		switch remoteAdminState {
+		case .establishing:
+			HStack {
+				ProgressView()
+				Text("Establishing remote admin for \(targetName)")
+			}
+		case .active:
+			Button {
+				remoteAdminState = .establishing
+				remoteAdminAttemptID = UUID()
+			} label: {
+				Label("Remote Admin: \(targetName)", systemImage: "checkmark.shield")
+			}
+		case .failed(let result):
+			VStack(alignment: .leading) {
+				Button {
+					remoteAdminState = .establishing
+					remoteAdminAttemptID = UUID()
+				} label: {
+					Label("Retry Remote Admin for \(targetName)", systemImage: "arrow.clockwise")
+				}
+				Text("Remote admin failed: \(RemoteAdminSessionWaiter.description(for: result)).")
+					.font(.caption)
+					.foregroundStyle(.orange)
+			}
+			.disabled(administrationUserPair == nil || !UserDefaults.enableAdministration)
+		case .stale:
+			VStack(alignment: .leading) {
+				Button {
+					remoteAdminState = .establishing
+					remoteAdminAttemptID = UUID()
+				} label: {
+					Label("Remote Admin: \(targetName)", systemImage: "shield")
+				}
+				if !UserDefaults.enableAdministration {
+					Text("Enable Administration in App Settings to use remote admin.")
+						.font(.caption)
+						.foregroundStyle(.orange)
+				}
+			}
+			.disabled(administrationUserPair == nil || !UserDefaults.enableAdministration)
+		}
+	}
+
+	@MainActor
+	private func establishRemoteAdminSession() async {
+		guard let attemptID = remoteAdminAttemptID,
+			let radioNum = accessoryManager.activeDeviceNum,
+			nodeNum != radioNum else {
+			remoteAdminState = .failed(.targetChanged)
+			return
+		}
+		guard UserDefaults.enableAdministration else {
+			remoteAdminState = .failed(.requestFailed)
+			return
+		}
+		guard let administrationUserPair else {
+			remoteAdminState = .failed(.disconnected)
+			return
+		}
+		let result = await RemoteAdminSessionOrchestrator.establish(
+			allowed: { UserDefaults.enableAdministration && accessoryManager.isConnected },
+			attemptIsCurrent: { [weak accessoryManager, weak node, weak router] in
+				accessoryManager?.activeDeviceNum == radioNum
+					&& node?.modelContext != nil && node?.isDeleted == false
+					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
+					&& self.remoteAdminAttemptID == attemptID
+			},
+			fresh: { [weak node] in node?.hasLiveAdminSession == true },
+			request: {
+				_ = try await accessoryManager.requestDeviceMetadata(
+					fromUser: administrationUserPair.fromUser,
+					toUser: administrationUserPair.toUser
+				)
+			},
+			wait: {
+				await RemoteAdminSessionWaiter.wait(
+					isLive: { [weak node] in node?.hasLiveAdminSession == true },
+					isConnected: { [weak accessoryManager] in
+						accessoryManager?.isConnected == true
+						&& accessoryManager?.activeDeviceNum == radioNum
+						&& self.remoteAdminAttemptID == attemptID
+					},
+					targetIsCurrent: { [weak node, weak router] in
+						node?.modelContext != nil && node?.isDeleted == false
+						&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
+					}
+				)
+			}
+		)
+		guard result == .active else {
+			remoteAdminState = .failed(result)
+			return
+		}
+		guard UserDefaults.enableAdministration,
+			accessoryManager.isConnected,
+			accessoryManager.activeDeviceNum == radioNum,
+			node.modelContext != nil, !node.isDeleted,
+			remoteAdminAttemptID == attemptID else {
+			remoteAdminState = .failed(.targetChanged)
+			return
+		}
+		remoteAdminState = .active
+		router.navigateToSettings(nodeNum: nodeNum)
 	}
 
 	private func refreshNodeSummary() {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -70,6 +70,7 @@ struct NodeDetail: View {
 	@State private var showingShareContactQR = false
 	@State private var remoteAdminState: RemoteAdminSessionState = .stale
 	@State private var remoteAdminAttemptID: UUID?
+	@State private var remoteSettingsDestination: RemoteAdminSettingsDestination?
 
 	init(node: NodeInfoEntity, nodeNum: Int64, showMapLink: Bool = true) {
 		self.node = node
@@ -169,16 +170,16 @@ struct NodeDetail: View {
 							refreshNodeSummary()
 						}
 						.onChange(of: accessoryManager.activeDeviceNum) { _, _ in
+							remoteSettingsDestination = nil
 							remoteAdminAttemptID = nil
-							if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
 							if !accessoryManager.isConnected {
 								remoteAdminState = .stale
 							}
 						}
 						.onChange(of: accessoryManager.isConnected) { _, connected in
 							if !connected {
+								remoteSettingsDestination = nil
 								remoteAdminAttemptID = nil
-								if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
 								remoteAdminState = .stale
 							}
 						}
@@ -191,6 +192,27 @@ struct NodeDetail: View {
 							guard remoteAdminAttemptID != nil else { return }
 							await establishRemoteAdminSession()
 						}
+					.onChange(of: accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) }) { _, connectionID in
+						if let destination = remoteSettingsDestination, destination.connectionID != connectionID {
+							remoteSettingsDestination = nil
+						}
+					}
+					.navigationDestination(isPresented: Binding(
+						get: { remoteSettingsDestination != nil },
+						set: { if !$0 { remoteSettingsDestination = nil } }
+					)) {
+						if let destination = remoteSettingsDestination {
+							Settings(remoteNodeNum: destination.nodeNum)
+								.disabled(!destination.isCurrent(
+									radioNum: accessoryManager.activeDeviceNum,
+									connectionID: accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) },
+									isConnected: accessoryManager.isConnected))
+						}
+					}
+					.onChange(of: nodeNum) { _, _ in
+						remoteSettingsDestination = nil
+						remoteAdminAttemptID = nil
+					}
 					.navigationTitle(String((currentUser?.displayLongName ?? "Unknown".localized).addingVariationSelectors))
 					.navigationBarTitleDisplayMode(.inline)
 					.id(displayNameRefresh)
@@ -1027,6 +1049,7 @@ struct NodeDetail: View {
 				remoteAdminAttemptID = UUID()
 			} label: {
 				Label("Remote Admin: \(targetName)", systemImage: "checkmark.shield")
+					.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 			}
 		case .failed(let result):
 			VStack(alignment: .leading) {
@@ -1035,6 +1058,7 @@ struct NodeDetail: View {
 					remoteAdminAttemptID = UUID()
 				} label: {
 					Label("Retry Remote Admin for \(targetName)", systemImage: "arrow.clockwise")
+						.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 				}
 				Text("Remote admin failed: \(RemoteAdminSessionWaiter.description(for: result)).")
 					.font(.caption)
@@ -1048,6 +1072,7 @@ struct NodeDetail: View {
 					remoteAdminAttemptID = UUID()
 				} label: {
 					Label("Remote Admin: \(targetName)", systemImage: "shield")
+						.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 				}
 				if !UserDefaults.enableAdministration {
 					Text("Enable Administration in App Settings to use remote admin.")
@@ -1086,7 +1111,8 @@ struct NodeDetail: View {
 					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
 					&& self.remoteAdminAttemptID == attemptID
 			},
-			fresh: { [weak node] in node?.hasLiveAdminSession == true },
+			// Fetch to refresh the retained main-context node after the packet actor saves a session.
+			fresh: { getNodeInfo(id: nodeNum, context: context)?.hasLiveAdminSession == true },
 			request: {
 				_ = try await accessoryManager.requestDeviceMetadata(
 					fromUser: administrationUserPair.fromUser,
@@ -1095,7 +1121,7 @@ struct NodeDetail: View {
 			},
 			wait: {
 				await RemoteAdminSessionWaiter.wait(
-					isLive: { [weak node] in node?.hasLiveAdminSession == true },
+					isLive: { getNodeInfo(id: nodeNum, context: context)?.hasLiveAdminSession == true },
 					isConnected: { [weak accessoryManager] in
 						accessoryManager?.isConnected == true
 						&& accessoryManager?.activeDeviceNum == radioNum
@@ -1123,7 +1149,7 @@ struct NodeDetail: View {
 			return
 		}
 		remoteAdminState = .active
-		router.navigateToSettings(nodeNum: nodeNum)
+		remoteSettingsDestination = RemoteAdminSettingsDestination(nodeNum: nodeNum, radioNum: radioNum, connectionID: connectionID)
 	}
 
 	private func refreshNodeSummary() {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -42,6 +42,7 @@ struct NodeDetail: View {
 		.accessibilityElement(children: .combine)
 	}
 	private let gridItemLayout = Array(repeating: GridItem(.flexible(), spacing: 10), count: 2)
+	private let nodeDetailScrollContentTopMargin: CGFloat = 0
 	private static let relativeFormatter: RelativeDateTimeFormatter = {
 		let formatter = RelativeDateTimeFormatter()
 		formatter.unitsStyle = .full
@@ -187,7 +188,7 @@ struct NodeDetail: View {
 							guard notification.object as? Int64 == nodeNum else { return }
 							refreshNodeSummary()
 						}
-						.contentMargins(.top, 0, for: .scrollContent)
+						.contentMargins(.top, nodeDetailScrollContentTopMargin, for: .scrollContent)
 						.task(id: remoteAdminAttemptID) {
 							guard remoteAdminAttemptID != nil else { return }
 							await establishRemoteAdminSession()

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1063,6 +1063,7 @@ struct NodeDetail: View {
 	private func establishRemoteAdminSession() async {
 		guard let attemptID = remoteAdminAttemptID,
 			let radioNum = accessoryManager.activeDeviceNum,
+			let connection = accessoryManager.activeConnection?.connection,
 			nodeNum != radioNum else {
 			remoteAdminState = .failed(.targetChanged)
 			return
@@ -1075,10 +1076,12 @@ struct NodeDetail: View {
 			remoteAdminState = .failed(.disconnected)
 			return
 		}
+		let connectionID = ObjectIdentifier(connection)
 		let result = await RemoteAdminSessionOrchestrator.establish(
 			allowed: { UserDefaults.enableAdministration && accessoryManager.isConnected },
 			attemptIsCurrent: { [weak accessoryManager, weak node, weak router] in
 				accessoryManager?.activeDeviceNum == radioNum
+					&& accessoryManager?.activeConnection.map { ObjectIdentifier($0.connection) } == connectionID
 					&& node?.modelContext != nil && node?.isDeleted == false
 					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
 					&& self.remoteAdminAttemptID == attemptID
@@ -1096,6 +1099,7 @@ struct NodeDetail: View {
 					isConnected: { [weak accessoryManager] in
 						accessoryManager?.isConnected == true
 						&& accessoryManager?.activeDeviceNum == radioNum
+						&& accessoryManager?.activeConnection.map { ObjectIdentifier($0.connection) } == connectionID
 						&& self.remoteAdminAttemptID == attemptID
 					},
 					targetIsCurrent: { [weak node, weak router] in
@@ -1112,6 +1116,7 @@ struct NodeDetail: View {
 		guard UserDefaults.enableAdministration,
 			accessoryManager.isConnected,
 			accessoryManager.activeDeviceNum == radioNum,
+			accessoryManager.activeConnection.map({ ObjectIdentifier($0.connection) }) == connectionID,
 			node.modelContext != nil, !node.isDeleted,
 			remoteAdminAttemptID == attemptID else {
 			remoteAdminState = .failed(.targetChanged)

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1093,6 +1093,11 @@ struct NodeDetail: View {
 			remoteAdminState = .failed(.targetChanged)
 			return
 		}
+		defer {
+			if remoteAdminAttemptID == attemptID {
+				remoteAdminAttemptID = nil
+			}
+		}
 		guard UserDefaults.enableAdministration else {
 			remoteAdminState = .failed(.requestFailed)
 			return

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+enum RemoteAdminSessionState: Equatable {
+	case stale
+	case establishing
+	case active
+	case failed(RemoteAdminSessionWaiter.Result)
+}
+
+enum RemoteAdminSessionFreshness {
+	static func isFresh(passkey: Data?, expiration: Date?, now: Date = Date()) -> Bool {
+		guard let passkey, !passkey.isEmpty, let expiration else { return false }
+		return expiration >= now
+	}
+}
+
+enum RemoteAdminSessionWaiter {
+	enum Result: Equatable {
+		case active
+		case timedOut
+		case disconnected
+		case targetChanged
+		case cancelled
+		case requestFailed
+	}
+
+	static func description(for result: Result) -> String {
+		switch result {
+		case .active: return "active"
+		case .timedOut: return "timed out"
+		case .disconnected: return "disconnected"
+		case .targetChanged: return "target changed"
+		case .cancelled: return "cancelled"
+		case .requestFailed: return "request failed"
+		}
+	}
+
+	@MainActor static func wait(
+		timeout: Duration = .seconds(30),
+		pollInterval: Duration = .milliseconds(200),
+		isLive: @escaping @MainActor () -> Bool,
+		isConnected: @escaping @MainActor () -> Bool,
+		targetIsCurrent: @escaping @MainActor () -> Bool,
+		sleep: @escaping @MainActor (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+	) async -> Result {
+		var elapsed = Duration.zero
+		while true {
+			if Task.isCancelled { return .cancelled }
+			if !isConnected() { return .disconnected }
+			if !targetIsCurrent() { return .targetChanged }
+			if isLive() { return .active }
+			if elapsed >= timeout { return .timedOut }
+			do {
+				let delay = min(pollInterval, timeout - elapsed)
+				try await sleep(delay)
+				elapsed += delay
+			} catch {
+				return .cancelled
+			}
+		}
+	}
+}
+
+enum RemoteAdminSessionOrchestrator {
+	@MainActor
+	static func establish(
+		allowed: @escaping @MainActor () -> Bool,
+		attemptIsCurrent: @escaping @MainActor () -> Bool,
+		fresh: @escaping @MainActor () -> Bool,
+		request: @escaping @MainActor () async throws -> Void,
+		wait: @escaping @MainActor () async -> RemoteAdminSessionWaiter.Result
+	) async -> RemoteAdminSessionWaiter.Result {
+		guard allowed() else { return .requestFailed }
+		guard !fresh() else { return .active }
+		guard attemptIsCurrent() else { return .targetChanged }
+		do {
+			try await request()
+		} catch is CancellationError {
+			return .cancelled
+		} catch {
+			return .requestFailed
+		}
+		guard attemptIsCurrent() else { return .targetChanged }
+		let result = await wait()
+		guard result == .active else { return result }
+		guard allowed() else { return .requestFailed }
+		guard attemptIsCurrent() else { return .targetChanged }
+		return .active
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -1,4 +1,13 @@
+//
+//  RemoteAdminSession.swift
+//  Meshtastic
+//
+//  Coordinates remote administration session state and confirmation waits.
+//
+
 import Foundation
+
+// MARK: - Session State
 
 enum RemoteAdminSessionState: Equatable {
 	case stale
@@ -7,12 +16,16 @@ enum RemoteAdminSessionState: Equatable {
 	case failed(RemoteAdminSessionWaiter.Result)
 }
 
+// MARK: - Session Freshness
+
 enum RemoteAdminSessionFreshness {
 	static func isFresh(passkey: Data?, expiration: Date?, now: Date = Date()) -> Bool {
 		guard let passkey, !passkey.isEmpty, let expiration else { return false }
 		return expiration >= now
 	}
 }
+
+// MARK: - Session Waiter
 
 enum RemoteAdminSessionWaiter {
 	enum Result: Equatable {
@@ -62,6 +75,8 @@ enum RemoteAdminSessionWaiter {
 	}
 }
 
+// MARK: - Session Orchestration
+
 enum RemoteAdminSessionOrchestrator {
 	@MainActor
 	static func establish(
@@ -89,6 +104,8 @@ enum RemoteAdminSessionOrchestrator {
 		return .active
 	}
 }
+
+// MARK: - Settings Destination
 
 struct RemoteAdminSettingsDestination {
 	let nodeNum: Int64

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -43,6 +43,7 @@ enum RemoteAdminSessionWaiter {
 		targetIsCurrent: @escaping @MainActor () -> Bool,
 		sleep: @escaping @MainActor (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
 	) async -> Result {
+		guard pollInterval > .zero else { return .timedOut }
 		var elapsed = Duration.zero
 		while true {
 			if Task.isCancelled { return .cancelled }
@@ -86,5 +87,15 @@ enum RemoteAdminSessionOrchestrator {
 		guard allowed() else { return .requestFailed }
 		guard attemptIsCurrent() else { return .targetChanged }
 		return .active
+	}
+}
+
+struct RemoteAdminSettingsDestination {
+	let nodeNum: Int64
+	let radioNum: Int64
+	let connectionID: ObjectIdentifier
+
+	func isCurrent(radioNum: Int64?, connectionID: ObjectIdentifier?, isConnected: Bool) -> Bool {
+		isConnected && radioNum == self.radioNum && connectionID == self.connectionID
 	}
 }

--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -27,7 +27,17 @@ struct BluetoothConfig: View {
 	}()
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Bluetooth", config: \.bluetoothConfig, node: node, onAppear: setBluetoothValues)
+			ConfigHeader(title: "Bluetooth", config: \.bluetoothConfig, node: node, onAppear: setBluetoothValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.bluetoothConfig == nil },
+				section: "Bluetooth",
+				request: accessoryManager.requestBluetoothConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -101,6 +101,7 @@ struct BluetoothConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.bluetoothConfig == nil },
+				section: "Bluetooth",
 				request: accessoryManager.requestBluetoothConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -18,7 +18,7 @@ struct ConfigHeader<T>: View {
 		} else if node != nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			// Let users know what is going on if they are using remote admin and don't have the config yet
 			let expiration = node?.sessionExpiration ?? Date()
-			if node?[keyPath: config] == nil  || expiration < node?.sessionExpiration ?? Date() {
+			if node?[keyPath: config] == nil || expiration < Date() {
 				Text("\(title) config data was requested via PKC admin but no response has been returned from the remote node.")
 					.font(.callout)
 					.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -8,6 +8,7 @@ struct ConfigHeader<T>: View {
 	let config: KeyPath<NodeInfoEntity, T?>
 	let node: NodeInfoEntity?
 	let onAppear: () -> Void
+	var onRetry: (() -> Void)? = nil
 
 	var body: some View {
 		let request = node.flatMap { accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .request, section: title) }
@@ -19,8 +20,10 @@ struct ConfigHeader<T>: View {
 				Text(result == .timedOut ? "No response was received from the remote node." : "The configuration request failed.")
 					.font(.callout)
 					.foregroundColor(.red)
-				Button("Retry") { onAppear() }
-					.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+				if let onRetry {
+					Button("Retry", action: onRetry)
+						.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+				}
 			}
 		} else if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			Text("There has been no response to a request for device metadata via PKC admin for this node.")

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -10,7 +10,19 @@ struct ConfigHeader<T>: View {
 	let onAppear: () -> Void
 
 	var body: some View {
-		if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
+		let request = node.flatMap { accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .request, section: title) }
+		if let request, !request.isFinished {
+			ProgressView("Requesting \(title) configuration…")
+				.font(.callout)
+		} else if let request, let result = request.result, result != .succeeded {
+			VStack(spacing: 8) {
+				Text(result == .timedOut ? "No response was received from the remote node." : "The configuration request failed.")
+					.font(.callout)
+					.foregroundColor(.red)
+				Button("Retry") { onAppear() }
+					.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+			}
+		} else if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			Text("There has been no response to a request for device metadata via PKC admin for this node.")
 				.font(.callout)
 				.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -17,8 +17,7 @@ struct ConfigHeader<T>: View {
 
 		} else if node != nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			// Let users know what is going on if they are using remote admin and don't have the config yet
-			let expiration = node?.sessionExpiration ?? Date()
-			if node?[keyPath: config] == nil || expiration < Date() {
+			if node?[keyPath: config] == nil || node?.hasLiveAdminSession != true {
 				Text("\(title) config data was requested via PKC admin but no response has been returned from the remote node.")
 					.font(.callout)
 					.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -60,7 +60,31 @@ func performConfigSave(
 		do {
 			if let operationID {
 				try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
-					try await save(fromUser, toUser)
+					var saveUser = toUser
+					if !targetNode.hasLiveAdminSession {
+						// A routing rejection clears the cached passkey. Before a user-initiated
+						// save retry, establish a new session and use the refreshed user entity.
+						// The metadata request is not the save operation, so it must not complete
+						// or fail this operation's packet tracker.
+						try await RemoteAdminConfigTracker.$currentOperationID.withValue(nil) {
+							_ = try await accessoryManager.requestDeviceMetadata(fromUser: fromUser, toUser: toUser)
+						}
+						let result = await RemoteAdminSessionWaiter.wait(
+							isLive: { targetNode.hasLiveAdminSession },
+							isConnected: { accessoryManager.isConnected },
+							targetIsCurrent: { accessoryManager.activeDeviceNum == deviceNum }
+						)
+						guard result == .active else {
+							throw AccessoryError.ioFailed("Remote admin authorization was not refreshed. Please retry.")
+						}
+						guard let refreshedNode = getNodeInfo(id: targetNode.num, context: context),
+							  refreshedNode.hasLiveAdminSession,
+							  let refreshedUser = refreshedNode.user else {
+							throw AccessoryError.ioFailed("Remote admin authorization was not refreshed. Please retry.")
+						}
+						saveUser = refreshedUser
+					}
+					try await save(fromUser, saveUser)
 				}
 			} else {
 				try await save(fromUser, toUser)

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -55,6 +55,7 @@ func performConfigSave(
 		accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "A configuration save is already in progress for this node. Please wait for it to finish.")
 		return
 	}
+	let connectionID = accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) }
 
 	Task {
 		do {
@@ -72,9 +73,17 @@ func performConfigSave(
 						let result = await RemoteAdminSessionWaiter.wait(
 							isLive: { targetNode.hasLiveAdminSession },
 							isConnected: { accessoryManager.isConnected },
-							targetIsCurrent: { accessoryManager.activeDeviceNum == deviceNum }
+							targetIsCurrent: {
+								accessoryManager.activeDeviceNum == deviceNum
+									&& accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } == connectionID
+							}
 						)
 						guard result == .active else {
+							throw AccessoryError.ioFailed("Remote admin authorization was not refreshed. Please retry.")
+						}
+						guard accessoryManager.isConnected,
+							  accessoryManager.activeDeviceNum == deviceNum,
+							  accessoryManager.activeConnection.map({ ObjectIdentifier($0.connection) }) == connectionID else {
 							throw AccessoryError.ioFailed("Remote admin authorization was not refreshed. Please retry.")
 						}
 						guard let refreshedNode = getNodeInfo(id: targetNode.num, context: context),

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -42,18 +42,51 @@ func performConfigSave(
 	guard let deviceNum = accessoryManager.activeDeviceNum,
 		  let connectedNode = getNodeInfo(id: deviceNum, context: context),
 		  let fromUser = connectedNode.user,
-		  let toUser = node?.user
+		  let toUser = node?.user,
+		  let targetNode = node
 	else {
 		Logger.mesh.warning("⚠️ Cannot save config: missing connected node or user entities")
+		return
+	}
+	let operationID = targetNode.num == deviceNum
+		? nil
+		: accessoryManager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: targetNode.num)
+	if targetNode.num != deviceNum, operationID == nil {
+		accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "A configuration save is already in progress for this node. Please wait for it to finish.")
 		return
 	}
 
 	Task {
 		do {
-			try await save(fromUser, toUser)
-			hasChanges.wrappedValue = false
-			dismiss()
+			if let operationID {
+				try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+					try await save(fromUser, toUser)
+				}
+			} else {
+				try await save(fromUser, toUser)
+			}
+			if targetNode.num == deviceNum {
+				hasChanges.wrappedValue = false
+				dismiss()
+				return
+			}
+			guard let operationID else { return }
+			switch accessoryManager.remoteAdminConfigTracker.finish(operationID) {
+			case .succeeded:
+				hasChanges.wrappedValue = false
+				dismiss()
+			case .failed(let message):
+				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, message)
+				Logger.mesh.error("🚨 Config save rejected: \(message, privacy: .public)")
+			case .timedOut:
+				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "No confirmation was received from the remote node. Check that it is online and retry.")
+				Logger.mesh.error("🚨 Config save timed out")
+			}
 		} catch {
+			if let operationID {
+				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)
+			}
+			accessoryManager.remoteAdminConfigFeedback = (targetNode.num, error.localizedDescription)
 			Logger.mesh.error("🚨 Config save failed: \(error.localizedDescription)")
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -52,7 +52,10 @@ func performConfigSave(
 		? nil
 		: accessoryManager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: targetNode.num)
 	if targetNode.num != deviceNum, operationID == nil {
-		accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "A configuration save is already in progress for this node. Please wait for it to finish.")
+		accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+			targetNodeNum: targetNode.num,
+			kind: .save,
+			message: "A configuration save is already in progress for this node. Please wait for it to finish.")
 		return
 	}
 	let connectionID = accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) }
@@ -109,17 +112,22 @@ func performConfigSave(
 				hasChanges.wrappedValue = false
 				dismiss()
 			case .failed(let message):
-				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, message)
+				accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+					targetNodeNum: targetNode.num, kind: .save, message: message)
 				Logger.mesh.error("🚨 Config save rejected: \(message, privacy: .public)")
 			case .timedOut:
-				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "No confirmation was received from the remote node. Check that it is online and retry.")
+				accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+					targetNodeNum: targetNode.num,
+					kind: .save,
+					message: "No confirmation was received from the remote node. Check that it is online and retry.")
 				Logger.mesh.error("🚨 Config save timed out")
 			}
 		} catch {
 			if let operationID {
 				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)
 			}
-			accessoryManager.remoteAdminConfigFeedback = (targetNode.num, error.localizedDescription)
+			accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+				targetNodeNum: targetNode.num, kind: .save, message: error.localizedDescription)
 			Logger.mesh.error("🚨 Config save failed: \(error.localizedDescription)")
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -42,7 +42,16 @@ struct DeviceConfig: View {
 			}
 		} else {
 		Form {
-			ConfigHeader(title: "Device", config: \.deviceConfig, node: node, onAppear: setDeviceValues)
+			ConfigHeader(title: "Device", config: \.deviceConfig, node: node, onAppear: setDeviceValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.deviceConfig == nil },
+					section: "Device",
+					request: accessoryManager.requestDeviceConfig,
+					force: true)
+			})
 			
 			Section(header: Text("Options")) {
 				VStack(alignment: .leading) {
@@ -319,33 +328,13 @@ struct DeviceConfig: View {
 		} // end else
 		} // end Group
 		.onFirstAppear {
-			// Need to request a DeviceConfig from the remote node before allowing changes
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration {
-							/// 2.5 Administration with session passkey
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.deviceConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired device config requesting via PKI admin")
-										try await accessoryManager.requestDeviceConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.error("🚨 Device config request failed")
-									}
-								}
-							}
-						} else {
-							if node.deviceConfig == nil {
-								/// Legacy Administration
-								Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-							}
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.deviceConfig == nil },
+				section: "Device",
+				request: accessoryManager.requestDeviceConfig)
 		}
 		.onChange(of: deviceRole) { oldRole, newRole in
 			guard !isResetting else { return }

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -50,6 +50,7 @@ struct DeviceConfig: View {
 					configIsNil: { $0.deviceConfig == nil },
 					section: "Device",
 					request: accessoryManager.requestDeviceConfig,
+					requestForConnectedNode: true,
 					force: true)
 			})
 			
@@ -334,7 +335,8 @@ struct DeviceConfig: View {
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.deviceConfig == nil },
 				section: "Device",
-				request: accessoryManager.requestDeviceConfig)
+				request: accessoryManager.requestDeviceConfig,
+				requestForConnectedNode: true)
 		}
 		.onChange(of: deviceRole) { oldRole, newRole in
 			guard !isResetting else { return }

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -32,7 +32,17 @@ struct DisplayConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Display", config: \.displayConfig, node: node, onAppear: setDisplayValues)
+			ConfigHeader(title: "Display", config: \.displayConfig, node: node, onAppear: setDisplayValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.displayConfig == nil },
+				section: "Display",
+				request: accessoryManager.requestDisplayConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Device Screen")) {
 				

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -171,6 +171,7 @@ struct DisplayConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.displayConfig == nil },
+				section: "Display",
 				request: accessoryManager.requestDisplayConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -254,7 +254,17 @@ struct LoRaConfig: View {
 	/// See `body` — the Form and its chrome, split out for type-check time.
 	private var loRaForm: some View {
 		Form {
-			ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues)
+			ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.loRaConfig == nil },
+				section: "LoRa",
+				request: accessoryManager.requestLoRaConfig,
+				force: true
+			)
+		})
 
 			optionsSection
 

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -286,6 +286,7 @@ struct LoRaConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.loRaConfig == nil },
+				section: "LoRa",
 				request: accessoryManager.requestLoRaConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -24,7 +24,17 @@ struct AmbientLightingConfig: View {
 	@State private var components: Color.Resolved?
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Ambient Lighting", config: \.ambientLightingConfig, node: node, onAppear: setAmbientLightingConfigValue)
+			ConfigHeader(title: "Ambient Lighting", config: \.ambientLightingConfig, node: node, onAppear: setAmbientLightingConfigValue, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.ambientLightingConfig == nil },
+				section: "Ambient Lighting",
+				request: accessoryManager.requestAmbientLightingConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -87,6 +87,7 @@ struct AmbientLightingConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.ambientLightingConfig == nil },
+				section: "Ambient Lighting",
 				request: accessoryManager.requestAmbientLightingConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
@@ -156,6 +156,7 @@ struct AudioConfig: View {
 					context: context,
 					accessoryManager: accessoryManager,
 					configIsNil: { $0.audioConfig == nil },
+					section: "Audio",
 					request: accessoryManager.requestAudioModuleConfig
 				)
 			}

--- a/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
@@ -29,7 +29,18 @@ struct AudioConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				ConfigHeader(title: "Audio", config: \.audioConfig, node: node, onAppear: setAudioValues)
+				ConfigHeader(title: "Audio", config: \.audioConfig, node: node, onAppear: setAudioValues, onRetry: {
+			requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.audioConfig == nil },
+					section: "Audio",
+					request: accessoryManager.requestAudioModuleConfig
+				,
+				force: true
+			)
+		})
 
 				Section(header: Text("Options")) {
 					Toggle(isOn: $codec2Enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -221,6 +221,7 @@ struct CannedMessagesConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.cannedMessageConfig == nil },
+				section: "Canned messages",
 				request: accessoryManager.requestCannedMessagesModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -38,7 +38,17 @@ struct CannedMessagesConfig: View {
 	@State var messages = ""
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Canned messages", config: \.cannedMessageConfig, node: node, onAppear: setCannedMessagesValues)
+			ConfigHeader(title: "Canned messages", config: \.cannedMessageConfig, node: node, onAppear: setCannedMessagesValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.cannedMessageConfig == nil },
+				section: "Canned messages",
+				request: accessoryManager.requestCannedMessagesModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -183,6 +183,7 @@ struct DetectionSensorConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.detectionSensorConfig == nil },
+				section: "Detection Sensor",
 				request: accessoryManager.requestDetectionSensorModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -44,7 +44,17 @@ struct DetectionSensorConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Detection Sensor", config: \.detectionSensorConfig, node: node, onAppear: setDetectionSensorValues)
+			ConfigHeader(title: "Detection Sensor", config: \.detectionSensorConfig, node: node, onAppear: setDetectionSensorValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.detectionSensorConfig == nil },
+				section: "Detection Sensor",
+				request: accessoryManager.requestDetectionSensorModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -174,6 +174,7 @@ struct ExternalNotificationConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.externalNotificationConfig == nil },
+				section: "External notification",
 				request: accessoryManager.requestExternalNotificationModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -36,7 +36,17 @@ struct ExternalNotificationConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "External notification", config: \.externalNotificationConfig, node: node, onAppear: setExternalNotificationValues)
+			ConfigHeader(title: "External notification", config: \.externalNotificationConfig, node: node, onAppear: setExternalNotificationValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.externalNotificationConfig == nil },
+				section: "External notification",
+				request: accessoryManager.requestExternalNotificationModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -50,7 +50,17 @@ struct MQTTConfig: View {
 					}
 				}
 				
-				ConfigHeader(title: "MQTT", config: \.mqttConfig, node: node, onAppear: setMqttValues)
+				ConfigHeader(title: "MQTT", config: \.mqttConfig, node: node, onAppear: setMqttValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.mqttConfig == nil },
+				section: "MQTT",
+				request: accessoryManager.requestMqttModuleConfig,
+				force: true
+			)
+		})
 				
 				Section(header: Text("Options")) {
 					

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -353,6 +353,7 @@ struct MQTTConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.mqttConfig == nil },
+				section: "MQTT",
 				request: accessoryManager.requestMqttModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/NeighborInfoConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/NeighborInfoConfig.swift
@@ -22,7 +22,16 @@ struct NeighborInfoConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Neighbor Info", config: \.neighborInfoConfig, node: node, onAppear: setNeighborInfoValues)
+			ConfigHeader(title: "Neighbor Info", config: \.neighborInfoConfig, node: node, onAppear: setNeighborInfoValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.neighborInfoConfig == nil },
+					section: "Neighbor Info",
+					request: accessoryManager.requestNeighborInfoModuleConfig,
+					force: true)
+			})
 
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {
@@ -82,28 +91,13 @@ struct NeighborInfoConfig: View {
 			}
 		}
 		.onFirstAppear {
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration && node.num != connectedNode.num {
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.neighborInfoConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired neighbor info module config requesting via PKI admin")
-										try await accessoryManager.requestNeighborInfoModuleConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.info("🚨 Request for neighbor info module config failed")
-									}
-								}
-							}
-						} else {
-							Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.neighborInfoConfig == nil },
+				section: "Neighbor Info",
+				request: accessoryManager.requestNeighborInfoModuleConfig)
 		}
 		.onChange(of: enabled) { oldEnabled, newEnabled in
 			if oldEnabled != newEnabled && newEnabled != (node?.neighborInfoConfig?.enabled ?? false) { hasChanges = true }

--- a/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
@@ -24,7 +24,16 @@ struct PaxCounterConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "PAX Counter Config", config: \.powerConfig, node: node, onAppear: setPaxValues)
+			ConfigHeader(title: "PAX Counter Config", config: \.powerConfig, node: node, onAppear: setPaxValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.paxCounterConfig == nil },
+					section: "PAX Counter Config",
+					request: accessoryManager.requestPaxCounterModuleConfig,
+					force: true)
+			})
 			
 			Section {
 				Toggle(isOn: $enabled) {
@@ -108,31 +117,13 @@ struct PaxCounterConfig: View {
 			}
 		}
 		.onFirstAppear {
-			// Need to request a PaxCounterModuleConfig from the remote node before allowing changes
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration && node.num != connectedNode.num {
-							/// 2.5 Administration with session passkey
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.paxCounterConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired pax counter module config requesting via PKI admin")
-										try await accessoryManager.requestPaxCounterModuleConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.info("🚨 Request for pax counter module config failed")
-									}
-								}
-							}
-						} else {
-							/// Legacy Administration
-							Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.paxCounterConfig == nil },
+				section: "PAX Counter Config",
+				request: accessoryManager.requestPaxCounterModuleConfig)
 		}
 		.onChange(of: enabled) { oldEnabled, newEnabled in
 			if oldEnabled != newEnabled && newEnabled != (node?.paxCounterConfig?.enabled ?? false) { hasChanges = true }

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -37,7 +37,18 @@ struct RangeTestConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Range", config: \.rangeTestConfig, node: node, onAppear: setRangeTestValues)
+			ConfigHeader(title: "Range", config: \.rangeTestConfig, node: node, onAppear: setRangeTestValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.rangeTestConfig == nil },
+				section: "Range",
+				request: accessoryManager.requestRangeTestModuleConfig,
+				requestForConnectedNode: true,
+				force: true
+			)
+		})
 
 			if isPrimaryChannelPublic {
 				Section {

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -107,6 +107,7 @@ struct RangeTestConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.rangeTestConfig == nil },
+				section: "Range",
 				request: accessoryManager.requestRangeTestModuleConfig,
 				requestForConnectedNode: true
 			)

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -75,6 +75,7 @@ struct RtttlConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.rtttlConfig == nil },
+				section: "Ringtone",
 				request: accessoryManager.requestRtttlConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -21,7 +21,17 @@ struct RtttlConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Ringtone", config: \.rtttlConfig, node: node, onAppear: setRtttLConfigValue)
+			ConfigHeader(title: "Ringtone", config: \.rtttlConfig, node: node, onAppear: setRtttLConfigValue, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.rtttlConfig == nil },
+				section: "Ringtone",
+				request: accessoryManager.requestRtttlConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				HStack {

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -131,6 +131,7 @@ struct SerialConfig: View {
 					context: context,
 					accessoryManager: accessoryManager,
 					configIsNil: { $0.serialConfig == nil },
+					section: "Serial",
 					request: accessoryManager.requestSerialModuleConfig
 				)
 			}

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -31,7 +31,18 @@ struct SerialConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				ConfigHeader(title: "Serial", config: \.serialConfig, node: node, onAppear: setSerialValues)
+				ConfigHeader(title: "Serial", config: \.serialConfig, node: node, onAppear: setSerialValues, onRetry: {
+			requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.serialConfig == nil },
+					section: "Serial",
+					request: accessoryManager.requestSerialModuleConfig
+				,
+				force: true
+			)
+		})
 				
 				Section(header: Text("Options")) {
 					

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -31,7 +31,17 @@ struct StoreForwardConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Store & Forward", config: \.storeForwardConfig, node: node, onAppear: setStoreAndForwardValues)
+			ConfigHeader(title: "Store & Forward", config: \.storeForwardConfig, node: node, onAppear: setStoreAndForwardValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.storeForwardConfig == nil },
+				section: "Store & Forward",
+				request: accessoryManager.requestStoreAndForwardModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -132,6 +132,7 @@ struct StoreForwardConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.storeForwardConfig == nil },
+				section: "Store & Forward",
 				request: accessoryManager.requestStoreAndForwardModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
@@ -32,7 +32,17 @@ struct TAKModuleConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "TAK", config: \.takConfig, node: node, onAppear: setTAKValues)
+			ConfigHeader(title: "TAK", config: \.takConfig, node: node, onAppear: setTAKValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.takConfig == nil },
+				section: "TAK",
+				request: accessoryManager.requestTAKModuleConfig,
+				force: true
+			)
+		})
 
 			if accessoryManager.isConnected, node?.takConfig == nil {
 				Section {

--- a/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
@@ -132,6 +132,7 @@ struct TAKModuleConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.takConfig == nil },
+				section: "TAK",
 				request: accessoryManager.requestTAKModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -32,7 +32,17 @@ struct TelemetryConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Telemetry", config: \.telemetryConfig, node: node, onAppear: setTelemetryValues)
+			ConfigHeader(title: "Telemetry", config: \.telemetryConfig, node: node, onAppear: setTelemetryValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.telemetryConfig == nil },
+				section: "Telemetry",
+				request: accessoryManager.requestTelemetryModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Device Options")) {
 				if accessoryManager.checkIsVersionSupported(forVersion: "2.7.12") {

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -179,6 +179,7 @@ struct TelemetryConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.telemetryConfig == nil },
+				section: "Telemetry",
 				request: accessoryManager.requestTelemetryModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
@@ -196,6 +196,7 @@ struct TrafficManagementConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.trafficManagementConfig == nil },
+				section: "Traffic Management",
 				request: accessoryManager.requestTrafficManagementModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
@@ -36,7 +36,17 @@ struct TrafficManagementConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Traffic Management", config: \.trafficManagementConfig, node: node, onAppear: setTrafficManagementValues)
+			ConfigHeader(title: "Traffic Management", config: \.trafficManagementConfig, node: node, onAppear: setTrafficManagementValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.trafficManagementConfig == nil },
+					section: "Traffic Management",
+					request: accessoryManager.requestTrafficManagementModuleConfig,
+					force: true
+				)
+			})
 				.onAppear(perform: refreshDirectNeighborCount)
 
 			Section(header: Text("Placement")) {

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -35,7 +35,17 @@ struct NetworkConfig: View {
 	var body: some View {
 		let staticValid = staticConfigIsValid
 		Form {
-			ConfigHeader(title: "Network", config: \.networkConfig, node: node, onAppear: setNetworkValues)
+			ConfigHeader(title: "Network", config: \.networkConfig, node: node, onAppear: setNetworkValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.networkConfig == nil },
+				section: "Network",
+				request: accessoryManager.requestNetworkConfig,
+				force: true
+			)
+		})
 			
 			if let node {
 				if node.metadata?.hasWifi ?? false {

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -235,6 +235,7 @@ struct NetworkConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.networkConfig == nil },
+				section: "Network",
 				request: accessoryManager.requestNetworkConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -349,7 +349,17 @@ struct PositionConfig: View {
 	var body: some View {
 		
 		Form {
-			ConfigHeader(title: "Position", config: \.positionConfig, node: node, onAppear: setPositionValues)
+			ConfigHeader(title: "Position", config: \.positionConfig, node: node, onAppear: setPositionValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.positionConfig == nil },
+				section: "Position",
+				request: accessoryManager.requestPositionConfig,
+				force: true
+			)
+		})
 			positionPacketSection
 			deviceGPSSection
 			positionFlagsSection

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -395,6 +395,7 @@ struct PositionConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.positionConfig == nil },
+				section: "Position",
 				request: accessoryManager.requestPositionConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -28,7 +28,17 @@ struct PowerConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Power Config", config: \.powerConfig, node: node, onAppear: setPowerValues)
+			ConfigHeader(title: "Power Config", config: \.powerConfig, node: node, onAppear: setPowerValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.powerConfig == nil },
+				section: "Power Config",
+				request: accessoryManager.requestPowerConfig,
+				force: true
+			)
+		})
 
 			Section {
 				if let architecture, (architecture == .esp32 || architecture == .esp32S3) || (architecture == .nrf52840 && (node?.deviceConfig?.role ?? 0 == 5 || node?.deviceConfig?.role ?? 0 == 6)) {

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -133,6 +133,7 @@ struct PowerConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.powerConfig == nil },
+				section: "Power Config",
 				request: accessoryManager.requestPowerConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
+++ b/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
@@ -1,0 +1,144 @@
+//
+//  RemoteAdminConfigTracker.swift
+//  Meshtastic
+//
+
+import Combine
+import Foundation
+import MeshtasticProtobufs
+
+enum RemoteAdminConfigOperationKind: Equatable {
+	case request
+	case save
+}
+
+enum RemoteAdminConfigOperationResult: Equatable {
+	case succeeded
+	case failed(String)
+	case timedOut
+}
+
+struct RemoteAdminConfigOperation: Identifiable, Equatable {
+	let id: UUID
+	let sequence: UInt64
+	let kind: RemoteAdminConfigOperationKind
+	let targetNodeNum: Int64
+	let section: String
+	var pendingPacketIDs: Set<UInt32> = []
+	var result: RemoteAdminConfigOperationResult?
+
+	var isFinished: Bool { result != nil }
+}
+
+/// Tracks only explicitly enrolled remote-admin work. The operation token is carried through the
+/// async request/save closure with TaskLocal, so unrelated admin packets can never be enrolled by
+/// target-node coincidence.
+@MainActor
+final class RemoteAdminConfigTracker: ObservableObject {
+	@TaskLocal static var currentOperationID: UUID?
+
+	@Published private(set) var operations: [UUID: RemoteAdminConfigOperation] = [:]
+	private var nextSequence: UInt64 = 0
+
+	static func isAdminResponse(_ message: AdminMessage) -> Bool {
+		switch message.payloadVariant {
+		case .getChannelResponse, .getOwnerResponse, .getConfigResponse, .getModuleConfigResponse,
+				.getCannedMessageModuleMessagesResponse, .getDeviceMetadataResponse, .getRingtoneResponse,
+				.getDeviceConnectionStatusResponse, .getNodeRemoteHardwarePinsResponse, .getUiConfigResponse:
+			return true
+		default:
+			return false
+		}
+	}
+
+	@discardableResult
+	func begin(kind: RemoteAdminConfigOperationKind, targetNodeNum: Int64, section: String = "save") -> UUID? {
+		if operations.values.contains(where: {
+			$0.kind == kind && $0.targetNodeNum == targetNodeNum && $0.section == section && !$0.isFinished
+		}) { return nil }
+		nextSequence += 1
+		let id = UUID()
+		operations[id] = RemoteAdminConfigOperation(id: id, sequence: nextSequence, kind: kind, targetNodeNum: targetNodeNum, section: section)
+		return id
+	}
+
+	func registerPacket(packetID: UInt32, targetNodeNum: Int64, operationID: UUID?) -> Bool {
+		guard let operationID, var operation = operations[operationID], !operation.isFinished,
+			  operation.targetNodeNum == targetNodeNum else { return false }
+		operation.pendingPacketIDs.insert(packetID)
+		operations[operationID] = operation
+		return true
+	}
+
+	func resolveAdminResponse(packetID: UInt32, sourceNodeNum: Int64) -> UUID? {
+		guard let operation = operations.values.first(where: {
+			$0.pendingPacketIDs.contains(packetID) && $0.targetNodeNum == sourceNodeNum && !$0.isFinished
+		}) else { return nil }
+		return resolvePacket(packetID: packetID, operationID: operation.id, result: .succeeded)
+	}
+
+	func resolveRouting(packetID: UInt32, sourceNodeNum: Int64, reason: String?, isFailure: Bool) -> UUID? {
+		guard let operation = operations.values.first(where: { $0.pendingPacketIDs.contains(packetID) && !$0.isFinished }) else { return nil }
+		guard isFailure || (operation.kind == .save && operation.targetNodeNum == sourceNodeNum) else { return nil }
+		let result: RemoteAdminConfigOperationResult = isFailure ? .failed(reason ?? "Remote delivery failed") : .succeeded
+		return resolvePacket(packetID: packetID, operationID: operation.id, result: result)
+	}
+
+	private func resolvePacket(packetID: UInt32, operationID: UUID, result: RemoteAdminConfigOperationResult) -> UUID {
+		guard var operation = operations[operationID], !operation.isFinished else { return operationID }
+		operation.pendingPacketIDs.remove(packetID)
+		if case .failed = result { operation.result = result }
+		operations[operationID] = operation
+		return operationID
+	}
+
+	func waitForPacket(packetID: UInt32, operationID: UUID, timeout: Duration = .seconds(30)) async -> RemoteAdminConfigOperationResult {
+		let deadline = ContinuousClock.now + timeout
+		while !Task.isCancelled {
+			guard let operation = operations[operationID] else { return .failed("Operation cancelled") }
+			if let result = operation.result { return result }
+			if !operation.pendingPacketIDs.contains(packetID) { return .succeeded }
+			if ContinuousClock.now >= deadline {
+				self.timeout(operationID)
+				return .timedOut
+			}
+			try? await Task.sleep(for: .milliseconds(50))
+		}
+		fail(operationID, with: "Operation cancelled")
+		return .failed("Operation cancelled")
+	}
+
+	func timeout(_ operationID: UUID) {
+		guard var operation = operations[operationID], !operation.isFinished else { return }
+		operation.pendingPacketIDs.removeAll()
+		operation.result = .timedOut
+		operations[operationID] = operation
+	}
+
+	func finish(_ operationID: UUID) -> RemoteAdminConfigOperationResult {
+		guard var operation = operations[operationID], !operation.isFinished else { return operations[operationID]?.result ?? .failed("Operation cancelled") }
+		guard operation.pendingPacketIDs.isEmpty else { return .timedOut }
+		operation.result = .succeeded
+		operations[operationID] = operation
+		return .succeeded
+	}
+
+	func fail(_ operationID: UUID, with error: Error) {
+		fail(operationID, with: error.localizedDescription)
+	}
+
+	func fail(_ operationID: UUID, with message: String) {
+		guard var operation = operations[operationID], !operation.isFinished else { return }
+		operation.pendingPacketIDs.removeAll()
+		operation.result = .failed(message)
+		operations[operationID] = operation
+	}
+
+	func failAll(with message: String) {
+		for operationID in Array(operations.keys) { fail(operationID, with: message) }
+	}
+
+	func latest(for targetNodeNum: Int64, kind: RemoteAdminConfigOperationKind, section: String) -> RemoteAdminConfigOperation? {
+		operations.values.filter { $0.targetNodeNum == targetNodeNum && $0.kind == kind && $0.section == section }.max { $0.sequence < $1.sequence }
+	}
+}

--- a/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
+++ b/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
@@ -30,6 +30,12 @@ struct RemoteAdminConfigOperation: Identifiable, Equatable {
 	var isFinished: Bool { result != nil }
 }
 
+struct RemoteAdminConfigFeedback: Equatable {
+	let targetNodeNum: Int64
+	let kind: RemoteAdminConfigOperationKind
+	let message: String
+}
+
 /// Tracks only explicitly enrolled remote-admin work. The operation token is carried through the
 /// async request/save closure with TaskLocal, so unrelated admin packets can never be enrolled by
 /// target-node coincidence.

--- a/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
+++ b/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
@@ -18,6 +18,7 @@ func requestRemoteConfig(
 	context: ModelContext,
 	accessoryManager: AccessoryManager,
 	configIsNil: @escaping (NodeInfoEntity) -> Bool,
+	section: String,
 	request: @escaping (_ fromUser: UserEntity, _ toUser: UserEntity) async throws -> Void,
 	requestForConnectedNode: Bool = false
 ) {
@@ -29,7 +30,9 @@ func requestRemoteConfig(
 	if requestForConnectedNode && node.num == deviceNum && configIsNil(node) {
 		Task {
 			do {
-				guard let fromUser = connectedNode.user, let toUser = node.user else { return }
+				guard let fromUser = connectedNode.user, let toUser = node.user else {
+					return
+				}
 				Logger.mesh.info("⚙️ Config missing for connected node, requesting")
 				try await request(fromUser, toUser)
 			} catch {
@@ -44,13 +47,24 @@ func requestRemoteConfig(
 	if UserDefaults.enableAdministration {
 		let expiration = node.sessionExpiration ?? Date()
 		if expiration < Date() || configIsNil(node) {
+			let operationID = accessoryManager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: node.num, section: section)
+			guard let operationID else { return }
 			Task {
 				do {
-					guard let fromUser = connectedNode.user, let toUser = node.user else { return }
+					guard let fromUser = connectedNode.user, let toUser = node.user else {
+						accessoryManager.remoteAdminConfigTracker.fail(operationID, with: AccessoryError.appError("Missing user identity"))
+						return
+					}
 					Logger.mesh.info("⚙️ Empty or expired config requesting via PKI admin")
+				try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
 					try await request(fromUser, toUser)
-				} catch {
-					Logger.mesh.error("🚨 Config request failed")
+				}
+				if case .failed(let message) = accessoryManager.remoteAdminConfigTracker.finish(operationID) {
+					accessoryManager.remoteAdminConfigFeedback = (node.num, message)
+				}
+			} catch {
+				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)
+				Logger.mesh.error("🚨 Config request failed")
 				}
 			}
 		}

--- a/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
+++ b/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
@@ -20,7 +20,8 @@ func requestRemoteConfig(
 	configIsNil: @escaping (NodeInfoEntity) -> Bool,
 	section: String,
 	request: @escaping (_ fromUser: UserEntity, _ toUser: UserEntity) async throws -> Void,
-	requestForConnectedNode: Bool = false
+	requestForConnectedNode: Bool = false,
+	force: Bool = false
 ) {
 	guard let deviceNum = accessoryManager.activeDeviceNum,
 		  let node,
@@ -46,7 +47,7 @@ func requestRemoteConfig(
 
 	if UserDefaults.enableAdministration {
 		let expiration = node.sessionExpiration ?? Date()
-		if expiration < Date() || configIsNil(node) {
+		if force || expiration < Date() || configIsNil(node) {
 			let operationID = accessoryManager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: node.num, section: section)
 			guard let operationID else { return }
 			Task {

--- a/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
+++ b/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
@@ -61,7 +61,8 @@ func requestRemoteConfig(
 					try await request(fromUser, toUser)
 				}
 				if case .failed(let message) = accessoryManager.remoteAdminConfigTracker.finish(operationID) {
-					accessoryManager.remoteAdminConfigFeedback = (node.num, message)
+					accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+						targetNodeNum: node.num, kind: .request, message: message)
 				}
 			} catch {
 				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)

--- a/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
+++ b/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
@@ -22,7 +22,9 @@ struct SaveConfigButton: View {
 	
 	var body: some View {
 		if accessoryManager.isConnected && hasChanges {
-			let feedback = node.map { accessoryManager.remoteAdminConfigFeedback?.targetNodeNum == $0.num ? accessoryManager.remoteAdminConfigFeedback?.message : nil } ?? nil
+			let feedback = node.flatMap {
+				accessoryManager.remoteAdminConfigFeedback(for: $0.num, kind: .save)
+			}
 			let remoteSaveInProgress = node.flatMap {
 				accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .save, section: "save")
 			}?.isFinished == false

--- a/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
+++ b/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
@@ -22,6 +22,24 @@ struct SaveConfigButton: View {
 	
 	var body: some View {
 		if accessoryManager.isConnected && hasChanges {
+			let feedback = node.map { accessoryManager.remoteAdminConfigFeedback?.targetNodeNum == $0.num ? accessoryManager.remoteAdminConfigFeedback?.message : nil } ?? nil
+			let remoteSaveInProgress = node.flatMap {
+				accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .save, section: "save")
+			}?.isFinished == false
+			if let feedback {
+				VStack(spacing: 8) {
+					Label(feedback, systemImage: "exclamationmark.triangle")
+						.foregroundColor(.red)
+					Button("Retry") {
+						accessoryManager.remoteAdminConfigFeedback = nil
+						onConfirmation()
+					}
+				}
+				.padding(.bottom)
+			} else if remoteSaveInProgress {
+				ProgressView("Saving…")
+					.padding(.bottom)
+			} else {
 			if #available(iOS 26.0, *) {
 				Button {
 					isPresentingSaveConfirm = true
@@ -67,6 +85,7 @@ struct SaveConfigButton: View {
 				} message: {
 					Text(confirmationMessage)
 				}
+			}
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -135,7 +135,17 @@ struct SecurityConfig: View {
 	/// See `body` — the Form and its chrome, split out for type-check time.
 	private var securityForm: some View {
 		Form {
-			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues)
+			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.securityConfig == nil },
+				section: "Security",
+				request: accessoryManager.requestSecurityConfig,
+				force: true
+			)
+		})
 			Text("Security Config Settings require a firmware version 2.5+")
 				.font(.title3)
 			packetAuthenticitySection

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -107,6 +107,7 @@ struct SecurityConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.securityConfig == nil },
+				section: "Security",
 				request: accessoryManager.requestSecurityConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -259,7 +259,7 @@ struct Settings: View {
 					.foregroundColor(.gray)
 			}
 
-			NavigationLink(value: SettingsNavigationState.lora) {
+			settingsLink(value: .lora) {
 				Label {
 					Text("LoRa")
 				} icon: {
@@ -268,7 +268,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.channels) {
+			settingsLink(value: .channels) {
 				Label {
 					Text("Channels")
 				} icon: {
@@ -277,7 +277,7 @@ struct Settings: View {
 			}
 			.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
-			NavigationLink(value: SettingsNavigationState.security) {
+			settingsLink(value: .security) {
 				Label {
 					Text("Security")
 				} icon: {
@@ -285,7 +285,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.shareQRCode) {
+			settingsLink(value: .shareQRCode) {
 				Label {
 					Text("Share QR Code")
 				} icon: {
@@ -298,7 +298,7 @@ struct Settings: View {
 
 	var deviceConfigurationSection: some View {
 		Section("Device Configuration") {
-			NavigationLink(value: SettingsNavigationState.user) {
+			settingsLink(value: .user) {
 				Label {
 					Text("User")
 				} icon: {
@@ -306,7 +306,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.bluetooth) {
+			settingsLink(value: .bluetooth) {
 				Label {
 					Text("Bluetooth")
 				} icon: {
@@ -314,7 +314,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.device) {
+			settingsLink(value: .device) {
 				Label {
 					Text("Device")
 				} icon: {
@@ -322,7 +322,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.display) {
+			settingsLink(value: .display) {
 				Label {
 					Text("Display")
 				} icon: {
@@ -330,7 +330,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.network) {
+			settingsLink(value: .network) {
 				Label {
 					Text("Network")
 				} icon: {
@@ -338,7 +338,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.position) {
+			settingsLink(value: .position) {
 				Label {
 					Text("Position")
 				} icon: {
@@ -346,7 +346,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.power) {
+			settingsLink(value: .power) {
 				Label {
 					Text("Power")
 				} icon: {
@@ -364,7 +364,7 @@ struct Settings: View {
 		let excludedModules = node?.excludedModules ?? 0
 		return Section {
 			if isModuleSupported(.ambientlightingConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.ambientLighting) {
+				settingsLink(value: .ambientLighting) {
 					Label {
 						Text("Ambient Lighting")
 					} icon: {
@@ -374,7 +374,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.audioConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.audio) {
+				settingsLink(value: .audio) {
 					Label {
 						Text("Audio")
 					} icon: {
@@ -384,7 +384,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.cannedmsgConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.cannedMessages) {
+				settingsLink(value: .cannedMessages) {
 					Label {
 						Text("Canned Messages")
 					} icon: {
@@ -394,7 +394,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.detectionsensorConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.detectionSensor) {
+				settingsLink(value: .detectionSensor) {
 					Label {
 						Text("Detection Sensor")
 					} icon: {
@@ -404,7 +404,7 @@ struct Settings: View {
 			}
 
 			if isMeshBeaconModuleSupported(node) {
-				NavigationLink(value: SettingsNavigationState.meshBeacon) {
+				settingsLink(value: .meshBeacon) {
 					Label {
 						Text("Mesh Beacon")
 					} icon: {
@@ -414,7 +414,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.extnotifConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.externalNotification) {
+				settingsLink(value: .externalNotification) {
 					Label {
 						Text("External Notification")
 					} icon: {
@@ -424,7 +424,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.mqttConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.mqtt) {
+				settingsLink(value: .mqtt) {
 					Label {
 						Text("MQTT")
 					} icon: {
@@ -434,7 +434,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.neighborinfoConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.neighborInfo) {
+				settingsLink(value: .neighborInfo) {
 					Label {
 						Text("Neighbor Info")
 					} icon: {
@@ -444,7 +444,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.rangetestConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.rangeTest) {
+				settingsLink(value: .rangeTest) {
 					Label {
 						Text("Range Test")
 					} icon: {
@@ -454,7 +454,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.paxcounterConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.paxCounter) {
+				settingsLink(value: .paxCounter) {
 					Label {
 						Text("PAX Counter")
 					} icon: {
@@ -464,7 +464,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.extnotifConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.ringtone) {
+				settingsLink(value: .ringtone) {
 					Label {
 						Text("Ringtone")
 					} icon: {
@@ -474,7 +474,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.serialConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.serial) {
+				settingsLink(value: .serial) {
 					Label {
 						Text("Serial")
 					} icon: {
@@ -484,7 +484,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.storeforwardConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.storeAndForward) {
+				settingsLink(value: .storeAndForward) {
 					Label {
 						Text("Store & Forward")
 					} icon: {
@@ -499,7 +499,7 @@ struct Settings: View {
 			// the top, and the in-app TAK Server controls (Enable, channel,
 			// mTLS certificates, data package export) below it. The TAK
 			// section at the bottom of this screen links to the same view.
-			NavigationLink(value: SettingsNavigationState.tak) {
+			settingsLink(value: .tak) {
 				Label {
 					Text("TAK Server")
 				} icon: {
@@ -508,7 +508,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.telemetryConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.telemetry) {
+				settingsLink(value: .telemetry) {
 					Label {
 						Text("Telemetry")
 					} icon: {
@@ -518,7 +518,7 @@ struct Settings: View {
 			}
 
 			if isTrafficManagementModuleSupported(node) {
-				NavigationLink(value: SettingsNavigationState.trafficManagement) {
+				settingsLink(value: .trafficManagement) {
 					Label {
 						Text("Traffic Management")
 					} icon: {
@@ -538,14 +538,14 @@ struct Settings: View {
 
 	var loggingSection: some View {
 		Section(header: Text("Logging")) {
-			NavigationLink(value: SettingsNavigationState.debugLogs) {
+			settingsLink(value: .debugLogs) {
 				Label {
 					Text("Logs")
 				} icon: {
 					Image(systemName: "scroll")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.traceRoutes) {
+			settingsLink(value: .traceRoutes) {
 				Label {
 					Text("Trace Routes")
 				} icon: {
@@ -557,28 +557,28 @@ struct Settings: View {
 
 	var developersSection: some View {
 		Section(header: Text("Developers")) {
-			NavigationLink(value: SettingsNavigationState.backupManagement) {
+			settingsLink(value: .backupManagement) {
 				Label {
 					Text("Backup Management")
 				} icon: {
 					Image(systemName: "externaldrive")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.coreDataBrowser) {
+			settingsLink(value: .coreDataBrowser) {
 				Label {
 					Text("Data Browser")
 				} icon: {
 					Image(systemName: "tablecells")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.deviceLinks) {
+			settingsLink(value: .deviceLinks) {
 				Label {
 					Text("Device Links")
 				} icon: {
 					Image(systemName: "link")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.appFiles) {
+			settingsLink(value: .appFiles) {
 				Label {
 					Text("App Files")
 				} icon: {
@@ -592,7 +592,7 @@ struct Settings: View {
 			#if !targetEnvironment(macCatalyst)
 			if #available(iOS 18, *) {
 				if NFCReader.isAvailable || accessoryManager.isConnected {
-					NavigationLink(value: SettingsNavigationState.tools) {
+					settingsLink(value: .tools) {
 						Label {
 							Text("Tools")
 						} icon: {
@@ -613,13 +613,26 @@ struct Settings: View {
 			// TAK — the Module Config link discovers the feature alongside
 			// other module configs, and the dedicated TAK section advertises
 			// the TAK Server functionality at a glance.
-			NavigationLink(value: SettingsNavigationState.tak) {
+			settingsLink(value: .tak) {
 				Label {
 					Text("TAK Server")
 				} icon: {
 					Image(systemName: "target")
 				}
 			}
+		}
+	}
+
+	@ViewBuilder
+	private func settingsLink<Label: View>(value: SettingsNavigationState, @ViewBuilder label: () -> Label) -> some View {
+		if remoteNodeNum != nil {
+			NavigationLink {
+				settingsDestination(value)
+			} label: {
+				label()
+			}
+		} else {
+			NavigationLink(value: value, label: label)
 		}
 	}
 
@@ -638,7 +651,7 @@ struct Settings: View {
 			let node = nodeSnapshot(for: preferredNodeNum)
 			List {
 				if remoteNodeNum == nil {
-				NavigationLink(value: SettingsNavigationState.about) {
+				settingsLink(value: .about) {
 					Label {
 						Text("About Meshtastic")
 					} icon: {
@@ -646,7 +659,7 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.helpDocs) {
+				settingsLink(value: .helpDocs) {
 					Label {
 						Text("Help & Documentation")
 					} icon: {
@@ -654,21 +667,21 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.appSettings) {
+				settingsLink(value: .appSettings) {
 					Label {
 						Text("App Settings")
 					} icon: {
 						Image(systemName: "gearshape")
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.localMeshDiscovery) {
+				settingsLink(value: .localMeshDiscovery) {
 					Label {
 						Text("Local Mesh Discovery")
 					} icon: {
 						Image(systemName: "antenna.radiowaves.left.and.right")
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.routes) {
+				settingsLink(value: .routes) {
 					Label {
 						Text("Routes")
 					} icon: {
@@ -676,7 +689,7 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.routeRecorder) {
+				settingsLink(value: .routeRecorder) {
 					Label {
 						Text("Route Recorder")
 					} icon: {
@@ -684,7 +697,7 @@ struct Settings: View {
 							.foregroundColor(.red)
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.firmwareUpdates) {
+				settingsLink(value: .firmwareUpdates) {
 					Label {
 						Text("Firmware Updates")
 					} icon: {
@@ -780,6 +793,82 @@ struct Settings: View {
 				}
 			}
 			.navigationDestination(for: SettingsNavigationState.self) { destination in
+				settingsDestination(destination)
+			}
+
+			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
+				// If the preferred node changes, then select the newly preferred node
+				// This should only happen during connect
+				preferredNodeNum = newConnectedNode
+				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
+			}
+			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
+				// If we are on this screen, haven't iniatialized the selection yet,
+				// And we transition, to connected, then initialize the selection
+				if isConnectedNow, self.selectedNode == 0 {
+					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
+					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
+				}
+			}
+			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
+				if remoteNodeNum != nil {
+					preferredNodeNum = Int(newDevice ?? 0)
+					selectedNode = 0
+					applyRemoteSettingsNode()
+					return
+				}
+				if newDevice == nil {
+					selectedNode = 0
+					preferredNodeNum = 0
+				} else if oldDevice != newDevice {
+					// Physical connection changed — any prior remote admin session is invalid
+					preferredNodeNum = Int(newDevice!)
+					selectedNode = Int(newDevice!)
+				}
+			}
+			.onAppear {
+				// If the selection hasn't be initialized yet, try to initalize it.
+				// If we are not fully connected yet, then setSelectedNode will
+				// not select the node and it will remain 0
+				refreshNodes()
+				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
+					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
+					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
+				}
+				applyRemoteSettingsNode()
+			}
+			.task(id: router.selectedTab) {
+				// Refresh the node snapshot on a gentle cadence, and only while Settings is
+				// the frontmost tab — the stale snapshot is invisible from other tabs, this
+				// task re-fires on every tab switch (so the guard comes first), and switching
+				// here restarts it for an immediate refresh.
+				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
+				refreshNodes()
+				while !Task.isCancelled {
+					do {
+						try await Task.sleep(for: .seconds(2))
+					} catch {
+						break
+					}
+					guard !Task.isCancelled else { break }
+					refreshNodes()
+				}
+			}
+			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
+			.toolbar {
+				if remoteNodeNum == nil {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
+					}
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	private func settingsDestination(_ destination: SettingsNavigationState) -> some View {
 				let node = liveNode(for: preferredNodeNum)
 				let configNode = liveNode(for: selectedNode)
 				switch destination {
@@ -874,76 +963,6 @@ struct Settings: View {
 				case .backupManagement:
 					BackupManagement()
 				}
-			}
-			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
-				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
-				// If the preferred node changes, then select the newly preferred node
-				// This should only happen during connect
-				preferredNodeNum = newConnectedNode
-				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
-			}
-			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
-				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
-				// If we are on this screen, haven't iniatialized the selection yet,
-				// And we transition, to connected, then initialize the selection
-				if isConnectedNow, self.selectedNode == 0 {
-					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
-					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
-				}
-			}
-			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
-				if remoteNodeNum != nil {
-					preferredNodeNum = Int(newDevice ?? 0)
-					selectedNode = 0
-					applyRemoteSettingsNode()
-					return
-				}
-				if newDevice == nil {
-					selectedNode = 0
-					preferredNodeNum = 0
-				} else if oldDevice != newDevice {
-					// Physical connection changed — any prior remote admin session is invalid
-					preferredNodeNum = Int(newDevice!)
-					selectedNode = Int(newDevice!)
-				}
-			}
-			.onAppear {
-				// If the selection hasn't be initialized yet, try to initalize it.
-				// If we are not fully connected yet, then setSelectedNode will
-				// not select the node and it will remain 0
-				refreshNodes()
-				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
-					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
-					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
-				}
-				applyRemoteSettingsNode()
-			}
-			.task(id: router.selectedTab) {
-				// Refresh the node snapshot on a gentle cadence, and only while Settings is
-				// the frontmost tab — the stale snapshot is invisible from other tabs, this
-				// task re-fires on every tab switch (so the guard comes first), and switching
-				// here restarts it for an immediate refresh.
-				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
-				refreshNodes()
-				while !Task.isCancelled {
-					do {
-						try await Task.sleep(for: .seconds(2))
-					} catch {
-						break
-					}
-					guard !Task.isCancelled else { break }
-					refreshNodes()
-				}
-			}
-			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
-			.toolbar {
-				if remoteNodeNum == nil {
-				ToolbarItem(placement: .topBarLeading) {
-					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
-					}
-				}
-			}
-		}
 	}
 
 	func setSelectedNode(to nodeNum: Int) {

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -102,6 +102,25 @@ struct SettingsNodeSnapshot: Identifiable, Equatable {
 }
 
 struct Settings: View {
+	static func remoteSettingsSelection(
+		requestedNodeNum: Int64?,
+		activeDeviceNum: Int64?,
+		availableNodeNums: Set<Int64>,
+		isConnected: Bool
+	) -> (preferredNodeNum: Int64, selectedNode: Int64)? {
+		guard let requestedNodeNum,
+			let activeDeviceNum,
+			availableNodeNums.contains(requestedNodeNum),
+			isConnected else { return nil }
+		return (activeDeviceNum, requestedNodeNum)
+	}
+
+	let remoteNodeNum: Int64?
+
+	init(remoteNodeNum: Int64? = nil) {
+		self.remoteNodeNum = remoteNodeNum
+	}
+
 	@Environment(\.modelContext) private var context
 	@Environment(\.colorScheme) private var colorScheme
 	@EnvironmentObject var accessoryManager: AccessoryManager
@@ -115,7 +134,7 @@ struct Settings: View {
 		let descriptor = FetchDescriptor<NodeInfoEntity>(sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)])
 		let refreshedNodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
 		nodes = refreshedNodes
-		applyPendingSettingsNode(availableNodes: refreshedNodes)
+		applyRemoteSettingsNode(availableNodes: refreshedNodes)
 	}
 
 	/// Nodes for the admin / configuration picker, ordered favorites-first while
@@ -179,7 +198,8 @@ struct Settings: View {
 	}
 
 	private func isMeshBeaconModuleSupported(_ node: SettingsNodeSnapshot?) -> Bool {
-		guard node != nil else { return false }
+		// Mesh Beacon currently has no remote read path.
+		guard let node, node.num == accessoryManager.activeDeviceNum else { return false }
 		return accessoryManager.checkIsVersionSupported(forVersion: "2.8.0")
 	}
 
@@ -604,11 +624,20 @@ struct Settings: View {
 	}
 
 	var body: some View {
-		NavigationStack(
-			path: $router.settingsPath
-		) {
+		if remoteNodeNum != nil {
+			settingsContent
+		} else {
+			NavigationStack(path: $router.settingsPath) {
+				settingsContent
+			}
+		}
+	}
+
+	@ViewBuilder
+	private var settingsContent: some View {
 			let node = nodeSnapshot(for: preferredNodeNum)
 			List {
+				if remoteNodeNum == nil {
 				NavigationLink(value: SettingsNavigationState.about) {
 					Label {
 						Text("About Meshtastic")
@@ -664,6 +693,8 @@ struct Settings: View {
 				}
 				.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
+				}
+
 				// A managed radio hides the configuration sections; say why instead of
 				// showing nothing (same message as Android).
 				if let node, node.isManaged, accessoryManager.isConnected {
@@ -676,7 +707,9 @@ struct Settings: View {
 				if let node, !node.isManaged {
 					if accessoryManager.isConnected {
 						Section("Configure") {
-							if node.canRemoteAdmin {
+							if let remoteNodeNum {
+								LabeledContent("Node", value: nodeSnapshot(for: Int(remoteNodeNum))?.userLongName ?? "Unknown")
+							} else if node.canRemoteAdmin {
 								Picker("Node", selection: $selectedNode) {
 									if selectedNode == 0 {
 										Text("Connect to a Node").tag(0)
@@ -740,8 +773,8 @@ struct Settings: View {
 					radioConfigurationSection
 					deviceConfigurationSection
 					moduleConfigurationSection
-					loggingSection
-					if showsDevelopersSection {
+					if remoteNodeNum == nil { loggingSection }
+					if remoteNodeNum == nil && showsDevelopersSection {
 					developersSection
 					}
 				}
@@ -843,12 +876,14 @@ struct Settings: View {
 				}
 			}
 			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
 				// If the preferred node changes, then select the newly preferred node
 				// This should only happen during connect
 				preferredNodeNum = newConnectedNode
 				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
 			}
 			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
 				// If we are on this screen, haven't iniatialized the selection yet,
 				// And we transition, to connected, then initialize the selection
 				if isConnectedNow, self.selectedNode == 0 {
@@ -857,6 +892,12 @@ struct Settings: View {
 				}
 			}
 			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
+				if remoteNodeNum != nil {
+					preferredNodeNum = Int(newDevice ?? 0)
+					selectedNode = 0
+					applyRemoteSettingsNode()
+					return
+				}
 				if newDevice == nil {
 					selectedNode = 0
 					preferredNodeNum = 0
@@ -871,21 +912,18 @@ struct Settings: View {
 				// If we are not fully connected yet, then setSelectedNode will
 				// not select the node and it will remain 0
 				refreshNodes()
-				if self.preferredNodeNum <= 0 {
+				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
 					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
 					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
 				}
-				applyPendingSettingsNode()
-			}
-			.onChange(of: router.settingsNodeNum) { _, _ in
-				applyPendingSettingsNode()
+				applyRemoteSettingsNode()
 			}
 			.task(id: router.selectedTab) {
 				// Refresh the node snapshot on a gentle cadence, and only while Settings is
 				// the frontmost tab — the stale snapshot is invisible from other tabs, this
 				// task re-fires on every tab switch (so the guard comes first), and switching
 				// here restarts it for an immediate refresh.
-				guard router.selectedTab == .settings else { return }
+				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
 				refreshNodes()
 				while !Task.isCancelled {
 					do {
@@ -897,8 +935,9 @@ struct Settings: View {
 					refreshNodes()
 				}
 			}
-			.navigationTitle("Settings")
+			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
 			.toolbar {
+				if remoteNodeNum == nil {
 				ToolbarItem(placement: .topBarLeading) {
 					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
 					}
@@ -922,13 +961,14 @@ struct Settings: View {
 		}
 	}
 
-	private func applyPendingSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
-		guard let requestedNodeNum = router.settingsNodeNum,
-			(availableNodes ?? sortedNodes).contains(where: { $0.num == requestedNodeNum }),
-			accessoryManager.isConnected else { return }
-		preferredNodeNum = Int(accessoryManager.activeDeviceNum ?? Int64(requestedNodeNum))
-		selectedNode = Int(requestedNodeNum)
-		router.settingsNodeNum = nil
+	private func applyRemoteSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
+		guard let selection = Self.remoteSettingsSelection(
+			requestedNodeNum: remoteNodeNum,
+			activeDeviceNum: accessoryManager.activeDeviceNum,
+			availableNodeNums: Set((availableNodes ?? sortedNodes).map(\.num)),
+			isConnected: accessoryManager.isConnected) else { return }
+		preferredNodeNum = Int(selection.preferredNodeNum)
+		selectedNode = Int(selection.selectedNode)
 	}
 
 	private func handleSelectedNodeChange(_ newValue: Int) {

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -113,7 +113,9 @@ struct Settings: View {
 
 	private func refreshNodes() {
 		let descriptor = FetchDescriptor<NodeInfoEntity>(sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)])
-		nodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
+		let refreshedNodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
+		nodes = refreshedNodes
+		applyPendingSettingsNode(availableNodes: refreshedNodes)
 	}
 
 	/// Nodes for the admin / configuration picker, ordered favorites-first while
@@ -873,6 +875,10 @@ struct Settings: View {
 					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
 					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
 				}
+				applyPendingSettingsNode()
+			}
+			.onChange(of: router.settingsNodeNum) { _, _ in
+				applyPendingSettingsNode()
 			}
 			.task(id: router.selectedTab) {
 				// Refresh the node snapshot on a gentle cadence, and only while Settings is
@@ -914,6 +920,15 @@ struct Settings: View {
 		} else {
 			self.selectedNode = Int(accessoryManager.isConnected ? nodeNum: 0)
 		}
+	}
+
+	private func applyPendingSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
+		guard let requestedNodeNum = router.settingsNodeNum,
+			(availableNodes ?? sortedNodes).contains(where: { $0.num == requestedNodeNum }),
+			accessoryManager.isConnected else { return }
+		preferredNodeNum = Int(accessoryManager.activeDeviceNum ?? Int64(requestedNodeNum))
+		selectedNode = Int(requestedNodeNum)
+		router.settingsNodeNum = nil
 	}
 
 	private func handleSelectedNodeChange(_ newValue: Int) {

--- a/MeshtasticTests/AccessoryManagerDisconnectTests.swift
+++ b/MeshtasticTests/AccessoryManagerDisconnectTests.swift
@@ -6,6 +6,7 @@
 // MARK: AccessoryManagerDisconnectTests
 
 import Foundation
+import SwiftData
 import Testing
 
 @testable import Meshtastic
@@ -119,5 +120,33 @@ struct AccessoryManagerDisconnectTests {
 		await expectTornDown(manager, connection: connection)
 		#expect(manager.packetsReceived == 1)
 		#expect(manager.shouldAutomaticallyConnectToPreferredPeripheralAfterError)
+	}
+
+	@Test func teardownInvalidatesAllRemoteAdminSessions() async throws {
+		let connection = DisconnectTestConnection()
+		let manager = makeManager(connection: connection)
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let administeredNode = NodeInfoEntity()
+		administeredNode.num = 101
+		administeredNode.sessionPasskey = Data([0xA5, 0x5A])
+		administeredNode.sessionExpiration = Date().addingTimeInterval(300)
+		administeredNode.hasBeenAdministered = true
+		let expirationOnlyNode = NodeInfoEntity()
+		expirationOnlyNode.num = 202
+		expirationOnlyNode.sessionExpiration = Date().addingTimeInterval(300)
+		context.insert(administeredNode)
+		context.insert(expirationOnlyNode)
+		try context.save()
+		manager.context = context
+
+		try await manager.closeConnection()
+
+		let nodes = try context.fetch(FetchDescriptor<NodeInfoEntity>())
+		#expect(nodes.allSatisfy { $0.sessionPasskey == nil && $0.sessionExpiration == nil })
+		#expect(nodes.first(where: { $0.num == 101 })?.hasBeenAdministered == true)
 	}
 }

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -126,6 +126,18 @@ struct NodeAdministrationTests {
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
+		#expect(node.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(node.sessionExpiration != nil)
+		let expiration = node.sessionExpiration
+		admin.sessionPasskey = Data()
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+		let emptyResponseNode = try fetchNode(num: num, in: container)
+		#expect(emptyResponseNode.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(emptyResponseNode.sessionExpiration == expiration)
+		await mesh.moduleConfig(config: moduleConfig, nodeNum: num, nodeLongName: "Remote Node")
+		let mirroredNode = try fetchNode(num: num, in: container)
+		#expect(mirroredNode.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(mirroredNode.sessionExpiration == expiration)
 	}
 
 	@Test func metadataResponseWithPasskeyMarksUnknownNode() async throws {
@@ -169,8 +181,7 @@ struct NodeAdministrationTests {
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(!node.hasBeenAdministered)
-		// The local download still stamps the (empty) passkey as before.
-		#expect(node.sessionPasskey == Data())
+		#expect(node.sessionPasskey == nil)
 	}
 
 	@Test func setConfigRequestWithPasskeyDoesNotMark() async throws {

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -87,6 +87,30 @@ struct NodeAdministrationTests {
 		#expect(node.sessionExpiration != nil)
 	}
 
+	@Test func refetchMakesReceivedSessionVisibleToRetainedNode() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x13AB34
+		try seedNode(num: num, in: container)
+		let mainContext = container.mainContext
+		let cachedNode = try #require(getNodeInfo(id: num, context: mainContext))
+		#expect(!cachedNode.hasLiveAdminSession)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0xA5, 0x5A])
+		var metadata = DeviceMetadata()
+		metadata.firmwareVersion = "2.8.0"
+		admin.getDeviceMetadataResponse = metadata
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .milliseconds(20),
+			isLive: { getNodeInfo(id: num, context: mainContext)?.hasLiveAdminSession == true },
+			isConnected: { true }, targetIsCurrent: { true })
+		#expect(result == .active)
+		#expect(cachedNode.hasLiveAdminSession)
+		#expect(cachedNode.metadata?.firmwareVersion == "2.8")
+	}
+
 	@Test func moduleConfigResponseWithPasskeyMarksAdministered() async throws {
 		let (mesh, container) = try freshMesh()
 		let num: Int64 = 0x22BB33

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -140,6 +140,23 @@ struct NodeAdministrationTests {
 		#expect(mirroredNode.sessionExpiration == expiration)
 	}
 
+	@Test func ringtoneResponsePersistsSessionPasskey() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x2A2B2C
+		try seedNode(num: num, in: container)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0xCA, 0xFE])
+		admin.getRingtoneResponse = "Beep:d=4,o=5,b=120:c"
+
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.rtttlConfig?.ringtone == "Beep:d=4,o=5,b=120:c")
+		#expect(node.sessionPasskey == Data([0xCA, 0xFE]))
+		#expect(node.sessionExpiration != nil)
+	}
+
 	@Test func metadataResponseWithPasskeyMarksUnknownNode() async throws {
 		// A metadata response is the first admin exchange when selecting a remote node,
 		// and its handler creates the node if it has never been heard.

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -8,7 +8,8 @@ import MeshtasticProtobufs
 private actor RemoteAdminReceiveConnection: Connection {
 	let type: TransportType = .ble
 	var isConnected = true
-	func send(_ data: ToRadio) async throws {}
+	private(set) var sendCount = 0
+	func send(_ data: ToRadio) async throws { sendCount += 1 }
 	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
 	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {}
 	func drainPendingPackets() async throws {}
@@ -57,6 +58,25 @@ struct RemoteAdminConfigTrackerTests {
 		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
 		#expect(!tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: nil))
 		#expect(tracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+	}
+
+	@Test func finishedOperationIsRejectedBeforeDispatch() async throws {
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.finish(operationID) == .succeeded)
+
+		do {
+			try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+				try await manager.saveTimeZone(config: Config.DeviceConfig(), user: 42)
+			}
+			Issue.record("A finished remote-admin operation was dispatched")
+		} catch let error as AccessoryError {
+			#expect(error.localizedDescription.contains("no longer active"))
+		} catch {
+			Issue.record("Unexpected error: \(error)")
+		}
+		#expect(await connection.sendCount == 0)
 	}
 
 	@Test func responseMustMatchPacketIDAndTarget() throws {

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import Testing
+import SwiftData
 @testable import Meshtastic
 import MeshtasticProtobufs
 
@@ -134,6 +135,43 @@ struct RemoteAdminConfigTrackerTests {
 		let bluetooth = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Bluetooth"))
 		#expect(tracker.latest(for: 42, kind: .request, section: "Device")?.id == device)
 		#expect(tracker.latest(for: 42, kind: .request, section: "Bluetooth")?.id == bluetooth)
+	}
+
+	@Test func forcedRemoteConfigRetryDispatchesRequest() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let local = NodeInfoEntity(); local.num = 1; local.id = 1
+		let remote = NodeInfoEntity(); remote.num = 2; remote.id = 2
+		let from = UserEntity(); from.num = 1; from.userNode = local
+		let to = UserEntity(); to.num = 2; to.userNode = remote
+		local.user = from; remote.user = to
+		context.insert(local); context.insert(remote); context.insert(from); context.insert(to)
+		try context.save()
+
+		let manager = AccessoryManager(transports: [])
+		manager.context = context
+		manager.activeDeviceNum = 1
+		manager.updateState(.subscribed)
+		let previousAdministration = UserDefaults.enableAdministration
+		UserDefaults.enableAdministration = true
+		defer { UserDefaults.enableAdministration = previousAdministration }
+
+		var requests = 0
+		requestRemoteConfig(
+			node: remote,
+			context: context,
+			accessoryManager: manager,
+			configIsNil: { _ in false },
+			section: "Retry test",
+			request: { _, _ in requests += 1 },
+			force: true)
+		for _ in 0..<20 where requests == 0 {
+			try await Task.sleep(for: .milliseconds(10))
+		}
+		#expect(requests == 1)
 	}
 
 	@Test func managerPublishesNestedTrackerMutations() {

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -84,6 +84,52 @@ struct RemoteAdminConfigTrackerTests {
 		#expect(tracker.operations[operationID]?.result == .failed("No route"))
 	}
 
+	@Test func routingRejectionInvalidatesOnlyRejectedTargetSession() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let rejectedTarget = NodeInfoEntity()
+		rejectedTarget.num = 42
+		rejectedTarget.sessionPasskey = Data([0xA5])
+		rejectedTarget.sessionExpiration = Date().addingTimeInterval(300)
+		let unaffectedTarget = NodeInfoEntity()
+		unaffectedTarget.num = 99
+		unaffectedTarget.sessionPasskey = Data([0x5A])
+		unaffectedTarget.sessionExpiration = Date().addingTimeInterval(300)
+		context.insert(rejectedTarget)
+		context.insert(unaffectedTarget)
+		try context.save()
+
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		manager.context = context
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+
+		var routing = Routing()
+		routing.errorReason = .adminBadSessionKey
+		var data = DataMessage()
+		data.portnum = .routingApp
+		data.requestID = 100
+		data.payload = try routing.serializedData()
+		var packet = MeshPacket()
+		packet.from = 1
+		packet.to = 42
+		packet.decoded = data
+		var fromRadio = FromRadio()
+		fromRadio.packet = packet
+
+		await manager.didReceive(.data(fromRadio))
+
+		#expect(rejectedTarget.sessionPasskey == nil)
+		#expect(rejectedTarget.sessionExpiration == nil)
+		#expect(unaffectedTarget.sessionPasskey == Data([0x5A]))
+		#expect(unaffectedTarget.sessionExpiration != nil)
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.result == .failed("Remote node rejected the request: adminBadSessionKey"))
+	}
+
 	@Test func relaySuccessIsIgnoredUntilTargetConfirms() throws {
 		let tracker = RemoteAdminConfigTracker()
 		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Combine
+import Testing
+@testable import Meshtastic
+import MeshtasticProtobufs
+
+private actor RemoteAdminReceiveConnection: Connection {
+	let type: TransportType = .ble
+	var isConnected = true
+	func send(_ data: ToRadio) async throws {}
+	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
+	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {}
+	func drainPendingPackets() async throws {}
+	func startDrainPendingPackets() throws {}
+	func appDidEnterBackground() {}
+	func appDidBecomeActive() {}
+}
+
+@Suite("Remote admin configuration operation tracking")
+@MainActor
+struct RemoteAdminConfigTrackerTests {
+	private func makeManager(connection: RemoteAdminReceiveConnection) -> AccessoryManager {
+		let manager = AccessoryManager(transports: [])
+		let device = Device(id: UUID(), name: "Test Radio", transportType: .ble, identifier: "remote-admin-test", connectionState: .connected, num: 1)
+		manager.activeConnection = (device: device, connection: connection)
+		manager.activeDeviceNum = 1
+		manager.updateState(.subscribed)
+		return manager
+	}
+
+	@Test func encodedAdminResponseResolvesThroughReceivePath() async throws {
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+
+		var admin = AdminMessage()
+		admin.getModuleConfigResponse = ModuleConfig()
+		var data = DataMessage()
+		data.portnum = .adminApp
+		data.requestID = 100
+		data.payload = try admin.serializedData()
+		var packet = MeshPacket()
+		packet.from = 42
+		packet.to = 1
+		packet.decoded = data
+		var fromRadio = FromRadio()
+		fromRadio.packet = packet
+
+		await manager.didReceive(.data(fromRadio))
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+		#expect(manager.remoteAdminConfigTracker.finish(operationID) == .succeeded)
+	}
+	@Test func unrelatedPacketsCannotEnroll() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(!tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: nil))
+		#expect(tracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+	}
+
+	@Test func responseMustMatchPacketIDAndTarget() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+		#expect(tracker.resolveAdminResponse(packetID: 101, sourceNodeNum: 42) == nil)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 43) == nil)
+		#expect(tracker.operations[operationID]?.result == nil)
+	}
+
+	@Test func targetResponseSucceeds() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .request, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == operationID)
+		#expect(tracker.finish(operationID) == .succeeded)
+	}
+
+	@Test func routingFailurePropagatesByPacketID() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.resolveRouting(packetID: 100, sourceNodeNum: 99, reason: "No route", isFailure: true)
+		#expect(tracker.operations[operationID]?.result == .failed("No route"))
+	}
+
+	@Test func relaySuccessIsIgnoredUntilTargetConfirms() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 99, reason: nil, isFailure: false) == nil)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 42, reason: nil, isFailure: false) == operationID)
+	}
+
+	@Test func requestRequiresAdminResponseInsteadOfRoutingSuccess() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Ambient Lighting"))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 42, reason: nil, isFailure: false) == nil)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == operationID)
+	}
+
+	@Test func multiPacketOperationWaitsForEveryPacket() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.registerPacket(packetID: 200, targetNodeNum: 42, operationID: operationID)
+		tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42)
+		#expect(tracker.finish(operationID) == .timedOut)
+		tracker.resolveAdminResponse(packetID: 200, sourceNodeNum: 42)
+		#expect(tracker.finish(operationID) == .succeeded)
+	}
+
+	@Test func packetTimeoutIsRetainedAsTimeout() async throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(await tracker.waitForPacket(packetID: 100, operationID: operationID, timeout: .milliseconds(1)) == .timedOut)
+		#expect(tracker.operations[operationID]?.result == .timedOut)
+		#expect(tracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+	}
+
+	@Test func duplicateSaveIsBlockedAndRetryGetsNewSequence() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let first = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.begin(kind: .save, targetNodeNum: 42) == nil)
+		tracker.fail(first, with: "failed")
+		let retry = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.latest(for: 42, kind: .save, section: "save")?.id == retry)
+	}
+
+	@Test func requestStateIsScopedToConfigurationSection() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let device = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Device"))
+		let bluetooth = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Bluetooth"))
+		#expect(tracker.latest(for: 42, kind: .request, section: "Device")?.id == device)
+		#expect(tracker.latest(for: 42, kind: .request, section: "Bluetooth")?.id == bluetooth)
+	}
+
+	@Test func managerPublishesNestedTrackerMutations() {
+		let manager = AccessoryManager(transports: [])
+		var changeCount = 0
+		let cancellable = manager.objectWillChange.sink { _ in changeCount += 1 }
+		_ = manager.remoteAdminConfigTracker.begin(kind: .request, targetNodeNum: 42, section: "Device")
+		#expect(changeCount > 0)
+		cancellable.cancel()
+	}
+
+	@Test func disconnectInvalidatesPendingPacketsAndLateAck() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.failAll(with: "disconnected")
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == nil)
+		#expect(tracker.operations[operationID]?.result == .failed("disconnected"))
+	}
+}

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -53,6 +53,72 @@ struct RemoteAdminConfigTrackerTests {
 		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
 		#expect(manager.remoteAdminConfigTracker.finish(operationID) == .succeeded)
 	}
+
+	@Test func replyIDCannotResolveRemoteAdminOperationWithoutRequestID() async throws {
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+
+		var admin = AdminMessage()
+		admin.getModuleConfigResponse = ModuleConfig()
+		var data = DataMessage()
+		data.portnum = .adminApp
+		data.replyID = 100
+		data.payload = try admin.serializedData()
+		var packet = MeshPacket()
+		packet.from = 42
+		packet.to = 1
+		packet.decoded = data
+		var fromRadio = FromRadio()
+		fromRadio.packet = packet
+
+		await manager.didReceive(.data(fromRadio))
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.pendingPacketIDs == [100])
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.result == nil)
+	}
+
+	@Test func connectedNodeMissingDeviceConfigRequestsIt() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let local = NodeInfoEntity(); local.num = 1; local.id = 1
+		let user = UserEntity(); user.num = 1; user.userNode = local
+		local.user = user
+		context.insert(local); context.insert(user)
+		try context.save()
+
+		let manager = AccessoryManager(transports: [])
+		manager.context = context
+		manager.activeDeviceNum = 1
+		manager.updateState(.subscribed)
+
+		var requests = 0
+		requestRemoteConfig(
+			node: local,
+			context: context,
+			accessoryManager: manager,
+			configIsNil: { $0.deviceConfig == nil },
+			section: "Device",
+			request: { _, _ in requests += 1 },
+			requestForConnectedNode: true)
+		for _ in 0..<20 where requests == 0 {
+			try await Task.sleep(for: .milliseconds(10))
+		}
+		#expect(requests == 1)
+	}
+
+	@Test func requestFeedbackIsScopedAwayFromSaveButton() {
+		let manager = AccessoryManager(transports: [])
+		manager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+			targetNodeNum: 42,
+			kind: .request,
+			message: "request failed")
+		#expect(manager.remoteAdminConfigFeedback(for: 42, kind: .save) == nil)
+		#expect(manager.remoteAdminConfigFeedback(for: 42, kind: .request) == "request failed")
+	}
 	@Test func unrelatedPacketsCannotEnroll() throws {
 		let tracker = RemoteAdminConfigTracker()
 		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -22,10 +22,12 @@ struct RemoteAdminEntryTests {
 
 	@Test @MainActor func orchestrator_staleSessionSendsAndWaits() async {
 		var sends = 0
+		var waits = 0
 		var fresh = false
-		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { fresh ? .active : .timedOut })
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { waits += 1; return fresh ? .active : .timedOut })
 		#expect(result == .active)
 		#expect(sends == 1)
+		#expect(waits == 1)
 	}
 
 	@Test @MainActor func orchestrator_identityChangeAfterSendCannotActivate() async {
@@ -96,7 +98,7 @@ struct RemoteAdminEntryTests {
 	@Test func sessionWaiter_stopsWhenConnectionDrops() async {
 		let result = await RemoteAdminSessionWaiter.wait(
 			timeout: .seconds(30),
-			pollInterval: .zero,
+			pollInterval: .milliseconds(1),
 			isLive: { false },
 			isConnected: { false },
 			targetIsCurrent: { true }
@@ -107,7 +109,7 @@ struct RemoteAdminEntryTests {
 	@Test func sessionWaiter_stopsWhenTargetChanges() async {
 		let result = await RemoteAdminSessionWaiter.wait(
 			timeout: .seconds(30),
-			pollInterval: .zero,
+			pollInterval: .milliseconds(1),
 			isLive: { false },
 			isConnected: { true },
 			targetIsCurrent: { false }
@@ -115,11 +117,38 @@ struct RemoteAdminEntryTests {
 		#expect(result == .targetChanged)
 	}
 
-	@Test @MainActor func routerStoresPendingSettingsNodeUntilSettingsAppears() {
-		let router = Router()
-		router.navigateToSettings(nodeNum: 42)
-		#expect(router.selectedTab == .settings)
-		#expect(router.settingsNodeNum == 42)
-		#expect(router.settingsPath.isEmpty)
+	@Test func sessionWaiter_rejectsNonPositivePollInterval() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { true }
+		)
+		#expect(result == .timedOut)
+	}
+
+	@Test @MainActor func remoteSettingsSelectionRequiresActiveDevice() {
+		#expect(Settings.remoteSettingsSelection(
+			requestedNodeNum: 42,
+			activeDeviceNum: nil,
+			availableNodeNums: [42],
+			isConnected: true
+		) == nil)
+		#expect(Settings.remoteSettingsSelection(
+			requestedNodeNum: 42,
+			activeDeviceNum: 7,
+			availableNodeNums: [42],
+			isConnected: true
+		)?.preferredNodeNum == 7)
+	}
+	@Test func remoteSettingsDestinationRejectsSourceReplacement() {
+		let connection = NSObject()
+		let replacement = NSObject()
+		let destination = RemoteAdminSettingsDestination(nodeNum: 42, radioNum: 7, connectionID: ObjectIdentifier(connection))
+		#expect(destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(connection), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 8, connectionID: ObjectIdentifier(connection), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(replacement), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(connection), isConnected: false))
 	}
 }

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -57,6 +57,22 @@ struct RemoteAdminEntryTests {
 		#expect(result == .requestFailed)
 	}
 
+	@Test @MainActor func sameRadioWithReplacementConnectionCannotActivate() async {
+		let initial = NSObject()
+		let replacement = NSObject()
+		let capturedID = ObjectIdentifier(initial)
+		var connectionID = capturedID
+		let radioNum = 42
+		let result = await RemoteAdminSessionOrchestrator.establish(
+			allowed: { true },
+			attemptIsCurrent: { radioNum == 42 && connectionID == capturedID },
+			fresh: { false },
+			request: { connectionID = ObjectIdentifier(replacement) },
+			wait: { .active }
+		)
+		#expect(result == .targetChanged)
+	}
+
 	@Test func sessionFreshness_requiresPasskeyAndFutureExpiration() {
 		let now = Date(timeIntervalSince1970: 100)
 		#expect(RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now.addingTimeInterval(1), now: now))

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Remote admin entry")
+struct RemoteAdminEntryTests {
+
+	@Test @MainActor func orchestrator_disabledSendsZero() async {
+		var sends = 0
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { false }, attemptIsCurrent: { true }, fresh: { false }, request: { sends += 1 }, wait: { .active })
+		#expect(result == .requestFailed)
+		#expect(sends == 0)
+	}
+
+	@Test @MainActor func orchestrator_freshSessionSendsZero() async {
+		var sends = 0
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { true }, request: { sends += 1 }, wait: { .active })
+		#expect(result == .active)
+		#expect(sends == 0)
+	}
+
+	@Test @MainActor func orchestrator_staleSessionSendsAndWaits() async {
+		var sends = 0
+		var fresh = false
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { fresh ? .active : .timedOut })
+		#expect(result == .active)
+		#expect(sends == 1)
+	}
+
+	@Test @MainActor func orchestrator_identityChangeAfterSendCannotActivate() async {
+		var current = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { current }, fresh: { false }, request: { current = false }, wait: { .active })
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func orchestrator_sendErrorIsRequestFailed() async {
+		struct SendError: Error {}
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { false }, request: { throw SendError() }, wait: { .active })
+		#expect(result == .requestFailed)
+	}
+
+	@Test @MainActor func orchestrator_cancelledSendDoesNotActivate() async {
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { false }, request: { throw CancellationError() }, wait: { .active })
+		#expect(result == .cancelled)
+	}
+
+	@Test @MainActor func orchestrator_postWaitIdentityChangeCannotActivate() async {
+		var current = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { current }, fresh: { false }, request: {}, wait: { current = false; return .active })
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func orchestrator_postWaitDisableCannotActivate() async {
+		var allowed = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { allowed }, attemptIsCurrent: { true }, fresh: { false }, request: {}, wait: { allowed = false; return .active })
+		#expect(result == .requestFailed)
+	}
+
+	@Test func sessionFreshness_requiresPasskeyAndFutureExpiration() {
+		let now = Date(timeIntervalSince1970: 100)
+		#expect(RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: nil, expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: Data(), expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now, now: now.addingTimeInterval(1)))
+	}
+
+	@Test func sessionWaiter_timesOutWhenResponseNeverArrives() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .milliseconds(1),
+			pollInterval: .milliseconds(1),
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { true },
+			sleep: { _ in }
+		)
+		#expect(result == .timedOut)
+	}
+
+	@Test func sessionWaiter_stopsWhenConnectionDrops() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { false },
+			targetIsCurrent: { true }
+		)
+		#expect(result == .disconnected)
+	}
+
+	@Test func sessionWaiter_stopsWhenTargetChanges() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { false }
+		)
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func routerStoresPendingSettingsNodeUntilSettingsAppears() {
+		let router = Router()
+		router.navigateToSettings(nodeNum: 42)
+		#expect(router.selectedTab == .settings)
+		#expect(router.settingsNodeNum == 42)
+		#expect(router.settingsPath.isEmpty)
+	}
+}

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -111,6 +111,12 @@ Long-press any node in the list to access quick actions:
 - **Ignore / Remove from ignored** — hide this node from normal views
 - **Remove** — remove the node from your local database
 
+## Remote Admin
+
+Remote Admin pushes a Settings page for that node within the Nodes navigation stack. Open a configuration section and use Back to return to the node’s Settings; use Back again to return to the node details. The target stays fixed while this page is open.
+
+On a node's detail screen, **Remote Admin** requires a connected radio and **Administration** enabled in App Settings. When the target has no live admin session, the app requests device metadata through the connected radio and waits for the session to become active before opening the target's configuration. If the request fails, the radio disconnects, the target changes, the request is cancelled, or the 30-second wait expires, the screen shows the reason and a **Retry Remote Admin** action. Retry after restoring the connection, selecting the intended target, or enabling Administration.
+
 ## Display Names
 
 You can give any node a local nickname that's shown throughout the app instead of its device long name — in the node list, node details, and messages. Set it from the node's long-press menu ("Display name") or from the **Name** row in Node Detail. The avatar circle always shows the node's actual short code, unaffected by the nickname.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -45,6 +45,10 @@ The Remote Admin page stays inside node navigation: Back from a configuration se
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.
 
+### Remote configuration
+
+When you configure another node, Settings shows progress while the request or save is being confirmed by that node. A timeout or delivery error keeps your edits on screen and provides a **Retry** action, so you can check the node and try again without re-entering the values.
+
 ### LoRa
 
 LoRa settings control how your radio communicates on the mesh:

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -39,6 +39,8 @@ Radio configuration requires a connected node. Select your node from the **Confi
 
 From a node's detail screen, **Remote Admin** opens that node's configuration directly. If the app does not have a current admin session, it requests fresh device metadata first and shows the target name while the session is established. A disconnected radio, changed target, or 30-second timeout leaves the screen in an error state with a **Retry Remote Admin** action; Settings is opened only after the session becomes active.
 
+The Remote Admin page stays inside node navigation: Back from a configuration section returns to the remote Settings page, and Back from that page returns to the node. It does not switch to the app’s Settings tab.
+
 ### Node selection
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -35,6 +35,10 @@ Turning a toggle off suppresses only the alert — messages, reactions, waypoint
 
 Radio configuration requires a connected node. Select your node from the **Configure** section if you have multiple nodes.
 
+### Remote administration
+
+From a node's detail screen, **Remote Admin** opens that node's configuration directly. If the app does not have a current admin session, it requests fresh device metadata first and shows the target name while the session is established. A disconnected radio, changed target, or 30-second timeout leaves the screen in an error state with a **Retry Remote Admin** action; Settings is opened only after the session becomes active.
+
 ### Node selection
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.


### PR DESCRIPTION
## Summary

- Adds target-scoped tracking for remote configuration requests, saves, retries, and confirmed responses for Android parity.
- Preserves Remote Admin session state across incoming configuration updates.
- Keeps feedback tied to the selected remote node rather than applying it to the local node or a later selection.

## Design specification

Implements the proposed [Remote Administration design issue](https://github.com/meshtastic/design/issues/144), especially target-scoped state, non-blocking loading/retry feedback, and confirmed remote saves.

## Why

Multi-hop responses are delayed and can arrive after navigation or selection changes. The tracker makes request state explicit, retries the right target, and prevents stale configuration feedback from being presented as another node’s result.

## Validation

- `xcodebuild test -workspace Meshtastic.xcworkspace -scheme Meshtastic -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' -derivedDataPath /tmp/remote-admin-feedback-main-build -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -parallel-testing-enabled NO -only-testing:MeshtasticTests/RemoteAdminEntryTests -only-testing:MeshtasticTests/NodeAdministrationTests -only-testing:MeshtasticTests/RemoteAdminConfigTrackerTests`
- Result: **41 passed, 0 failed, 0 skipped**.
- `git diff --check` passed.

## Evidence

- [Real-bench Remote Admin journey](https://github.com/meshtastic/Meshtastic-Apple/pull/2409#issuecomment-5549672299)
- The design specification defines the expected loading, timeout/retry, and target-scoping states.

## Review note

This replaces closed stacked PR #2413. It is based directly on current `main` and includes the prerequisite Remote Admin entry implementation without a GitHub stack dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote administration for configuring connected and remote nodes.
  * Added remote settings navigation with node-specific configuration screens.
  * Added session validation and automatic setup before remote administration.
  * Added progress indicators, completion feedback, and retry actions for remote configuration requests and saves.

* **Bug Fixes**
  * Remote configuration failures, timeouts, disconnections, and routing errors now provide clear feedback.
  * Session credentials are preserved correctly when received and are not cleared by empty responses.
  * Prevented duplicate remote configuration saves while one is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
