### PR TITLE
Add truthful remote reset actions for Android parity

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -200,7 +200,23 @@ extension AccessoryManager {
 		toRadio = ToRadio()
 		toRadio.packet = meshPacket
 
+		let operationID = RemoteAdminConfigTracker.currentOperationID
+		let enrolled = remoteAdminConfigTracker.registerPacket(
+			packetID: meshPacket.id,
+			targetNodeNum: Int64(meshPacket.to),
+			operationID: operationID
+		)
 		try await send(toRadio)
+		if enrolled, let operationID {
+			switch await remoteAdminConfigTracker.waitForPacket(packetID: meshPacket.id, operationID: operationID) {
+			case .succeeded:
+				break
+			case .failed(let message):
+				throw AccessoryError.ioFailed(message)
+			case .timedOut:
+				throw AccessoryError.timeout
+			}
+		}
 		if let adminDescription {
 			Logger.admin.debug("\(adminDescription, privacy: .public)")
 		}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -207,6 +207,9 @@ extension AccessoryManager {
 			targetNodeNum: Int64(meshPacket.to),
 			operationID: operationID
 		)
+		if operationID != nil && !enrolled {
+			throw AccessoryError.ioFailed("Remote admin operation is no longer active.")
+		}
 		try await send(toRadio)
 		if enrolled, let operationID {
 			let result = await remoteAdminConfigTracker.waitForPacket(packetID: meshPacket.id, operationID: operationID)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -897,6 +897,9 @@ extension AccessoryManager {
 	public func saveChannel(channel: Channel, fromUser: UserEntity, toUser: UserEntity) async throws -> Int64 {
 		var adminPacket = AdminMessage()
 		adminPacket.setChannel = channel
+		if fromUser != toUser {
+			adminPacket.sessionPasskey = toUser.userNode?.sessionPasskey ?? Data()
+		}
 		var meshPacket: MeshPacket = MeshPacket()
 		meshPacket.to = UInt32(toUser.num)
 		meshPacket.from	= UInt32(fromUser.num)
@@ -914,6 +917,23 @@ extension AccessoryManager {
 		let messageDescription = "🛟 Saved Channel \(channel.index) for \(toUser.longName ?? "Unknown".localized)"
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 		return Int64(meshPacket.id)
+	}
+
+	/// Requests one channel from a remote admin target. The wire request is one based while
+	/// the response's Channel.index remains zero based.
+	public func requestRemoteChannel(index: Int32, fromUser: UserEntity, toUser: UserEntity) async throws -> UInt32 {
+		guard (0...7).contains(index) else {
+			throw AccessoryError.appError("Channel index must be between 0 and 7")
+		}
+		let sessionPasskey = toUser.userNode?.sessionPasskey ?? Data()
+		let packet = try RemoteChannelsPacketBuilder.getRequest(
+			index: index, from: UInt32(fromUser.num), to: UInt32(toUser.num), sessionPasskey: sessionPasskey
+		)
+		try await sendAdminMessageToRadio(
+			meshPacket: packet,
+			adminDescription: "🛟 Requested remote Channel \(index) for \(toUser.longName ?? "Unknown".localized)"
+		)
+		return packet.id
 	}
 
 	/// Join a mesh advertised by a beacon: set the primary channel to the offered channel (name +

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -119,8 +119,39 @@ extension AccessoryManager {
 		meshPacket.decoded = dataMessage
 
 		let messageDescription = "⌚ Device Config timezone was empty set timezone to \(config.tzdef)"
-		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
-		return Int64(meshPacket.id)
+		func sendRequest() async throws -> Int64 {
+			try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+			return Int64(meshPacket.id)
+		}
+
+		// A remote metadata response establishes a PKI session. Enroll the request so
+		// only a response matched to this packet can persist its passkey.
+		guard fromUserNum != toUserNum, RemoteAdminConfigTracker.currentOperationID == nil else {
+			return try await sendRequest()
+		}
+		guard let operationID = beginRemoteAdminConfigOperation(
+			kind: .request,
+			targetNodeNum: Int64(toUserNum),
+			section: "Metadata"
+		) else {
+			throw AccessoryError.ioFailed("A remote metadata request is already in progress for this node")
+		}
+		do {
+			let value = try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+				try await sendRequest()
+			}
+			switch remoteAdminConfigTracker.finish(operationID) {
+			case .succeeded:
+				return value
+			case .failed(let message):
+				throw AccessoryError.ioFailed(message)
+			case .timedOut:
+				throw AccessoryError.timeout
+			}
+		} catch {
+			remoteAdminConfigTracker.fail(operationID, with: error)
+			throw error
+		}
 	}
 
 	// MARK: - Edit transactions

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -194,7 +194,8 @@ extension AccessoryManager {
 	}
 
 	// Send an admin message to a radio, save a message to core data for logging
-	private func sendAdminMessageToRadio(meshPacket: MeshPacket, adminDescription: String?) async throws {
+	@discardableResult
+	private func sendAdminMessageToRadio(meshPacket: MeshPacket, adminDescription: String?) async throws -> RemoteAdminConfigOperationResult? {
 
 		var toRadio: ToRadio!
 		toRadio = ToRadio()
@@ -208,17 +209,53 @@ extension AccessoryManager {
 		)
 		try await send(toRadio)
 		if enrolled, let operationID {
-			switch await remoteAdminConfigTracker.waitForPacket(packetID: meshPacket.id, operationID: operationID) {
+			let result = await remoteAdminConfigTracker.waitForPacket(packetID: meshPacket.id, operationID: operationID)
+			switch result {
 			case .succeeded:
+				break
+			case .acknowledged:
 				break
 			case .failed(let message):
 				throw AccessoryError.ioFailed(message)
 			case .timedOut:
 				throw AccessoryError.timeout
+			case .unconfirmed:
+				break
 			}
+			if let adminDescription {
+				Logger.admin.debug("\(adminDescription, privacy: .public)")
+			}
+			return result
 		}
 		if let adminDescription {
 			Logger.admin.debug("\(adminDescription, privacy: .public)")
+		}
+		return nil
+	}
+
+	private func sendRemoteAdminAction(
+		meshPacket: MeshPacket,
+		targetNodeNum: Int64,
+		adminDescription: String
+	) async throws -> RemoteAdminActionResult {
+		guard let operationID = beginRemoteAdminConfigOperation(kind: .action, targetNodeNum: targetNodeNum, section: "action") else {
+			throw AccessoryError.ioFailed("A remote admin action is already in progress for this node.")
+		}
+		do {
+			let transportResult = try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+				try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: adminDescription)
+			}
+			switch transportResult {
+			case .acknowledged, .succeeded:
+				return .acknowledged
+			case .unconfirmed, .timedOut, nil:
+				return .unconfirmed
+			case .failed(let message):
+				return .failed(message)
+			}
+		} catch {
+			remoteAdminConfigTracker.fail(operationID, with: error)
+			throw error
 		}
 	}
 
@@ -2312,7 +2349,8 @@ extension AccessoryManager {
 		return Int64(meshPacket.id)
 	}
 
-	public func sendFactoryReset(fromUser: UserEntity, toUser: UserEntity, resetDevice: Bool = false) async throws {
+	@discardableResult
+	public func sendFactoryReset(fromUser: UserEntity, toUser: UserEntity, resetDevice: Bool = false) async throws -> RemoteAdminActionResult {
 		var adminPacket = AdminMessage()
 		if resetDevice {
 			adminPacket.factoryResetDevice = 5
@@ -2332,13 +2370,21 @@ extension AccessoryManager {
 		if let serializedData: Data = try? adminPacket.serializedData() {
 			dataMessage.payload = serializedData
 			dataMessage.portnum = PortNum.adminApp
+			dataMessage.wantResponse = true
 			meshPacket.decoded = dataMessage
 		} else {
 			throw AccessoryError.ioFailed("saveLicensedUser: Unable to serialize admin packet")
 		}
 
 		let messageDescription = "🚀 Sent Factory Reset Admin Message to: \(toUser.longName ?? "Unknown".localized) from: \(fromUser.longName ??  "Unknown".localized)"
-		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+		if fromUser.num == toUser.num {
+			try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+			return .acknowledged
+		}
+		return try await sendRemoteAdminAction(
+			meshPacket: meshPacket,
+			targetNodeNum: toUser.num,
+			adminDescription: messageDescription)
 	}
 
 	public func setFixedPosition(fromUser: UserEntity, channel: Int32) async throws {
@@ -2672,7 +2718,8 @@ extension AccessoryManager {
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 	}
 
-	public func sendNodeDBReset(fromUser: UserEntity, toUser: UserEntity, preserveFavorites: Bool = true) async throws {
+	@discardableResult
+	public func sendNodeDBReset(fromUser: UserEntity, toUser: UserEntity, preserveFavorites: Bool = true) async throws -> RemoteAdminActionResult {
 		var adminPacket = AdminMessage()
 		// nodedbReset = true means preserve favorites; false means wipe all nodes.
 		adminPacket.nodedbReset = preserveFavorites
@@ -2681,7 +2728,7 @@ extension AccessoryManager {
 		}
 		var meshPacket: MeshPacket = MeshPacket()
 		meshPacket.to = UInt32(toUser.num)
-		meshPacket.from	= 0 // UInt32(fromUser.num)
+		meshPacket.from	= UInt32(fromUser.num)
 		meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
 		meshPacket.priority =  MeshPacket.Priority.reliable
 		meshPacket.wantAck = true
@@ -2691,10 +2738,18 @@ extension AccessoryManager {
 		}
 		dataMessage.payload = adminData
 		dataMessage.portnum = PortNum.adminApp
+		dataMessage.wantResponse = true
 
 		meshPacket.decoded = dataMessage
 		let messageDescription = "🚀 Sent NodeDB Reset Admin Message to: \(toUser.longName ?? "unknown".localized) from: \(fromUser.longName ?? "unknown".localized)"
-		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+		if fromUser.num == toUser.num {
+			try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+			return .acknowledged
+		}
+		return try await sendRemoteAdminAction(
+			meshPacket: meshPacket,
+			targetNodeNum: toUser.num,
+			adminDescription: messageDescription)
 	}
 
 	public func requestBluetoothConfig(fromUser: UserEntity, toUser: UserEntity) async throws {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -1029,11 +1029,11 @@ extension AccessoryManager {
 					try await operation()
 				}
 				switch remoteAdminConfigTracker.finish(operationID) {
-				case .succeeded:
+				case .succeeded, .acknowledged:
 					return value
 				case .failed(let message):
 					throw AccessoryError.ioFailed(message)
-				case .timedOut:
+				case .timedOut, .unconfirmed:
 					throw AccessoryError.timeout
 				}
 			} catch {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -380,7 +380,8 @@ extension AccessoryManager {
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 	}
 
-	public func sendTime(fromUser: UserEntity, toUser: UserEntity) async throws {
+	@discardableResult
+	public func sendTime(fromUser: UserEntity, toUser: UserEntity) async throws -> RemoteAdminActionResult {
 		var adminPacket = AdminMessage()
 		adminPacket.setTimeOnly = UInt32(Date().timeIntervalSince1970)
 		if fromUser != toUser {
@@ -396,12 +397,20 @@ extension AccessoryManager {
 		if let serializedData: Data = try? adminPacket.serializedData() {
 			dataMessage.payload = serializedData
 			dataMessage.portnum = PortNum.adminApp
+			dataMessage.wantResponse = true
 			meshPacket.decoded = dataMessage
 		} else {
 			throw AccessoryError.ioFailed("sendTime(fromUser:toUser:): Unable to serialize admin packet")
 		}
 		let messageDescription = "🕛 Sent Set Time Admin Message to: \(toUser.longName ?? "Unknown".localized) from: \(fromUser.longName ?? "Unknown".localized)"
-		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+		if fromUser.num == toUser.num {
+			try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+			return .acknowledged
+		}
+		return try await sendRemoteAdminAction(
+			meshPacket: meshPacket,
+			targetNodeNum: toUser.num,
+			adminDescription: messageDescription)
 	}
 	
 	public func sendShutdown(fromUser: UserEntity, toUser: UserEntity) async throws {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -119,39 +119,8 @@ extension AccessoryManager {
 		meshPacket.decoded = dataMessage
 
 		let messageDescription = "⌚ Device Config timezone was empty set timezone to \(config.tzdef)"
-		func sendRequest() async throws -> Int64 {
-			try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
-			return Int64(meshPacket.id)
-		}
-
-		// A remote metadata response establishes a PKI session. Enroll the request so
-		// only a response matched to this packet can persist its passkey.
-		guard fromUserNum != toUserNum, RemoteAdminConfigTracker.currentOperationID == nil else {
-			return try await sendRequest()
-		}
-		guard let operationID = beginRemoteAdminConfigOperation(
-			kind: .request,
-			targetNodeNum: Int64(toUserNum),
-			section: "Metadata"
-		) else {
-			throw AccessoryError.ioFailed("A remote metadata request is already in progress for this node")
-		}
-		do {
-			let value = try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
-				try await sendRequest()
-			}
-			switch remoteAdminConfigTracker.finish(operationID) {
-			case .succeeded:
-				return value
-			case .failed(let message):
-				throw AccessoryError.ioFailed(message)
-			case .timedOut:
-				throw AccessoryError.timeout
-			}
-		} catch {
-			remoteAdminConfigTracker.fail(operationID, with: error)
-			throw error
-		}
+		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+		return Int64(meshPacket.id)
 	}
 
 	// MARK: - Edit transactions
@@ -1540,8 +1509,37 @@ extension AccessoryManager {
 		}
 
 		let messageDescription = "🛎️ [Device Metadata] Requested for node \(toUser?.longName ?? "#\(toUserNum)") by \(fromUser?.longName ?? "#\(fromUserNum)")"
-		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
-		return Int64(meshPacket.id)
+		func sendRequest() async throws -> Int64 {
+			try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+			return Int64(meshPacket.id)
+		}
+
+		guard fromUserNum != toUserNum, RemoteAdminConfigTracker.currentOperationID == nil else {
+			return try await sendRequest()
+		}
+		guard let operationID = beginRemoteAdminConfigOperation(
+			kind: .request,
+			targetNodeNum: Int64(toUserNum),
+			section: "Metadata"
+		) else {
+			throw AccessoryError.ioFailed("A remote metadata request is already in progress for this node")
+		}
+		do {
+			let value = try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+				try await sendRequest()
+			}
+			switch remoteAdminConfigTracker.finish(operationID) {
+			case .succeeded, .acknowledged:
+				return value
+			case .failed(let message):
+				throw AccessoryError.ioFailed(message)
+			case .timedOut, .unconfirmed:
+				throw AccessoryError.timeout
+			}
+		} catch {
+			remoteAdminConfigTracker.fail(operationID, with: error)
+			throw error
+		}
 	}
 
 	public func saveAmbientLightingModuleConfig(config: ModuleConfig.AmbientLightingConfig, fromUser: UserEntity, toUser: UserEntity) async throws -> Int64 {

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -988,8 +988,10 @@ extension AccessoryManager {
 		meshPacket.decoded = dataMessage
 
 		let messageDescription = "🛟 Saved Channel \(channel.index) for \(toUser.longName ?? "Unknown".localized)"
-		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
-		return Int64(meshPacket.id)
+		return try await withRemoteChannelOperation(kind: .save, targetNodeNum: toUser.num, isRemote: fromUser != toUser) {
+			try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+			return Int64(meshPacket.id)
+		}
 	}
 
 	/// Requests one channel from a remote admin target. The wire request is one based while
@@ -1002,11 +1004,46 @@ extension AccessoryManager {
 		let packet = try RemoteChannelsPacketBuilder.getRequest(
 			index: index, from: UInt32(fromUser.num), to: UInt32(toUser.num), sessionPasskey: sessionPasskey
 		)
-		try await sendAdminMessageToRadio(
-			meshPacket: packet,
-			adminDescription: "🛟 Requested remote Channel \(index) for \(toUser.longName ?? "Unknown".localized)"
-		)
-		return packet.id
+		return try await withRemoteChannelOperation(kind: .request, targetNodeNum: toUser.num, isRemote: fromUser != toUser) {
+			try await sendAdminMessageToRadio(
+				meshPacket: packet,
+				adminDescription: "🛟 Requested remote Channel \(index) for \(toUser.longName ?? "Unknown".localized)"
+			)
+			return packet.id
+		}
+	}
+
+	private func withRemoteChannelOperation<T>(
+		kind: RemoteAdminConfigOperationKind,
+		targetNodeNum: Int64,
+		isRemote: Bool,
+		operation: () async throws -> T
+	) async throws -> T {
+		guard isRemote else { return try await operation() }
+		guard let existingOperationID = RemoteAdminConfigTracker.currentOperationID else {
+			guard let operationID = beginRemoteAdminConfigOperation(kind: kind, targetNodeNum: targetNodeNum, section: "Channels") else {
+				throw AccessoryError.ioFailed("A remote channel operation is already in progress for this node")
+			}
+			do {
+				let value = try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+					try await operation()
+				}
+				switch remoteAdminConfigTracker.finish(operationID) {
+				case .succeeded:
+					return value
+				case .failed(let message):
+					throw AccessoryError.ioFailed(message)
+				case .timedOut:
+					throw AccessoryError.timeout
+				}
+			} catch {
+				remoteAdminConfigTracker.fail(operationID, with: error)
+				throw error
+			}
+		}
+		return try await RemoteAdminConfigTracker.$currentOperationID.withValue(existingOperationID) {
+			try await operation()
+		}
 	}
 
 	/// Join a mesh advertised by a beacon: set the primary channel to the offered channel (name +

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -342,6 +342,30 @@ extension AccessoryManager {
 		let messageDescription = "🕛 Sent Set Time Admin Message to the connected node."
 		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
 	}
+
+	public func sendTime(fromUser: UserEntity, toUser: UserEntity) async throws {
+		var adminPacket = AdminMessage()
+		adminPacket.setTimeOnly = UInt32(Date().timeIntervalSince1970)
+		if fromUser != toUser {
+			adminPacket.sessionPasskey = toUser.userNode?.sessionPasskey ?? Data()
+		}
+		var meshPacket: MeshPacket = MeshPacket()
+		meshPacket.to = UInt32(toUser.num)
+		meshPacket.from = UInt32(fromUser.num)
+		meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+		meshPacket.priority = MeshPacket.Priority.reliable
+		meshPacket.wantAck = true
+		var dataMessage = DataMessage()
+		if let serializedData: Data = try? adminPacket.serializedData() {
+			dataMessage.payload = serializedData
+			dataMessage.portnum = PortNum.adminApp
+			meshPacket.decoded = dataMessage
+		} else {
+			throw AccessoryError.ioFailed("sendTime(fromUser:toUser:): Unable to serialize admin packet")
+		}
+		let messageDescription = "🕛 Sent Set Time Admin Message to: \(toUser.longName ?? "Unknown".localized) from: \(fromUser.longName ?? "Unknown".localized)"
+		try await sendAdminMessageToRadio(meshPacket: meshPacket, adminDescription: messageDescription)
+	}
 	
 	public func sendShutdown(fromUser: UserEntity, toUser: UserEntity) async throws {
 		var adminPacket = AdminMessage()

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -622,6 +622,25 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 	}
 
+	/// A routing rejection invalidates only the remote node whose session was rejected.
+	/// The local transport and sessions for other remote nodes remain usable.
+	@discardableResult
+	func invalidateRemoteAdminSession(for targetNodeNum: Int64) -> Bool {
+		let descriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == targetNodeNum })
+		guard let node = try? context.fetch(descriptor).first,
+			  node.sessionPasskey != nil || node.sessionExpiration != nil else { return false }
+
+		node.sessionPasskey = nil
+		node.sessionExpiration = nil
+		do {
+			try context.save()
+			return true
+		} catch {
+			Logger.data.error("💥 [AccessoryManager] Failed to clear remote admin session for node \(targetNodeNum, privacy: .public): \(error.localizedDescription, privacy: .public)")
+			return false
+		}
+	}
+
 	func closeConnection() async throws {
 		failRemoteAdminConfigOperations(with: "The radio connection was closed before the remote node confirmed the configuration.")
 		guard !isClosingConnection else {
@@ -828,11 +847,17 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 	}
 
-	func resolveRemoteAdminRoutingError(packetID: UInt32, reason: String) {
-		guard let operationID = remoteAdminConfigTracker.resolveRouting(packetID: packetID, sourceNodeNum: 0, reason: reason, isFailure: true),
+	func resolveRemoteAdminRoutingError(packetID: UInt32, reason: Routing.Error) {
+		let message = "Remote node rejected the request: \(reason)"
+		guard let operationID = remoteAdminConfigTracker.resolveRouting(packetID: packetID, sourceNodeNum: 0, reason: message, isFailure: true),
 			  let operation = remoteAdminConfigTracker.operations[operationID]
 		else { return }
-		remoteAdminConfigFeedback = (operation.targetNodeNum, reason)
+		// A rejected passkey must not be retried. Other routing errors do not prove that
+		// the cached authorization material itself is invalid.
+		if reason == .adminBadSessionKey {
+			invalidateRemoteAdminSession(for: operation.targetNodeNum)
+		}
+		remoteAdminConfigFeedback = (operation.targetNodeNum, message)
 	}
 
 	func failRemoteAdminConfigOperations(with message: String) {
@@ -1032,7 +1057,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 						} else {
 							resolveRemoteAdminRoutingError(
 								packetID: responseID,
-								reason: "Remote node rejected the request: \(reason)")
+								reason: reason)
 						}
 					}
 				}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -162,6 +162,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// back off repeats (see `shouldSurfaceFirmwareNotice`). In memory on purpose: after a
 	/// relaunch a standing notice alerts once more, which is the useful behaviour.
 	var firmwareNoticeHistory: [String: (count: Int, lastShown: Date)] = [:]
+	let remoteAdminConfigTracker = RemoteAdminConfigTracker()
+	@Published var remoteAdminConfigFeedback: (targetNodeNum: Int64, message: String)? = nil
 	/// Delay before the Nth repeat of the same notice may alert again.
 	static let firmwareNoticeBackoff: [TimeInterval] = [0, 300, 1_800, 7_200, 43_200]
 	/// A notice unseen for this long is forgotten, so it alerts immediately if it returns.
@@ -328,6 +330,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// monitor. True while sustained inbound mesh traffic is high enough to pause the map flyover.
 	@Published private(set) var isHighMeshTraffic = false
 	private var meshTrafficCancellable: AnyCancellable?
+	private var remoteAdminTrackerCancellable: AnyCancellable?
 
 	/// Packet count at the last periodic MeshPackets recycle (see `didReceive`). The ingest
 	/// actor's ModelContext registers every entity it inserts or faults and never lets go, so a
@@ -393,6 +396,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			.sink { [weak self] isHigh in
 				self?.isHighMeshTraffic = isHigh
 			}
+		remoteAdminTrackerCancellable = remoteAdminConfigTracker.objectWillChange
+			.sink { [weak self] _ in self?.objectWillChange.send() }
 	}
 
 	func transportForType(_ type: TransportType) -> Transport? {
@@ -595,6 +600,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	// If you are calling this in response to an error, then you should have
 	// exposed the error to the UI or handled the error prior to calling this.
 	func closeConnection() async throws {
+		failRemoteAdminConfigOperations(with: "The radio connection was closed before the remote node confirmed the configuration.")
 		guard !isClosingConnection else {
 			Logger.transport.debug("[AccessoryManager] closeConnection ignored while teardown is already in progress")
 			return
@@ -782,6 +788,31 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 	}
 
+	@discardableResult
+	func beginRemoteAdminConfigOperation(kind: RemoteAdminConfigOperationKind, targetNodeNum: Int64, section: String = "save") -> UUID? {
+		remoteAdminConfigTracker.begin(kind: kind, targetNodeNum: targetNodeNum, section: section)
+	}
+
+	func resolveRemoteAdminConfigPacket(packetID: UInt32, sourceNodeNum: Int64, result: RemoteAdminConfigOperationResult) {
+		guard let operationID = remoteAdminConfigTracker.resolveAdminResponse(packetID: packetID, sourceNodeNum: sourceNodeNum),
+			  let operation = remoteAdminConfigTracker.operations[operationID]
+		else { return }
+		if case .failed(let message) = result {
+			remoteAdminConfigFeedback = (operation.targetNodeNum, message)
+		}
+	}
+
+	func resolveRemoteAdminRoutingError(packetID: UInt32, reason: String) {
+		guard let operationID = remoteAdminConfigTracker.resolveRouting(packetID: packetID, sourceNodeNum: 0, reason: reason, isFailure: true),
+			  let operation = remoteAdminConfigTracker.operations[operationID]
+		else { return }
+		remoteAdminConfigFeedback = (operation.targetNodeNum, reason)
+	}
+
+	func failRemoteAdminConfigOperations(with message: String) {
+		remoteAdminConfigTracker.failAll(with: message)
+	}
+
 	func didReceive(_ event: ConnectionEvent) async {
 		let shouldIgnoreTransientEvent = isClosingConnection || userRequestedConnectionCancellation || activeConnection == nil
 
@@ -833,6 +864,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			updateDevice(deviceId: deviceId, key: \.rssi, value: rssi)
 			
 		case .error(let error), .errorWithoutReconnect(let error):
+			failRemoteAdminConfigOperations(with: "The radio connection was lost before the remote node confirmed the configuration.")
 			Task {
 				// Figure out if we'll reconnect
 				if case .errorWithoutReconnect = event {
@@ -864,6 +896,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			}
 			
 		case .disconnected:
+			failRemoteAdminConfigOperations(with: "The radio connection was lost before the remote node confirmed the configuration.")
 			guard !shouldIgnoreTransientEvent else {
 				Logger.transport.info("[Accessory] Ignoring disconnect event during teardown.")
 				return
@@ -951,6 +984,32 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 			// Dispatch based on packet contents.
 			if case let .decoded(data) = packet.payloadVariant {
+				let responseID = data.requestID != 0 ? data.requestID : data.replyID
+				if responseID != 0 {
+					if data.portnum == .adminApp,
+						let adminMessage = try? AdminMessage(serializedBytes: data.payload),
+						RemoteAdminConfigTracker.isAdminResponse(adminMessage) {
+						resolveRemoteAdminConfigPacket(
+							packetID: responseID,
+							sourceNodeNum: Int64(packet.from),
+							result: .succeeded
+						)
+					} else if data.portnum == .routingApp,
+						   let routing = try? Routing(serializedBytes: data.payload),
+						   case .errorReason(let reason)? = routing.variant {
+						if reason == .none {
+							remoteAdminConfigTracker.resolveRouting(
+								packetID: responseID,
+								sourceNodeNum: Int64(packet.from),
+								reason: nil,
+								isFailure: false)
+						} else {
+							resolveRemoteAdminRoutingError(
+								packetID: responseID,
+								reason: "Remote node rejected the request: \(reason)")
+						}
+					}
+				}
 				// Forward packets to discovery scan engine if active
 				if let engine = discoveryScanEngine, engine.isScanning {
 					engine.handleMeshPacket(packet, portNum: data.portnum)

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -163,7 +163,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	/// relaunch a standing notice alerts once more, which is the useful behaviour.
 	var firmwareNoticeHistory: [String: (count: Int, lastShown: Date)] = [:]
 	let remoteAdminConfigTracker = RemoteAdminConfigTracker()
-	@Published var remoteAdminConfigFeedback: (targetNodeNum: Int64, message: String)? = nil
+	@Published var remoteAdminConfigFeedback: RemoteAdminConfigFeedback?
 	/// Delay before the Nth repeat of the same notice may alert again.
 	static let firmwareNoticeBackoff: [TimeInterval] = [0, 300, 1_800, 7_200, 43_200]
 	/// A notice unseen for this long is forgotten, so it alerts immediately if it returns.
@@ -838,13 +838,21 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		remoteAdminConfigTracker.begin(kind: kind, targetNodeNum: targetNodeNum, section: section)
 	}
 
+	func remoteAdminConfigFeedback(for targetNodeNum: Int64, kind: RemoteAdminConfigOperationKind) -> String? {
+		guard let feedback = remoteAdminConfigFeedback,
+			  feedback.targetNodeNum == targetNodeNum,
+			  feedback.kind == kind else { return nil }
+		return feedback.message
+	}
+
 	@discardableResult
 	func resolveRemoteAdminConfigPacket(packetID: UInt32, sourceNodeNum: Int64, result: RemoteAdminConfigOperationResult) -> Bool {
 		guard let operationID = remoteAdminConfigTracker.resolveAdminResponse(packetID: packetID, sourceNodeNum: sourceNodeNum),
 			  let operation = remoteAdminConfigTracker.operations[operationID]
 		else { return false }
 		if case .failed(let message) = result {
-			remoteAdminConfigFeedback = (operation.targetNodeNum, message)
+			remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+				targetNodeNum: operation.targetNodeNum, kind: operation.kind, message: message)
 		}
 		return true
 	}
@@ -859,7 +867,8 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		if reason == .adminBadSessionKey {
 			invalidateRemoteAdminSession(for: operation.targetNodeNum)
 		}
-		remoteAdminConfigFeedback = (operation.targetNodeNum, message)
+		remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+			targetNodeNum: operation.targetNodeNum, kind: operation.kind, message: message)
 	}
 
 	func failRemoteAdminConfigOperations(with message: String) {
@@ -1038,7 +1047,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 			// Dispatch based on packet contents.
 			if case let .decoded(data) = packet.payloadVariant {
 				var isCorrelatedRemoteAdminResponse = false
-				let responseID = data.requestID != 0 ? data.requestID : data.replyID
+				let responseID = data.requestID
 				if responseID != 0 {
 					if data.portnum == .adminApp,
 						packet.to == UInt32(self.activeDeviceNum ?? 0),

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -599,6 +599,29 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	// Fully tears down a connection and sets up the AccessoryManager for the next.
 	// If you are calling this in response to an error, then you should have
 	// exposed the error to the UI or handled the error prior to calling this.
+	/// Clears every cached remote-admin authorization before the next transport can be used.
+	/// Session passkeys are scoped to the local transport session; retaining one across a
+	/// disconnect would let a reconnect reuse authorization established by the previous link.
+	@discardableResult
+	func invalidateRemoteAdminSessions() -> Int {
+		do {
+			let nodes = try context.fetch(FetchDescriptor<NodeInfoEntity>())
+			var invalidated = 0
+			for node in nodes where node.sessionPasskey != nil || node.sessionExpiration != nil {
+				node.sessionPasskey = nil
+				node.sessionExpiration = nil
+				invalidated += 1
+			}
+			if invalidated > 0 {
+				try context.save()
+			}
+			return invalidated
+		} catch {
+			Logger.data.error("💥 [AccessoryManager] Failed to clear remote admin sessions: \(error.localizedDescription, privacy: .public)")
+			return 0
+		}
+	}
+
 	func closeConnection() async throws {
 		failRemoteAdminConfigOperations(with: "The radio connection was closed before the remote node confirmed the configuration.")
 		guard !isClosingConnection else {
@@ -618,6 +641,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		}
 		self.activeDeviceNum = nil
 		self.firmwareUpdateRequired = false
+		// A remote-admin session is authorized by the local transport that established it.
+		// Clear all cached passkeys before a replacement/reconnect can observe them as fresh.
+		invalidateRemoteAdminSessions()
 		if let refresh = activeAutomaticConfigRefresh {
 			automaticConfigRefreshTask?.cancel()
 			await finishAutomaticConfigRefresh(owner: refresh.owner, error: CancellationError())

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -838,13 +838,15 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 		remoteAdminConfigTracker.begin(kind: kind, targetNodeNum: targetNodeNum, section: section)
 	}
 
-	func resolveRemoteAdminConfigPacket(packetID: UInt32, sourceNodeNum: Int64, result: RemoteAdminConfigOperationResult) {
+	@discardableResult
+	func resolveRemoteAdminConfigPacket(packetID: UInt32, sourceNodeNum: Int64, result: RemoteAdminConfigOperationResult) -> Bool {
 		guard let operationID = remoteAdminConfigTracker.resolveAdminResponse(packetID: packetID, sourceNodeNum: sourceNodeNum),
 			  let operation = remoteAdminConfigTracker.operations[operationID]
-		else { return }
+		else { return false }
 		if case .failed(let message) = result {
 			remoteAdminConfigFeedback = (operation.targetNodeNum, message)
 		}
+		return true
 	}
 
 	func resolveRemoteAdminRoutingError(packetID: UInt32, reason: Routing.Error) {
@@ -1035,12 +1037,14 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 			// Dispatch based on packet contents.
 			if case let .decoded(data) = packet.payloadVariant {
+				var isCorrelatedRemoteAdminResponse = false
 				let responseID = data.requestID != 0 ? data.requestID : data.replyID
 				if responseID != 0 {
 					if data.portnum == .adminApp,
+						packet.to == UInt32(self.activeDeviceNum ?? 0),
 						let adminMessage = try? AdminMessage(serializedBytes: data.payload),
 						RemoteAdminConfigTracker.isAdminResponse(adminMessage) {
-						resolveRemoteAdminConfigPacket(
+						isCorrelatedRemoteAdminResponse = resolveRemoteAdminConfigPacket(
 							packetID: responseID,
 							sourceNodeNum: Int64(packet.from),
 							result: .succeeded
@@ -1120,7 +1124,11 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 					}
 					await MeshPackets.shared.routingPacket(packet: packet, connectedNodeNum: deviceNum)
 				case .adminApp:
-					await MeshPackets.shared.adminAppPacket(packet: packet, connectedNodeNum: self.activeDeviceNum)
+					await MeshPackets.shared.adminAppPacket(
+						packet: packet,
+						connectedNodeNum: self.activeDeviceNum,
+						isCorrelatedRemoteAdminResponse: isCorrelatedRemoteAdminResponse
+					)
 				case .replyApp:
 					Logger.mesh.info("[Reply] packet received from \(packet.from.toHex(), privacy: .public)")
 					guard let deviceNum = activeConnection?.device.num else {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1209,7 +1209,17 @@ actor MeshPackets {
 					}
 				}
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getChannelResponse(adminMessage.getChannelResponse) {
-				channelPacket(channel: adminMessage.getChannelResponse, fromNum: Int64(packet.from))
+				// Remote Channels editing owns an in-memory target-scoped snapshot. Persisting a
+				// remote response through channelPacket would incorrectly attach it to MyInfo and
+				// overwrite the connected radio's local channel state.
+				if let connectedNodeNum, Int64(packet.from) == connectedNodeNum {
+					channelPacket(channel: adminMessage.getChannelResponse, fromNum: Int64(packet.from))
+				}
+				NotificationCenter.default.post(
+					name: .remoteChannelResponse,
+					object: nil,
+					userInfo: ["packet": packet, "response": adminMessage]
+				)
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getDeviceMetadataResponse(adminMessage.getDeviceMetadataResponse) {
 				deviceMetadataPacket(metadata: adminMessage.getDeviceMetadataResponse, fromNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getConfigResponse(adminMessage.getConfigResponse) {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1234,31 +1234,31 @@ actor MeshPackets {
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getModuleConfigResponse(adminMessage.getModuleConfigResponse) {
 				let moduleConfig = adminMessage.getModuleConfigResponse
 				if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.ambientLighting(moduleConfig.ambientLighting) {
-					self.upsertAmbientLightingModuleConfigPacket(config: moduleConfig.ambientLighting, nodeNum: Int64(packet.from))
+					self.upsertAmbientLightingModuleConfigPacket(config: moduleConfig.ambientLighting, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.audio(moduleConfig.audio) {
-					self.upsertAudioModuleConfigPacket(config: moduleConfig.audio, nodeNum: Int64(packet.from))
+					self.upsertAudioModuleConfigPacket(config: moduleConfig.audio, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.cannedMessage(moduleConfig.cannedMessage) {
-					self.upsertCannedMessagesModuleConfigPacket(config: moduleConfig.cannedMessage, nodeNum: Int64(packet.from))
+					self.upsertCannedMessagesModuleConfigPacket(config: moduleConfig.cannedMessage, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.detectionSensor(moduleConfig.detectionSensor) {
-					self.upsertDetectionSensorModuleConfigPacket(config: moduleConfig.detectionSensor, nodeNum: Int64(packet.from))
+					self.upsertDetectionSensorModuleConfigPacket(config: moduleConfig.detectionSensor, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.externalNotification(moduleConfig.externalNotification) {
-					self.upsertExternalNotificationModuleConfigPacket(config: moduleConfig.externalNotification, nodeNum: Int64(packet.from))
+					self.upsertExternalNotificationModuleConfigPacket(config: moduleConfig.externalNotification, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.mqtt(moduleConfig.mqtt) {
-					self.upsertMqttModuleConfigPacket(config: moduleConfig.mqtt, nodeNum: Int64(packet.from))
+					self.upsertMqttModuleConfigPacket(config: moduleConfig.mqtt, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.rangeTest(moduleConfig.rangeTest) {
-					self.upsertRangeTestModuleConfigPacket(config: moduleConfig.rangeTest, nodeNum: Int64(packet.from))
+					self.upsertRangeTestModuleConfigPacket(config: moduleConfig.rangeTest, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.serial(moduleConfig.serial) {
-					self.upsertSerialModuleConfigPacket(config: moduleConfig.serial, nodeNum: Int64(packet.from))
+					self.upsertSerialModuleConfigPacket(config: moduleConfig.serial, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.storeForward(moduleConfig.storeForward) {
-					self.upsertStoreForwardModuleConfigPacket(config: moduleConfig.storeForward, nodeNum: Int64(packet.from))
+					self.upsertStoreForwardModuleConfigPacket(config: moduleConfig.storeForward, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.telemetry(moduleConfig.telemetry) {
-					self.upsertTelemetryModuleConfigPacket(config: moduleConfig.telemetry, nodeNum: Int64(packet.from))
+					self.upsertTelemetryModuleConfigPacket(config: moduleConfig.telemetry, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.tak(moduleConfig.tak) {
-					self.upsertTAKModuleConfigPacket(config: moduleConfig.tak, nodeNum: Int64(packet.from))
+					self.upsertTAKModuleConfigPacket(config: moduleConfig.tak, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.statusmessage(moduleConfig.statusmessage) {
-					self.upsertStatusMessageModuleConfigPacket(config: moduleConfig.statusmessage, nodeNum: Int64(packet.from))
+					self.upsertStatusMessageModuleConfigPacket(config: moduleConfig.statusmessage, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.trafficManagement(moduleConfig.trafficManagement) {
-					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from))
+					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
 				}
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getRingtoneResponse(adminMessage.getRingtoneResponse) {
 				if let rt = try? RTTTLConfig(serializedBytes: packet.decoded.payload) {

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -881,6 +881,22 @@ actor MeshPackets {
 		Self.applyChannelRefresh(stagedChannel, to: channel)
 	}
 
+	/// Stores a session key only after the receive path has correlated the response
+	/// with an authenticated remote-admin request.
+	private func rememberAdminSession(passkey: Data, fromNum: Int64) {
+		guard fromNum > 0, !passkey.isEmpty else { return }
+		let fetchDescriptor = FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == fromNum })
+		do {
+			let fetchedNode = try modelContext.fetch(fetchDescriptor)
+			let node = fetchedNode.first ?? findOrCreateNode(num: fromNum, context: modelContext)
+			node.sessionPasskey = passkey
+			node.sessionExpiration = Date().addingTimeInterval(300)
+			savePendingChanges()
+		} catch {
+			Logger.data.error("Error saving admin session for \(fromNum.toHex(), privacy: .public): \(error.localizedDescription, privacy: .public)")
+		}
+	}
+
 	func deviceMetadataPacket (metadata: DeviceMetadata, fromNum: Int64, sessionPasskey: Data? = Data()) {
 		if metadata.isInitialized {
 			let logString = String.localizedStringWithFormat("Device Metadata received from: %@".localized, fromNum.toHex())

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -1180,8 +1180,13 @@ actor MeshPackets {
 		return nil
 	}
 
-	func adminAppPacket (packet: MeshPacket, connectedNodeNum: Int64? = nil) {
+	func adminAppPacket (
+		packet: MeshPacket,
+		connectedNodeNum: Int64? = nil,
+		isCorrelatedRemoteAdminResponse: Bool = false
+	) {
 		if let adminMessage = try? AdminMessage(serializedBytes: packet.decoded.payload) {
+			let correlatedPasskey = isCorrelatedRemoteAdminResponse ? adminMessage.sessionPasskey : Data()
 
 			if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getCannedMessageModuleMessagesResponse(adminMessage.getCannedMessageModuleMessagesResponse) {
 
@@ -1215,65 +1220,70 @@ actor MeshPackets {
 				if let connectedNodeNum, Int64(packet.from) == connectedNodeNum {
 					channelPacket(channel: adminMessage.getChannelResponse, fromNum: Int64(packet.from))
 				}
+				if isCorrelatedRemoteAdminResponse {
+					rememberAdminSession(passkey: correlatedPasskey, fromNum: Int64(packet.from))
+				}
 				NotificationCenter.default.post(
 					name: .remoteChannelResponse,
 					object: nil,
 					userInfo: ["packet": packet, "response": adminMessage]
 				)
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getDeviceMetadataResponse(adminMessage.getDeviceMetadataResponse) {
-				deviceMetadataPacket(metadata: adminMessage.getDeviceMetadataResponse, fromNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+				deviceMetadataPacket(metadata: adminMessage.getDeviceMetadataResponse, fromNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getConfigResponse(adminMessage.getConfigResponse) {
 				let config = adminMessage.getConfigResponse
 				if config.payloadVariant == Config.OneOf_PayloadVariant.bluetooth(config.bluetooth) {
-					upsertBluetoothConfigPacket(config: config.bluetooth, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					upsertBluetoothConfigPacket(config: config.bluetooth, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if config.payloadVariant == Config.OneOf_PayloadVariant.device(config.device) {
-					upsertDeviceConfigPacket(config: config.device, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					upsertDeviceConfigPacket(config: config.device, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if config.payloadVariant == Config.OneOf_PayloadVariant.display(config.display) {
-					self.upsertDisplayConfigPacket(config: config.display, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertDisplayConfigPacket(config: config.display, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if config.payloadVariant == Config.OneOf_PayloadVariant.lora(config.lora) {
-					self.upsertLoRaConfigPacket(config: config.lora, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertLoRaConfigPacket(config: config.lora, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if config.payloadVariant == Config.OneOf_PayloadVariant.network(config.network) {
-					self.upsertNetworkConfigPacket(config: config.network, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertNetworkConfigPacket(config: config.network, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if config.payloadVariant == Config.OneOf_PayloadVariant.position(config.position) {
-					self.upsertPositionConfigPacket(config: config.position, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertPositionConfigPacket(config: config.position, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if config.payloadVariant == Config.OneOf_PayloadVariant.power(config.power) {
-					self.upsertPowerConfigPacket(config: config.power, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertPowerConfigPacket(config: config.power, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if config.payloadVariant == Config.OneOf_PayloadVariant.security(config.security) {
-					self.upsertSecurityConfigPacket(config: config.security, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertSecurityConfigPacket(config: config.security, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				}
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getModuleConfigResponse(adminMessage.getModuleConfigResponse) {
 				let moduleConfig = adminMessage.getModuleConfigResponse
 				if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.ambientLighting(moduleConfig.ambientLighting) {
-					self.upsertAmbientLightingModuleConfigPacket(config: moduleConfig.ambientLighting, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertAmbientLightingModuleConfigPacket(config: moduleConfig.ambientLighting, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.audio(moduleConfig.audio) {
-					self.upsertAudioModuleConfigPacket(config: moduleConfig.audio, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertAudioModuleConfigPacket(config: moduleConfig.audio, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.cannedMessage(moduleConfig.cannedMessage) {
-					self.upsertCannedMessagesModuleConfigPacket(config: moduleConfig.cannedMessage, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertCannedMessagesModuleConfigPacket(config: moduleConfig.cannedMessage, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.detectionSensor(moduleConfig.detectionSensor) {
-					self.upsertDetectionSensorModuleConfigPacket(config: moduleConfig.detectionSensor, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertDetectionSensorModuleConfigPacket(config: moduleConfig.detectionSensor, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.externalNotification(moduleConfig.externalNotification) {
-					self.upsertExternalNotificationModuleConfigPacket(config: moduleConfig.externalNotification, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertExternalNotificationModuleConfigPacket(config: moduleConfig.externalNotification, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.mqtt(moduleConfig.mqtt) {
-					self.upsertMqttModuleConfigPacket(config: moduleConfig.mqtt, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertMqttModuleConfigPacket(config: moduleConfig.mqtt, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.rangeTest(moduleConfig.rangeTest) {
-					self.upsertRangeTestModuleConfigPacket(config: moduleConfig.rangeTest, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertRangeTestModuleConfigPacket(config: moduleConfig.rangeTest, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.serial(moduleConfig.serial) {
-					self.upsertSerialModuleConfigPacket(config: moduleConfig.serial, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertSerialModuleConfigPacket(config: moduleConfig.serial, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.storeForward(moduleConfig.storeForward) {
-					self.upsertStoreForwardModuleConfigPacket(config: moduleConfig.storeForward, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertStoreForwardModuleConfigPacket(config: moduleConfig.storeForward, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.telemetry(moduleConfig.telemetry) {
-					self.upsertTelemetryModuleConfigPacket(config: moduleConfig.telemetry, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertTelemetryModuleConfigPacket(config: moduleConfig.telemetry, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.tak(moduleConfig.tak) {
-					self.upsertTAKModuleConfigPacket(config: moduleConfig.tak, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertTAKModuleConfigPacket(config: moduleConfig.tak, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.statusmessage(moduleConfig.statusmessage) {
-					self.upsertStatusMessageModuleConfigPacket(config: moduleConfig.statusmessage, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertStatusMessageModuleConfigPacket(config: moduleConfig.statusmessage, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				} else if moduleConfig.payloadVariant == ModuleConfig.OneOf_PayloadVariant.trafficManagement(moduleConfig.trafficManagement) {
-					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from), sessionPasskey: adminMessage.sessionPasskey)
+					self.upsertTrafficManagementModuleConfigPacket(config: moduleConfig.trafficManagement, nodeNum: Int64(packet.from), sessionPasskey: correlatedPasskey)
 				}
 			} else if adminMessage.payloadVariant == AdminMessage.OneOf_PayloadVariant.getRingtoneResponse(adminMessage.getRingtoneResponse) {
-				if let rt = try? RTTTLConfig(serializedBytes: packet.decoded.payload) {
-					self.upsertRtttlConfigPacket(ringtone: rt.ringtone, nodeNum: Int64(packet.from))
-				}
+				self.upsertRtttlConfigPacket(
+					ringtone: adminMessage.getRingtoneResponse,
+					nodeNum: Int64(packet.from),
+					sessionPasskey: correlatedPasskey
+				)
 			} else {
 				Logger.admin.error("🕸️ MESH PACKET received Admin App UNHANDLED \((try? packet.decoded.jsonString()) ?? "JSON Decode Failure", privacy: .public)")
 			}
@@ -1284,9 +1294,7 @@ actor MeshPackets {
 			// to the connected node — an unsolicited or forwarded admin message never
 			// unlocks the remote-admin UI. Runs after the handlers above so a node first
 			// heard via a metadata response exists by now.
-			if let connectedNodeNum,
-			   packet.decoded.requestID != 0,
-			   Int64(packet.to) == connectedNodeNum,
+			if isCorrelatedRemoteAdminResponse,
 			   !adminMessage.sessionPasskey.isEmpty {
 				switch adminMessage.payloadVariant {
 				case .getChannelResponse, .getOwnerResponse, .getConfigResponse, .getModuleConfigResponse,

--- a/Meshtastic/Model/NodeInfoEntity.swift
+++ b/Meshtastic/Model/NodeInfoEntity.swift
@@ -180,7 +180,7 @@ extension NodeInfoEntity {
 	/// session passkey inside the firmware's 5-minute session window. Empty-passkey stamps
 	/// (from the local config download and post-save mirrors) don't count.
 	var hasLiveAdminSession: Bool {
-		sessionPasskey?.isEmpty == false && (sessionExpiration ?? .distantPast) >= Date()
+		RemoteAdminSessionFreshness.isFresh(passkey: sessionPasskey, expiration: sessionExpiration)
 	}
 
 	/// Whether this node's own reported firmware supports the Status Message module (2.8+,

--- a/Meshtastic/Persistence/UpdateSwiftData.swift
+++ b/Meshtastic/Persistence/UpdateSwiftData.swift
@@ -771,7 +771,7 @@ extension MeshPackets {
 		savePendingChanges()
 	}
 
-	func upsertBluetoothConfigPacket(config: Config.BluetoothConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertBluetoothConfigPacket(config: Config.BluetoothConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Bluetooth config received: %@".localized, String(nodeNum))
 		Logger.admin.info("📶 \(logString, privacy: .public)")
@@ -795,7 +795,7 @@ extension MeshPackets {
 					fetchedNode[0].bluetoothConfig?.mode = Int32(config.mode.rawValue)
 					fetchedNode[0].bluetoothConfig?.fixedPin = Int32(truncatingIfNeeded: config.fixedPin)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -810,7 +810,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertDeviceConfigPacket(config: Config.DeviceConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDeviceConfigPacket(config: Config.DeviceConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Device config received: %@".localized, String(nodeNum))
 		Logger.admin.info("📟 \(logString, privacy: .public)")
@@ -847,7 +847,7 @@ extension MeshPackets {
 					fetchedNode[0].deviceConfig?.isManaged = config.isManaged
 					fetchedNode[0].deviceConfig?.tzdef = config.tzdef
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -860,7 +860,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertDisplayConfigPacket(config: Config.DisplayConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDisplayConfigPacket(config: Config.DisplayConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Display config received: %@".localized, nodeNum.toHex())
 		Logger.data.info("🖥️ \(logString, privacy: .public)")
@@ -900,7 +900,7 @@ extension MeshPackets {
 					fetchedNode[0].displayConfig?.headingBold = config.headingBold
 					fetchedNode[0].displayConfig?.use12HClock = config.use12HClock
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -916,7 +916,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertLoRaConfigPacket(config: Config.LoRaConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertLoRaConfigPacket(config: Config.LoRaConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("LoRa config received: %@".localized, nodeNum.toHex())
 		Logger.data.info("📻 \(logString, privacy: .public)")
@@ -968,7 +968,7 @@ extension MeshPackets {
 					fetchedNode[0].loRaConfig?.okToMqtt = config.configOkToMqtt
 					fetchedNode[0].loRaConfig?.sx126xRxBoostedGain = config.sx126XRxBoostedGain
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -983,7 +983,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertNetworkConfigPacket(config: Config.NetworkConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertNetworkConfigPacket(config: Config.NetworkConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Network config received: %@".localized, String(nodeNum))
 		Logger.data.info("🌐 \(logString, privacy: .public)")
@@ -1025,7 +1025,7 @@ extension MeshPackets {
 					fetchedNode[0].networkConfig?.subnet = Int32(bitPattern: config.ipv4Config.subnet)
 					fetchedNode[0].networkConfig?.dns = Int32(bitPattern: config.ipv4Config.dns)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1040,7 +1040,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertPositionConfigPacket(config: Config.PositionConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPositionConfigPacket(config: Config.PositionConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Position config received: %@".localized, String(nodeNum))
 		Logger.data.info("🗺️ \(logString, privacy: .public)")
@@ -1084,7 +1084,7 @@ extension MeshPackets {
 					fetchedNode[0].positionConfig?.gpsUpdateInterval = Int32(truncatingIfNeeded: config.gpsUpdateInterval)
 					fetchedNode[0].positionConfig?.positionFlags = Int32(truncatingIfNeeded: config.positionFlags)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1099,7 +1099,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertPowerConfigPacket(config: Config.PowerConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPowerConfigPacket(config: Config.PowerConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		let logString = String.localizedStringWithFormat("Power config received: %@".localized, String(nodeNum))
 		Logger.data.info("🗺️ \(logString, privacy: .public)")
 		
@@ -1130,7 +1130,7 @@ extension MeshPackets {
 					fetchedNode[0].powerConfig?.onBatteryShutdownAfterSecs = Int32(truncatingIfNeeded: config.onBatteryShutdownAfterSecs)
 					fetchedNode[0].powerConfig?.waitBluetoothSecs = Int32(truncatingIfNeeded: config.waitBluetoothSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1155,7 +1155,7 @@ extension MeshPackets {
 		entity.adminKey3 = adminKeys.count > 2 ? adminKeys[2] : nil
 	}
 
-	func upsertSecurityConfigPacket(config: Config.SecurityConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertSecurityConfigPacket(config: Config.SecurityConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Security config received: @".localized, String(nodeNum))
 		Logger.data.info("🛡️ \(logString, privacy: .public)")
@@ -1189,7 +1189,7 @@ extension MeshPackets {
 					securityConfig.adminChannelEnabled = config.adminChannelEnabled
 					securityConfig.packetSignaturePolicy = Int32(config.packetSignaturePolicy.rawValue)
 				}
-				if sessionPasskey?.count != 0 {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1204,7 +1204,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertAudioModuleConfigPacket(config: ModuleConfig.AudioConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertAudioModuleConfigPacket(config: ModuleConfig.AudioConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Audio module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🔊 \(logString, privacy: .public)")
@@ -1235,7 +1235,7 @@ extension MeshPackets {
 					fetchedNode[0].audioConfig?.i2sDin = Int32(truncatingIfNeeded: config.i2SDin)
 					fetchedNode[0].audioConfig?.i2sSck = Int32(truncatingIfNeeded: config.i2SSck)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1250,7 +1250,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertAmbientLightingModuleConfigPacket(config: ModuleConfig.AmbientLightingConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertAmbientLightingModuleConfigPacket(config: ModuleConfig.AmbientLightingConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Ambient Lighting module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🏮 \(logString, privacy: .public)")
@@ -1285,7 +1285,7 @@ extension MeshPackets {
 					fetchedNode[0].ambientLightingConfig?.green = Int32(truncatingIfNeeded: config.green)
 					fetchedNode[0].ambientLightingConfig?.blue = Int32(truncatingIfNeeded: config.blue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1300,7 +1300,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertCannedMessagesModuleConfigPacket(config: ModuleConfig.CannedMessageConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertCannedMessagesModuleConfigPacket(config: ModuleConfig.CannedMessageConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Canned Message module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🥫 \(logString, privacy: .public)")
@@ -1340,7 +1340,7 @@ extension MeshPackets {
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventCcw = Int32(config.inputbrokerEventCcw.rawValue)
 					fetchedNode[0].cannedMessageConfig?.inputbrokerEventPress = Int32(config.inputbrokerEventPress.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1355,7 +1355,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertDetectionSensorModuleConfigPacket(config: ModuleConfig.DetectionSensorConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertDetectionSensorModuleConfigPacket(config: ModuleConfig.DetectionSensorConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Detection Sensor module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🕵️ \(logString, privacy: .public)")
@@ -1389,7 +1389,7 @@ extension MeshPackets {
 					fetchedNode[0].detectionSensorConfig?.minimumBroadcastSecs = Int32(truncatingIfNeeded: config.minimumBroadcastSecs)
 					fetchedNode[0].detectionSensorConfig?.stateBroadcastSecs = Int32(truncatingIfNeeded: config.stateBroadcastSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1406,7 +1406,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertMeshBeaconModuleConfigPacket(config: ModuleConfig.MeshBeaconConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertMeshBeaconModuleConfigPacket(config: ModuleConfig.MeshBeaconConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Mesh Beacon module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📡 \(logString, privacy: .public)")
@@ -1448,7 +1448,7 @@ extension MeshPackets {
 					return newTarget
 				}
 
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1465,7 +1465,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertExternalNotificationModuleConfigPacket(config: ModuleConfig.ExternalNotificationConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertExternalNotificationModuleConfigPacket(config: ModuleConfig.ExternalNotificationConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("External Notification module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📣 \(logString, privacy: .public)")
@@ -1514,7 +1514,7 @@ extension MeshPackets {
 					fetchedNode[0].externalNotificationConfig?.nagTimeout = Int32(truncatingIfNeeded: config.nagTimeout)
 					fetchedNode[0].externalNotificationConfig?.useI2SAsBuzzer = config.useI2SAsBuzzer
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1529,7 +1529,7 @@ extension MeshPackets {
 		}
 	}
 	
-	func upsertNeighborInfoModuleConfigPacket(config: ModuleConfig.NeighborInfoConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertNeighborInfoModuleConfigPacket(config: ModuleConfig.NeighborInfoConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Neighbor Info config received: %@".localized, String(nodeNum))
 		Logger.data.info("🏘️ \(logString, privacy: .public)")
@@ -1552,7 +1552,7 @@ extension MeshPackets {
 					fetchedNode[0].neighborInfoConfig?.updateInterval = Int32(truncatingIfNeeded: config.updateInterval)
 					fetchedNode[0].neighborInfoConfig?.transmitOverLora = config.transmitOverLora
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1567,7 +1567,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertPaxCounterModuleConfigPacket(config: ModuleConfig.PaxcounterConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertPaxCounterModuleConfigPacket(config: ModuleConfig.PaxcounterConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("PAX Counter config received: %@".localized, String(nodeNum))
 		Logger.data.info("🧑‍🤝‍🧑 \(logString, privacy: .public)")
@@ -1593,7 +1593,7 @@ extension MeshPackets {
 					fetchedNode[0].paxCounterConfig?.wifiThreshold = config.wifiThreshold
 					fetchedNode[0].paxCounterConfig?.bleThreshold = config.bleThreshold
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1608,7 +1608,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertRtttlConfigPacket(ringtone: String, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertRtttlConfigPacket(ringtone: String, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("RTTTL Ringtone config received: %@".localized, String(nodeNum))
 		Logger.data.info("⛰️ \(logString, privacy: .public)")
@@ -1628,7 +1628,7 @@ extension MeshPackets {
 				} else {
 					fetchedNode[0].rtttlConfig?.ringtone = ringtone
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1643,7 +1643,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertMqttModuleConfigPacket(config: ModuleConfig.MQTTConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertMqttModuleConfigPacket(config: ModuleConfig.MQTTConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("MQTT module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🌉 \(logString, privacy: .public)")
@@ -1687,7 +1687,7 @@ extension MeshPackets {
 					fetchedNode[0].mqttConfig?.mapPositionPrecision = Int32(truncatingIfNeeded: config.mapReportSettings.positionPrecision)
 					fetchedNode[0].mqttConfig?.mapPublishIntervalSecs = Int32(truncatingIfNeeded: config.mapReportSettings.publishIntervalSecs)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1702,7 +1702,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertRangeTestModuleConfigPacket(config: ModuleConfig.RangeTestConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertRangeTestModuleConfigPacket(config: ModuleConfig.RangeTestConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Range Test module config received: %@".localized, String(nodeNum))
 		Logger.data.info("⛰️ \(logString, privacy: .public)")
@@ -1726,7 +1726,7 @@ extension MeshPackets {
 					fetchedNode[0].rangeTestConfig?.enabled = config.enabled
 					fetchedNode[0].rangeTestConfig?.save = config.save
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1741,7 +1741,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertSerialModuleConfigPacket(config: ModuleConfig.SerialConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertSerialModuleConfigPacket(config: ModuleConfig.SerialConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Serial module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🤖 \(logString, privacy: .public)")
@@ -1773,7 +1773,7 @@ extension MeshPackets {
 					fetchedNode[0].serialConfig?.timeout = Int32(truncatingIfNeeded: config.timeout)
 					fetchedNode[0].serialConfig?.mode = Int32(config.mode.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1789,7 +1789,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertStatusMessageModuleConfigPacket(config: ModuleConfig.StatusMessageConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertStatusMessageModuleConfigPacket(config: ModuleConfig.StatusMessageConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Status Message module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📬 \(logString, privacy: .public)")
@@ -1812,7 +1812,7 @@ extension MeshPackets {
 				// status too — displays prefer the live field and would otherwise show the
 				// old status until the next broadcast arrives.
 				fetchedNode[0].nodeStatus = config.nodeStatus.isEmpty ? nil : config.nodeStatus
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1858,7 +1858,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertStoreForwardModuleConfigPacket(config: ModuleConfig.StoreForwardConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertStoreForwardModuleConfigPacket(config: ModuleConfig.StoreForwardConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Store & Forward module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📬 \(logString, privacy: .public)")
@@ -1890,7 +1890,7 @@ extension MeshPackets {
 					// reflected after the first sync and the device-profile export keeps writing the old value.
 					fetchedNode[0].storeForwardConfig?.isRouter = config.isServer
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1905,7 +1905,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTelemetryModuleConfigPacket(config: ModuleConfig.TelemetryConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTelemetryModuleConfigPacket(config: ModuleConfig.TelemetryConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 		
 		let logString = String.localizedStringWithFormat("Telemetry module config received: %@".localized, String(nodeNum))
 		Logger.data.info("📈 \(logString, privacy: .public)")
@@ -1945,7 +1945,7 @@ extension MeshPackets {
 					fetchedNode[0].telemetryConfig?.powerUpdateInterval = Int32(truncatingIfNeeded: config.powerUpdateInterval)
 					fetchedNode[0].telemetryConfig?.powerScreenEnabled = config.powerScreenEnabled
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1962,7 +1962,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTAKModuleConfigPacket(config: ModuleConfig.TAKConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTAKModuleConfigPacket(config: ModuleConfig.TAKConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("TAK module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🎯 \(logString, privacy: .public)")
@@ -1983,7 +1983,7 @@ extension MeshPackets {
 					fetchedNode[0].takConfig?.team = Int32(config.team.rawValue)
 					fetchedNode[0].takConfig?.role = Int32(config.role.rawValue)
 				}
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}
@@ -1998,7 +1998,7 @@ extension MeshPackets {
 		}
 	}
 
-	func upsertTrafficManagementModuleConfigPacket(config: ModuleConfig.TrafficManagementConfig, nodeNum: Int64, sessionPasskey: Data? = Data()) {
+	func upsertTrafficManagementModuleConfigPacket(config: ModuleConfig.TrafficManagementConfig, nodeNum: Int64, sessionPasskey: Data? = nil) {
 
 		let logString = String.localizedStringWithFormat("Traffic Management module config received: %@".localized, String(nodeNum))
 		Logger.data.info("🚦 \(logString, privacy: .public)")
@@ -2037,7 +2037,7 @@ extension MeshPackets {
 				entity.rateLimitMaxPackets = Int32(truncatingIfNeeded: config.rateLimitMaxPackets)
 				entity.dropUnknownEnabled = dropUnknown
 				entity.unknownPacketThreshold = Int32(truncatingIfNeeded: config.unknownPacketThreshold)
-				if sessionPasskey != nil {
+				if let sessionPasskey, !sessionPasskey.isEmpty {
 					fetchedNode[0].sessionPasskey = sessionPasskey
 					fetchedNode[0].sessionExpiration = Date().addingTimeInterval(300)
 				}

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -62,6 +62,10 @@ class Router: ObservableObject {
 	/// The currently selected node in the NavigationSplitView detail pane.
 	@Published var selectedNodeNum: Int64?
 
+	/// One-shot request consumed by Settings after a remote-admin entry point selects a node.
+	/// It remains pending while the Settings tab is lazy or its node snapshot is still loading.
+	@Published var settingsNodeNum: Int64?
+
 	// MARK: Node Object ID Cache
 
 	/// In-memory cache mapping node numbers to their SwiftData `PersistentIdentifier` for O(1) lookups.
@@ -189,6 +193,13 @@ class Router: ObservableObject {
 		Logger.services.info("🛣 [App] Direct route to node detail \(nodeNum, privacy: .public)")
 		selectedTab = .nodes
 		selectedNodeNum = nodeNum
+	}
+
+	func navigateToSettings(nodeNum: Int64) {
+		Logger.services.info("🛣 [App] Direct route to settings for node \(nodeNum, privacy: .public)")
+		settingsNodeNum = nodeNum
+		settingsPath = []
+		selectedTab = .settings
 	}
 
 	func popToRoot(tab: NavigationState.Tab) {

--- a/Meshtastic/Router/Router.swift
+++ b/Meshtastic/Router/Router.swift
@@ -62,10 +62,6 @@ class Router: ObservableObject {
 	/// The currently selected node in the NavigationSplitView detail pane.
 	@Published var selectedNodeNum: Int64?
 
-	/// One-shot request consumed by Settings after a remote-admin entry point selects a node.
-	/// It remains pending while the Settings tab is lazy or its node snapshot is still loading.
-	@Published var settingsNodeNum: Int64?
-
 	// MARK: Node Object ID Cache
 
 	/// In-memory cache mapping node numbers to their SwiftData `PersistentIdentifier` for O(1) lookups.
@@ -193,13 +189,6 @@ class Router: ObservableObject {
 		Logger.services.info("🛣 [App] Direct route to node detail \(nodeNum, privacy: .public)")
 		selectedTab = .nodes
 		selectedNodeNum = nodeNum
-	}
-
-	func navigateToSettings(nodeNum: Int64) {
-		Logger.services.info("🛣 [App] Direct route to settings for node \(nodeNum, privacy: .public)")
-		settingsNodeNum = nodeNum
-		settingsPath = []
-		selectedTab = .settings
 	}
 
 	func popToRoot(tab: NavigationState.Tab) {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -56,6 +56,12 @@ struct NodeDetail: View {
 	@EnvironmentObject var router: Router
 	@State private var showingShutdownConfirm: Bool = false
 	@State private var showingRebootConfirm: Bool = false
+	@State private var showingSetTimeConfirm: Bool = false
+	@State private var showingFactoryResetConfirm: Bool = false
+	@State private var showingNodeDBResetConfirm: Bool = false
+	@State private var isPerformingAdminAction: Bool = false
+	@State private var adminErrorMessage: String?
+	@State private var pendingAdminTarget: RemoteAdminActionTarget?
 	@State private var dateFormatRelative: Bool = true
 	@Bindable	var node: NodeInfoEntity
 	private let nodeNum: Int64
@@ -119,6 +125,15 @@ struct NodeDetail: View {
 			return nil
 		}
 		return (fromUser, toUser)
+	}
+	private var currentAdminTarget: RemoteAdminActionTarget? {
+		guard let radioNum = accessoryManager.activeDeviceNum,
+			  let connection = accessoryManager.activeConnection?.connection else { return nil }
+		return RemoteAdminActionTarget(
+			nodeNum: nodeNum,
+			name: currentUser?.displayLongName ?? "Unknown",
+			radioNum: radioNum,
+			connectionID: ObjectIdentifier(connection))
 	}
 	/// The status row opens the status message editor for the connected node, or for a remote
 	/// node we have successfully administered before. Firmware 2.8+ in both cases: the
@@ -1015,8 +1030,8 @@ struct NodeDetail: View {
 					"Are you sure?",
 					isPresented: $showingRebootConfirm
 				) {
-					Button("Reboot node?", role: .destructive) {
-						Task {
+						Button("Reboot node?", role: .destructive) {
+							Task {
 							guard let administrationUserPair else { return }
 							do {
 								try await accessoryManager.sendReboot(
@@ -1030,7 +1045,149 @@ struct NodeDetail: View {
 					}
 				}
 				.disabled(administrationUserPair == nil)
+				Button {
+					pendingAdminTarget = currentAdminTarget
+					showingSetTimeConfirm = true
+				} label: {
+					Label("Set Time", systemImage: "clock")
 				}
+				.confirmationDialog(
+					"Set time on \(pendingAdminTarget?.name ?? "node")?",
+					isPresented: $showingSetTimeConfirm
+				) {
+					Button("Set time to now") {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendTime(fromUser: pair.fromUser, toUser: pair.toUser)
+							}
+							if let error { adminErrorMessage = "Set Time failed for \(target.name): \(error)" }
+						}
+					}
+				}
+				.disabled(administrationUserPair == nil || nodeNum == accessoryManager.activeDeviceNum || isPerformingAdminAction)
+				Button {
+					pendingAdminTarget = currentAdminTarget
+					showingFactoryResetConfirm = true
+				} label: {
+					Label("Factory Reset", systemImage: "arrowcounterclockwise")
+				}
+				.confirmationDialog(
+					"Factory reset \(pendingAdminTarget?.name ?? "node")?",
+					isPresented: $showingFactoryResetConfirm
+				) {
+					Button("Delete all config?", role: .destructive) {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser)
+							}
+							if let error { adminErrorMessage = "Factory Reset failed for \(target.name): \(error)" }
+						}
+					}
+					Button("Delete all config, keys and BLE bonds?", role: .destructive) {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser, resetDevice: true)
+							}
+							if let error { adminErrorMessage = "Factory Reset failed for \(target.name): \(error)" }
+						}
+					}
+				}
+				.disabled(administrationUserPair == nil || nodeNum == accessoryManager.activeDeviceNum || isPerformingAdminAction)
+				Button {
+					pendingAdminTarget = currentAdminTarget
+					showingNodeDBResetConfirm = true
+				} label: {
+					Label("NodeDB Reset", systemImage: "list.bullet.rectangle")
+				}
+				.confirmationDialog(
+					"Reset node database on \(pendingAdminTarget?.name ?? "node")?",
+					isPresented: $showingNodeDBResetConfirm
+				) {
+					Button("Reset node database, preserving favorites") {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: true)
+							}
+							if let error { adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)" }
+						}
+					}
+					Button("Reset node database and favorites?", role: .destructive) {
+						Task {
+							guard let target = pendingAdminTarget else { return }
+							isPerformingAdminAction = true
+							defer { isPerformingAdminAction = false }
+							let error = await RemoteAdminActionGuard.run(
+								target: target,
+								activeRadioNum: { accessoryManager.activeDeviceNum },
+								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
+								isConnected: { accessoryManager.isConnected },
+								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
+							) {
+								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
+								try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: false)
+							}
+							if let error { adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)" }
+						}
+					}
+				}
+				.disabled(administrationUserPair == nil || nodeNum == accessoryManager.activeDeviceNum || isPerformingAdminAction)
+				if isPerformingAdminAction {
+					HStack {
+						ProgressView()
+						Text("Sending command…")
+							.foregroundColor(.secondary)
+							.font(.caption)
+					}
+				}
+				}
+			}
+			.alert("Admin Action Failed", isPresented: Binding(
+				get: { adminErrorMessage != nil },
+				set: { if !$0 { adminErrorMessage = nil } }
+			)) {
+				Button("OK", role: .cancel) { adminErrorMessage = nil }
+			} message: {
+				Text(adminErrorMessage ?? "")
 			}
 		}
 	}

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1052,7 +1052,7 @@ struct NodeDetail: View {
 					Label("Set Time", systemImage: "clock")
 				}
 				.confirmationDialog(
-					"Set time on \(pendingAdminTarget?.name ?? "node")?",
+					"Set time on \(pendingAdminTarget?.confirmationLabel ?? "node")?",
 					isPresented: $showingSetTimeConfirm,
 					titleVisibility: .visible
 				) {
@@ -1061,7 +1061,7 @@ struct NodeDetail: View {
 							guard let target = pendingAdminTarget else { return }
 							isPerformingAdminAction = true
 							defer { isPerformingAdminAction = false }
-							let error = await RemoteAdminActionGuard.run(
+							let result = await RemoteAdminActionGuard.runOutcome(
 								target: target,
 								activeRadioNum: { accessoryManager.activeDeviceNum },
 								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
@@ -1069,9 +1069,14 @@ struct NodeDetail: View {
 								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
 							) {
 								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
-								try await accessoryManager.sendTime(fromUser: pair.fromUser, toUser: pair.toUser)
+								return try await accessoryManager.sendTime(fromUser: pair.fromUser, toUser: pair.toUser)
 							}
-							if let error { adminErrorMessage = "Set Time failed for \(target.name): \(error)" }
+							switch result {
+							case .acknowledged: adminErrorMessage = "Set Time acknowledged for \(target.confirmationLabel)."
+							case .verified: adminErrorMessage = "Set Time verified for \(target.confirmationLabel)."
+							case .unconfirmed: adminErrorMessage = "Set Time unconfirmed for \(target.confirmationLabel). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "Set Time failed for \(target.confirmationLabel): \(error)"
+							}
 						}
 					}
 				}
@@ -1083,11 +1088,11 @@ struct NodeDetail: View {
 					Label("Factory Reset", systemImage: "arrowcounterclockwise")
 				}
 				.confirmationDialog(
-					"Factory reset \(pendingAdminTarget?.name ?? "node")?",
+					"Factory reset \(pendingAdminTarget?.confirmationLabel ?? "node")?",
 					isPresented: $showingFactoryResetConfirm,
 					titleVisibility: .visible
 				) {
-					Button("Delete all config?", role: .destructive) {
+					Button("Delete all config", role: .destructive) {
 						Task {
 							guard let target = pendingAdminTarget else { return }
 							isPerformingAdminAction = true
@@ -1103,14 +1108,14 @@ struct NodeDetail: View {
 								return try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser)
 							}
 							switch result {
-							case .acknowledged: adminErrorMessage = "Factory Reset acknowledged for \(target.name)."
-							case .verified: adminErrorMessage = "Factory Reset verified for \(target.name)."
-							case .unconfirmed: adminErrorMessage = "Factory Reset unconfirmed for \(target.name). Check the target before retrying."
-							case .failed(let error): adminErrorMessage = "Factory Reset failed for \(target.name): \(error)"
+							case .acknowledged: adminErrorMessage = "Factory Reset acknowledged for \(target.confirmationLabel)."
+							case .verified: adminErrorMessage = "Factory Reset verified for \(target.confirmationLabel)."
+							case .unconfirmed: adminErrorMessage = "Factory Reset unconfirmed for \(target.confirmationLabel). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "Factory Reset failed for \(target.confirmationLabel): \(error)"
 							}
 						}
 					}
-					Button("Delete all config, keys and BLE bonds?", role: .destructive) {
+					Button("Delete all config, keys and Bluetooth bonds", role: .destructive) {
 						Task {
 							guard let target = pendingAdminTarget else { return }
 							isPerformingAdminAction = true
@@ -1126,13 +1131,15 @@ struct NodeDetail: View {
 								return try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser, resetDevice: true)
 							}
 							switch result {
-							case .acknowledged: adminErrorMessage = "Factory Reset acknowledged for \(target.name)."
-							case .verified: adminErrorMessage = "Factory Reset verified for \(target.name)."
-							case .unconfirmed: adminErrorMessage = "Factory Reset unconfirmed for \(target.name). Check the target before retrying."
-							case .failed(let error): adminErrorMessage = "Factory Reset failed for \(target.name): \(error)"
+							case .acknowledged: adminErrorMessage = "Factory Reset acknowledged for \(target.confirmationLabel)."
+							case .verified: adminErrorMessage = "Factory Reset verified for \(target.confirmationLabel)."
+							case .unconfirmed: adminErrorMessage = "Factory Reset unconfirmed for \(target.confirmationLabel). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "Factory Reset failed for \(target.confirmationLabel): \(error)"
 							}
 						}
 					}
+				} message: {
+					Text(pendingAdminTarget?.factoryResetConfirmationMessage(resetDevice: true) ?? "This action cannot be undone.")
 				}
 				.disabled(administrationUserPair == nil || nodeNum == accessoryManager.activeDeviceNum || isPerformingAdminAction)
 				Button {
@@ -1142,7 +1149,7 @@ struct NodeDetail: View {
 					Label("NodeDB Reset", systemImage: "list.bullet.rectangle")
 				}
 				.confirmationDialog(
-					"Reset node database on \(pendingAdminTarget?.name ?? "node")?",
+					"Reset node database on \(pendingAdminTarget?.confirmationLabel ?? "node")?",
 					isPresented: $showingNodeDBResetConfirm,
 					titleVisibility: .visible
 				) {
@@ -1162,14 +1169,14 @@ struct NodeDetail: View {
 								return try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: true)
 							}
 							switch result {
-							case .acknowledged: adminErrorMessage = "NodeDB Reset acknowledged for \(target.name)."
-							case .verified: adminErrorMessage = "NodeDB Reset verified for \(target.name)."
-							case .unconfirmed: adminErrorMessage = "NodeDB Reset unconfirmed for \(target.name). Check the target before retrying."
-							case .failed(let error): adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)"
+							case .acknowledged: adminErrorMessage = "NodeDB Reset acknowledged for \(target.confirmationLabel)."
+							case .verified: adminErrorMessage = "NodeDB Reset verified for \(target.confirmationLabel)."
+							case .unconfirmed: adminErrorMessage = "NodeDB Reset unconfirmed for \(target.confirmationLabel). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "NodeDB Reset failed for \(target.confirmationLabel): \(error)"
 							}
 						}
 					}
-					Button("Reset node database and favorites?", role: .destructive) {
+					Button("Reset node database and favorites", role: .destructive) {
 						Task {
 							guard let target = pendingAdminTarget else { return }
 							isPerformingAdminAction = true
@@ -1185,13 +1192,15 @@ struct NodeDetail: View {
 								return try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: false)
 							}
 							switch result {
-							case .acknowledged: adminErrorMessage = "NodeDB Reset acknowledged for \(target.name)."
-							case .verified: adminErrorMessage = "NodeDB Reset verified for \(target.name)."
-							case .unconfirmed: adminErrorMessage = "NodeDB Reset unconfirmed for \(target.name). Check the target before retrying."
-							case .failed(let error): adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)"
+							case .acknowledged: adminErrorMessage = "NodeDB Reset acknowledged for \(target.confirmationLabel)."
+							case .verified: adminErrorMessage = "NodeDB Reset verified for \(target.confirmationLabel)."
+							case .unconfirmed: adminErrorMessage = "NodeDB Reset unconfirmed for \(target.confirmationLabel). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "NodeDB Reset failed for \(target.confirmationLabel): \(error)"
 							}
 						}
 					}
+				} message: {
+					Text(pendingAdminTarget?.nodeDBResetConfirmationMessage(preserveFavorites: false) ?? "This action cannot be undone.")
 				}
 				.disabled(administrationUserPair == nil || nodeNum == accessoryManager.activeDeviceNum || isPerformingAdminAction)
 				if isPerformingAdminAction {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -68,6 +68,8 @@ struct NodeDetail: View {
 	@State private var latestPowerMetrics: TelemetryEntity?
 	@State private var logAvailability = NodeDetailLogAvailability()
 	@State private var showingShareContactQR = false
+	@State private var remoteAdminState: RemoteAdminSessionState = .stale
+	@State private var remoteAdminAttemptID: UUID?
 
 	init(node: NodeInfoEntity, nodeNum: Int64, showMapLink: Bool = true) {
 		self.node = node
@@ -166,11 +168,29 @@ struct NodeDetail: View {
 						.onChange(of: node.lastHeard) {
 							refreshNodeSummary()
 						}
+						.onChange(of: accessoryManager.activeDeviceNum) { _, _ in
+							remoteAdminAttemptID = nil
+							if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
+							if !accessoryManager.isConnected {
+								remoteAdminState = .stale
+							}
+						}
+						.onChange(of: accessoryManager.isConnected) { _, connected in
+							if !connected {
+								remoteAdminAttemptID = nil
+								if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
+								remoteAdminState = .stale
+							}
+						}
 						.onReceive(NotificationCenter.default.publisher(for: .nodeLogAvailabilityDidChange)) { notification in
 							guard notification.object as? Int64 == nodeNum else { return }
 							refreshNodeSummary()
 						}
 						.contentMargins(.top, 0, for: .scrollContent)
+						.task(id: remoteAdminAttemptID) {
+							guard remoteAdminAttemptID != nil else { return }
+							await establishRemoteAdminSession()
+						}
 					.navigationTitle(String((currentUser?.displayLongName ?? "Unknown".localized).addingVariationSelectors))
 					.navigationBarTitleDisplayMode(.inline)
 					.id(displayNameRefresh)
@@ -906,11 +926,13 @@ struct NodeDetail: View {
 
 	@ViewBuilder
 	private var administrationSection: some View {
-		if let metadata = node.metadata,
-		   connectedNode != nil,
-		   accessoryManager.isConnected {
+		if connectedNode != nil, accessoryManager.isConnected {
 			Section("Administration") {
 				let administrationUserPair = self.administrationUserPair
+				if nodeNum != accessoryManager.activeDeviceNum {
+					remoteAdminEntry(administrationUserPair: administrationUserPair)
+				}
+				if let metadata = node.metadata {
 				if UserDefaults.enableAdministration {
 					Button {
 						Task {
@@ -985,8 +1007,118 @@ struct NodeDetail: View {
 					}
 				}
 				.disabled(administrationUserPair == nil)
+				}
 			}
 		}
+	}
+
+	@ViewBuilder
+	private func remoteAdminEntry(administrationUserPair: (fromUser: UserEntity, toUser: UserEntity)?) -> some View {
+		let targetName = currentUser?.displayLongName ?? "Unknown".localized
+		switch remoteAdminState {
+		case .establishing:
+			HStack {
+				ProgressView()
+				Text("Establishing remote admin for \(targetName)")
+			}
+		case .active:
+			Button {
+				remoteAdminState = .establishing
+				remoteAdminAttemptID = UUID()
+			} label: {
+				Label("Remote Admin: \(targetName)", systemImage: "checkmark.shield")
+			}
+		case .failed(let result):
+			VStack(alignment: .leading) {
+				Button {
+					remoteAdminState = .establishing
+					remoteAdminAttemptID = UUID()
+				} label: {
+					Label("Retry Remote Admin for \(targetName)", systemImage: "arrow.clockwise")
+				}
+				Text("Remote admin failed: \(RemoteAdminSessionWaiter.description(for: result)).")
+					.font(.caption)
+					.foregroundStyle(.orange)
+			}
+			.disabled(administrationUserPair == nil || !UserDefaults.enableAdministration)
+		case .stale:
+			VStack(alignment: .leading) {
+				Button {
+					remoteAdminState = .establishing
+					remoteAdminAttemptID = UUID()
+				} label: {
+					Label("Remote Admin: \(targetName)", systemImage: "shield")
+				}
+				if !UserDefaults.enableAdministration {
+					Text("Enable Administration in App Settings to use remote admin.")
+						.font(.caption)
+						.foregroundStyle(.orange)
+				}
+			}
+			.disabled(administrationUserPair == nil || !UserDefaults.enableAdministration)
+		}
+	}
+
+	@MainActor
+	private func establishRemoteAdminSession() async {
+		guard let attemptID = remoteAdminAttemptID,
+			let radioNum = accessoryManager.activeDeviceNum,
+			nodeNum != radioNum else {
+			remoteAdminState = .failed(.targetChanged)
+			return
+		}
+		guard UserDefaults.enableAdministration else {
+			remoteAdminState = .failed(.requestFailed)
+			return
+		}
+		guard let administrationUserPair else {
+			remoteAdminState = .failed(.disconnected)
+			return
+		}
+		let result = await RemoteAdminSessionOrchestrator.establish(
+			allowed: { UserDefaults.enableAdministration && accessoryManager.isConnected },
+			attemptIsCurrent: { [weak accessoryManager, weak node, weak router] in
+				accessoryManager?.activeDeviceNum == radioNum
+					&& node?.modelContext != nil && node?.isDeleted == false
+					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
+					&& self.remoteAdminAttemptID == attemptID
+			},
+			fresh: { [weak node] in node?.hasLiveAdminSession == true },
+			request: {
+				_ = try await accessoryManager.requestDeviceMetadata(
+					fromUser: administrationUserPair.fromUser,
+					toUser: administrationUserPair.toUser
+				)
+			},
+			wait: {
+				await RemoteAdminSessionWaiter.wait(
+					isLive: { [weak node] in node?.hasLiveAdminSession == true },
+					isConnected: { [weak accessoryManager] in
+						accessoryManager?.isConnected == true
+						&& accessoryManager?.activeDeviceNum == radioNum
+						&& self.remoteAdminAttemptID == attemptID
+					},
+					targetIsCurrent: { [weak node, weak router] in
+						node?.modelContext != nil && node?.isDeleted == false
+						&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
+					}
+				)
+			}
+		)
+		guard result == .active else {
+			remoteAdminState = .failed(result)
+			return
+		}
+		guard UserDefaults.enableAdministration,
+			accessoryManager.isConnected,
+			accessoryManager.activeDeviceNum == radioNum,
+			node.modelContext != nil, !node.isDeleted,
+			remoteAdminAttemptID == attemptID else {
+			remoteAdminState = .failed(.targetChanged)
+			return
+		}
+		remoteAdminState = .active
+		router.navigateToSettings(nodeNum: nodeNum)
 	}
 
 	private func refreshNodeSummary() {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -188,9 +188,7 @@ struct NodeDetail: View {
 						.onChange(of: accessoryManager.activeDeviceNum) { _, _ in
 							remoteSettingsDestination = nil
 							remoteAdminAttemptID = nil
-							if !accessoryManager.isConnected {
-								remoteAdminState = .stale
-							}
+							remoteAdminState.invalidateForActiveRadioReplacement()
 						}
 						.onChange(of: accessoryManager.isConnected) { _, connected in
 							if !connected {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -70,6 +70,7 @@ struct NodeDetail: View {
 	@State private var showingShareContactQR = false
 	@State private var remoteAdminState: RemoteAdminSessionState = .stale
 	@State private var remoteAdminAttemptID: UUID?
+	@State private var remoteSettingsDestination: RemoteAdminSettingsDestination?
 
 	init(node: NodeInfoEntity, nodeNum: Int64, showMapLink: Bool = true) {
 		self.node = node
@@ -169,16 +170,16 @@ struct NodeDetail: View {
 							refreshNodeSummary()
 						}
 						.onChange(of: accessoryManager.activeDeviceNum) { _, _ in
+							remoteSettingsDestination = nil
 							remoteAdminAttemptID = nil
-							if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
 							if !accessoryManager.isConnected {
 								remoteAdminState = .stale
 							}
 						}
 						.onChange(of: accessoryManager.isConnected) { _, connected in
 							if !connected {
+								remoteSettingsDestination = nil
 								remoteAdminAttemptID = nil
-								if router.settingsNodeNum == nodeNum { router.settingsNodeNum = nil }
 								remoteAdminState = .stale
 							}
 						}
@@ -191,6 +192,27 @@ struct NodeDetail: View {
 							guard remoteAdminAttemptID != nil else { return }
 							await establishRemoteAdminSession()
 						}
+					.onChange(of: accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) }) { _, connectionID in
+						if let destination = remoteSettingsDestination, destination.connectionID != connectionID {
+							remoteSettingsDestination = nil
+						}
+					}
+					.navigationDestination(isPresented: Binding(
+						get: { remoteSettingsDestination != nil },
+						set: { if !$0 { remoteSettingsDestination = nil } }
+					)) {
+						if let destination = remoteSettingsDestination {
+							Settings(remoteNodeNum: destination.nodeNum)
+								.disabled(!destination.isCurrent(
+									radioNum: accessoryManager.activeDeviceNum,
+									connectionID: accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) },
+									isConnected: accessoryManager.isConnected))
+						}
+					}
+					.onChange(of: nodeNum) { _, _ in
+						remoteSettingsDestination = nil
+						remoteAdminAttemptID = nil
+					}
 					.navigationTitle(String((currentUser?.displayLongName ?? "Unknown".localized).addingVariationSelectors))
 					.navigationBarTitleDisplayMode(.inline)
 					.id(displayNameRefresh)
@@ -1027,6 +1049,7 @@ struct NodeDetail: View {
 				remoteAdminAttemptID = UUID()
 			} label: {
 				Label("Remote Admin: \(targetName)", systemImage: "checkmark.shield")
+					.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 			}
 		case .failed(let result):
 			VStack(alignment: .leading) {
@@ -1035,6 +1058,7 @@ struct NodeDetail: View {
 					remoteAdminAttemptID = UUID()
 				} label: {
 					Label("Retry Remote Admin for \(targetName)", systemImage: "arrow.clockwise")
+						.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 				}
 				Text("Remote admin failed: \(RemoteAdminSessionWaiter.description(for: result)).")
 					.font(.caption)
@@ -1048,6 +1072,7 @@ struct NodeDetail: View {
 					remoteAdminAttemptID = UUID()
 				} label: {
 					Label("Remote Admin: \(targetName)", systemImage: "shield")
+						.frame(minWidth: 48, minHeight: 48, alignment: .leading)
 				}
 				if !UserDefaults.enableAdministration {
 					Text("Enable Administration in App Settings to use remote admin.")
@@ -1086,7 +1111,8 @@ struct NodeDetail: View {
 					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
 					&& self.remoteAdminAttemptID == attemptID
 			},
-			fresh: { [weak node] in node?.hasLiveAdminSession == true },
+			// Fetch to refresh the retained main-context node after the packet actor saves a session.
+			fresh: { getNodeInfo(id: nodeNum, context: context)?.hasLiveAdminSession == true },
 			request: {
 				_ = try await accessoryManager.requestDeviceMetadata(
 					fromUser: administrationUserPair.fromUser,
@@ -1095,7 +1121,7 @@ struct NodeDetail: View {
 			},
 			wait: {
 				await RemoteAdminSessionWaiter.wait(
-					isLive: { [weak node] in node?.hasLiveAdminSession == true },
+					isLive: { getNodeInfo(id: nodeNum, context: context)?.hasLiveAdminSession == true },
 					isConnected: { [weak accessoryManager] in
 						accessoryManager?.isConnected == true
 						&& accessoryManager?.activeDeviceNum == radioNum
@@ -1123,7 +1149,7 @@ struct NodeDetail: View {
 			return
 		}
 		remoteAdminState = .active
-		router.navigateToSettings(nodeNum: nodeNum)
+		remoteSettingsDestination = RemoteAdminSettingsDestination(nodeNum: nodeNum, radioNum: radioNum, connectionID: connectionID)
 	}
 
 	private func refreshNodeSummary() {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1092,7 +1092,7 @@ struct NodeDetail: View {
 							guard let target = pendingAdminTarget else { return }
 							isPerformingAdminAction = true
 							defer { isPerformingAdminAction = false }
-							let error = await RemoteAdminActionGuard.run(
+							let result = await RemoteAdminActionGuard.runOutcome(
 								target: target,
 								activeRadioNum: { accessoryManager.activeDeviceNum },
 								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
@@ -1100,9 +1100,14 @@ struct NodeDetail: View {
 								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
 							) {
 								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
-								try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser)
+								return try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser)
 							}
-							if let error { adminErrorMessage = "Factory Reset failed for \(target.name): \(error)" }
+							switch result {
+							case .acknowledged: adminErrorMessage = "Factory Reset acknowledged for \(target.name)."
+							case .verified: adminErrorMessage = "Factory Reset verified for \(target.name)."
+							case .unconfirmed: adminErrorMessage = "Factory Reset unconfirmed for \(target.name). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "Factory Reset failed for \(target.name): \(error)"
+							}
 						}
 					}
 					Button("Delete all config, keys and BLE bonds?", role: .destructive) {
@@ -1110,7 +1115,7 @@ struct NodeDetail: View {
 							guard let target = pendingAdminTarget else { return }
 							isPerformingAdminAction = true
 							defer { isPerformingAdminAction = false }
-							let error = await RemoteAdminActionGuard.run(
+							let result = await RemoteAdminActionGuard.runOutcome(
 								target: target,
 								activeRadioNum: { accessoryManager.activeDeviceNum },
 								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
@@ -1118,9 +1123,14 @@ struct NodeDetail: View {
 								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
 							) {
 								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
-								try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser, resetDevice: true)
+								return try await accessoryManager.sendFactoryReset(fromUser: pair.fromUser, toUser: pair.toUser, resetDevice: true)
 							}
-							if let error { adminErrorMessage = "Factory Reset failed for \(target.name): \(error)" }
+							switch result {
+							case .acknowledged: adminErrorMessage = "Factory Reset acknowledged for \(target.name)."
+							case .verified: adminErrorMessage = "Factory Reset verified for \(target.name)."
+							case .unconfirmed: adminErrorMessage = "Factory Reset unconfirmed for \(target.name). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "Factory Reset failed for \(target.name): \(error)"
+							}
 						}
 					}
 				}
@@ -1141,7 +1151,7 @@ struct NodeDetail: View {
 							guard let target = pendingAdminTarget else { return }
 							isPerformingAdminAction = true
 							defer { isPerformingAdminAction = false }
-							let error = await RemoteAdminActionGuard.run(
+							let result = await RemoteAdminActionGuard.runOutcome(
 								target: target,
 								activeRadioNum: { accessoryManager.activeDeviceNum },
 								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
@@ -1149,9 +1159,14 @@ struct NodeDetail: View {
 								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
 							) {
 								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
-								try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: true)
+								return try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: true)
 							}
-							if let error { adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)" }
+							switch result {
+							case .acknowledged: adminErrorMessage = "NodeDB Reset acknowledged for \(target.name)."
+							case .verified: adminErrorMessage = "NodeDB Reset verified for \(target.name)."
+							case .unconfirmed: adminErrorMessage = "NodeDB Reset unconfirmed for \(target.name). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)"
+							}
 						}
 					}
 					Button("Reset node database and favorites?", role: .destructive) {
@@ -1159,7 +1174,7 @@ struct NodeDetail: View {
 							guard let target = pendingAdminTarget else { return }
 							isPerformingAdminAction = true
 							defer { isPerformingAdminAction = false }
-							let error = await RemoteAdminActionGuard.run(
+							let result = await RemoteAdminActionGuard.runOutcome(
 								target: target,
 								activeRadioNum: { accessoryManager.activeDeviceNum },
 								activeConnectionID: { accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } },
@@ -1167,9 +1182,14 @@ struct NodeDetail: View {
 								hasLiveSession: { getNodeInfo(id: target.nodeNum, context: context)?.hasLiveAdminSession == true }
 							) {
 								guard let pair = administrationUserPair, pair.toUser.num == target.nodeNum else { throw AccessoryError.connectionFailed("The selected target is no longer available") }
-								try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: false)
+								return try await accessoryManager.sendNodeDBReset(fromUser: pair.fromUser, toUser: pair.toUser, preserveFavorites: false)
 							}
-							if let error { adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)" }
+							switch result {
+							case .acknowledged: adminErrorMessage = "NodeDB Reset acknowledged for \(target.name)."
+							case .verified: adminErrorMessage = "NodeDB Reset verified for \(target.name)."
+							case .unconfirmed: adminErrorMessage = "NodeDB Reset unconfirmed for \(target.name). Check the target before retrying."
+							case .failed(let error): adminErrorMessage = "NodeDB Reset failed for \(target.name): \(error)"
+							}
 						}
 					}
 				}
@@ -1177,14 +1197,14 @@ struct NodeDetail: View {
 				if isPerformingAdminAction {
 					HStack {
 						ProgressView()
-						Text("Sending command…")
+						Text("Waiting for target acknowledgement…")
 							.foregroundColor(.secondary)
 							.font(.caption)
 					}
 				}
 				}
 			}
-			.alert("Admin Action Failed", isPresented: Binding(
+			.alert("Admin Action Result", isPresented: Binding(
 				get: { adminErrorMessage != nil },
 				set: { if !$0 { adminErrorMessage = nil } }
 			)) {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -42,6 +42,7 @@ struct NodeDetail: View {
 		.accessibilityElement(children: .combine)
 	}
 	private let gridItemLayout = Array(repeating: GridItem(.flexible(), spacing: 10), count: 2)
+	private let nodeDetailScrollContentTopMargin: CGFloat = 0
 	private static let relativeFormatter: RelativeDateTimeFormatter = {
 		let formatter = RelativeDateTimeFormatter()
 		formatter.unitsStyle = .full
@@ -187,7 +188,7 @@ struct NodeDetail: View {
 							guard notification.object as? Int64 == nodeNum else { return }
 							refreshNodeSummary()
 						}
-						.contentMargins(.top, 0, for: .scrollContent)
+						.contentMargins(.top, nodeDetailScrollContentTopMargin, for: .scrollContent)
 						.task(id: remoteAdminAttemptID) {
 							guard remoteAdminAttemptID != nil else { return }
 							await establishRemoteAdminSession()

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1053,7 +1053,8 @@ struct NodeDetail: View {
 				}
 				.confirmationDialog(
 					"Set time on \(pendingAdminTarget?.name ?? "node")?",
-					isPresented: $showingSetTimeConfirm
+					isPresented: $showingSetTimeConfirm,
+					titleVisibility: .visible
 				) {
 					Button("Set time to now") {
 						Task {
@@ -1083,7 +1084,8 @@ struct NodeDetail: View {
 				}
 				.confirmationDialog(
 					"Factory reset \(pendingAdminTarget?.name ?? "node")?",
-					isPresented: $showingFactoryResetConfirm
+					isPresented: $showingFactoryResetConfirm,
+					titleVisibility: .visible
 				) {
 					Button("Delete all config?", role: .destructive) {
 						Task {
@@ -1131,7 +1133,8 @@ struct NodeDetail: View {
 				}
 				.confirmationDialog(
 					"Reset node database on \(pendingAdminTarget?.name ?? "node")?",
-					isPresented: $showingNodeDBResetConfirm
+					isPresented: $showingNodeDBResetConfirm,
+					titleVisibility: .visible
 				) {
 					Button("Reset node database, preserving favorites") {
 						Task {
@@ -1252,9 +1255,7 @@ struct NodeDetail: View {
 			return
 		}
 		defer {
-			if remoteAdminAttemptID == attemptID {
-				remoteAdminAttemptID = nil
-			}
+			if remoteAdminAttemptID == attemptID { remoteAdminAttemptID = nil }
 		}
 		guard UserDefaults.enableAdministration else {
 			remoteAdminState = .failed(.requestFailed)

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1063,6 +1063,7 @@ struct NodeDetail: View {
 	private func establishRemoteAdminSession() async {
 		guard let attemptID = remoteAdminAttemptID,
 			let radioNum = accessoryManager.activeDeviceNum,
+			let connection = accessoryManager.activeConnection?.connection,
 			nodeNum != radioNum else {
 			remoteAdminState = .failed(.targetChanged)
 			return
@@ -1075,10 +1076,12 @@ struct NodeDetail: View {
 			remoteAdminState = .failed(.disconnected)
 			return
 		}
+		let connectionID = ObjectIdentifier(connection)
 		let result = await RemoteAdminSessionOrchestrator.establish(
 			allowed: { UserDefaults.enableAdministration && accessoryManager.isConnected },
 			attemptIsCurrent: { [weak accessoryManager, weak node, weak router] in
 				accessoryManager?.activeDeviceNum == radioNum
+					&& accessoryManager?.activeConnection.map { ObjectIdentifier($0.connection) } == connectionID
 					&& node?.modelContext != nil && node?.isDeleted == false
 					&& (router?.selectedNodeNum == nil || router?.selectedNodeNum == nodeNum)
 					&& self.remoteAdminAttemptID == attemptID
@@ -1096,6 +1099,7 @@ struct NodeDetail: View {
 					isConnected: { [weak accessoryManager] in
 						accessoryManager?.isConnected == true
 						&& accessoryManager?.activeDeviceNum == radioNum
+						&& accessoryManager?.activeConnection.map { ObjectIdentifier($0.connection) } == connectionID
 						&& self.remoteAdminAttemptID == attemptID
 					},
 					targetIsCurrent: { [weak node, weak router] in
@@ -1112,6 +1116,7 @@ struct NodeDetail: View {
 		guard UserDefaults.enableAdministration,
 			accessoryManager.isConnected,
 			accessoryManager.activeDeviceNum == radioNum,
+			accessoryManager.activeConnection.map({ ObjectIdentifier($0.connection) }) == connectionID,
 			node.modelContext != nil, !node.isDeleted,
 			remoteAdminAttemptID == attemptID else {
 			remoteAdminState = .failed(.targetChanged)

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -1093,6 +1093,11 @@ struct NodeDetail: View {
 			remoteAdminState = .failed(.targetChanged)
 			return
 		}
+		defer {
+			if remoteAdminAttemptID == attemptID {
+				remoteAdminAttemptID = nil
+			}
+		}
 		guard UserDefaults.enableAdministration else {
 			remoteAdminState = .failed(.requestFailed)
 			return

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminActionTarget.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminActionTarget.swift
@@ -7,8 +7,28 @@ struct RemoteAdminActionTarget: Equatable {
 	let connectionID: ObjectIdentifier
 }
 
+enum RemoteAdminActionResult: Equatable {
+	case acknowledged
+	case verified
+	case unconfirmed
+	case failed(String)
+}
+
 @MainActor
 enum RemoteAdminActionGuard {
+	private static func validate(
+		target: RemoteAdminActionTarget,
+		activeRadioNum: @escaping @MainActor () -> Int64?,
+		activeConnectionID: @escaping @MainActor () -> ObjectIdentifier?,
+		isConnected: @escaping @MainActor () -> Bool,
+		hasLiveSession: @escaping @MainActor () -> Bool
+	) -> String? {
+		guard isConnected(), activeRadioNum() == target.radioNum,
+			  activeConnectionID() == target.connectionID else { return "Connection changed. Please try again." }
+		guard hasLiveSession() else { return "Session expired for \(target.name). Refresh device metadata first." }
+		return nil
+	}
+
 	static func run(
 		target: RemoteAdminActionTarget,
 		activeRadioNum: @escaping @MainActor () -> Int64?,
@@ -17,14 +37,38 @@ enum RemoteAdminActionGuard {
 		hasLiveSession: @escaping @MainActor () -> Bool,
 		action: @escaping @MainActor () async throws -> Void
 	) async -> String? {
-		guard isConnected(), activeRadioNum() == target.radioNum,
-			  activeConnectionID() == target.connectionID else { return "Connection changed. Please try again." }
-		guard hasLiveSession() else { return "Session expired for \(target.name). Refresh device metadata first." }
+		if let error = validate(
+			target: target,
+			activeRadioNum: activeRadioNum,
+			activeConnectionID: activeConnectionID,
+			isConnected: isConnected,
+			hasLiveSession: hasLiveSession) { return error }
 		do {
 			try await action()
 			return nil
 		} catch {
 			return error.localizedDescription
+		}
+	}
+
+	static func runOutcome(
+		target: RemoteAdminActionTarget,
+		activeRadioNum: @escaping @MainActor () -> Int64?,
+		activeConnectionID: @escaping @MainActor () -> ObjectIdentifier?,
+		isConnected: @escaping @MainActor () -> Bool,
+		hasLiveSession: @escaping @MainActor () -> Bool,
+		action: @escaping @MainActor () async throws -> RemoteAdminActionResult
+	) async -> RemoteAdminActionResult {
+		if let error = validate(
+			target: target,
+			activeRadioNum: activeRadioNum,
+			activeConnectionID: activeConnectionID,
+			isConnected: isConnected,
+			hasLiveSession: hasLiveSession) { return .failed(error) }
+		do {
+			return try await action()
+		} catch {
+			return .failed(error.localizedDescription)
 		}
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminActionTarget.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminActionTarget.swift
@@ -5,6 +5,22 @@ struct RemoteAdminActionTarget: Equatable {
 	let name: String
 	let radioNum: Int64
 	let connectionID: ObjectIdentifier
+
+	var confirmationLabel: String { "\(name) (node \(nodeNum))" }
+
+	func factoryResetConfirmationMessage(resetDevice: Bool) -> String {
+		if resetDevice {
+			return "This irreversibly erases \(confirmationLabel)'s configuration, identity, admin keys, channels, and Bluetooth bonds. This cannot be undone."
+		}
+		return "This irreversibly erases \(confirmationLabel)'s configuration. This cannot be undone."
+	}
+
+	func nodeDBResetConfirmationMessage(preserveFavorites: Bool) -> String {
+		if preserveFavorites {
+			return "This irreversibly resets \(confirmationLabel)'s node database while preserving favorites. This cannot be undone."
+		}
+		return "This irreversibly erases \(confirmationLabel)'s node database and favorites. This cannot be undone."
+	}
 }
 
 enum RemoteAdminActionResult: Equatable {

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminActionTarget.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminActionTarget.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct RemoteAdminActionTarget: Equatable {
+	let nodeNum: Int64
+	let name: String
+	let radioNum: Int64
+	let connectionID: ObjectIdentifier
+}
+
+@MainActor
+enum RemoteAdminActionGuard {
+	static func run(
+		target: RemoteAdminActionTarget,
+		activeRadioNum: @escaping @MainActor () -> Int64?,
+		activeConnectionID: @escaping @MainActor () -> ObjectIdentifier?,
+		isConnected: @escaping @MainActor () -> Bool,
+		hasLiveSession: @escaping @MainActor () -> Bool,
+		action: @escaping @MainActor () async throws -> Void
+	) async -> String? {
+		guard isConnected(), activeRadioNum() == target.radioNum,
+			  activeConnectionID() == target.connectionID else { return "Connection changed. Please try again." }
+		guard hasLiveSession() else { return "Session expired for \(target.name). Refresh device metadata first." }
+		do {
+			try await action()
+			return nil
+		} catch {
+			return error.localizedDescription
+		}
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+enum RemoteAdminSessionState: Equatable {
+	case stale
+	case establishing
+	case active
+	case failed(RemoteAdminSessionWaiter.Result)
+}
+
+enum RemoteAdminSessionFreshness {
+	static func isFresh(passkey: Data?, expiration: Date?, now: Date = Date()) -> Bool {
+		guard let passkey, !passkey.isEmpty, let expiration else { return false }
+		return expiration >= now
+	}
+}
+
+enum RemoteAdminSessionWaiter {
+	enum Result: Equatable {
+		case active
+		case timedOut
+		case disconnected
+		case targetChanged
+		case cancelled
+		case requestFailed
+	}
+
+	static func description(for result: Result) -> String {
+		switch result {
+		case .active: return "active"
+		case .timedOut: return "timed out"
+		case .disconnected: return "disconnected"
+		case .targetChanged: return "target changed"
+		case .cancelled: return "cancelled"
+		case .requestFailed: return "request failed"
+		}
+	}
+
+	@MainActor static func wait(
+		timeout: Duration = .seconds(30),
+		pollInterval: Duration = .milliseconds(200),
+		isLive: @escaping @MainActor () -> Bool,
+		isConnected: @escaping @MainActor () -> Bool,
+		targetIsCurrent: @escaping @MainActor () -> Bool,
+		sleep: @escaping @MainActor (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+	) async -> Result {
+		var elapsed = Duration.zero
+		while true {
+			if Task.isCancelled { return .cancelled }
+			if !isConnected() { return .disconnected }
+			if !targetIsCurrent() { return .targetChanged }
+			if isLive() { return .active }
+			if elapsed >= timeout { return .timedOut }
+			do {
+				let delay = min(pollInterval, timeout - elapsed)
+				try await sleep(delay)
+				elapsed += delay
+			} catch {
+				return .cancelled
+			}
+		}
+	}
+}
+
+enum RemoteAdminSessionOrchestrator {
+	@MainActor
+	static func establish(
+		allowed: @escaping @MainActor () -> Bool,
+		attemptIsCurrent: @escaping @MainActor () -> Bool,
+		fresh: @escaping @MainActor () -> Bool,
+		request: @escaping @MainActor () async throws -> Void,
+		wait: @escaping @MainActor () async -> RemoteAdminSessionWaiter.Result
+	) async -> RemoteAdminSessionWaiter.Result {
+		guard allowed() else { return .requestFailed }
+		guard !fresh() else { return .active }
+		guard attemptIsCurrent() else { return .targetChanged }
+		do {
+			try await request()
+		} catch is CancellationError {
+			return .cancelled
+		} catch {
+			return .requestFailed
+		}
+		guard attemptIsCurrent() else { return .targetChanged }
+		let result = await wait()
+		guard result == .active else { return result }
+		guard allowed() else { return .requestFailed }
+		guard attemptIsCurrent() else { return .targetChanged }
+		return .active
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -1,4 +1,13 @@
+//
+//  RemoteAdminSession.swift
+//  Meshtastic
+//
+//  Coordinates remote administration session state and confirmation waits.
+//
+
 import Foundation
+
+// MARK: - Session State
 
 enum RemoteAdminSessionState: Equatable {
 	case stale
@@ -7,12 +16,16 @@ enum RemoteAdminSessionState: Equatable {
 	case failed(RemoteAdminSessionWaiter.Result)
 }
 
+// MARK: - Session Freshness
+
 enum RemoteAdminSessionFreshness {
 	static func isFresh(passkey: Data?, expiration: Date?, now: Date = Date()) -> Bool {
 		guard let passkey, !passkey.isEmpty, let expiration else { return false }
 		return expiration >= now
 	}
 }
+
+// MARK: - Session Waiter
 
 enum RemoteAdminSessionWaiter {
 	enum Result: Equatable {
@@ -62,6 +75,8 @@ enum RemoteAdminSessionWaiter {
 	}
 }
 
+// MARK: - Session Orchestration
+
 enum RemoteAdminSessionOrchestrator {
 	@MainActor
 	static func establish(
@@ -89,6 +104,8 @@ enum RemoteAdminSessionOrchestrator {
 		return .active
 	}
 }
+
+// MARK: - Settings Destination
 
 struct RemoteAdminSettingsDestination {
 	let nodeNum: Int64

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -43,6 +43,7 @@ enum RemoteAdminSessionWaiter {
 		targetIsCurrent: @escaping @MainActor () -> Bool,
 		sleep: @escaping @MainActor (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
 	) async -> Result {
+		guard pollInterval > .zero else { return .timedOut }
 		var elapsed = Duration.zero
 		while true {
 			if Task.isCancelled { return .cancelled }
@@ -86,5 +87,15 @@ enum RemoteAdminSessionOrchestrator {
 		guard allowed() else { return .requestFailed }
 		guard attemptIsCurrent() else { return .targetChanged }
 		return .active
+	}
+}
+
+struct RemoteAdminSettingsDestination {
+	let nodeNum: Int64
+	let radioNum: Int64
+	let connectionID: ObjectIdentifier
+
+	func isCurrent(radioNum: Int64?, connectionID: ObjectIdentifier?, isConnected: Bool) -> Bool {
+		isConnected && radioNum == self.radioNum && connectionID == self.connectionID
 	}
 }

--- a/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
+++ b/Meshtastic/Views/Nodes/Helpers/RemoteAdminSession.swift
@@ -14,6 +14,10 @@ enum RemoteAdminSessionState: Equatable {
 	case establishing
 	case active
 	case failed(RemoteAdminSessionWaiter.Result)
+
+	mutating func invalidateForActiveRadioReplacement() {
+		self = .stale
+	}
 }
 
 // MARK: - Session Freshness

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -509,7 +509,7 @@ private struct ChannelConfigSummaryRow: View {
 	}
 }
 
-private struct ChannelRow: View {
+struct ChannelRow: View {
 	let channel: ChannelEntity
 	let sharesLocation: Bool
 

--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -27,7 +27,17 @@ struct BluetoothConfig: View {
 	}()
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Bluetooth", config: \.bluetoothConfig, node: node, onAppear: setBluetoothValues)
+			ConfigHeader(title: "Bluetooth", config: \.bluetoothConfig, node: node, onAppear: setBluetoothValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.bluetoothConfig == nil },
+				section: "Bluetooth",
+				request: accessoryManager.requestBluetoothConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -101,6 +101,7 @@ struct BluetoothConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.bluetoothConfig == nil },
+				section: "Bluetooth",
 				request: accessoryManager.requestBluetoothConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
+++ b/Meshtastic/Views/Settings/Config/BluetoothConfig.swift
@@ -78,7 +78,7 @@ struct BluetoothConfig: View {
 				}
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.bluetoothConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -18,7 +18,7 @@ struct ConfigHeader<T>: View {
 		} else if node != nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			// Let users know what is going on if they are using remote admin and don't have the config yet
 			let expiration = node?.sessionExpiration ?? Date()
-			if node?[keyPath: config] == nil  || expiration < node?.sessionExpiration ?? Date() {
+			if node?[keyPath: config] == nil || expiration < Date() {
 				Text("\(title) config data was requested via PKC admin but no response has been returned from the remote node.")
 					.font(.callout)
 					.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -8,6 +8,7 @@ struct ConfigHeader<T>: View {
 	let config: KeyPath<NodeInfoEntity, T?>
 	let node: NodeInfoEntity?
 	let onAppear: () -> Void
+	var onRetry: (() -> Void)? = nil
 
 	var body: some View {
 		let request = node.flatMap { accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .request, section: title) }
@@ -19,8 +20,10 @@ struct ConfigHeader<T>: View {
 				Text(result == .timedOut ? "No response was received from the remote node." : "The configuration request failed.")
 					.font(.callout)
 					.foregroundColor(.red)
-				Button("Retry") { onAppear() }
-					.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+				if let onRetry {
+					Button("Retry", action: onRetry)
+						.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+				}
 			}
 		} else if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			Text("There has been no response to a request for device metadata via PKC admin for this node.")

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -10,7 +10,19 @@ struct ConfigHeader<T>: View {
 	let onAppear: () -> Void
 
 	var body: some View {
-		if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
+		let request = node.flatMap { accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .request, section: title) }
+		if let request, !request.isFinished {
+			ProgressView("Requesting \(title) configuration…")
+				.font(.callout)
+		} else if let request, let result = request.result, result != .succeeded {
+			VStack(spacing: 8) {
+				Text(result == .timedOut ? "No response was received from the remote node." : "The configuration request failed.")
+					.font(.callout)
+					.foregroundColor(.red)
+				Button("Retry") { onAppear() }
+					.environment(\.isEnabled, accessoryManager.isConnected && UserDefaults.enableAdministration)
+			}
+		} else if node != nil && node?.metadata == nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			Text("There has been no response to a request for device metadata via PKC admin for this node.")
 				.font(.callout)
 				.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -17,8 +17,7 @@ struct ConfigHeader<T>: View {
 
 		} else if node != nil && node?.num ?? 0 != accessoryManager.activeDeviceNum ?? 0 {
 			// Let users know what is going on if they are using remote admin and don't have the config yet
-			let expiration = node?.sessionExpiration ?? Date()
-			if node?[keyPath: config] == nil || expiration < Date() {
+			if node?[keyPath: config] == nil || node?.hasLiveAdminSession != true {
 				Text("\(title) config data was requested via PKC admin but no response has been returned from the remote node.")
 					.font(.callout)
 					.foregroundColor(.orange)

--- a/Meshtastic/Views/Settings/Config/ConfigHeader.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigHeader.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import SwiftData
 
+enum ConfigFormAvailability {
+	static func isDisabled(isConnected: Bool) -> Bool { !isConnected }
+}
+
 struct ConfigHeader<T>: View {
 	@EnvironmentObject var accessoryManager: AccessoryManager
 

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -75,12 +75,18 @@ func performConfigSave(
 			case .succeeded:
 				hasChanges.wrappedValue = false
 				dismiss()
+			case .acknowledged:
+				hasChanges.wrappedValue = false
+				dismiss()
 			case .failed(let message):
 				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, message)
 				Logger.mesh.error("🚨 Config save rejected: \(message, privacy: .public)")
 			case .timedOut:
 				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "No confirmation was received from the remote node. Check that it is online and retry.")
 				Logger.mesh.error("🚨 Config save timed out")
+			case .unconfirmed:
+				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "The remote node did not confirm the configuration. Check its state before retrying.")
+				Logger.mesh.error("🚨 Config save unconfirmed")
 			}
 		} catch {
 			if let operationID {

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -60,7 +60,31 @@ func performConfigSave(
 		do {
 			if let operationID {
 				try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
-					try await save(fromUser, toUser)
+					var saveUser = toUser
+					if !targetNode.hasLiveAdminSession {
+						// A routing rejection clears the cached passkey. Before a user-initiated
+						// save retry, establish a new session and use the refreshed user entity.
+						// The metadata request is not the save operation, so it must not complete
+						// or fail this operation's packet tracker.
+						try await RemoteAdminConfigTracker.$currentOperationID.withValue(nil) {
+							_ = try await accessoryManager.requestDeviceMetadata(fromUser: fromUser, toUser: toUser)
+						}
+						let result = await RemoteAdminSessionWaiter.wait(
+							isLive: { targetNode.hasLiveAdminSession },
+							isConnected: { accessoryManager.isConnected },
+							targetIsCurrent: { accessoryManager.activeDeviceNum == deviceNum }
+						)
+						guard result == .active else {
+							throw AccessoryError.ioFailed("Remote admin authorization was not refreshed. Please retry.")
+						}
+						guard let refreshedNode = getNodeInfo(id: targetNode.num, context: context),
+							  refreshedNode.hasLiveAdminSession,
+							  let refreshedUser = refreshedNode.user else {
+							throw AccessoryError.ioFailed("Remote admin authorization was not refreshed. Please retry.")
+						}
+						saveUser = refreshedUser
+					}
+					try await save(fromUser, saveUser)
 				}
 			} else {
 				try await save(fromUser, toUser)

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -55,6 +55,7 @@ func performConfigSave(
 		accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "A configuration save is already in progress for this node. Please wait for it to finish.")
 		return
 	}
+	let connectionID = accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) }
 
 	Task {
 		do {
@@ -72,9 +73,17 @@ func performConfigSave(
 						let result = await RemoteAdminSessionWaiter.wait(
 							isLive: { targetNode.hasLiveAdminSession },
 							isConnected: { accessoryManager.isConnected },
-							targetIsCurrent: { accessoryManager.activeDeviceNum == deviceNum }
+							targetIsCurrent: {
+								accessoryManager.activeDeviceNum == deviceNum
+									&& accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) } == connectionID
+							}
 						)
 						guard result == .active else {
+							throw AccessoryError.ioFailed("Remote admin authorization was not refreshed. Please retry.")
+						}
+						guard accessoryManager.isConnected,
+							  accessoryManager.activeDeviceNum == deviceNum,
+							  accessoryManager.activeConnection.map({ ObjectIdentifier($0.connection) }) == connectionID else {
 							throw AccessoryError.ioFailed("Remote admin authorization was not refreshed. Please retry.")
 						}
 						guard let refreshedNode = getNodeInfo(id: targetNode.num, context: context),

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -42,18 +42,51 @@ func performConfigSave(
 	guard let deviceNum = accessoryManager.activeDeviceNum,
 		  let connectedNode = getNodeInfo(id: deviceNum, context: context),
 		  let fromUser = connectedNode.user,
-		  let toUser = node?.user
+		  let toUser = node?.user,
+		  let targetNode = node
 	else {
 		Logger.mesh.warning("⚠️ Cannot save config: missing connected node or user entities")
+		return
+	}
+	let operationID = targetNode.num == deviceNum
+		? nil
+		: accessoryManager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: targetNode.num)
+	if targetNode.num != deviceNum, operationID == nil {
+		accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "A configuration save is already in progress for this node. Please wait for it to finish.")
 		return
 	}
 
 	Task {
 		do {
-			try await save(fromUser, toUser)
-			hasChanges.wrappedValue = false
-			dismiss()
+			if let operationID {
+				try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+					try await save(fromUser, toUser)
+				}
+			} else {
+				try await save(fromUser, toUser)
+			}
+			if targetNode.num == deviceNum {
+				hasChanges.wrappedValue = false
+				dismiss()
+				return
+			}
+			guard let operationID else { return }
+			switch accessoryManager.remoteAdminConfigTracker.finish(operationID) {
+			case .succeeded:
+				hasChanges.wrappedValue = false
+				dismiss()
+			case .failed(let message):
+				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, message)
+				Logger.mesh.error("🚨 Config save rejected: \(message, privacy: .public)")
+			case .timedOut:
+				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "No confirmation was received from the remote node. Check that it is online and retry.")
+				Logger.mesh.error("🚨 Config save timed out")
+			}
 		} catch {
+			if let operationID {
+				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)
+			}
+			accessoryManager.remoteAdminConfigFeedback = (targetNode.num, error.localizedDescription)
 			Logger.mesh.error("🚨 Config save failed: \(error.localizedDescription)")
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -52,7 +52,10 @@ func performConfigSave(
 		? nil
 		: accessoryManager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: targetNode.num)
 	if targetNode.num != deviceNum, operationID == nil {
-		accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "A configuration save is already in progress for this node. Please wait for it to finish.")
+		accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+			targetNodeNum: targetNode.num,
+			kind: .save,
+			message: "A configuration save is already in progress for this node. Please wait for it to finish.")
 		return
 	}
 	let connectionID = accessoryManager.activeConnection.map { ObjectIdentifier($0.connection) }
@@ -112,10 +115,14 @@ func performConfigSave(
 				hasChanges.wrappedValue = false
 				dismiss()
 			case .failed(let message):
-				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, message)
+				accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+					targetNodeNum: targetNode.num, kind: .save, message: message)
 				Logger.mesh.error("🚨 Config save rejected: \(message, privacy: .public)")
 			case .timedOut:
-				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "No confirmation was received from the remote node. Check that it is online and retry.")
+				accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+					targetNodeNum: targetNode.num,
+					kind: .save,
+					message: "No confirmation was received from the remote node. Check that it is online and retry.")
 				Logger.mesh.error("🚨 Config save timed out")
 			case .unconfirmed:
 				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "The remote node did not confirm the configuration. Check its state before retrying.")
@@ -125,7 +132,8 @@ func performConfigSave(
 			if let operationID {
 				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)
 			}
-			accessoryManager.remoteAdminConfigFeedback = (targetNode.num, error.localizedDescription)
+			accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+				targetNodeNum: targetNode.num, kind: .save, message: error.localizedDescription)
 			Logger.mesh.error("🚨 Config save failed: \(error.localizedDescription)")
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
+++ b/Meshtastic/Views/Settings/Config/ConfigSaveHelper.swift
@@ -125,7 +125,10 @@ func performConfigSave(
 					message: "No confirmation was received from the remote node. Check that it is online and retry.")
 				Logger.mesh.error("🚨 Config save timed out")
 			case .unconfirmed:
-				accessoryManager.remoteAdminConfigFeedback = (targetNode.num, "The remote node did not confirm the configuration. Check its state before retrying.")
+				accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+					targetNodeNum: targetNode.num,
+					kind: .save,
+					message: "The remote node did not confirm the configuration. Check its state before retrying.")
 				Logger.mesh.error("🚨 Config save unconfirmed")
 			}
 		} catch {

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -42,7 +42,16 @@ struct DeviceConfig: View {
 			}
 		} else {
 		Form {
-			ConfigHeader(title: "Device", config: \.deviceConfig, node: node, onAppear: setDeviceValues)
+			ConfigHeader(title: "Device", config: \.deviceConfig, node: node, onAppear: setDeviceValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.deviceConfig == nil },
+					section: "Device",
+					request: accessoryManager.requestDeviceConfig,
+					force: true)
+			})
 			
 			Section(header: Text("Options")) {
 				VStack(alignment: .leading) {
@@ -319,33 +328,13 @@ struct DeviceConfig: View {
 		} // end else
 		} // end Group
 		.onFirstAppear {
-			// Need to request a DeviceConfig from the remote node before allowing changes
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration {
-							/// 2.5 Administration with session passkey
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.deviceConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired device config requesting via PKI admin")
-										try await accessoryManager.requestDeviceConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.error("🚨 Device config request failed")
-									}
-								}
-							}
-						} else {
-							if node.deviceConfig == nil {
-								/// Legacy Administration
-								Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-							}
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.deviceConfig == nil },
+				section: "Device",
+				request: accessoryManager.requestDeviceConfig)
 		}
 		.onChange(of: deviceRole) { oldRole, newRole in
 			guard !isResetting else { return }

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -174,7 +174,7 @@ struct DeviceConfig: View {
 				.pickerStyle(DefaultPickerStyle())
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.deviceConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			VStack(spacing: 0) {
 				// Only show these buttons for the BLE connected node

--- a/Meshtastic/Views/Settings/Config/DeviceConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DeviceConfig.swift
@@ -50,6 +50,7 @@ struct DeviceConfig: View {
 					configIsNil: { $0.deviceConfig == nil },
 					section: "Device",
 					request: accessoryManager.requestDeviceConfig,
+					requestForConnectedNode: true,
 					force: true)
 			})
 			
@@ -334,7 +335,8 @@ struct DeviceConfig: View {
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.deviceConfig == nil },
 				section: "Device",
-				request: accessoryManager.requestDeviceConfig)
+				request: accessoryManager.requestDeviceConfig,
+				requestForConnectedNode: true)
 		}
 		.onChange(of: deviceRole) { oldRole, newRole in
 			guard !isResetting else { return }

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -32,7 +32,17 @@ struct DisplayConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Display", config: \.displayConfig, node: node, onAppear: setDisplayValues)
+			ConfigHeader(title: "Display", config: \.displayConfig, node: node, onAppear: setDisplayValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.displayConfig == nil },
+				section: "Display",
+				request: accessoryManager.requestDisplayConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Device Screen")) {
 				

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -171,6 +171,7 @@ struct DisplayConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.displayConfig == nil },
+				section: "Display",
 				request: accessoryManager.requestDisplayConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/DisplayConfig.swift
+++ b/Meshtastic/Views/Settings/Config/DisplayConfig.swift
@@ -141,7 +141,7 @@ struct DisplayConfig: View {
 				}
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.displayConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 				SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -271,7 +271,7 @@ struct LoRaConfig: View {
 			advancedSection
 		}
 		.scrollDismissesKeyboard(.immediately)
-		.disabled(!accessoryManager.isConnected || node?.loRaConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 				SaveConfigButton(

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -254,7 +254,17 @@ struct LoRaConfig: View {
 	/// See `body` — the Form and its chrome, split out for type-check time.
 	private var loRaForm: some View {
 		Form {
-			ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues)
+			ConfigHeader(title: "LoRa", config: \.loRaConfig, node: node, onAppear: setLoRaValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.loRaConfig == nil },
+				section: "LoRa",
+				request: accessoryManager.requestLoRaConfig,
+				force: true
+			)
+		})
 
 			optionsSection
 

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -286,6 +286,7 @@ struct LoRaConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.loRaConfig == nil },
+				section: "LoRa",
 				request: accessoryManager.requestLoRaConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -24,7 +24,17 @@ struct AmbientLightingConfig: View {
 	@State private var components: Color.Resolved?
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Ambient Lighting", config: \.ambientLightingConfig, node: node, onAppear: setAmbientLightingConfigValue)
+			ConfigHeader(title: "Ambient Lighting", config: \.ambientLightingConfig, node: node, onAppear: setAmbientLightingConfigValue, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.ambientLightingConfig == nil },
+				section: "Ambient Lighting",
+				request: accessoryManager.requestAmbientLightingConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -87,6 +87,7 @@ struct AmbientLightingConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.ambientLightingConfig == nil },
+				section: "Ambient Lighting",
 				request: accessoryManager.requestAmbientLightingConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AmbientLightingConfig.swift
@@ -61,7 +61,7 @@ struct AmbientLightingConfig: View {
 				}
 			}
 		}
-		.disabled(!self.accessoryManager.isConnected || node?.ambientLightingConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
@@ -156,6 +156,7 @@ struct AudioConfig: View {
 					context: context,
 					accessoryManager: accessoryManager,
 					configIsNil: { $0.audioConfig == nil },
+					section: "Audio",
 					request: accessoryManager.requestAudioModuleConfig
 				)
 			}

--- a/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
@@ -29,7 +29,18 @@ struct AudioConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				ConfigHeader(title: "Audio", config: \.audioConfig, node: node, onAppear: setAudioValues)
+				ConfigHeader(title: "Audio", config: \.audioConfig, node: node, onAppear: setAudioValues, onRetry: {
+			requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.audioConfig == nil },
+					section: "Audio",
+					request: accessoryManager.requestAudioModuleConfig
+				,
+				force: true
+			)
+		})
 
 				Section(header: Text("Options")) {
 					Toggle(isOn: $codec2Enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/AudioConfig.swift
@@ -131,7 +131,7 @@ struct AudioConfig: View {
 				}
 			}
 			.scrollDismissesKeyboard(.immediately)
-			.disabled(!accessoryManager.isConnected || node?.audioConfig == nil)
+			.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 			.safeAreaInset(edge: .bottom, alignment: .center) {
 				HStack(spacing: 0) {
 				SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -221,6 +221,7 @@ struct CannedMessagesConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.cannedMessageConfig == nil },
+				section: "Canned messages",
 				request: accessoryManager.requestCannedMessagesModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -38,7 +38,17 @@ struct CannedMessagesConfig: View {
 	@State var messages = ""
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Canned messages", config: \.cannedMessageConfig, node: node, onAppear: setCannedMessagesValues)
+			ConfigHeader(title: "Canned messages", config: \.cannedMessageConfig, node: node, onAppear: setCannedMessagesValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.cannedMessageConfig == nil },
+				section: "Canned messages",
+				request: accessoryManager.requestCannedMessagesModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/CannedMessagesConfig.swift
@@ -170,7 +170,7 @@ struct CannedMessagesConfig: View {
 			.disabled(configPreset > 0)
 		}
 		.scrollDismissesKeyboard(.immediately)
-		.disabled(!accessoryManager.isConnected || node?.cannedMessageConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -183,6 +183,7 @@ struct DetectionSensorConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.detectionSensorConfig == nil },
+				section: "Detection Sensor",
 				request: accessoryManager.requestDetectionSensorModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -44,7 +44,17 @@ struct DetectionSensorConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Detection Sensor", config: \.detectionSensorConfig, node: node, onAppear: setDetectionSensorValues)
+			ConfigHeader(title: "Detection Sensor", config: \.detectionSensorConfig, node: node, onAppear: setDetectionSensorValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.detectionSensorConfig == nil },
+				section: "Detection Sensor",
+				request: accessoryManager.requestDetectionSensorModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/DetectionSensorConfig.swift
@@ -158,7 +158,7 @@ struct DetectionSensorConfig: View {
 			}
 		}
 		.scrollDismissesKeyboard(.interactively)
-		.disabled(!accessoryManager.isConnected || node?.detectionSensorConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -174,6 +174,7 @@ struct ExternalNotificationConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.externalNotificationConfig == nil },
+				section: "External notification",
 				request: accessoryManager.requestExternalNotificationModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -36,7 +36,17 @@ struct ExternalNotificationConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "External notification", config: \.externalNotificationConfig, node: node, onAppear: setExternalNotificationValues)
+			ConfigHeader(title: "External notification", config: \.externalNotificationConfig, node: node, onAppear: setExternalNotificationValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.externalNotificationConfig == nil },
+				section: "External notification",
+				request: accessoryManager.requestExternalNotificationModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				

--- a/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/ExternalNotificationConfig.swift
@@ -140,7 +140,7 @@ struct ExternalNotificationConfig: View {
 				}
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.externalNotificationConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -50,7 +50,17 @@ struct MQTTConfig: View {
 					}
 				}
 				
-				ConfigHeader(title: "MQTT", config: \.mqttConfig, node: node, onAppear: setMqttValues)
+				ConfigHeader(title: "MQTT", config: \.mqttConfig, node: node, onAppear: setMqttValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.mqttConfig == nil },
+				section: "MQTT",
+				request: accessoryManager.requestMqttModuleConfig,
+				force: true
+			)
+		})
 				
 				Section(header: Text("Options")) {
 					

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -353,6 +353,7 @@ struct MQTTConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.mqttConfig == nil },
+				section: "MQTT",
 				request: accessoryManager.requestMqttModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -261,7 +261,7 @@ struct MQTTConfig: View {
 					.font(.callout)
 			}
 			.scrollDismissesKeyboard(.immediately)
-			.disabled(!accessoryManager.isConnected || node?.mqttConfig == nil)
+			.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 			.safeAreaInset(edge: .bottom, alignment: .center) {
 				HStack(spacing: 0) {
 				SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/MeshBeaconConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MeshBeaconConfig.swift
@@ -183,7 +183,7 @@ struct MeshBeaconConfig: View {
 			}
 		}
 		.scrollDismissesKeyboard(.interactively)
-		.disabled(!accessoryManager.isConnected || node?.meshBeaconConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {
 				performConfigSave(

--- a/Meshtastic/Views/Settings/Config/Module/NeighborInfoConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/NeighborInfoConfig.swift
@@ -22,7 +22,16 @@ struct NeighborInfoConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Neighbor Info", config: \.neighborInfoConfig, node: node, onAppear: setNeighborInfoValues)
+			ConfigHeader(title: "Neighbor Info", config: \.neighborInfoConfig, node: node, onAppear: setNeighborInfoValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.neighborInfoConfig == nil },
+					section: "Neighbor Info",
+					request: accessoryManager.requestNeighborInfoModuleConfig,
+					force: true)
+			})
 
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {
@@ -82,28 +91,13 @@ struct NeighborInfoConfig: View {
 			}
 		}
 		.onFirstAppear {
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration && node.num != connectedNode.num {
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.neighborInfoConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired neighbor info module config requesting via PKI admin")
-										try await accessoryManager.requestNeighborInfoModuleConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.info("🚨 Request for neighbor info module config failed")
-									}
-								}
-							}
-						} else {
-							Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.neighborInfoConfig == nil },
+				section: "Neighbor Info",
+				request: accessoryManager.requestNeighborInfoModuleConfig)
 		}
 		.onChange(of: enabled) { oldEnabled, newEnabled in
 			if oldEnabled != newEnabled && newEnabled != (node?.neighborInfoConfig?.enabled ?? false) { hasChanges = true }

--- a/Meshtastic/Views/Settings/Config/Module/NeighborInfoConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/NeighborInfoConfig.swift
@@ -59,7 +59,7 @@ struct NeighborInfoConfig: View {
 				}
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.neighborInfoConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
@@ -24,7 +24,16 @@ struct PaxCounterConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "PAX Counter Config", config: \.powerConfig, node: node, onAppear: setPaxValues)
+			ConfigHeader(title: "PAX Counter Config", config: \.powerConfig, node: node, onAppear: setPaxValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.paxCounterConfig == nil },
+					section: "PAX Counter Config",
+					request: accessoryManager.requestPaxCounterModuleConfig,
+					force: true)
+			})
 			
 			Section {
 				Toggle(isOn: $enabled) {
@@ -108,31 +117,13 @@ struct PaxCounterConfig: View {
 			}
 		}
 		.onFirstAppear {
-			// Need to request a PaxCounterModuleConfig from the remote node before allowing changes
-			if let deviceNum = accessoryManager.activeDeviceNum, let node {
-				let connectedNode = getNodeInfo(id: deviceNum, context: context)
-				if let connectedNode {
-					if node.num != deviceNum {
-						if UserDefaults.enableAdministration && node.num != connectedNode.num {
-							/// 2.5 Administration with session passkey
-							let expiration = node.sessionExpiration ?? Date()
-							if expiration < Date() || node.paxCounterConfig == nil {
-								Task {
-									do {
-										Logger.mesh.info("⚙️ Empty or expired pax counter module config requesting via PKI admin")
-										try await accessoryManager.requestPaxCounterModuleConfig(fromUser: connectedNode.user!, toUser: node.user!)
-									} catch {
-										Logger.mesh.info("🚨 Request for pax counter module config failed")
-									}
-								}
-							}
-						} else {
-							/// Legacy Administration
-							Logger.mesh.info("☠️ Using insecure legacy admin that is no longer supported, please upgrade your firmware.")
-						}
-					}
-				}
-			}
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.paxCounterConfig == nil },
+				section: "PAX Counter Config",
+				request: accessoryManager.requestPaxCounterModuleConfig)
 		}
 		.onChange(of: enabled) { oldEnabled, newEnabled in
 			if oldEnabled != newEnabled && newEnabled != (node?.paxCounterConfig?.enabled ?? false) { hasChanges = true }

--- a/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/PaxCounterConfig.swift
@@ -85,7 +85,7 @@ struct PaxCounterConfig: View {
 				Text("Options")
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.powerConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -37,7 +37,18 @@ struct RangeTestConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Range", config: \.rangeTestConfig, node: node, onAppear: setRangeTestValues)
+			ConfigHeader(title: "Range", config: \.rangeTestConfig, node: node, onAppear: setRangeTestValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.rangeTestConfig == nil },
+				section: "Range",
+				request: accessoryManager.requestRangeTestModuleConfig,
+				requestForConnectedNode: true,
+				force: true
+			)
+		})
 
 			if isPrimaryChannelPublic {
 				Section {

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -107,6 +107,7 @@ struct RangeTestConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.rangeTestConfig == nil },
+				section: "Range",
 				request: accessoryManager.requestRangeTestModuleConfig,
 				requestForConnectedNode: true
 			)

--- a/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RangeTestConfig.swift
@@ -87,7 +87,7 @@ struct RangeTestConfig: View {
 				
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.rangeTestConfig == nil || isPrimaryChannelPublic)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected) || isPrimaryChannelPublic)
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -75,6 +75,7 @@ struct RtttlConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.rtttlConfig == nil },
+				section: "Ringtone",
 				request: accessoryManager.requestRtttlConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -21,7 +21,17 @@ struct RtttlConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Ringtone", config: \.rtttlConfig, node: node, onAppear: setRtttLConfigValue)
+			ConfigHeader(title: "Ringtone", config: \.rtttlConfig, node: node, onAppear: setRtttLConfigValue, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.rtttlConfig == nil },
+				section: "Ringtone",
+				request: accessoryManager.requestRtttlConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				HStack {

--- a/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/RtttlConfig.swift
@@ -57,7 +57,7 @@ struct RtttlConfig: View {
 					.font(.callout)
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.rtttlConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -131,6 +131,7 @@ struct SerialConfig: View {
 					context: context,
 					accessoryManager: accessoryManager,
 					configIsNil: { $0.serialConfig == nil },
+					section: "Serial",
 					request: accessoryManager.requestSerialModuleConfig
 				)
 			}

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -31,7 +31,18 @@ struct SerialConfig: View {
 	var body: some View {
 		VStack {
 			Form {
-				ConfigHeader(title: "Serial", config: \.serialConfig, node: node, onAppear: setSerialValues)
+				ConfigHeader(title: "Serial", config: \.serialConfig, node: node, onAppear: setSerialValues, onRetry: {
+			requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.serialConfig == nil },
+					section: "Serial",
+					request: accessoryManager.requestSerialModuleConfig
+				,
+				force: true
+			)
+		})
 				
 				Section(header: Text("Options")) {
 					

--- a/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/SerialConfig.swift
@@ -105,7 +105,7 @@ struct SerialConfig: View {
 						.font(.callout)
 				}
 			}
-			.disabled(!accessoryManager.isConnected || node?.serialConfig == nil)
+			.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 			.safeAreaInset(edge: .bottom, alignment: .center) {
 				HStack(spacing: 0) {
 				SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -31,7 +31,17 @@ struct StoreForwardConfig: View {
 	
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Store & Forward", config: \.storeForwardConfig, node: node, onAppear: setStoreAndForwardValues)
+			ConfigHeader(title: "Store & Forward", config: \.storeForwardConfig, node: node, onAppear: setStoreAndForwardValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.storeForwardConfig == nil },
+				section: "Store & Forward",
+				request: accessoryManager.requestStoreAndForwardModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Options")) {
 				Toggle(isOn: $enabled) {

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -132,6 +132,7 @@ struct StoreForwardConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.storeForwardConfig == nil },
+				section: "Store & Forward",
 				request: accessoryManager.requestStoreAndForwardModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/StoreForwardConfig.swift
@@ -96,7 +96,7 @@ struct StoreForwardConfig: View {
 			}
 		}
 		.scrollDismissesKeyboard(.interactively)
-		.disabled(!accessoryManager.isConnected || node?.storeForwardConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
@@ -32,7 +32,17 @@ struct TAKModuleConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "TAK", config: \.takConfig, node: node, onAppear: setTAKValues)
+			ConfigHeader(title: "TAK", config: \.takConfig, node: node, onAppear: setTAKValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.takConfig == nil },
+				section: "TAK",
+				request: accessoryManager.requestTAKModuleConfig,
+				force: true
+			)
+		})
 
 			if accessoryManager.isConnected, node?.takConfig == nil {
 				Section {

--- a/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
@@ -132,6 +132,7 @@ struct TAKModuleConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.takConfig == nil },
+				section: "TAK",
 				request: accessoryManager.requestTAKModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TAKModuleConfig.swift
@@ -92,7 +92,7 @@ struct TAKModuleConfig: View {
 					.font(.callout)
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.takConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -32,7 +32,17 @@ struct TelemetryConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Telemetry", config: \.telemetryConfig, node: node, onAppear: setTelemetryValues)
+			ConfigHeader(title: "Telemetry", config: \.telemetryConfig, node: node, onAppear: setTelemetryValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.telemetryConfig == nil },
+				section: "Telemetry",
+				request: accessoryManager.requestTelemetryModuleConfig,
+				force: true
+			)
+		})
 			
 			Section(header: Text("Device Options")) {
 				if accessoryManager.checkIsVersionSupported(forVersion: "2.7.12") {

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -179,6 +179,7 @@ struct TelemetryConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.telemetryConfig == nil },
+				section: "Telemetry",
 				request: accessoryManager.requestTelemetryModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TelemetryConfig.swift
@@ -147,7 +147,7 @@ struct TelemetryConfig: View {
 				}
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.telemetryConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
@@ -196,6 +196,7 @@ struct TrafficManagementConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.trafficManagementConfig == nil },
+				section: "Traffic Management",
 				request: accessoryManager.requestTrafficManagementModuleConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
@@ -36,7 +36,17 @@ struct TrafficManagementConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Traffic Management", config: \.trafficManagementConfig, node: node, onAppear: setTrafficManagementValues)
+			ConfigHeader(title: "Traffic Management", config: \.trafficManagementConfig, node: node, onAppear: setTrafficManagementValues, onRetry: {
+				requestRemoteConfig(
+					node: node,
+					context: context,
+					accessoryManager: accessoryManager,
+					configIsNil: { $0.trafficManagementConfig == nil },
+					section: "Traffic Management",
+					request: accessoryManager.requestTrafficManagementModuleConfig,
+					force: true
+				)
+			})
 				.onAppear(perform: refreshDirectNeighborCount)
 
 			Section(header: Text("Placement")) {

--- a/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/TrafficManagementConfig.swift
@@ -170,7 +170,7 @@ struct TrafficManagementConfig: View {
 			}
 		}
 		.scrollDismissesKeyboard(.immediately)
-		.disabled(!accessoryManager.isConnected || node?.trafficManagementConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -35,7 +35,17 @@ struct NetworkConfig: View {
 	var body: some View {
 		let staticValid = staticConfigIsValid
 		Form {
-			ConfigHeader(title: "Network", config: \.networkConfig, node: node, onAppear: setNetworkValues)
+			ConfigHeader(title: "Network", config: \.networkConfig, node: node, onAppear: setNetworkValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.networkConfig == nil },
+				section: "Network",
+				request: accessoryManager.requestNetworkConfig,
+				force: true
+			)
+		})
 			
 			if let node {
 				if node.metadata?.hasWifi ?? false {

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -235,6 +235,7 @@ struct NetworkConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.networkConfig == nil },
+				section: "Network",
 				request: accessoryManager.requestNetworkConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/NetworkConfig.swift
+++ b/Meshtastic/Views/Settings/Config/NetworkConfig.swift
@@ -188,7 +188,7 @@ struct NetworkConfig: View {
 			}
 		}
 		.scrollDismissesKeyboard(.interactively)
-		.disabled(!accessoryManager.isConnected || node?.networkConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -349,7 +349,17 @@ struct PositionConfig: View {
 	var body: some View {
 		
 		Form {
-			ConfigHeader(title: "Position", config: \.positionConfig, node: node, onAppear: setPositionValues)
+			ConfigHeader(title: "Position", config: \.positionConfig, node: node, onAppear: setPositionValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.positionConfig == nil },
+				section: "Position",
+				request: accessoryManager.requestPositionConfig,
+				force: true
+			)
+		})
 			positionPacketSection
 			deviceGPSSection
 			positionFlagsSection

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -395,6 +395,7 @@ struct PositionConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.positionConfig == nil },
+				section: "Position",
 				request: accessoryManager.requestPositionConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -368,7 +368,7 @@ struct PositionConfig: View {
 				advancedDeviceGPSSection
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.positionConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.alert(setFixedAlertTitle, isPresented: $showingSetFixedAlert) {
 			Button("Cancel", role: .cancel) {
 				fixedPosition = !fixedPosition

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -28,7 +28,17 @@ struct PowerConfig: View {
 
 	var body: some View {
 		Form {
-			ConfigHeader(title: "Power Config", config: \.powerConfig, node: node, onAppear: setPowerValues)
+			ConfigHeader(title: "Power Config", config: \.powerConfig, node: node, onAppear: setPowerValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.powerConfig == nil },
+				section: "Power Config",
+				request: accessoryManager.requestPowerConfig,
+				force: true
+			)
+		})
 
 			Section {
 				if let architecture, (architecture == .esp32 || architecture == .esp32S3) || (architecture == .nrf52840 && (node?.deviceConfig?.role ?? 0 == 5 || node?.deviceConfig?.role ?? 0 == 6)) {

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -133,6 +133,7 @@ struct PowerConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.powerConfig == nil },
+				section: "Power Config",
 				request: accessoryManager.requestPowerConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/PowerConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PowerConfig.swift
@@ -82,7 +82,7 @@ struct PowerConfig: View {
 				}
 			}
 		}
-		.disabled(!accessoryManager.isConnected || node?.powerConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 			SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
+++ b/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
@@ -1,0 +1,144 @@
+//
+//  RemoteAdminConfigTracker.swift
+//  Meshtastic
+//
+
+import Combine
+import Foundation
+import MeshtasticProtobufs
+
+enum RemoteAdminConfigOperationKind: Equatable {
+	case request
+	case save
+}
+
+enum RemoteAdminConfigOperationResult: Equatable {
+	case succeeded
+	case failed(String)
+	case timedOut
+}
+
+struct RemoteAdminConfigOperation: Identifiable, Equatable {
+	let id: UUID
+	let sequence: UInt64
+	let kind: RemoteAdminConfigOperationKind
+	let targetNodeNum: Int64
+	let section: String
+	var pendingPacketIDs: Set<UInt32> = []
+	var result: RemoteAdminConfigOperationResult?
+
+	var isFinished: Bool { result != nil }
+}
+
+/// Tracks only explicitly enrolled remote-admin work. The operation token is carried through the
+/// async request/save closure with TaskLocal, so unrelated admin packets can never be enrolled by
+/// target-node coincidence.
+@MainActor
+final class RemoteAdminConfigTracker: ObservableObject {
+	@TaskLocal static var currentOperationID: UUID?
+
+	@Published private(set) var operations: [UUID: RemoteAdminConfigOperation] = [:]
+	private var nextSequence: UInt64 = 0
+
+	static func isAdminResponse(_ message: AdminMessage) -> Bool {
+		switch message.payloadVariant {
+		case .getChannelResponse, .getOwnerResponse, .getConfigResponse, .getModuleConfigResponse,
+				.getCannedMessageModuleMessagesResponse, .getDeviceMetadataResponse, .getRingtoneResponse,
+				.getDeviceConnectionStatusResponse, .getNodeRemoteHardwarePinsResponse, .getUiConfigResponse:
+			return true
+		default:
+			return false
+		}
+	}
+
+	@discardableResult
+	func begin(kind: RemoteAdminConfigOperationKind, targetNodeNum: Int64, section: String = "save") -> UUID? {
+		if operations.values.contains(where: {
+			$0.kind == kind && $0.targetNodeNum == targetNodeNum && $0.section == section && !$0.isFinished
+		}) { return nil }
+		nextSequence += 1
+		let id = UUID()
+		operations[id] = RemoteAdminConfigOperation(id: id, sequence: nextSequence, kind: kind, targetNodeNum: targetNodeNum, section: section)
+		return id
+	}
+
+	func registerPacket(packetID: UInt32, targetNodeNum: Int64, operationID: UUID?) -> Bool {
+		guard let operationID, var operation = operations[operationID], !operation.isFinished,
+			  operation.targetNodeNum == targetNodeNum else { return false }
+		operation.pendingPacketIDs.insert(packetID)
+		operations[operationID] = operation
+		return true
+	}
+
+	func resolveAdminResponse(packetID: UInt32, sourceNodeNum: Int64) -> UUID? {
+		guard let operation = operations.values.first(where: {
+			$0.pendingPacketIDs.contains(packetID) && $0.targetNodeNum == sourceNodeNum && !$0.isFinished
+		}) else { return nil }
+		return resolvePacket(packetID: packetID, operationID: operation.id, result: .succeeded)
+	}
+
+	func resolveRouting(packetID: UInt32, sourceNodeNum: Int64, reason: String?, isFailure: Bool) -> UUID? {
+		guard let operation = operations.values.first(where: { $0.pendingPacketIDs.contains(packetID) && !$0.isFinished }) else { return nil }
+		guard isFailure || (operation.kind == .save && operation.targetNodeNum == sourceNodeNum) else { return nil }
+		let result: RemoteAdminConfigOperationResult = isFailure ? .failed(reason ?? "Remote delivery failed") : .succeeded
+		return resolvePacket(packetID: packetID, operationID: operation.id, result: result)
+	}
+
+	private func resolvePacket(packetID: UInt32, operationID: UUID, result: RemoteAdminConfigOperationResult) -> UUID {
+		guard var operation = operations[operationID], !operation.isFinished else { return operationID }
+		operation.pendingPacketIDs.remove(packetID)
+		if case .failed = result { operation.result = result }
+		operations[operationID] = operation
+		return operationID
+	}
+
+	func waitForPacket(packetID: UInt32, operationID: UUID, timeout: Duration = .seconds(30)) async -> RemoteAdminConfigOperationResult {
+		let deadline = ContinuousClock.now + timeout
+		while !Task.isCancelled {
+			guard let operation = operations[operationID] else { return .failed("Operation cancelled") }
+			if let result = operation.result { return result }
+			if !operation.pendingPacketIDs.contains(packetID) { return .succeeded }
+			if ContinuousClock.now >= deadline {
+				self.timeout(operationID)
+				return .timedOut
+			}
+			try? await Task.sleep(for: .milliseconds(50))
+		}
+		fail(operationID, with: "Operation cancelled")
+		return .failed("Operation cancelled")
+	}
+
+	func timeout(_ operationID: UUID) {
+		guard var operation = operations[operationID], !operation.isFinished else { return }
+		operation.pendingPacketIDs.removeAll()
+		operation.result = .timedOut
+		operations[operationID] = operation
+	}
+
+	func finish(_ operationID: UUID) -> RemoteAdminConfigOperationResult {
+		guard var operation = operations[operationID], !operation.isFinished else { return operations[operationID]?.result ?? .failed("Operation cancelled") }
+		guard operation.pendingPacketIDs.isEmpty else { return .timedOut }
+		operation.result = .succeeded
+		operations[operationID] = operation
+		return .succeeded
+	}
+
+	func fail(_ operationID: UUID, with error: Error) {
+		fail(operationID, with: error.localizedDescription)
+	}
+
+	func fail(_ operationID: UUID, with message: String) {
+		guard var operation = operations[operationID], !operation.isFinished else { return }
+		operation.pendingPacketIDs.removeAll()
+		operation.result = .failed(message)
+		operations[operationID] = operation
+	}
+
+	func failAll(with message: String) {
+		for operationID in Array(operations.keys) { fail(operationID, with: message) }
+	}
+
+	func latest(for targetNodeNum: Int64, kind: RemoteAdminConfigOperationKind, section: String) -> RemoteAdminConfigOperation? {
+		operations.values.filter { $0.targetNodeNum == targetNodeNum && $0.kind == kind && $0.section == section }.max { $0.sequence < $1.sequence }
+	}
+}

--- a/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
+++ b/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
@@ -83,10 +83,12 @@ final class RemoteAdminConfigTracker: ObservableObject {
 
 	func resolveRouting(packetID: UInt32, sourceNodeNum: Int64, reason: String?, isFailure: Bool) -> UUID? {
 		guard let operation = operations.values.first(where: { $0.pendingPacketIDs.contains(packetID) && !$0.isFinished }) else { return nil }
-		guard isFailure || ((operation.kind == .save || operation.kind == .action) && operation.targetNodeNum == sourceNodeNum) else { return nil }
-		let result: RemoteAdminConfigOperationResult = isFailure
-			? .failed(reason ?? "Remote delivery failed")
-			: (operation.kind == .action ? .acknowledged : .succeeded)
+		guard isFailure || (operation.kind == .save && operation.targetNodeNum == sourceNodeNum) else { return nil }
+		// A routing ACK only proves that the mesh accepted the packet for delivery. It does not
+		// prove that the target executed a destructive action. Keep action packets pending until
+		// an admin response (or another target-specific evidence packet) resolves them; timeout
+		// then reports `.unconfirmed`.
+		let result: RemoteAdminConfigOperationResult = isFailure ? .failed(reason ?? "Remote delivery failed") : .succeeded
 		return resolvePacket(packetID: packetID, operationID: operation.id, result: result)
 	}
 

--- a/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
+++ b/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
@@ -10,12 +10,15 @@ import MeshtasticProtobufs
 enum RemoteAdminConfigOperationKind: Equatable {
 	case request
 	case save
+	case action
 }
 
 enum RemoteAdminConfigOperationResult: Equatable {
 	case succeeded
+	case acknowledged
 	case failed(String)
 	case timedOut
+	case unconfirmed
 }
 
 struct RemoteAdminConfigOperation: Identifiable, Equatable {
@@ -74,13 +77,16 @@ final class RemoteAdminConfigTracker: ObservableObject {
 		guard let operation = operations.values.first(where: {
 			$0.pendingPacketIDs.contains(packetID) && $0.targetNodeNum == sourceNodeNum && !$0.isFinished
 		}) else { return nil }
-		return resolvePacket(packetID: packetID, operationID: operation.id, result: .succeeded)
+		let result: RemoteAdminConfigOperationResult = operation.kind == .action ? .acknowledged : .succeeded
+		return resolvePacket(packetID: packetID, operationID: operation.id, result: result)
 	}
 
 	func resolveRouting(packetID: UInt32, sourceNodeNum: Int64, reason: String?, isFailure: Bool) -> UUID? {
 		guard let operation = operations.values.first(where: { $0.pendingPacketIDs.contains(packetID) && !$0.isFinished }) else { return nil }
-		guard isFailure || (operation.kind == .save && operation.targetNodeNum == sourceNodeNum) else { return nil }
-		let result: RemoteAdminConfigOperationResult = isFailure ? .failed(reason ?? "Remote delivery failed") : .succeeded
+		guard isFailure || ((operation.kind == .save || operation.kind == .action) && operation.targetNodeNum == sourceNodeNum) else { return nil }
+		let result: RemoteAdminConfigOperationResult = isFailure
+			? .failed(reason ?? "Remote delivery failed")
+			: (operation.kind == .action ? .acknowledged : .succeeded)
 		return resolvePacket(packetID: packetID, operationID: operation.id, result: result)
 	}
 
@@ -88,6 +94,7 @@ final class RemoteAdminConfigTracker: ObservableObject {
 		guard var operation = operations[operationID], !operation.isFinished else { return operationID }
 		operation.pendingPacketIDs.remove(packetID)
 		if case .failed = result { operation.result = result }
+		if case .acknowledged = result { operation.result = result }
 		operations[operationID] = operation
 		return operationID
 	}
@@ -97,10 +104,12 @@ final class RemoteAdminConfigTracker: ObservableObject {
 		while !Task.isCancelled {
 			guard let operation = operations[operationID] else { return .failed("Operation cancelled") }
 			if let result = operation.result { return result }
-			if !operation.pendingPacketIDs.contains(packetID) { return .succeeded }
+			if !operation.pendingPacketIDs.contains(packetID) {
+				return operation.kind == .action ? .acknowledged : .succeeded
+			}
 			if ContinuousClock.now >= deadline {
 				self.timeout(operationID)
-				return .timedOut
+				return operation.kind == .action ? .unconfirmed : .timedOut
 			}
 			try? await Task.sleep(for: .milliseconds(50))
 		}
@@ -111,16 +120,16 @@ final class RemoteAdminConfigTracker: ObservableObject {
 	func timeout(_ operationID: UUID) {
 		guard var operation = operations[operationID], !operation.isFinished else { return }
 		operation.pendingPacketIDs.removeAll()
-		operation.result = .timedOut
+		operation.result = operation.kind == .action ? .unconfirmed : .timedOut
 		operations[operationID] = operation
 	}
 
 	func finish(_ operationID: UUID) -> RemoteAdminConfigOperationResult {
 		guard var operation = operations[operationID], !operation.isFinished else { return operations[operationID]?.result ?? .failed("Operation cancelled") }
-		guard operation.pendingPacketIDs.isEmpty else { return .timedOut }
-		operation.result = .succeeded
+		guard operation.pendingPacketIDs.isEmpty else { return operation.kind == .action ? .unconfirmed : .timedOut }
+		operation.result = operation.kind == .action ? .acknowledged : .succeeded
 		operations[operationID] = operation
-		return .succeeded
+		return operation.result ?? .failed("Operation cancelled")
 	}
 
 	func fail(_ operationID: UUID, with error: Error) {

--- a/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
+++ b/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
@@ -33,6 +33,12 @@ struct RemoteAdminConfigOperation: Identifiable, Equatable {
 	var isFinished: Bool { result != nil }
 }
 
+struct RemoteAdminConfigFeedback: Equatable {
+	let targetNodeNum: Int64
+	let kind: RemoteAdminConfigOperationKind
+	let message: String
+}
+
 /// Tracks only explicitly enrolled remote-admin work. The operation token is carried through the
 /// async request/save closure with TaskLocal, so unrelated admin packets can never be enrolled by
 /// target-node coincidence.

--- a/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
+++ b/Meshtastic/Views/Settings/Config/RemoteAdminConfigTracker.swift
@@ -128,7 +128,10 @@ final class RemoteAdminConfigTracker: ObservableObject {
 
 	func finish(_ operationID: UUID) -> RemoteAdminConfigOperationResult {
 		guard var operation = operations[operationID], !operation.isFinished else { return operations[operationID]?.result ?? .failed("Operation cancelled") }
-		guard operation.pendingPacketIDs.isEmpty else { return operation.kind == .action ? .unconfirmed : .timedOut }
+		guard operation.pendingPacketIDs.isEmpty else {
+			timeout(operationID)
+			return operation.kind == .action ? .unconfirmed : .timedOut
+		}
 		operation.result = operation.kind == .action ? .acknowledged : .succeeded
 		operations[operationID] = operation
 		return operation.result ?? .failed("Operation cancelled")

--- a/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
+++ b/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
@@ -18,6 +18,7 @@ func requestRemoteConfig(
 	context: ModelContext,
 	accessoryManager: AccessoryManager,
 	configIsNil: @escaping (NodeInfoEntity) -> Bool,
+	section: String,
 	request: @escaping (_ fromUser: UserEntity, _ toUser: UserEntity) async throws -> Void,
 	requestForConnectedNode: Bool = false
 ) {
@@ -29,7 +30,9 @@ func requestRemoteConfig(
 	if requestForConnectedNode && node.num == deviceNum && configIsNil(node) {
 		Task {
 			do {
-				guard let fromUser = connectedNode.user, let toUser = node.user else { return }
+				guard let fromUser = connectedNode.user, let toUser = node.user else {
+					return
+				}
 				Logger.mesh.info("⚙️ Config missing for connected node, requesting")
 				try await request(fromUser, toUser)
 			} catch {
@@ -44,13 +47,24 @@ func requestRemoteConfig(
 	if UserDefaults.enableAdministration {
 		let expiration = node.sessionExpiration ?? Date()
 		if expiration < Date() || configIsNil(node) {
+			let operationID = accessoryManager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: node.num, section: section)
+			guard let operationID else { return }
 			Task {
 				do {
-					guard let fromUser = connectedNode.user, let toUser = node.user else { return }
+					guard let fromUser = connectedNode.user, let toUser = node.user else {
+						accessoryManager.remoteAdminConfigTracker.fail(operationID, with: AccessoryError.appError("Missing user identity"))
+						return
+					}
 					Logger.mesh.info("⚙️ Empty or expired config requesting via PKI admin")
+				try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
 					try await request(fromUser, toUser)
-				} catch {
-					Logger.mesh.error("🚨 Config request failed")
+				}
+				if case .failed(let message) = accessoryManager.remoteAdminConfigTracker.finish(operationID) {
+					accessoryManager.remoteAdminConfigFeedback = (node.num, message)
+				}
+			} catch {
+				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)
+				Logger.mesh.error("🚨 Config request failed")
 				}
 			}
 		}

--- a/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
+++ b/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
@@ -20,7 +20,8 @@ func requestRemoteConfig(
 	configIsNil: @escaping (NodeInfoEntity) -> Bool,
 	section: String,
 	request: @escaping (_ fromUser: UserEntity, _ toUser: UserEntity) async throws -> Void,
-	requestForConnectedNode: Bool = false
+	requestForConnectedNode: Bool = false,
+	force: Bool = false
 ) {
 	guard let deviceNum = accessoryManager.activeDeviceNum,
 		  let node,
@@ -46,7 +47,7 @@ func requestRemoteConfig(
 
 	if UserDefaults.enableAdministration {
 		let expiration = node.sessionExpiration ?? Date()
-		if expiration < Date() || configIsNil(node) {
+		if force || expiration < Date() || configIsNil(node) {
 			let operationID = accessoryManager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: node.num, section: section)
 			guard let operationID else { return }
 			Task {

--- a/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
+++ b/Meshtastic/Views/Settings/Config/RequestConfigOnAppear.swift
@@ -61,7 +61,8 @@ func requestRemoteConfig(
 					try await request(fromUser, toUser)
 				}
 				if case .failed(let message) = accessoryManager.remoteAdminConfigTracker.finish(operationID) {
-					accessoryManager.remoteAdminConfigFeedback = (node.num, message)
+					accessoryManager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+						targetNodeNum: node.num, kind: .request, message: message)
 				}
 			} catch {
 				accessoryManager.remoteAdminConfigTracker.fail(operationID, with: error)

--- a/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
+++ b/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
@@ -22,7 +22,9 @@ struct SaveConfigButton: View {
 	
 	var body: some View {
 		if accessoryManager.isConnected && hasChanges {
-			let feedback = node.map { accessoryManager.remoteAdminConfigFeedback?.targetNodeNum == $0.num ? accessoryManager.remoteAdminConfigFeedback?.message : nil } ?? nil
+			let feedback = node.flatMap {
+				accessoryManager.remoteAdminConfigFeedback(for: $0.num, kind: .save)
+			}
 			let remoteSaveInProgress = node.flatMap {
 				accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .save, section: "save")
 			}?.isFinished == false

--- a/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
+++ b/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
@@ -22,6 +22,24 @@ struct SaveConfigButton: View {
 	
 	var body: some View {
 		if accessoryManager.isConnected && hasChanges {
+			let feedback = node.map { accessoryManager.remoteAdminConfigFeedback?.targetNodeNum == $0.num ? accessoryManager.remoteAdminConfigFeedback?.message : nil } ?? nil
+			let remoteSaveInProgress = node.flatMap {
+				accessoryManager.remoteAdminConfigTracker.latest(for: $0.num, kind: .save, section: "save")
+			}?.isFinished == false
+			if let feedback {
+				VStack(spacing: 8) {
+					Label(feedback, systemImage: "exclamationmark.triangle")
+						.foregroundColor(.red)
+					Button("Retry") {
+						accessoryManager.remoteAdminConfigFeedback = nil
+						onConfirmation()
+					}
+				}
+				.padding(.bottom)
+			} else if remoteSaveInProgress {
+				ProgressView("Saving…")
+					.padding(.bottom)
+			} else {
 			if #available(iOS 26.0, *) {
 				Button {
 					isPresentingSaveConfirm = true
@@ -67,6 +85,7 @@ struct SaveConfigButton: View {
 				} message: {
 					Text(confirmationMessage)
 				}
+			}
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -135,7 +135,17 @@ struct SecurityConfig: View {
 	/// See `body` — the Form and its chrome, split out for type-check time.
 	private var securityForm: some View {
 		Form {
-			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues)
+			ConfigHeader(title: "Security", config: \.securityConfig, node: node, onAppear: setSecurityValues, onRetry: {
+			requestRemoteConfig(
+				node: node,
+				context: context,
+				accessoryManager: accessoryManager,
+				configIsNil: { $0.securityConfig == nil },
+				section: "Security",
+				request: accessoryManager.requestSecurityConfig,
+				force: true
+			)
+		})
 			Text("Security Config Settings require a firmware version 2.5+")
 				.font(.title3)
 			packetAuthenticitySection

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -107,6 +107,7 @@ struct SecurityConfig: View {
 				context: context,
 				accessoryManager: accessoryManager,
 				configIsNil: { $0.securityConfig == nil },
+				section: "Security",
 				request: accessoryManager.requestSecurityConfig
 			)
 		}

--- a/Meshtastic/Views/Settings/Config/SecurityConfig.swift
+++ b/Meshtastic/Views/Settings/Config/SecurityConfig.swift
@@ -155,7 +155,7 @@ struct SecurityConfig: View {
 			logsSection
 			administrationSection
 		}
-		.disabled(!accessoryManager.isConnected || node?.securityConfig == nil)
+		.disabled(ConfigFormAvailability.isDisabled(isConnected: accessoryManager.isConnected))
 		.safeAreaInset(edge: .bottom, alignment: .center) {
 			HStack(spacing: 0) {
 				SaveConfigButton(node: node, hasChanges: $hasChanges) {

--- a/Meshtastic/Views/Settings/RemoteChannels.swift
+++ b/Meshtastic/Views/Settings/RemoteChannels.swift
@@ -1,0 +1,423 @@
+import Foundation
+import MeshtasticProtobufs
+import SwiftUI
+
+enum RemoteChannelsPacketBuilder {
+    static func getRequest(index: Int32, from: UInt32, to: UInt32, sessionPasskey: Data, id: UInt32 = .random(in: 256...UInt32.max)) throws -> MeshPacket {
+        precondition((0...7).contains(index))
+        var admin = AdminMessage()
+        admin.getChannelRequest = UInt32(index + 1)
+        admin.sessionPasskey = sessionPasskey
+        var packet = MeshPacket()
+        packet.id = id
+        packet.from = from
+        packet.to = to
+        packet.priority = .reliable
+        packet.wantAck = true
+        var data = DataMessage()
+        data.payload = try admin.serializedData()
+        data.portnum = .adminApp
+        data.wantResponse = true
+        packet.decoded = data
+        return packet
+    }
+
+    static func matchesResponse(packet: MeshPacket, response: AdminMessage, requestID: UInt32, target: UInt32, index: Int32) -> Bool {
+        guard packet.from == target, packet.decoded.requestID == requestID else { return false }
+        guard case .getChannelResponse(let channel) = response.payloadVariant else { return false }
+        return channel.index == index
+    }
+}
+
+enum RemoteChannelsWriteResult: Equatable {
+    case success
+    case failure(index: Int32)
+}
+
+enum RemoteChannelsWritePlan {
+    static func execute(_ channels: [Channel], write: (Channel) async throws -> Void) async throws -> RemoteChannelsWriteResult {
+        for channel in channels.sorted(by: { $0.index < $1.index }) {
+            do {
+                try await write(channel)
+            } catch {
+                if error is CancellationError { throw error }
+                return .failure(index: Int32(channel.index))
+            }
+        }
+        return .success
+    }
+}
+
+enum RemoteChannelsReadPlan {
+    static func retry<T>(retries: Int, operation: () async throws -> T) async throws -> T {
+        var lastError: Error = AccessoryError.timeout
+        for attempt in 0...retries {
+            do { return try await operation() }
+			catch {
+				if error is CancellationError { throw error }
+				if case AccessoryError.disconnected = error { throw error }
+                lastError = error
+                if attempt == retries { throw lastError }
+            }
+        }
+        throw lastError
+    }
+}
+
+extension Foundation.Notification.Name {
+    static let remoteChannelResponse = Foundation.Notification.Name("Meshtastic.RemoteChannelResponse")
+}
+
+@MainActor
+protocol RemoteChannelsTransport {
+	var isConnected: Bool { get }
+	var connectedDeviceNum: Int64? { get }
+	var connectionID: ObjectIdentifier? { get }
+	var hasLiveSession: Bool { get }
+	var responseTimeout: Duration { get }
+	var sessionTimeout: Duration { get }
+	func refreshMetadata() async throws
+	func requestChannel(index: Int32) async throws -> UInt32
+	func saveChannel(_ channel: Channel) async throws
+}
+
+@MainActor
+final class AccessoryManagerRemoteChannelsTransport: RemoteChannelsTransport {
+	private let manager: AccessoryManager
+	private let fromUser: UserEntity
+	private let toUser: UserEntity
+
+	init(manager: AccessoryManager, fromUser: UserEntity, toUser: UserEntity) {
+		self.manager = manager
+		self.fromUser = fromUser
+		self.toUser = toUser
+	}
+
+	var isConnected: Bool { manager.isConnected }
+	var connectedDeviceNum: Int64? { manager.activeDeviceNum }
+	var connectionID: ObjectIdentifier? {
+		guard let connection = manager.activeConnection?.connection else { return nil }
+		return ObjectIdentifier(connection)
+	}
+	var hasLiveSession: Bool { toUser.userNode?.hasLiveAdminSession == true }
+	var responseTimeout: Duration { .seconds(30) }
+	var sessionTimeout: Duration { .seconds(30) }
+	func refreshMetadata() async throws { _ = try await manager.requestDeviceMetadata(fromUser: fromUser, toUser: toUser) }
+	func requestChannel(index: Int32) async throws -> UInt32 {
+		try await manager.requestRemoteChannel(index: index, fromUser: fromUser, toUser: toUser)
+	}
+	func saveChannel(_ channel: Channel) async throws {
+		_ = try await manager.saveChannel(channel: channel, fromUser: fromUser, toUser: toUser)
+	}
+}
+
+@MainActor
+final class RemoteChannelsCoordinator: ObservableObject {
+    @Published private(set) var channels: [Int32: Channel] = [:]
+    @Published private(set) var progress: Int = 0
+    @Published private(set) var isLoading = false
+    @Published private(set) var isSaving = false
+
+	private let transport: any RemoteChannelsTransport
+	private let sourceConnectionID: ObjectIdentifier?
+    private var responses: [(requestID: UInt32, target: UInt32, channel: Channel)] = []
+    private let sourceNum: Int64
+    private let targetNum: Int64
+
+	init(transport: any RemoteChannelsTransport, sourceNum: Int64, targetNum: Int64) {
+		self.transport = transport
+		self.sourceNum = sourceNum
+		self.targetNum = targetNum
+		self.sourceConnectionID = transport.connectionID
+    }
+
+    func receive(_ notification: Foundation.Notification) {
+        guard let packet = notification.userInfo?["packet"] as? MeshPacket,
+              let response = notification.userInfo?["response"] as? AdminMessage,
+              case .getChannelResponse(let channel) = response.payloadVariant,
+				packet.from == UInt32(targetNum), packet.to == UInt32(sourceNum) else { return }
+        responses.append((packet.decoded.requestID, packet.from, channel))
+    }
+
+    func load() async throws {
+        try validateConnection()
+        isLoading = true
+        progress = 0
+        defer { isLoading = false }
+        try await refreshSessionIfNeeded()
+        var loaded: [Int32: Channel] = [:]
+        for index in Int32(0)...Int32(7) {
+            try Task.checkCancellation()
+            try validateConnection()
+            let channel = try await read(index: index, retries: 1)
+            loaded[index] = channel
+            progress = Int(index) + 1
+        }
+        channels = loaded
+    }
+
+    func save(_ changed: [Channel]) async throws {
+        guard !isSaving else { return }
+        isSaving = true
+        defer { isSaving = false }
+        try Task.checkCancellation()
+        try validateConnection()
+        try await refreshSessionIfNeeded()
+		let result = try await RemoteChannelsWritePlan.execute(changed) { [weak self] channel in
+			guard let self else { throw AccessoryError.disconnected("Remote Channels was closed") }
+			try self.validateEditableChannel(channel)
+			var outgoing = channel
+			if outgoing.role == .disabled { outgoing.clearSettings() }
+			try Task.checkCancellation()
+			try self.validateConnection()
+			try await self.transport.saveChannel(outgoing)
+			let actual = try await self.read(index: Int32(outgoing.index), retries: 1)
+			guard self.matchesEditableChannel(actual, desired: outgoing) else {
+				throw AccessoryError.ioFailed("Remote channel \(channel.index) did not match the saved values")
+			}
+            self.channels[Int32(channel.index)] = actual
+        }
+        if case .failure(let index) = result {
+            throw AccessoryError.ioFailed("Remote channel \(index) was not confirmed")
+        }
+    }
+
+    private func read(index: Int32, retries: Int) async throws -> Channel {
+        try await RemoteChannelsReadPlan.retry(retries: retries) {
+                try Task.checkCancellation()
+                try self.validateConnection()
+				let requestID = try await transport.requestChannel(index: index)
+				let deadline = ContinuousClock.now + transport.responseTimeout
+                while ContinuousClock.now < deadline {
+                    try Task.checkCancellation()
+                    try self.validateConnection()
+					if let match = responses.firstIndex(where: { $0.requestID == requestID && $0.target == UInt32(targetNum) && $0.channel.index == index }) {
+                        return responses.remove(at: match).channel
+                    }
+                    try await Task.sleep(for: .milliseconds(50))
+                }
+                throw AccessoryError.timeout
+        }
+    }
+
+    private func refreshSessionIfNeeded() async throws {
+		// Remote Channels requires a live PKI administration session before any slot access.
+		guard !transport.hasLiveSession else { return }
+		try validateConnection()
+		try await transport.refreshMetadata()
+		let deadline = ContinuousClock.now + transport.sessionTimeout
+        while ContinuousClock.now < deadline {
+            try Task.checkCancellation()
+            try validateConnection()
+			if transport.hasLiveSession { return }
+            try await Task.sleep(for: .milliseconds(250))
+        }
+        throw AccessoryError.ioFailed("Remote admin session expired; refresh the node and try again")
+    }
+
+	private func validateConnection() throws {
+		guard transport.isConnected, transport.connectedDeviceNum == sourceNum,
+			  transport.connectionID == sourceConnectionID else {
+			throw AccessoryError.disconnected("The connected radio changed or disconnected")
+		}
+	}
+
+	private func validateEditableChannel(_ channel: Channel) throws {
+		guard (0...7).contains(channel.index) else { throw AccessoryError.appError("Channel index must be between 0 and 7") }
+		guard channel.index == 0 ? channel.role == .primary : channel.role != .primary else {
+			throw AccessoryError.appError("Only channel 0 can be primary")
+		}
+		guard channel.settings.name.utf8.count <= 11 else { throw AccessoryError.appError("Channel names must be 11 bytes or fewer") }
+		guard [0, 1, 16, 32].contains(channel.settings.psk.count) else { throw AccessoryError.appError("Channel key has an unsupported length") }
+	}
+
+	private func matchesEditableChannel(_ actual: Channel, desired: Channel) -> Bool {
+		guard actual.index == desired.index, actual.role == desired.role else { return false }
+		guard desired.role != .disabled else { return true }
+		return actual.settings.name == desired.settings.name &&
+			actual.settings.psk == desired.settings.psk &&
+			actual.settings.uplinkEnabled == desired.settings.uplinkEnabled &&
+			actual.settings.downlinkEnabled == desired.settings.downlinkEnabled &&
+			actual.settings.moduleSettings.positionPrecision == desired.settings.moduleSettings.positionPrecision &&
+			actual.settings.moduleSettings.isMuted == desired.settings.moduleSettings.isMuted
+	}
+	}
+
+struct RemoteChannels: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var accessoryManager: AccessoryManager
+    let node: NodeInfoEntity
+    let connectedNode: NodeInfoEntity
+    let fromUser: UserEntity
+    let toUser: UserEntity
+    @StateObject private var coordinator: RemoteChannelsCoordinator
+    @State private var selected: Channel?
+    @State private var errorMessage: String?
+
+    init(node: NodeInfoEntity, connectedNode: NodeInfoEntity, fromUser: UserEntity, toUser: UserEntity, accessoryManager: AccessoryManager) {
+        self.node = node
+        self.connectedNode = connectedNode
+        self.fromUser = fromUser
+        self.toUser = toUser
+		self.accessoryManager = accessoryManager
+		_coordinator = StateObject(wrappedValue: RemoteChannelsCoordinator(
+			transport: AccessoryManagerRemoteChannelsTransport(manager: accessoryManager, fromUser: fromUser, toUser: toUser),
+			sourceNum: fromUser.num, targetNum: toUser.num
+		))
+    }
+
+    var body: some View {
+        List {
+            if coordinator.isLoading {
+                ProgressView("Reading remote channels (\(coordinator.progress)/8)…")
+            }
+            ForEach(Int32(0)...Int32(7), id: \.self) { index in
+                if let channel = coordinator.channels[index] {
+                    Button {
+                        selected = channel
+                    } label: {
+                        HStack {
+                            Text(channel.settings.name.isEmpty ? "Channel \(index)" : channel.settings.name)
+                            Spacer()
+                            Text(channel.role == .primary ? "Primary" : channel.role == .disabled ? "Disabled" : "Secondary")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .navigationTitle("Remote Channels")
+        .task {
+            do { try await coordinator.load() }
+            catch { errorMessage = error.localizedDescription }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Retry") {
+                    Task {
+                        do { try await coordinator.load(); errorMessage = nil }
+                        catch { errorMessage = error.localizedDescription }
+                    }
+                }
+                .disabled(coordinator.isLoading || coordinator.isSaving)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .remoteChannelResponse).receive(on: RunLoop.main)) { coordinator.receive($0) }
+        .alert("Remote Channels", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: { Text(errorMessage ?? "") }
+        .sheet(isPresented: Binding(get: { selected != nil }, set: { if !$0 { selected = nil } })) {
+            if let channel = selected {
+                RemoteChannelEditor(channel: channel, isSaving: coordinator.isSaving) { edited in
+                    try await coordinator.save([edited])
+                    selected = nil
+                }
+            }
+        }
+    }
+}
+
+struct RemoteChannelsUnavailable: View {
+	let nodeName: String
+
+	var body: some View {
+		VStack(spacing: 12) {
+			Image(systemName: "lock.slash").font(.largeTitle).foregroundStyle(.secondary)
+			Text("Remote Channels Unavailable").font(.headline)
+			Text("\(nodeName) does not have a live PKI administration session. Refresh node administration and try again.")
+				.multilineTextAlignment(.center).foregroundStyle(.secondary)
+		}
+		.padding()
+		.navigationTitle("Remote Channels")
+	}
+}
+
+private struct RemoteChannelEditor: View {
+    @Environment(\.dismiss) private var dismiss
+    let channel: Channel
+    let isSaving: Bool
+    let onSave: (Channel) async throws -> Void
+    @State private var name: String
+    @State private var key: String
+    @State private var role: Channel.Role
+    @State private var uplink: Bool
+    @State private var downlink: Bool
+    @State private var precision: Int
+    @State private var muted: Bool
+    @State private var errorMessage: String?
+
+    init(channel: Channel, isSaving: Bool, onSave: @escaping (Channel) async throws -> Void) {
+        self.channel = channel
+        self.isSaving = isSaving
+        self.onSave = onSave
+        _name = State(initialValue: channel.settings.name)
+        _key = State(initialValue: channel.settings.psk.base64EncodedString())
+        _role = State(initialValue: channel.role)
+        _uplink = State(initialValue: channel.settings.uplinkEnabled)
+        _downlink = State(initialValue: channel.settings.downlinkEnabled)
+        _precision = State(initialValue: Int(channel.settings.moduleSettings.positionPrecision))
+        _muted = State(initialValue: channel.settings.moduleSettings.isMuted)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Name", text: $name)
+                    .onChange(of: name) { _, value in
+                        let compact = value.replacingOccurrences(of: " ", with: "")
+                        var limited = ""
+                        for scalar in compact.unicodeScalars {
+                            guard limited.utf8.count + String(scalar).utf8.count <= 11 else { break }
+                            limited.append(String(scalar))
+                        }
+                        name = limited
+                    }
+                TextField("Key (base64)", text: $key)
+                    .textSelection(.enabled)
+                Picker("Role", selection: $role) {
+                    if channel.index == 0 {
+                        Text("Primary").tag(Channel.Role.primary)
+                    } else {
+                        Text("Secondary").tag(Channel.Role.secondary)
+                        Text("Disabled").tag(Channel.Role.disabled)
+                    }
+                }
+                Toggle("MQTT Uplink Enabled", isOn: $uplink)
+                Toggle("MQTT Downlink Enabled", isOn: $downlink)
+                Toggle("Mute", isOn: $muted)
+                Stepper("Position Precision: \(precision)", value: $precision, in: 0...32)
+                if let errorMessage { Text(errorMessage).foregroundStyle(.red).font(.callout) }
+            }
+            .navigationTitle("Channel \(channel.index)")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isSaving ? "Saving…" : "Save") {
+                        guard name.utf8.count <= 11 else {
+                            errorMessage = "Channel names must be 11 bytes or fewer"
+                            return
+                        }
+                        guard let decodedKey = Data(base64Encoded: key), [0, 1, 16, 32].contains(decodedKey.count) else {
+                            errorMessage = "Key must be valid base64 with 0, 1, 16, or 32 bytes"
+                            return
+                        }
+                        var edited = channel
+                        edited.settings.name = name
+                        edited.settings.psk = decodedKey
+                        edited.role = role
+                        edited.settings.uplinkEnabled = uplink
+                        edited.settings.downlinkEnabled = downlink
+                        edited.settings.moduleSettings.positionPrecision = UInt32(precision)
+                        edited.settings.moduleSettings.isMuted = muted
+                        Task {
+                            do { try await onSave(edited) }
+                            catch { errorMessage = error.localizedDescription }
+                        }
+                    }
+                    .disabled(isSaving)
+                }
+            }
+        }
+    }
+}

--- a/Meshtastic/Views/Settings/RemoteChannels.swift
+++ b/Meshtastic/Views/Settings/RemoteChannels.swift
@@ -182,10 +182,11 @@ final class RemoteChannelsCoordinator: ObservableObject {
         }
     }
 
-    private func read(index: Int32, retries: Int) async throws -> Channel {
-        try await RemoteChannelsReadPlan.retry(retries: retries) {
-                try Task.checkCancellation()
-                try self.validateConnection()
+	private func read(index: Int32, retries: Int) async throws -> Channel {
+		try await RemoteChannelsReadPlan.retry(retries: retries) {
+				try Task.checkCancellation()
+				try self.validateConnection()
+				try await self.refreshSessionIfNeeded()
 				let requestID = try await transport.requestChannel(index: index)
 				let deadline = ContinuousClock.now + transport.responseTimeout
                 while ContinuousClock.now < deadline {

--- a/Meshtastic/Views/Settings/RemoteChannels.swift
+++ b/Meshtastic/Views/Settings/RemoteChannels.swift
@@ -345,6 +345,9 @@ struct RemoteChannels: View {
 
 	var body: some View {
 		List {
+			RemoteTargetIdentity(name: toUser.displayLongName, nodeNum: toUser.num)
+				.listRowInsets(EdgeInsets(top: 8, leading: 20, bottom: 8, trailing: 20))
+				.listRowSeparator(.hidden)
 			if coordinator.isLoading {
 				ProgressView("Reading remote channels (\(coordinator.progress)/8)…")
 			}
@@ -379,7 +382,11 @@ struct RemoteChannels: View {
 		} message: { Text(errorMessage ?? "") }
 		.sheet(isPresented: Binding(get: { selected != nil }, set: { if !$0 { selected = nil } })) {
 			NavigationStack {
-				ChannelForm(channelIndex: $channelIndex, channelName: $channelName, channelKeySize: $channelKeySize, channelKey: $channelKey, channelRole: $channelRole, uplink: $uplink, downlink: $downlink, positionPrecision: $positionPrecision, preciseLocation: $preciseLocation, positionsEnabled: $positionsEnabled, hasChanges: $hasChanges, hasValidKey: $hasValidKey, supportedVersion: $supportedVersion)
+				VStack(spacing: 0) {
+					RemoteTargetIdentity(name: toUser.displayLongName, nodeNum: toUser.num)
+						.padding(.horizontal)
+					ChannelForm(channelIndex: $channelIndex, channelName: $channelName, channelKeySize: $channelKeySize, channelKey: $channelKey, channelRole: $channelRole, uplink: $uplink, downlink: $downlink, positionPrecision: $positionPrecision, preciseLocation: $preciseLocation, positionsEnabled: $positionsEnabled, hasChanges: $hasChanges, hasValidKey: $hasValidKey, supportedVersion: $supportedVersion)
+				}
 					.navigationTitle("Channel \(channelIndex)")
 					.toolbar {
 						ToolbarItem(placement: .cancellationAction) { Button("Cancel") { selected = nil } }
@@ -393,6 +400,39 @@ struct RemoteChannels: View {
 					}
 			}
 		}
+	}
+}
+
+struct RemoteTargetIdentity: View {
+	let name: String
+	let nodeNum: Int64
+
+	static func accessibilityLabel(name: String, nodeNum: Int64) -> String {
+		let nodeNumber = String(nodeNum)
+		return String(localized: "Remote target \(name), node number \(nodeNumber)", comment: "VoiceOver label identifying the node whose remote settings are being edited")
+	}
+
+	var body: some View {
+		HStack(alignment: .top, spacing: 12) {
+			Image(systemName: "antenna.radiowaves.left.and.right")
+				.font(.title3)
+				.foregroundStyle(.tint)
+				.accessibilityHidden(true)
+			VStack(alignment: .leading, spacing: 3) {
+				Text("Remote target")
+					.font(.caption)
+					.foregroundStyle(.secondary)
+				Text(name)
+					.font(.headline)
+				Text("Node number \(nodeNum)")
+					.font(.caption)
+					.foregroundStyle(.secondary)
+					.monospacedDigit()
+			}
+			Spacer(minLength: 0)
+		}
+		.accessibilityElement(children: .ignore)
+		.accessibilityLabel(Self.accessibilityLabel(name: name, nodeNum: nodeNum))
 	}
 }
 

--- a/Meshtastic/Views/Settings/RemoteChannels.swift
+++ b/Meshtastic/Views/Settings/RemoteChannels.swift
@@ -244,78 +244,156 @@ final class RemoteChannelsCoordinator: ObservableObject {
 	}
 
 struct RemoteChannels: View {
-    @Environment(\.dismiss) private var dismiss
-    @ObservedObject var accessoryManager: AccessoryManager
-    let node: NodeInfoEntity
-    let connectedNode: NodeInfoEntity
-    let fromUser: UserEntity
-    let toUser: UserEntity
-    @StateObject private var coordinator: RemoteChannelsCoordinator
-    @State private var selected: Channel?
-    @State private var errorMessage: String?
+	@ObservedObject var accessoryManager: AccessoryManager
+	let node: NodeInfoEntity
+	let connectedNode: NodeInfoEntity
+	let fromUser: UserEntity
+	let toUser: UserEntity
+	@StateObject private var coordinator: RemoteChannelsCoordinator
+	@State private var selected: Channel?
+	@State private var errorMessage: String?
+	@State private var editorErrorMessage: String?
+	@State private var channelIndex: Int32 = 0
+	@State private var channelName = ""
+	@State private var channelKeySize = 16
+	@State private var channelKey = "AQ=="
+	@State private var channelRole = 0
+	@State private var uplink = false
+	@State private var downlink = false
+	@State private var positionPrecision = 32.0
+	@State private var preciseLocation = true
+	@State private var positionsEnabled = true
+	@State private var hasChanges = false
+	@State private var hasValidKey = true
+	@State private var supportedVersion = true
 
-    init(node: NodeInfoEntity, connectedNode: NodeInfoEntity, fromUser: UserEntity, toUser: UserEntity, accessoryManager: AccessoryManager) {
-        self.node = node
-        self.connectedNode = connectedNode
-        self.fromUser = fromUser
-        self.toUser = toUser
+	init(node: NodeInfoEntity, connectedNode: NodeInfoEntity, fromUser: UserEntity, toUser: UserEntity, accessoryManager: AccessoryManager) {
+		self.node = node
+		self.connectedNode = connectedNode
+		self.fromUser = fromUser
+		self.toUser = toUser
 		self.accessoryManager = accessoryManager
 		_coordinator = StateObject(wrappedValue: RemoteChannelsCoordinator(
 			transport: AccessoryManagerRemoteChannelsTransport(manager: accessoryManager, fromUser: fromUser, toUser: toUser),
 			sourceNum: fromUser.num, targetNum: toUser.num
 		))
-    }
+	}
 
-    var body: some View {
-        List {
-            if coordinator.isLoading {
-                ProgressView("Reading remote channels (\(coordinator.progress)/8)…")
-            }
-            ForEach(Int32(0)...Int32(7), id: \.self) { index in
-                if let channel = coordinator.channels[index] {
-                    Button {
-                        selected = channel
-                    } label: {
-                        HStack {
-                            Text(channel.settings.name.isEmpty ? "Channel \(index)" : channel.settings.name)
-                            Spacer()
-                            Text(channel.role == .primary ? "Primary" : channel.role == .disabled ? "Disabled" : "Secondary")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-        }
-        .navigationTitle("Remote Channels")
-        .task {
-            do { try await coordinator.load() }
-            catch { errorMessage = error.localizedDescription }
-        }
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("Retry") {
-                    Task {
-                        do { try await coordinator.load(); errorMessage = nil }
-                        catch { errorMessage = error.localizedDescription }
-                    }
-                }
-                .disabled(coordinator.isLoading || coordinator.isSaving)
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .remoteChannelResponse).receive(on: RunLoop.main)) { coordinator.receive($0) }
-        .alert("Remote Channels", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
-            Button("OK", role: .cancel) { errorMessage = nil }
-        } message: { Text(errorMessage ?? "") }
-        .sheet(isPresented: Binding(get: { selected != nil }, set: { if !$0 { selected = nil } })) {
-            if let channel = selected {
-                RemoteChannelEditor(channel: channel, isSaving: coordinator.isSaving) { edited in
-                    try await coordinator.save([edited])
-                    selected = nil
-                }
-            }
-        }
-    }
+	private func select(_ channel: Channel) {
+		selected = channel
+		channelIndex = channel.index
+		channelRole = channel.index == 0 ? 1 : (channel.role == .primary ? 1 : channel.role == .secondary ? 2 : 0)
+		channelName = channel.settings.name
+		channelKey = channel.settings.psk.base64EncodedString()
+		channelKeySize = channel.settings.psk.isEmpty ? 0 : (channel.settings.psk == Data([1]) ? -1 : channel.settings.psk.count)
+		uplink = channel.settings.uplinkEnabled
+		downlink = channel.settings.downlinkEnabled
+		positionPrecision = Double(channel.settings.moduleSettings.positionPrecision)
+		positionsEnabled = positionPrecision > 0
+		preciseLocation = positionPrecision == 32
+		hasChanges = false
+		hasValidKey = true
+		editorErrorMessage = nil
+	}
+
+	private func displayEntity(_ channel: Channel) -> ChannelEntity {
+		let entity = ChannelEntity()
+		entity.index = channel.index
+		entity.id = channel.index
+		entity.role = channel.role == .primary ? 1 : channel.role == .secondary ? 2 : 0
+		entity.name = channel.settings.name
+		entity.psk = channel.settings.psk
+		entity.uplinkEnabled = channel.settings.uplinkEnabled
+		entity.downlinkEnabled = channel.settings.downlinkEnabled
+		entity.positionPrecision = Int32(channel.settings.moduleSettings.positionPrecision)
+		entity.mute = channel.settings.moduleSettings.isMuted
+		return entity
+	}
+
+	private func saveEditor() {
+		guard let original = selected else { return }
+		guard channelIndex == 0 ? channelRole == 1 : (channelRole == 0 || channelRole == 2) else {
+			editorErrorMessage = "Only slot 0 can be primary."
+			return
+		}
+		guard channelName.utf8.count <= 11 else {
+			editorErrorMessage = "Channel names must be 11 bytes or fewer"
+			return
+		}
+		guard let decodedKey = Data(base64Encoded: channelKey), [0, 1, 16, 32].contains(decodedKey.count) else {
+			editorErrorMessage = "Key must be valid base64 with 0, 1, 16, or 32 bytes"
+			return
+		}
+		var edited = original
+		edited.settings.name = channelName
+		edited.settings.psk = decodedKey
+		edited.role = ChannelRoles(rawValue: channelRole)?.protoEnumValue() ?? .disabled
+		edited.settings.uplinkEnabled = uplink
+		edited.settings.downlinkEnabled = downlink
+		edited.settings.moduleSettings.positionPrecision = UInt32(positionPrecision)
+		hasChanges = false
+		Task {
+			do {
+				try await coordinator.save([edited])
+				selected = nil
+			} catch {
+				editorErrorMessage = error.localizedDescription
+				hasChanges = true
+			}
+		}
+	}
+
+	var body: some View {
+		List {
+			if coordinator.isLoading {
+				ProgressView("Reading remote channels (\(coordinator.progress)/8)…")
+			}
+			ForEach(Int32(0)...Int32(7), id: \.self) { index in
+				if let channel = coordinator.channels[index] {
+					Button { select(channel) } label: {
+						ChannelRow(channel: displayEntity(channel), sharesLocation: channel.settings.moduleSettings.positionPrecision > 0)
+					}
+					.buttonStyle(.plain)
+				}
+			}
+		}
+		.navigationTitle("Channels")
+		.task {
+			do { try await coordinator.load() }
+			catch { errorMessage = error.localizedDescription }
+		}
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
+				Button("Retry") {
+					Task {
+						do { try await coordinator.load(); errorMessage = nil }
+						catch { errorMessage = error.localizedDescription }
+					}
+				}
+				.disabled(coordinator.isLoading || coordinator.isSaving)
+			}
+		}
+		.onReceive(NotificationCenter.default.publisher(for: .remoteChannelResponse).receive(on: RunLoop.main)) { coordinator.receive($0) }
+		.alert("Channels", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+			Button("OK", role: .cancel) { errorMessage = nil }
+		} message: { Text(errorMessage ?? "") }
+		.sheet(isPresented: Binding(get: { selected != nil }, set: { if !$0 { selected = nil } })) {
+			NavigationStack {
+				ChannelForm(channelIndex: $channelIndex, channelName: $channelName, channelKeySize: $channelKeySize, channelKey: $channelKey, channelRole: $channelRole, uplink: $uplink, downlink: $downlink, positionPrecision: $positionPrecision, preciseLocation: $preciseLocation, positionsEnabled: $positionsEnabled, hasChanges: $hasChanges, hasValidKey: $hasValidKey, supportedVersion: $supportedVersion)
+					.navigationTitle("Channel \(channelIndex)")
+					.toolbar {
+						ToolbarItem(placement: .cancellationAction) { Button("Cancel") { selected = nil } }
+						ToolbarItem(placement: .confirmationAction) {
+							Button(coordinator.isSaving ? "Saving…" : "Save", action: saveEditor)
+							.disabled(coordinator.isSaving || !hasValidKey)
+						}
+					}
+					.safeAreaInset(edge: .bottom) {
+						if let editorErrorMessage { Text(editorErrorMessage).foregroundStyle(.red).font(.callout).padding() }
+					}
+			}
+		}
+	}
 }
 
 struct RemoteChannelsUnavailable: View {
@@ -331,93 +409,4 @@ struct RemoteChannelsUnavailable: View {
 		.padding()
 		.navigationTitle("Remote Channels")
 	}
-}
-
-private struct RemoteChannelEditor: View {
-    @Environment(\.dismiss) private var dismiss
-    let channel: Channel
-    let isSaving: Bool
-    let onSave: (Channel) async throws -> Void
-    @State private var name: String
-    @State private var key: String
-    @State private var role: Channel.Role
-    @State private var uplink: Bool
-    @State private var downlink: Bool
-    @State private var precision: Int
-    @State private var muted: Bool
-    @State private var errorMessage: String?
-
-    init(channel: Channel, isSaving: Bool, onSave: @escaping (Channel) async throws -> Void) {
-        self.channel = channel
-        self.isSaving = isSaving
-        self.onSave = onSave
-        _name = State(initialValue: channel.settings.name)
-        _key = State(initialValue: channel.settings.psk.base64EncodedString())
-        _role = State(initialValue: channel.role)
-        _uplink = State(initialValue: channel.settings.uplinkEnabled)
-        _downlink = State(initialValue: channel.settings.downlinkEnabled)
-        _precision = State(initialValue: Int(channel.settings.moduleSettings.positionPrecision))
-        _muted = State(initialValue: channel.settings.moduleSettings.isMuted)
-    }
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                TextField("Name", text: $name)
-                    .onChange(of: name) { _, value in
-                        let compact = value.replacingOccurrences(of: " ", with: "")
-                        var limited = ""
-                        for scalar in compact.unicodeScalars {
-                            guard limited.utf8.count + String(scalar).utf8.count <= 11 else { break }
-                            limited.append(String(scalar))
-                        }
-                        name = limited
-                    }
-                TextField("Key (base64)", text: $key)
-                    .textSelection(.enabled)
-                Picker("Role", selection: $role) {
-                    if channel.index == 0 {
-                        Text("Primary").tag(Channel.Role.primary)
-                    } else {
-                        Text("Secondary").tag(Channel.Role.secondary)
-                        Text("Disabled").tag(Channel.Role.disabled)
-                    }
-                }
-                Toggle("MQTT Uplink Enabled", isOn: $uplink)
-                Toggle("MQTT Downlink Enabled", isOn: $downlink)
-                Toggle("Mute", isOn: $muted)
-                Stepper("Position Precision: \(precision)", value: $precision, in: 0...32)
-                if let errorMessage { Text(errorMessage).foregroundStyle(.red).font(.callout) }
-            }
-            .navigationTitle("Channel \(channel.index)")
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(isSaving ? "Saving…" : "Save") {
-                        guard name.utf8.count <= 11 else {
-                            errorMessage = "Channel names must be 11 bytes or fewer"
-                            return
-                        }
-                        guard let decodedKey = Data(base64Encoded: key), [0, 1, 16, 32].contains(decodedKey.count) else {
-                            errorMessage = "Key must be valid base64 with 0, 1, 16, or 32 bytes"
-                            return
-                        }
-                        var edited = channel
-                        edited.settings.name = name
-                        edited.settings.psk = decodedKey
-                        edited.role = role
-                        edited.settings.uplinkEnabled = uplink
-                        edited.settings.downlinkEnabled = downlink
-                        edited.settings.moduleSettings.positionPrecision = UInt32(precision)
-                        edited.settings.moduleSettings.isMuted = muted
-                        Task {
-                            do { try await onSave(edited) }
-                            catch { errorMessage = error.localizedDescription }
-                        }
-                    }
-                    .disabled(isSaving)
-                }
-            }
-        }
-    }
 }

--- a/Meshtastic/Views/Settings/RemoteChannels.swift
+++ b/Meshtastic/Views/Settings/RemoteChannels.swift
@@ -157,7 +157,9 @@ final class RemoteChannelsCoordinator: ObservableObject {
     }
 
     func save(_ changed: [Channel]) async throws {
-        guard !isSaving else { return }
+        guard !isSaving else {
+            throw AccessoryError.ioFailed("A remote channel save is already in progress")
+        }
         isSaving = true
         defer { isSaving = false }
         try Task.checkCancellation()

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -259,7 +259,7 @@ struct Settings: View {
 					.foregroundColor(.gray)
 			}
 
-			NavigationLink(value: SettingsNavigationState.lora) {
+			settingsLink(value: .lora) {
 				Label {
 					Text("LoRa")
 				} icon: {
@@ -268,7 +268,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.channels) {
+			settingsLink(value: .channels) {
 				Label {
 					Text("Channels")
 				} icon: {
@@ -277,7 +277,7 @@ struct Settings: View {
 			}
 			.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
-			NavigationLink(value: SettingsNavigationState.security) {
+			settingsLink(value: .security) {
 				Label {
 					Text("Security")
 				} icon: {
@@ -285,7 +285,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.shareQRCode) {
+			settingsLink(value: .shareQRCode) {
 				Label {
 					Text("Share QR Code")
 				} icon: {
@@ -298,7 +298,7 @@ struct Settings: View {
 
 	var deviceConfigurationSection: some View {
 		Section("Device Configuration") {
-			NavigationLink(value: SettingsNavigationState.user) {
+			settingsLink(value: .user) {
 				Label {
 					Text("User")
 				} icon: {
@@ -306,7 +306,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.bluetooth) {
+			settingsLink(value: .bluetooth) {
 				Label {
 					Text("Bluetooth")
 				} icon: {
@@ -314,7 +314,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.device) {
+			settingsLink(value: .device) {
 				Label {
 					Text("Device")
 				} icon: {
@@ -322,7 +322,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.display) {
+			settingsLink(value: .display) {
 				Label {
 					Text("Display")
 				} icon: {
@@ -330,7 +330,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.network) {
+			settingsLink(value: .network) {
 				Label {
 					Text("Network")
 				} icon: {
@@ -338,7 +338,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.position) {
+			settingsLink(value: .position) {
 				Label {
 					Text("Position")
 				} icon: {
@@ -346,7 +346,7 @@ struct Settings: View {
 				}
 			}
 
-			NavigationLink(value: SettingsNavigationState.power) {
+			settingsLink(value: .power) {
 				Label {
 					Text("Power")
 				} icon: {
@@ -364,7 +364,7 @@ struct Settings: View {
 		let excludedModules = node?.excludedModules ?? 0
 		return Section {
 			if isModuleSupported(.ambientlightingConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.ambientLighting) {
+				settingsLink(value: .ambientLighting) {
 					Label {
 						Text("Ambient Lighting")
 					} icon: {
@@ -374,7 +374,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.audioConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.audio) {
+				settingsLink(value: .audio) {
 					Label {
 						Text("Audio")
 					} icon: {
@@ -384,7 +384,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.cannedmsgConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.cannedMessages) {
+				settingsLink(value: .cannedMessages) {
 					Label {
 						Text("Canned Messages")
 					} icon: {
@@ -394,7 +394,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.detectionsensorConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.detectionSensor) {
+				settingsLink(value: .detectionSensor) {
 					Label {
 						Text("Detection Sensor")
 					} icon: {
@@ -404,7 +404,7 @@ struct Settings: View {
 			}
 
 			if isMeshBeaconModuleSupported(node) {
-				NavigationLink(value: SettingsNavigationState.meshBeacon) {
+				settingsLink(value: .meshBeacon) {
 					Label {
 						Text("Mesh Beacon")
 					} icon: {
@@ -414,7 +414,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.extnotifConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.externalNotification) {
+				settingsLink(value: .externalNotification) {
 					Label {
 						Text("External Notification")
 					} icon: {
@@ -424,7 +424,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.mqttConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.mqtt) {
+				settingsLink(value: .mqtt) {
 					Label {
 						Text("MQTT")
 					} icon: {
@@ -434,7 +434,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.neighborinfoConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.neighborInfo) {
+				settingsLink(value: .neighborInfo) {
 					Label {
 						Text("Neighbor Info")
 					} icon: {
@@ -444,7 +444,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.rangetestConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.rangeTest) {
+				settingsLink(value: .rangeTest) {
 					Label {
 						Text("Range Test")
 					} icon: {
@@ -454,7 +454,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.paxcounterConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.paxCounter) {
+				settingsLink(value: .paxCounter) {
 					Label {
 						Text("PAX Counter")
 					} icon: {
@@ -464,7 +464,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.extnotifConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.ringtone) {
+				settingsLink(value: .ringtone) {
 					Label {
 						Text("Ringtone")
 					} icon: {
@@ -474,7 +474,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.serialConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.serial) {
+				settingsLink(value: .serial) {
 					Label {
 						Text("Serial")
 					} icon: {
@@ -484,7 +484,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.storeforwardConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.storeAndForward) {
+				settingsLink(value: .storeAndForward) {
 					Label {
 						Text("Store & Forward")
 					} icon: {
@@ -499,7 +499,7 @@ struct Settings: View {
 			// the top, and the in-app TAK Server controls (Enable, channel,
 			// mTLS certificates, data package export) below it. The TAK
 			// section at the bottom of this screen links to the same view.
-			NavigationLink(value: SettingsNavigationState.tak) {
+			settingsLink(value: .tak) {
 				Label {
 					Text("TAK Server")
 				} icon: {
@@ -508,7 +508,7 @@ struct Settings: View {
 			}
 
 			if isModuleSupported(.telemetryConfig, excludedModules: excludedModules) {
-				NavigationLink(value: SettingsNavigationState.telemetry) {
+				settingsLink(value: .telemetry) {
 					Label {
 						Text("Telemetry")
 					} icon: {
@@ -518,7 +518,7 @@ struct Settings: View {
 			}
 
 			if isTrafficManagementModuleSupported(node) {
-				NavigationLink(value: SettingsNavigationState.trafficManagement) {
+				settingsLink(value: .trafficManagement) {
 					Label {
 						Text("Traffic Management")
 					} icon: {
@@ -538,14 +538,14 @@ struct Settings: View {
 
 	var loggingSection: some View {
 		Section(header: Text("Logging")) {
-			NavigationLink(value: SettingsNavigationState.debugLogs) {
+			settingsLink(value: .debugLogs) {
 				Label {
 					Text("Logs")
 				} icon: {
 					Image(systemName: "scroll")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.traceRoutes) {
+			settingsLink(value: .traceRoutes) {
 				Label {
 					Text("Trace Routes")
 				} icon: {
@@ -557,28 +557,28 @@ struct Settings: View {
 
 	var developersSection: some View {
 		Section(header: Text("Developers")) {
-			NavigationLink(value: SettingsNavigationState.backupManagement) {
+			settingsLink(value: .backupManagement) {
 				Label {
 					Text("Backup Management")
 				} icon: {
 					Image(systemName: "externaldrive")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.coreDataBrowser) {
+			settingsLink(value: .coreDataBrowser) {
 				Label {
 					Text("Data Browser")
 				} icon: {
 					Image(systemName: "tablecells")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.deviceLinks) {
+			settingsLink(value: .deviceLinks) {
 				Label {
 					Text("Device Links")
 				} icon: {
 					Image(systemName: "link")
 				}
 			}
-			NavigationLink(value: SettingsNavigationState.appFiles) {
+			settingsLink(value: .appFiles) {
 				Label {
 					Text("App Files")
 				} icon: {
@@ -592,7 +592,7 @@ struct Settings: View {
 			#if !targetEnvironment(macCatalyst)
 			if #available(iOS 18, *) {
 				if NFCReader.isAvailable || accessoryManager.isConnected {
-					NavigationLink(value: SettingsNavigationState.tools) {
+					settingsLink(value: .tools) {
 						Label {
 							Text("Tools")
 						} icon: {
@@ -613,13 +613,26 @@ struct Settings: View {
 			// TAK — the Module Config link discovers the feature alongside
 			// other module configs, and the dedicated TAK section advertises
 			// the TAK Server functionality at a glance.
-			NavigationLink(value: SettingsNavigationState.tak) {
+			settingsLink(value: .tak) {
 				Label {
 					Text("TAK Server")
 				} icon: {
 					Image(systemName: "target")
 				}
 			}
+		}
+	}
+
+	@ViewBuilder
+	private func settingsLink<Label: View>(value: SettingsNavigationState, @ViewBuilder label: () -> Label) -> some View {
+		if remoteNodeNum != nil {
+			NavigationLink {
+				settingsDestination(value)
+			} label: {
+				label()
+			}
+		} else {
+			NavigationLink(value: value, label: label)
 		}
 	}
 
@@ -638,7 +651,7 @@ struct Settings: View {
 			let node = nodeSnapshot(for: preferredNodeNum)
 			List {
 				if remoteNodeNum == nil {
-				NavigationLink(value: SettingsNavigationState.about) {
+				settingsLink(value: .about) {
 					Label {
 						Text("About Meshtastic")
 					} icon: {
@@ -646,7 +659,7 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.helpDocs) {
+				settingsLink(value: .helpDocs) {
 					Label {
 						Text("Help & Documentation")
 					} icon: {
@@ -654,21 +667,21 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.appSettings) {
+				settingsLink(value: .appSettings) {
 					Label {
 						Text("App Settings")
 					} icon: {
 						Image(systemName: "gearshape")
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.localMeshDiscovery) {
+				settingsLink(value: .localMeshDiscovery) {
 					Label {
 						Text("Local Mesh Discovery")
 					} icon: {
 						Image(systemName: "antenna.radiowaves.left.and.right")
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.routes) {
+				settingsLink(value: .routes) {
 					Label {
 						Text("Routes")
 					} icon: {
@@ -676,7 +689,7 @@ struct Settings: View {
 					}
 				}
 
-				NavigationLink(value: SettingsNavigationState.routeRecorder) {
+				settingsLink(value: .routeRecorder) {
 					Label {
 						Text("Route Recorder")
 					} icon: {
@@ -684,7 +697,7 @@ struct Settings: View {
 							.foregroundColor(.red)
 					}
 				}
-				NavigationLink(value: SettingsNavigationState.firmwareUpdates) {
+				settingsLink(value: .firmwareUpdates) {
 					Label {
 						Text("Firmware Updates")
 					} icon: {
@@ -780,6 +793,82 @@ struct Settings: View {
 				}
 			}
 			.navigationDestination(for: SettingsNavigationState.self) { destination in
+				settingsDestination(destination)
+			}
+
+			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
+				// If the preferred node changes, then select the newly preferred node
+				// This should only happen during connect
+				preferredNodeNum = newConnectedNode
+				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
+			}
+			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
+				// If we are on this screen, haven't iniatialized the selection yet,
+				// And we transition, to connected, then initialize the selection
+				if isConnectedNow, self.selectedNode == 0 {
+					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
+					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
+				}
+			}
+			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
+				if remoteNodeNum != nil {
+					preferredNodeNum = Int(newDevice ?? 0)
+					selectedNode = 0
+					applyRemoteSettingsNode()
+					return
+				}
+				if newDevice == nil {
+					selectedNode = 0
+					preferredNodeNum = 0
+				} else if oldDevice != newDevice {
+					// Physical connection changed — any prior remote admin session is invalid
+					preferredNodeNum = Int(newDevice!)
+					selectedNode = Int(newDevice!)
+				}
+			}
+			.onAppear {
+				// If the selection hasn't be initialized yet, try to initalize it.
+				// If we are not fully connected yet, then setSelectedNode will
+				// not select the node and it will remain 0
+				refreshNodes()
+				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
+					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
+					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
+				}
+				applyRemoteSettingsNode()
+			}
+			.task(id: router.selectedTab) {
+				// Refresh the node snapshot on a gentle cadence, and only while Settings is
+				// the frontmost tab — the stale snapshot is invisible from other tabs, this
+				// task re-fires on every tab switch (so the guard comes first), and switching
+				// here restarts it for an immediate refresh.
+				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
+				refreshNodes()
+				while !Task.isCancelled {
+					do {
+						try await Task.sleep(for: .seconds(2))
+					} catch {
+						break
+					}
+					guard !Task.isCancelled else { break }
+					refreshNodes()
+				}
+			}
+			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
+			.toolbar {
+				if remoteNodeNum == nil {
+				ToolbarItem(placement: .topBarLeading) {
+					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
+					}
+				}
+			}
+		}
+	}
+
+	@ViewBuilder
+	private func settingsDestination(_ destination: SettingsNavigationState) -> some View {
 				let node = liveNode(for: preferredNodeNum)
 				let configNode = liveNode(for: selectedNode)
 				switch destination {
@@ -874,76 +963,6 @@ struct Settings: View {
 				case .backupManagement:
 					BackupManagement()
 				}
-			}
-			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
-				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
-				// If the preferred node changes, then select the newly preferred node
-				// This should only happen during connect
-				preferredNodeNum = newConnectedNode
-				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
-			}
-			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
-				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
-				// If we are on this screen, haven't iniatialized the selection yet,
-				// And we transition, to connected, then initialize the selection
-				if isConnectedNow, self.selectedNode == 0 {
-					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
-					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
-				}
-			}
-			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
-				if remoteNodeNum != nil {
-					preferredNodeNum = Int(newDevice ?? 0)
-					selectedNode = 0
-					applyRemoteSettingsNode()
-					return
-				}
-				if newDevice == nil {
-					selectedNode = 0
-					preferredNodeNum = 0
-				} else if oldDevice != newDevice {
-					// Physical connection changed — any prior remote admin session is invalid
-					preferredNodeNum = Int(newDevice!)
-					selectedNode = Int(newDevice!)
-				}
-			}
-			.onAppear {
-				// If the selection hasn't be initialized yet, try to initalize it.
-				// If we are not fully connected yet, then setSelectedNode will
-				// not select the node and it will remain 0
-				refreshNodes()
-				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
-					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
-					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
-				}
-				applyRemoteSettingsNode()
-			}
-			.task(id: router.selectedTab) {
-				// Refresh the node snapshot on a gentle cadence, and only while Settings is
-				// the frontmost tab — the stale snapshot is invisible from other tabs, this
-				// task re-fires on every tab switch (so the guard comes first), and switching
-				// here restarts it for an immediate refresh.
-				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
-				refreshNodes()
-				while !Task.isCancelled {
-					do {
-						try await Task.sleep(for: .seconds(2))
-					} catch {
-						break
-					}
-					guard !Task.isCancelled else { break }
-					refreshNodes()
-				}
-			}
-			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
-			.toolbar {
-				if remoteNodeNum == nil {
-				ToolbarItem(placement: .topBarLeading) {
-					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
-					}
-				}
-			}
-		}
 	}
 
 	func setSelectedNode(to nodeNum: Int) {

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -102,6 +102,25 @@ struct SettingsNodeSnapshot: Identifiable, Equatable {
 }
 
 struct Settings: View {
+	static func remoteSettingsSelection(
+		requestedNodeNum: Int64?,
+		activeDeviceNum: Int64?,
+		availableNodeNums: Set<Int64>,
+		isConnected: Bool
+	) -> (preferredNodeNum: Int64, selectedNode: Int64)? {
+		guard let requestedNodeNum,
+			let activeDeviceNum,
+			availableNodeNums.contains(requestedNodeNum),
+			isConnected else { return nil }
+		return (activeDeviceNum, requestedNodeNum)
+	}
+
+	let remoteNodeNum: Int64?
+
+	init(remoteNodeNum: Int64? = nil) {
+		self.remoteNodeNum = remoteNodeNum
+	}
+
 	@Environment(\.modelContext) private var context
 	@Environment(\.colorScheme) private var colorScheme
 	@EnvironmentObject var accessoryManager: AccessoryManager
@@ -115,7 +134,7 @@ struct Settings: View {
 		let descriptor = FetchDescriptor<NodeInfoEntity>(sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)])
 		let refreshedNodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
 		nodes = refreshedNodes
-		applyPendingSettingsNode(availableNodes: refreshedNodes)
+		applyRemoteSettingsNode(availableNodes: refreshedNodes)
 	}
 
 	/// Nodes for the admin / configuration picker, ordered favorites-first while
@@ -179,7 +198,8 @@ struct Settings: View {
 	}
 
 	private func isMeshBeaconModuleSupported(_ node: SettingsNodeSnapshot?) -> Bool {
-		guard node != nil else { return false }
+		// Mesh Beacon currently has no remote read path.
+		guard let node, node.num == accessoryManager.activeDeviceNum else { return false }
 		return accessoryManager.checkIsVersionSupported(forVersion: "2.8.0")
 	}
 
@@ -604,11 +624,20 @@ struct Settings: View {
 	}
 
 	var body: some View {
-		NavigationStack(
-			path: $router.settingsPath
-		) {
+		if remoteNodeNum != nil {
+			settingsContent
+		} else {
+			NavigationStack(path: $router.settingsPath) {
+				settingsContent
+			}
+		}
+	}
+
+	@ViewBuilder
+	private var settingsContent: some View {
 			let node = nodeSnapshot(for: preferredNodeNum)
 			List {
+				if remoteNodeNum == nil {
 				NavigationLink(value: SettingsNavigationState.about) {
 					Label {
 						Text("About Meshtastic")
@@ -664,6 +693,8 @@ struct Settings: View {
 				}
 				.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
+				}
+
 				// A managed radio hides the configuration sections; say why instead of
 				// showing nothing (same message as Android).
 				if let node, node.isManaged, accessoryManager.isConnected {
@@ -676,7 +707,9 @@ struct Settings: View {
 				if let node, !node.isManaged {
 					if accessoryManager.isConnected {
 						Section("Configure") {
-							if node.canRemoteAdmin {
+							if let remoteNodeNum {
+								LabeledContent("Node", value: nodeSnapshot(for: Int(remoteNodeNum))?.userLongName ?? "Unknown")
+							} else if node.canRemoteAdmin {
 								Picker("Node", selection: $selectedNode) {
 									if selectedNode == 0 {
 										Text("Connect to a Node").tag(0)
@@ -740,8 +773,8 @@ struct Settings: View {
 					radioConfigurationSection
 					deviceConfigurationSection
 					moduleConfigurationSection
-					loggingSection
-					if showsDevelopersSection {
+					if remoteNodeNum == nil { loggingSection }
+					if remoteNodeNum == nil && showsDevelopersSection {
 					developersSection
 					}
 				}
@@ -843,12 +876,14 @@ struct Settings: View {
 				}
 			}
 			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
 				// If the preferred node changes, then select the newly preferred node
 				// This should only happen during connect
 				preferredNodeNum = newConnectedNode
 				selectedNode = Int(accessoryManager.isConnected ? newConnectedNode : 0)
 			}
 			.onChange(of: accessoryManager.isConnected) { _, isConnectedNow in
+				guard remoteNodeNum == nil else { applyRemoteSettingsNode(); return }
 				// If we are on this screen, haven't iniatialized the selection yet,
 				// And we transition, to connected, then initialize the selection
 				if isConnectedNow, self.selectedNode == 0 {
@@ -857,6 +892,12 @@ struct Settings: View {
 				}
 			}
 			.onChange(of: accessoryManager.activeDeviceNum) { oldDevice, newDevice in
+				if remoteNodeNum != nil {
+					preferredNodeNum = Int(newDevice ?? 0)
+					selectedNode = 0
+					applyRemoteSettingsNode()
+					return
+				}
 				if newDevice == nil {
 					selectedNode = 0
 					preferredNodeNum = 0
@@ -871,21 +912,18 @@ struct Settings: View {
 				// If we are not fully connected yet, then setSelectedNode will
 				// not select the node and it will remain 0
 				refreshNodes()
-				if self.preferredNodeNum <= 0 {
+				if remoteNodeNum == nil && self.preferredNodeNum <= 0 {
 					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
 					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
 				}
-				applyPendingSettingsNode()
-			}
-			.onChange(of: router.settingsNodeNum) { _, _ in
-				applyPendingSettingsNode()
+				applyRemoteSettingsNode()
 			}
 			.task(id: router.selectedTab) {
 				// Refresh the node snapshot on a gentle cadence, and only while Settings is
 				// the frontmost tab — the stale snapshot is invisible from other tabs, this
 				// task re-fires on every tab switch (so the guard comes first), and switching
 				// here restarts it for an immediate refresh.
-				guard router.selectedTab == .settings else { return }
+				guard remoteNodeNum != nil || router.selectedTab == .settings else { return }
 				refreshNodes()
 				while !Task.isCancelled {
 					do {
@@ -897,8 +935,9 @@ struct Settings: View {
 					refreshNodes()
 				}
 			}
-			.navigationTitle("Settings")
+			.navigationTitle(remoteNodeNum == nil ? "Settings" : "Remote Settings")
 			.toolbar {
+				if remoteNodeNum == nil {
 				ToolbarItem(placement: .topBarLeading) {
 					MeshtasticLogo().onLongPressGesture(minimumDuration: 1.0) {
 					}
@@ -922,13 +961,14 @@ struct Settings: View {
 		}
 	}
 
-	private func applyPendingSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
-		guard let requestedNodeNum = router.settingsNodeNum,
-			(availableNodes ?? sortedNodes).contains(where: { $0.num == requestedNodeNum }),
-			accessoryManager.isConnected else { return }
-		preferredNodeNum = Int(accessoryManager.activeDeviceNum ?? Int64(requestedNodeNum))
-		selectedNode = Int(requestedNodeNum)
-		router.settingsNodeNum = nil
+	private func applyRemoteSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
+		guard let selection = Self.remoteSettingsSelection(
+			requestedNodeNum: remoteNodeNum,
+			activeDeviceNum: accessoryManager.activeDeviceNum,
+			availableNodeNums: Set((availableNodes ?? sortedNodes).map(\.num)),
+			isConnected: accessoryManager.isConnected) else { return }
+		preferredNodeNum = Int(selection.preferredNodeNum)
+		selectedNode = Int(selection.selectedNode)
 	}
 
 	private func handleSelectedNodeChange(_ newValue: Int) {

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -275,7 +275,6 @@ struct Settings: View {
 					Image(systemName: "fibrechannel")
 				}
 			}
-			.disabled(selectedNode > 0 && selectedNode != preferredNodeNum)
 
 			settingsLink(value: .security) {
 				Label {
@@ -883,7 +882,15 @@ struct Settings: View {
 				case .lora:
 					LoRaConfig(node: configNode)
 				case .channels:
-					if let node = node {
+					if let targetNode = configNode, let connectedNode = node,
+						 targetNode.num != connectedNode.num,
+						 let fromUser = connectedNode.user, let toUser = targetNode.user {
+						if targetNode.sessionPasskey?.isEmpty == false {
+							RemoteChannels(node: targetNode, connectedNode: connectedNode, fromUser: fromUser, toUser: toUser, accessoryManager: accessoryManager)
+						} else {
+							RemoteChannelsUnavailable(nodeName: targetNode.user?.longName ?? "Selected node")
+						}
+					} else if let node = node {
 						Channels(node: node)
 					} else {
 						Text("Loading...")

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -113,7 +113,9 @@ struct Settings: View {
 
 	private func refreshNodes() {
 		let descriptor = FetchDescriptor<NodeInfoEntity>(sortBy: [SortDescriptor(\NodeInfoEntity.lastHeard, order: .reverse)])
-		nodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
+		let refreshedNodes = ((try? context.fetch(descriptor)) ?? []).compactMap(SettingsNodeSnapshot.init)
+		nodes = refreshedNodes
+		applyPendingSettingsNode(availableNodes: refreshedNodes)
 	}
 
 	/// Nodes for the admin / configuration picker, ordered favorites-first while
@@ -873,6 +875,10 @@ struct Settings: View {
 					self.preferredNodeNum = UserDefaults.preferredPeripheralNum
 					setSelectedNode(to: UserDefaults.preferredPeripheralNum)
 				}
+				applyPendingSettingsNode()
+			}
+			.onChange(of: router.settingsNodeNum) { _, _ in
+				applyPendingSettingsNode()
 			}
 			.task(id: router.selectedTab) {
 				// Refresh the node snapshot on a gentle cadence, and only while Settings is
@@ -914,6 +920,15 @@ struct Settings: View {
 		} else {
 			self.selectedNode = Int(accessoryManager.isConnected ? nodeNum: 0)
 		}
+	}
+
+	private func applyPendingSettingsNode(availableNodes: [SettingsNodeSnapshot]? = nil) {
+		guard let requestedNodeNum = router.settingsNodeNum,
+			(availableNodes ?? sortedNodes).contains(where: { $0.num == requestedNodeNum }),
+			accessoryManager.isConnected else { return }
+		preferredNodeNum = Int(accessoryManager.activeDeviceNum ?? Int64(requestedNodeNum))
+		selectedNode = Int(requestedNodeNum)
+		router.settingsNodeNum = nil
 	}
 
 	private func handleSelectedNodeChange(_ newValue: Int) {

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -40,7 +40,7 @@ struct SettingsNodeSnapshot: Identifiable, Equatable {
 		num = node.num
 		favorite = node.favorite
 		canRemoteAdmin = node.canRemoteAdmin
-		hasSessionPasskey = node.sessionPasskey != nil
+		hasSessionPasskey = node.hasLiveAdminSession
 
 		if let user = node.user,
 			user.modelContext != nil,

--- a/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
+++ b/MeshtasticTests/AccessoryManagerChannelRefreshLifecycleTests.swift
@@ -155,10 +155,14 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 	private func startAutomaticConfigRefresh(
 		_ manager: AccessoryManager,
 		connection: ChannelRefreshLifecycleConnection
-	) async -> Task<Void, Error> {
+	) async throws -> Task<Void, Error> {
 		let refresh = Task { try await manager.sendWantConfig() }
-		while await connection.sentWantConfigIDs.isEmpty {
+		for _ in 0..<100 where await connection.sentWantConfigIDs.isEmpty {
 			await Task.yield()
+		}
+		guard !(await connection.sentWantConfigIDs.isEmpty) else {
+			refresh.cancel()
+			throw AccessoryError.ioFailed("Timed out waiting for automatic config refresh")
 		}
 		return refresh
 	}
@@ -179,7 +183,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "New Primary"))
@@ -201,7 +205,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Kept Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Discarded Primary"))
@@ -228,7 +232,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		)
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Primary"))
@@ -256,7 +260,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		let context = PersistenceController.shared.context
 		let persistedNodeNum = Int64(nodeNum)
@@ -287,7 +291,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		)
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 1, name: "Lone Secondary", role: .secondary))
@@ -310,7 +314,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		)
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 		var disabled = Channel()
 		disabled.index = 1
 		disabled.role = .disabled
@@ -335,7 +339,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		await connection.pauseNextWantConfigSend()
 
 		let firstRefresh = Task { try await manager.sendWantConfig() }
-		while await connection.sentWantConfigIDs.count < 1 {
+		for _ in 0..<100 where await connection.sentWantConfigIDs.count < 1 {
 			await Task.yield()
 		}
 		let secondRefresh = Task { try await manager.sendWantConfig() }
@@ -369,7 +373,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "New Primary"))
@@ -389,7 +393,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Kept Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Replacement Primary"))
@@ -407,7 +411,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Kept Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 1, name: "Incomplete Secondary", role: .secondary))
@@ -425,7 +429,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Old Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "New Primary"))
@@ -454,7 +458,7 @@ struct AccessoryManagerChannelRefreshLifecycleTests {
 		)
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Remote Primary"))
@@ -556,7 +560,7 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		await connection.pauseNextWantConfigSend()
 
 		let refresh = Task { try await manager.sendWantConfig() }
-		while await connection.sentWantConfigIDs.isEmpty {
+		for _ in 0..<100 where await connection.sentWantConfigIDs.isEmpty {
 			await Task.yield()
 		}
 
@@ -579,7 +583,7 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 		let validationReached = AsyncGate()
 		let allowCommitToContinue = AsyncGate()
 
@@ -664,7 +668,7 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		await connection.pauseNextWantConfigSend()
 
 		let cancelledWaiter = Task { try await manager.sendWantConfig() }
-		while await connection.sentWantConfigIDs.count < 1 {
+		for _ in 0..<100 where await connection.sentWantConfigIDs.count < 1 {
 			await Task.yield()
 		}
 		cancelledWaiter.cancel()
@@ -752,7 +756,7 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		try seedMyInfo(nodeNum: nodeNum, channelName: "Original Primary")
 		let connection = ChannelRefreshLifecycleConnection()
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Remote Primary"))
@@ -781,7 +785,7 @@ extension AccessoryManagerChannelRefreshLifecycleTests {
 		let manager = makeManager(nodeNum: nodeNum, connection: connection)
 		await connection.pauseNextWantConfigSend()
 		await connection.failNextPendingPacketDrain()
-		let refresh = await startAutomaticConfigRefresh(manager, connection: connection)
+		let refresh = try await startAutomaticConfigRefresh(manager, connection: connection)
 
 		await manager.handleMyInfo(myInfo(nodeNum: nodeNum))
 		await manager.handleChannel(channel(index: 0, name: "Failed Refresh Primary"))

--- a/MeshtasticTests/AccessoryManagerDisconnectTests.swift
+++ b/MeshtasticTests/AccessoryManagerDisconnectTests.swift
@@ -6,6 +6,7 @@
 // MARK: AccessoryManagerDisconnectTests
 
 import Foundation
+import SwiftData
 import Testing
 
 @testable import Meshtastic
@@ -119,5 +120,33 @@ struct AccessoryManagerDisconnectTests {
 		await expectTornDown(manager, connection: connection)
 		#expect(manager.packetsReceived == 1)
 		#expect(manager.shouldAutomaticallyConnectToPreferredPeripheralAfterError)
+	}
+
+	@Test func teardownInvalidatesAllRemoteAdminSessions() async throws {
+		let connection = DisconnectTestConnection()
+		let manager = makeManager(connection: connection)
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let administeredNode = NodeInfoEntity()
+		administeredNode.num = 101
+		administeredNode.sessionPasskey = Data([0xA5, 0x5A])
+		administeredNode.sessionExpiration = Date().addingTimeInterval(300)
+		administeredNode.hasBeenAdministered = true
+		let expirationOnlyNode = NodeInfoEntity()
+		expirationOnlyNode.num = 202
+		expirationOnlyNode.sessionExpiration = Date().addingTimeInterval(300)
+		context.insert(administeredNode)
+		context.insert(expirationOnlyNode)
+		try context.save()
+		manager.context = context
+
+		try await manager.closeConnection()
+
+		let nodes = try context.fetch(FetchDescriptor<NodeInfoEntity>())
+		#expect(nodes.allSatisfy { $0.sessionPasskey == nil && $0.sessionExpiration == nil })
+		#expect(nodes.first(where: { $0.num == 101 })?.hasBeenAdministered == true)
 	}
 }

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -126,6 +126,18 @@ struct NodeAdministrationTests {
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
+		#expect(node.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(node.sessionExpiration != nil)
+		let expiration = node.sessionExpiration
+		admin.sessionPasskey = Data()
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+		let emptyResponseNode = try fetchNode(num: num, in: container)
+		#expect(emptyResponseNode.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(emptyResponseNode.sessionExpiration == expiration)
+		await mesh.moduleConfig(config: moduleConfig, nodeNum: num, nodeLongName: "Remote Node")
+		let mirroredNode = try fetchNode(num: num, in: container)
+		#expect(mirroredNode.sessionPasskey == Data([0x01, 0x02, 0x03]))
+		#expect(mirroredNode.sessionExpiration == expiration)
 	}
 
 	@Test func metadataResponseWithPasskeyMarksUnknownNode() async throws {
@@ -169,8 +181,7 @@ struct NodeAdministrationTests {
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(!node.hasBeenAdministered)
-		// The local download still stamps the (empty) passkey as before.
-		#expect(node.sessionPasskey == Data())
+		#expect(node.sessionPasskey == nil)
 	}
 
 	@Test func setConfigRequestWithPasskeyDoesNotMark() async throws {

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -87,6 +87,30 @@ struct NodeAdministrationTests {
 		#expect(node.sessionExpiration != nil)
 	}
 
+	@Test func refetchMakesReceivedSessionVisibleToRetainedNode() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x13AB34
+		try seedNode(num: num, in: container)
+		let mainContext = container.mainContext
+		let cachedNode = try #require(getNodeInfo(id: num, context: mainContext))
+		#expect(!cachedNode.hasLiveAdminSession)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0xA5, 0x5A])
+		var metadata = DeviceMetadata()
+		metadata.firmwareVersion = "2.8.0"
+		admin.getDeviceMetadataResponse = metadata
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .milliseconds(20),
+			isLive: { getNodeInfo(id: num, context: mainContext)?.hasLiveAdminSession == true },
+			isConnected: { true }, targetIsCurrent: { true })
+		#expect(result == .active)
+		#expect(cachedNode.hasLiveAdminSession)
+		#expect(cachedNode.metadata?.firmwareVersion == "2.8")
+	}
+
 	@Test func moduleConfigResponseWithPasskeyMarksAdministered() async throws {
 		let (mesh, container) = try freshMesh()
 		let num: Int64 = 0x22BB33

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -182,6 +182,28 @@ struct NodeAdministrationTests {
 		#expect(node.sessionPasskey == nil)
 		#expect(node.sessionExpiration == nil)
 	}
+
+	@Test func ringtoneResponsePersistsSessionPasskey() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x2A2B2C
+		try seedNode(num: num, in: container)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0xCA, 0xFE])
+		admin.getRingtoneResponse = "Beep:d=4,o=5,b=120:c"
+
+		await mesh.adminAppPacket(
+			packet: try adminPacket(from: num, message: admin),
+			connectedNodeNum: Self.myNum,
+			isCorrelatedRemoteAdminResponse: true
+		)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.rtttlConfig?.ringtone == "Beep:d=4,o=5,b=120:c")
+		#expect(node.sessionPasskey == Data([0xCA, 0xFE]))
+		#expect(node.sessionExpiration != nil)
+	}
+
 	@Test func metadataResponseWithPasskeyMarksUnknownNode() async throws {
 		// A metadata response is the first admin exchange when selecting a remote node,
 		// and its handler creates the node if it has never been heard.

--- a/MeshtasticTests/NodeAdministrationTests.swift
+++ b/MeshtasticTests/NodeAdministrationTests.swift
@@ -79,7 +79,7 @@ struct NodeAdministrationTests {
 		try seedNode(num: num, in: container)
 
 		let admin = deviceConfigResponse(passkey: Data([0xA5, 0x5A, 0x99, 0x01]))
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum, isCorrelatedRemoteAdminResponse: true)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
@@ -100,7 +100,7 @@ struct NodeAdministrationTests {
 		var metadata = DeviceMetadata()
 		metadata.firmwareVersion = "2.8.0"
 		admin.getDeviceMetadataResponse = metadata
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum, isCorrelatedRemoteAdminResponse: true)
 
 		let result = await RemoteAdminSessionWaiter.wait(
 			timeout: .milliseconds(20),
@@ -122,7 +122,7 @@ struct NodeAdministrationTests {
 		moduleConfig.statusmessage = ModuleConfig.StatusMessageConfig()
 		admin.getModuleConfigResponse = moduleConfig
 
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum, isCorrelatedRemoteAdminResponse: true)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
@@ -130,7 +130,7 @@ struct NodeAdministrationTests {
 		#expect(node.sessionExpiration != nil)
 		let expiration = node.sessionExpiration
 		admin.sessionPasskey = Data()
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum, isCorrelatedRemoteAdminResponse: true)
 		let emptyResponseNode = try fetchNode(num: num, in: container)
 		#expect(emptyResponseNode.sessionPasskey == Data([0x01, 0x02, 0x03]))
 		#expect(emptyResponseNode.sessionExpiration == expiration)
@@ -140,6 +140,48 @@ struct NodeAdministrationTests {
 		#expect(mirroredNode.sessionExpiration == expiration)
 	}
 
+	@Test func channelResponseRefreshesTargetSessionPasskeyWithoutPersistingChannels() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x2CDD33
+		try seedNode(num: num, in: container)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0x0A, 0x0B, 0x0C])
+		var channel = Channel()
+		channel.index = 0
+		channel.role = .primary
+		channel.settings.name = "Remote Primary"
+		admin.getChannelResponse = channel
+
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum, isCorrelatedRemoteAdminResponse: true)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.sessionPasskey == Data([0x0A, 0x0B, 0x0C]))
+		#expect(node.sessionExpiration != nil)
+		#expect(node.myInfo == nil)
+	}
+
+	@Test func channelResponseAddressedToAnotherNodeDoesNotRefreshSession() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x2DEE44
+		try seedNode(num: num, in: container)
+
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0x0A, 0x0B, 0x0C])
+		var channel = Channel()
+		channel.index = 0
+		channel.role = .primary
+		admin.getChannelResponse = channel
+
+		await mesh.adminAppPacket(
+			packet: try adminPacket(from: num, message: admin, to: 0x0D00D),
+			connectedNodeNum: Self.myNum
+		)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.sessionPasskey == nil)
+		#expect(node.sessionExpiration == nil)
+	}
 	@Test func metadataResponseWithPasskeyMarksUnknownNode() async throws {
 		// A metadata response is the first admin exchange when selecting a remote node,
 		// and its handler creates the node if it has never been heard.
@@ -152,7 +194,7 @@ struct NodeAdministrationTests {
 		metadata.firmwareVersion = "2.8.0"
 		admin.getDeviceMetadataResponse = metadata
 
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum, isCorrelatedRemoteAdminResponse: true)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)
@@ -168,6 +210,40 @@ struct NodeAdministrationTests {
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(!node.hasBeenAdministered)
+	}
+
+	@Test func uncorrelatedModuleResponseDoesNotPersistItsPasskey() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x45DD66
+		try seedNode(num: num, in: container)
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0x01, 0x02])
+		admin.getModuleConfigResponse = ModuleConfig()
+
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: admin), connectedNodeNum: Self.myNum)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.sessionPasskey == nil)
+		#expect(node.sessionExpiration == nil)
+	}
+
+	@Test func correlatedRtttlResponsePersistsItsPasskey() async throws {
+		let (mesh, container) = try freshMesh()
+		let num: Int64 = 0x46DD77
+		try seedNode(num: num, in: container)
+		var admin = AdminMessage()
+		admin.sessionPasskey = Data([0x0A, 0x0B])
+		admin.getRingtoneResponse = "Beep:d=4,o=5,b=120:c"
+
+		await mesh.adminAppPacket(
+			packet: try adminPacket(from: num, message: admin),
+			connectedNodeNum: Self.myNum,
+			isCorrelatedRemoteAdminResponse: true
+		)
+
+		let node = try fetchNode(num: num, in: container)
+		#expect(node.sessionPasskey == Data([0x0A, 0x0B]))
+		#expect(node.rtttlConfig?.ringtone == "Beep:d=4,o=5,b=120:c")
 	}
 
 	@Test func localConfigDownloadDoesNotMark() async throws {
@@ -252,11 +328,11 @@ struct NodeAdministrationTests {
 		try seedNode(num: num, in: container)
 
 		let withPasskey = deviceConfigResponse(passkey: Data([0x01]))
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withPasskey), connectedNodeNum: Self.myNum)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withPasskey), connectedNodeNum: Self.myNum, isCorrelatedRemoteAdminResponse: true)
 
 		// A later response without a passkey must not clear the flag.
 		let withoutPasskey = deviceConfigResponse(passkey: nil)
-		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withoutPasskey), connectedNodeNum: Self.myNum)
+		await mesh.adminAppPacket(packet: try adminPacket(from: num, message: withoutPasskey), connectedNodeNum: Self.myNum, isCorrelatedRemoteAdminResponse: true)
 
 		let node = try fetchNode(num: num, in: container)
 		#expect(node.hasBeenAdministered)

--- a/MeshtasticTests/RemoteAdminActionsTests.swift
+++ b/MeshtasticTests/RemoteAdminActionsTests.swift
@@ -99,7 +99,7 @@ struct RemoteAdminActionTransportTests {
 		#expect(result == .acknowledged)
 	}
 
-	@Test func actionTrackerResolvesRoutingAckAsAcknowledged() async throws {
+	@Test func actionTrackerDoesNotTreatRoutingAckAsActionAcknowledgement() async throws {
 		let tracker = RemoteAdminConfigTracker()
 		let operationID = tracker.begin(kind: .action, targetNodeNum: 42, section: "reset")
 		#expect(operationID != nil)
@@ -110,7 +110,20 @@ struct RemoteAdminActionTransportTests {
 		}
 		await Task.yield()
 		tracker.resolveRouting(packetID: packetID, sourceNodeNum: 42, reason: nil, isFailure: false)
-		#expect(try await waitTask.value == .acknowledged)
+		#expect(try await waitTask.value == .unconfirmed)
+	}
+
+	@Test func actionTrackerResolvesActualAdminResponseAsAcknowledged() async throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .action, targetNodeNum: 42, section: "reset"))
+		let packetID: UInt32 = 126
+		#expect(tracker.registerPacket(packetID: packetID, targetNodeNum: 42, operationID: operationID))
+		let waitTask = Task {
+			await tracker.waitForPacket(packetID: packetID, operationID: operationID, timeout: .seconds(1))
+		}
+		await Task.yield()
+		#expect(tracker.resolveAdminResponse(packetID: packetID, sourceNodeNum: 42) == operationID)
+		#expect(await waitTask.value == .acknowledged)
 	}
 
 	@Test func actionTrackerIgnoresRoutingAckFromRelay() async throws {
@@ -142,10 +155,18 @@ struct RemoteAdminActionTransportTests {
 
 	@Test func sendTimeUsesProductionTransportAndRemoteAuth() async throws {
 		let fixture = try fixture()
-		try await fixture.manager.sendTime(fromUser: fixture.from, toUser: fixture.to)
+		let action = Task { try await fixture.manager.sendTime(fromUser: fixture.from, toUser: fixture.to) }
+		while await fixture.connection.sent.isEmpty { await Task.yield() }
+		let firstSent = try #require(await fixture.connection.sent.first)
+		let sentPacket = try admin(from: firstSent).0
+		#expect(fixture.manager.remoteAdminConfigTracker.operations.values.contains {
+			$0.kind == .action && $0.targetNodeNum == 42 && !$0.isFinished
+		})
+		#expect(fixture.manager.remoteAdminConfigTracker.resolveAdminResponse(packetID: sentPacket.id, sourceNodeNum: 42) != nil)
+		#expect(try await action.value == .acknowledged)
 		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
 		#expect(packet.from == 7); #expect(packet.to == 42); #expect(admin.sessionPasskey == Data([0xA5, 0x5A]))
-		#expect(admin.setTimeOnly > 0); #expect(packet.decoded.portnum == .adminApp)
+		#expect(admin.setTimeOnly > 0); #expect(packet.decoded.portnum == .adminApp); #expect(packet.decoded.wantResponse)
 	}
 
 	@Test(arguments: [false, true]) func factoryResetModesReachRemote(resetDevice: Bool) async throws {
@@ -155,7 +176,7 @@ struct RemoteAdminActionTransportTests {
 		}
 		while await fixture.connection.sent.isEmpty { await Task.yield() }
 		let (sentPacket, _) = try admin(from: await fixture.connection.sent[0])
-		fixture.manager.remoteAdminConfigTracker.resolveRouting(packetID: sentPacket.id, sourceNodeNum: Int64(sentPacket.to), reason: nil, isFailure: false)
+		#expect(fixture.manager.remoteAdminConfigTracker.resolveAdminResponse(packetID: sentPacket.id, sourceNodeNum: Int64(sentPacket.to)) != nil)
 		#expect(try await action.value == .acknowledged)
 		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
 		#expect(packet.to == 42); #expect(admin.sessionPasskey == Data([0xA5, 0x5A]))
@@ -173,7 +194,7 @@ struct RemoteAdminActionTransportTests {
 		}
 		while await fixture.connection.sent.isEmpty { await Task.yield() }
 		let (sentPacket, _) = try admin(from: await fixture.connection.sent[0])
-		fixture.manager.remoteAdminConfigTracker.resolveRouting(packetID: sentPacket.id, sourceNodeNum: Int64(sentPacket.to), reason: nil, isFailure: false)
+		#expect(fixture.manager.remoteAdminConfigTracker.resolveAdminResponse(packetID: sentPacket.id, sourceNodeNum: Int64(sentPacket.to)) != nil)
 		#expect(try await action.value == .acknowledged)
 		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
 		#expect(packet.from == 7); #expect(packet.to == 42); #expect(admin.nodedbReset == preserveFavorites)
@@ -181,5 +202,19 @@ struct RemoteAdminActionTransportTests {
 		#expect(stillThere?.favorite == true)
 		let targetStillTracked = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 42 })).first
 		#expect(targetStillTracked != nil)
+	}
+
+	@Test func destructiveActionConfirmationCapturesTargetAndIrreversibleEffects() {
+		let target = RemoteAdminActionTarget(
+			nodeNum: 42,
+			name: "Target",
+			radioNum: 7,
+			connectionID: ObjectIdentifier(RemoteActionConnection()))
+		#expect(target.confirmationLabel == "Target (node 42)")
+		#expect(target.factoryResetConfirmationMessage(resetDevice: false).contains("Target (node 42)"))
+		#expect(target.factoryResetConfirmationMessage(resetDevice: false).contains("irreversibly"))
+		#expect(target.factoryResetConfirmationMessage(resetDevice: true).contains("identity, admin keys, channels, and Bluetooth bonds"))
+		#expect(target.nodeDBResetConfirmationMessage(preserveFavorites: false).contains("Target (node 42)"))
+		#expect(target.nodeDBResetConfirmationMessage(preserveFavorites: false).contains("cannot be undone"))
 	}
 }

--- a/MeshtasticTests/RemoteAdminActionsTests.swift
+++ b/MeshtasticTests/RemoteAdminActionsTests.swift
@@ -89,6 +89,57 @@ struct RemoteAdminActionTransportTests {
 		#expect(error == nil); #expect(sends == 1)
 	}
 
+	@Test func actionGuardReturnsAcknowledgementStatus() async {
+		let connection = RemoteActionConnection()
+		let result = await RemoteAdminActionGuard.runOutcome(
+			target: guardTarget(connection: connection), activeRadioNum: { 7 },
+			activeConnectionID: { ObjectIdentifier(connection) }, isConnected: { true }, hasLiveSession: { true },
+			action: { .acknowledged }
+		)
+		#expect(result == .acknowledged)
+	}
+
+	@Test func actionTrackerResolvesRoutingAckAsAcknowledged() async throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = tracker.begin(kind: .action, targetNodeNum: 42, section: "reset")
+		#expect(operationID != nil)
+		let packetID: UInt32 = 123
+		#expect(tracker.registerPacket(packetID: packetID, targetNodeNum: 42, operationID: operationID))
+		let waitTask = Task {
+			await tracker.waitForPacket(packetID: packetID, operationID: try #require(operationID), timeout: .seconds(1))
+		}
+		await Task.yield()
+		tracker.resolveRouting(packetID: packetID, sourceNodeNum: 42, reason: nil, isFailure: false)
+		#expect(try await waitTask.value == .acknowledged)
+	}
+
+	@Test func actionTrackerIgnoresRoutingAckFromRelay() async throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .action, targetNodeNum: 42, section: "reset"))
+		let packetID: UInt32 = 124
+		#expect(tracker.registerPacket(packetID: packetID, targetNodeNum: 42, operationID: operationID))
+		#expect(tracker.resolveRouting(packetID: packetID, sourceNodeNum: 7, reason: nil, isFailure: false) == nil)
+		#expect(await tracker.waitForPacket(packetID: packetID, operationID: operationID, timeout: .milliseconds(1)) == .unconfirmed)
+	}
+
+	@Test func actionTrackerPropagatesRoutingFailure() async throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .action, targetNodeNum: 42, section: "reset"))
+		let packetID: UInt32 = 125
+		#expect(tracker.registerPacket(packetID: packetID, targetNodeNum: 42, operationID: operationID))
+		tracker.resolveRouting(packetID: packetID, sourceNodeNum: 42, reason: "No route", isFailure: true)
+		#expect(await tracker.waitForPacket(packetID: packetID, operationID: operationID) == .failed("No route"))
+	}
+
+	@Test func actionTrackerTimesOutAsUnconfirmed() async {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try! #require(tracker.begin(kind: .action, targetNodeNum: 42, section: "reset"))
+		let packetID: UInt32 = 456
+		#expect(tracker.registerPacket(packetID: packetID, targetNodeNum: 42, operationID: operationID))
+		let result = await tracker.waitForPacket(packetID: packetID, operationID: operationID, timeout: .milliseconds(1))
+		#expect(result == .unconfirmed)
+	}
+
 	@Test func sendTimeUsesProductionTransportAndRemoteAuth() async throws {
 		let fixture = try fixture()
 		try await fixture.manager.sendTime(fromUser: fixture.from, toUser: fixture.to)
@@ -99,7 +150,13 @@ struct RemoteAdminActionTransportTests {
 
 	@Test(arguments: [false, true]) func factoryResetModesReachRemote(resetDevice: Bool) async throws {
 		let fixture = try fixture()
-		try await fixture.manager.sendFactoryReset(fromUser: fixture.from, toUser: fixture.to, resetDevice: resetDevice)
+		let action = Task {
+			try await fixture.manager.sendFactoryReset(fromUser: fixture.from, toUser: fixture.to, resetDevice: resetDevice)
+		}
+		while await fixture.connection.sent.isEmpty { await Task.yield() }
+		let (sentPacket, _) = try admin(from: await fixture.connection.sent[0])
+		fixture.manager.remoteAdminConfigTracker.resolveRouting(packetID: sentPacket.id, sourceNodeNum: Int64(sentPacket.to), reason: nil, isFailure: false)
+		#expect(try await action.value == .acknowledged)
 		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
 		#expect(packet.to == 42); #expect(admin.sessionPasskey == Data([0xA5, 0x5A]))
 		#expect(resetDevice ? admin.factoryResetDevice == 5 : admin.factoryResetConfig == 5)
@@ -111,9 +168,15 @@ struct RemoteAdminActionTransportTests {
 		let context = ModelContext(fixture.container)
 		let local = try #require(try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 7 })).first)
 		local.favorite = true; try context.save()
-		try await fixture.manager.sendNodeDBReset(fromUser: fixture.from, toUser: fixture.to, preserveFavorites: preserveFavorites)
+		let action = Task {
+			try await fixture.manager.sendNodeDBReset(fromUser: fixture.from, toUser: fixture.to, preserveFavorites: preserveFavorites)
+		}
+		while await fixture.connection.sent.isEmpty { await Task.yield() }
+		let (sentPacket, _) = try admin(from: await fixture.connection.sent[0])
+		fixture.manager.remoteAdminConfigTracker.resolveRouting(packetID: sentPacket.id, sourceNodeNum: Int64(sentPacket.to), reason: nil, isFailure: false)
+		#expect(try await action.value == .acknowledged)
 		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
-		#expect(packet.to == 42); #expect(admin.nodedbReset == preserveFavorites)
+		#expect(packet.from == 7); #expect(packet.to == 42); #expect(admin.nodedbReset == preserveFavorites)
 		let stillThere = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 7 })).first
 		#expect(stillThere?.favorite == true)
 		let targetStillTracked = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 42 })).first

--- a/MeshtasticTests/RemoteAdminActionsTests.swift
+++ b/MeshtasticTests/RemoteAdminActionsTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+import SwiftData
+import MeshtasticProtobufs
+@testable import Meshtastic
+
+private actor RemoteActionConnection: Connection {
+	let type: TransportType = .ble
+	var isConnected = true
+	private(set) var sent: [ToRadio] = []
+
+	func send(_ data: ToRadio) async throws { sent.append(data) }
+	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
+	func disconnect(withError: Error?, shouldReconnect: Bool) async throws { isConnected = false }
+	func drainPendingPackets() async throws {}
+	func startDrainPendingPackets() throws {}
+	func appDidEnterBackground() {}
+	func appDidBecomeActive() {}
+}
+
+@MainActor
+@Suite("Remote admin action transport", .serialized)
+struct RemoteAdminActionTransportTests {
+	private struct Fixture {
+		let manager: AccessoryManager
+		let connection: RemoteActionConnection
+		let from: UserEntity
+		let to: UserEntity
+		let container: ModelContainer
+	}
+
+	private func fixture() throws -> Fixture {
+		let container = try ModelContainer(for: Schema(MeshtasticSchema.allModels), configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+		let context = ModelContext(container)
+		let localNode = NodeInfoEntity(); localNode.num = 7; localNode.id = 7
+		let remoteNode = NodeInfoEntity(); remoteNode.num = 42; remoteNode.id = 42
+		remoteNode.sessionPasskey = Data([0xA5, 0x5A]); remoteNode.sessionExpiration = .now.addingTimeInterval(300)
+		let from = UserEntity(); from.num = 7; from.userNode = localNode
+		let to = UserEntity(); to.num = 42; to.userNode = remoteNode
+		context.insert(localNode); context.insert(remoteNode); context.insert(from); context.insert(to)
+		try context.save()
+		let connection = RemoteActionConnection()
+		let manager = AccessoryManager(transports: [])
+		manager.context = context
+		manager.activeConnection = (device: Device(id: UUID(), name: "Test", transportType: .ble, identifier: "test", connectionState: .connected), connection: connection)
+		manager.activeDeviceNum = 7
+		manager.updateState(.subscribed)
+		return Fixture(manager: manager, connection: connection, from: from, to: to, container: container)
+	}
+
+	private func guardTarget(connection: RemoteActionConnection, radio: Int64 = 7) -> RemoteAdminActionTarget {
+		RemoteAdminActionTarget(nodeNum: 42, name: "Target", radioNum: radio, connectionID: ObjectIdentifier(connection))
+	}
+
+	private func admin(from toRadio: ToRadio) throws -> (MeshPacket, AdminMessage) {
+		guard case .packet(let packet) = toRadio.payloadVariant else { throw AccessoryError.ioFailed("missing packet") }
+		return (packet, try AdminMessage(serializedBytes: packet.decoded.payload))
+	}
+
+	@Test func guardRejectsExpiredSessionWithoutSending() async {
+		let connection = RemoteActionConnection()
+		var sends = 0
+		let error = await RemoteAdminActionGuard.run(
+			target: guardTarget(connection: connection), activeRadioNum: { 7 },
+			activeConnectionID: { ObjectIdentifier(connection) }, isConnected: { true }, hasLiveSession: { false },
+			action: { sends += 1 }
+		)
+		#expect(error?.contains("Session expired") == true); #expect(sends == 0)
+	}
+
+	@Test func guardRejectsDifferentConnectionOnSameRadioWithoutSending() async {
+		let expected = RemoteActionConnection(); let active = RemoteActionConnection()
+		var sends = 0
+		let error = await RemoteAdminActionGuard.run(
+			target: guardTarget(connection: expected), activeRadioNum: { 7 },
+			activeConnectionID: { ObjectIdentifier(active) }, isConnected: { true }, hasLiveSession: { true },
+			action: { sends += 1 }
+		)
+		#expect(error?.contains("Connection changed") == true); #expect(sends == 0)
+	}
+
+	@Test func guardAllowsLiveMatchingConnectionExactlyOnce() async {
+		let connection = RemoteActionConnection(); var sends = 0
+		let error = await RemoteAdminActionGuard.run(
+			target: guardTarget(connection: connection), activeRadioNum: { 7 },
+			activeConnectionID: { ObjectIdentifier(connection) }, isConnected: { true }, hasLiveSession: { true },
+			action: { sends += 1 }
+		)
+		#expect(error == nil); #expect(sends == 1)
+	}
+
+	@Test func sendTimeUsesProductionTransportAndRemoteAuth() async throws {
+		let fixture = try fixture()
+		try await fixture.manager.sendTime(fromUser: fixture.from, toUser: fixture.to)
+		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
+		#expect(packet.from == 7); #expect(packet.to == 42); #expect(admin.sessionPasskey == Data([0xA5, 0x5A]))
+		#expect(admin.setTimeOnly > 0); #expect(packet.decoded.portnum == .adminApp)
+	}
+
+	@Test(arguments: [false, true]) func factoryResetModesReachRemote(resetDevice: Bool) async throws {
+		let fixture = try fixture()
+		try await fixture.manager.sendFactoryReset(fromUser: fixture.from, toUser: fixture.to, resetDevice: resetDevice)
+		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
+		#expect(packet.to == 42); #expect(admin.sessionPasskey == Data([0xA5, 0x5A]))
+		#expect(resetDevice ? admin.factoryResetDevice == 5 : admin.factoryResetConfig == 5)
+		#expect(resetDevice ? admin.factoryResetConfig == 0 : admin.factoryResetDevice == 0)
+	}
+
+	@Test(arguments: [false, true]) func nodeDBResetPreservesRequestedFavoriteMode(preserveFavorites: Bool) async throws {
+		let fixture = try fixture()
+		let context = ModelContext(fixture.container)
+		let local = try #require(try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 7 })).first)
+		local.favorite = true; try context.save()
+		try await fixture.manager.sendNodeDBReset(fromUser: fixture.from, toUser: fixture.to, preserveFavorites: preserveFavorites)
+		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
+		#expect(packet.to == 42); #expect(admin.nodedbReset == preserveFavorites)
+		let stillThere = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 7 })).first
+		#expect(stillThere?.favorite == true)
+		let targetStillTracked = try context.fetch(FetchDescriptor<NodeInfoEntity>(predicate: #Predicate { $0.num == 42 })).first
+		#expect(targetStillTracked != nil)
+	}
+}

--- a/MeshtasticTests/RemoteAdminActionsTests.swift
+++ b/MeshtasticTests/RemoteAdminActionsTests.swift
@@ -57,6 +57,14 @@ struct RemoteAdminActionTransportTests {
 		return (packet, try AdminMessage(serializedBytes: packet.decoded.payload))
 	}
 
+	private func firstSent(from connection: RemoteActionConnection) async -> ToRadio? {
+		for _ in 0..<100 {
+			if let sent = await connection.sent.first { return sent }
+			await Task.yield()
+		}
+		return nil
+	}
+
 	@Test func guardRejectsExpiredSessionWithoutSending() async {
 		let connection = RemoteActionConnection()
 		var sends = 0
@@ -156,8 +164,7 @@ struct RemoteAdminActionTransportTests {
 	@Test func sendTimeUsesProductionTransportAndRemoteAuth() async throws {
 		let fixture = try fixture()
 		let action = Task { try await fixture.manager.sendTime(fromUser: fixture.from, toUser: fixture.to) }
-		while await fixture.connection.sent.isEmpty { await Task.yield() }
-		let firstSent = try #require(await fixture.connection.sent.first)
+		let firstSent = try #require(await firstSent(from: fixture.connection))
 		let sentPacket = try admin(from: firstSent).0
 		#expect(fixture.manager.remoteAdminConfigTracker.operations.values.contains {
 			$0.kind == .action && $0.targetNodeNum == 42 && !$0.isFinished
@@ -174,8 +181,8 @@ struct RemoteAdminActionTransportTests {
 		let action = Task {
 			try await fixture.manager.sendFactoryReset(fromUser: fixture.from, toUser: fixture.to, resetDevice: resetDevice)
 		}
-		while await fixture.connection.sent.isEmpty { await Task.yield() }
-		let (sentPacket, _) = try admin(from: await fixture.connection.sent[0])
+		let sent = try #require(await firstSent(from: fixture.connection))
+		let (sentPacket, _) = try admin(from: sent)
 		#expect(fixture.manager.remoteAdminConfigTracker.resolveAdminResponse(packetID: sentPacket.id, sourceNodeNum: Int64(sentPacket.to)) != nil)
 		#expect(try await action.value == .acknowledged)
 		let (packet, admin) = try admin(from: await fixture.connection.sent[0])
@@ -192,8 +199,8 @@ struct RemoteAdminActionTransportTests {
 		let action = Task {
 			try await fixture.manager.sendNodeDBReset(fromUser: fixture.from, toUser: fixture.to, preserveFavorites: preserveFavorites)
 		}
-		while await fixture.connection.sent.isEmpty { await Task.yield() }
-		let (sentPacket, _) = try admin(from: await fixture.connection.sent[0])
+		let sent = try #require(await firstSent(from: fixture.connection))
+		let (sentPacket, _) = try admin(from: sent)
 		#expect(fixture.manager.remoteAdminConfigTracker.resolveAdminResponse(packetID: sentPacket.id, sourceNodeNum: Int64(sentPacket.to)) != nil)
 		#expect(try await action.value == .acknowledged)
 		let (packet, admin) = try admin(from: await fixture.connection.sent[0])

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -8,7 +8,8 @@ import MeshtasticProtobufs
 private actor RemoteAdminReceiveConnection: Connection {
 	let type: TransportType = .ble
 	var isConnected = true
-	func send(_ data: ToRadio) async throws {}
+	private(set) var sendCount = 0
+	func send(_ data: ToRadio) async throws { sendCount += 1 }
 	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
 	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {}
 	func drainPendingPackets() async throws {}
@@ -57,6 +58,25 @@ struct RemoteAdminConfigTrackerTests {
 		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
 		#expect(!tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: nil))
 		#expect(tracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+	}
+
+	@Test func finishedOperationIsRejectedBeforeDispatch() async throws {
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.finish(operationID) == .succeeded)
+
+		do {
+			try await RemoteAdminConfigTracker.$currentOperationID.withValue(operationID) {
+				try await manager.saveTimeZone(config: Config.DeviceConfig(), user: 42)
+			}
+			Issue.record("A finished remote-admin operation was dispatched")
+		} catch let error as AccessoryError {
+			#expect(error.localizedDescription.contains("no longer active"))
+		} catch {
+			Issue.record("Unexpected error: \(error)")
+		}
+		#expect(await connection.sendCount == 0)
 	}
 
 	@Test func responseMustMatchPacketIDAndTarget() throws {

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import Testing
+import SwiftData
 @testable import Meshtastic
 import MeshtasticProtobufs
 
@@ -134,6 +135,43 @@ struct RemoteAdminConfigTrackerTests {
 		let bluetooth = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Bluetooth"))
 		#expect(tracker.latest(for: 42, kind: .request, section: "Device")?.id == device)
 		#expect(tracker.latest(for: 42, kind: .request, section: "Bluetooth")?.id == bluetooth)
+	}
+
+	@Test func forcedRemoteConfigRetryDispatchesRequest() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let local = NodeInfoEntity(); local.num = 1; local.id = 1
+		let remote = NodeInfoEntity(); remote.num = 2; remote.id = 2
+		let from = UserEntity(); from.num = 1; from.userNode = local
+		let to = UserEntity(); to.num = 2; to.userNode = remote
+		local.user = from; remote.user = to
+		context.insert(local); context.insert(remote); context.insert(from); context.insert(to)
+		try context.save()
+
+		let manager = AccessoryManager(transports: [])
+		manager.context = context
+		manager.activeDeviceNum = 1
+		manager.updateState(.subscribed)
+		let previousAdministration = UserDefaults.enableAdministration
+		UserDefaults.enableAdministration = true
+		defer { UserDefaults.enableAdministration = previousAdministration }
+
+		var requests = 0
+		requestRemoteConfig(
+			node: remote,
+			context: context,
+			accessoryManager: manager,
+			configIsNil: { _ in false },
+			section: "Retry test",
+			request: { _, _ in requests += 1 },
+			force: true)
+		for _ in 0..<20 where requests == 0 {
+			try await Task.sleep(for: .milliseconds(10))
+		}
+		#expect(requests == 1)
 	}
 
 	@Test func managerPublishesNestedTrackerMutations() {

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -8,8 +8,15 @@ import MeshtasticProtobufs
 private actor RemoteAdminReceiveConnection: Connection {
 	let type: TransportType = .ble
 	var isConnected = true
-	private(set) var sendCount = 0
-	func send(_ data: ToRadio) async throws { sendCount += 1 }
+	private(set) var sentPackets: [ToRadio] = []
+	var sendCount: Int { sentPackets.count }
+	var sentPacketIDs: [UInt32] {
+		sentPackets.compactMap { toRadio in
+			guard case .packet(let packet) = toRadio.payloadVariant else { return nil }
+			return packet.id
+		}
+	}
+	func send(_ data: ToRadio) async throws { sentPackets.append(data) }
 	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
 	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {}
 	func drainPendingPackets() async throws {}
@@ -148,6 +155,63 @@ struct RemoteAdminConfigTrackerTests {
 		#expect(unaffectedTarget.sessionPasskey == Data([0x5A]))
 		#expect(unaffectedTarget.sessionExpiration != nil)
 		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.result == .failed("Remote node rejected the request: adminBadSessionKey"))
+	}
+
+	@Test func remoteChannelRequestEnrollsBeforeRoutingRejection() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let rejectedTarget = NodeInfoEntity()
+		rejectedTarget.num = 42
+		rejectedTarget.sessionPasskey = Data([0xA5])
+		rejectedTarget.sessionExpiration = Date().addingTimeInterval(300)
+		let unaffectedTarget = NodeInfoEntity()
+		unaffectedTarget.num = 99
+		unaffectedTarget.sessionPasskey = Data([0x5A])
+		unaffectedTarget.sessionExpiration = Date().addingTimeInterval(300)
+		context.insert(rejectedTarget)
+		context.insert(unaffectedTarget)
+		try context.save()
+
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		manager.context = context
+		let fromUser = UserEntity()
+		fromUser.num = 1
+		let toUser = UserEntity()
+		toUser.num = 42
+		toUser.userNode = rejectedTarget
+
+		let request = Task { @MainActor in
+			try await manager.requestRemoteChannel(index: 0, fromUser: fromUser, toUser: toUser)
+		}
+		var packetID: UInt32?
+		for _ in 0..<20 where packetID == nil {
+			packetID = await connection.sentPacketIDs.first
+			if packetID == nil { try await Task.sleep(for: .milliseconds(10)) }
+		}
+		let requestID = try #require(packetID)
+
+		var routing = Routing()
+		routing.errorReason = .adminBadSessionKey
+		var data = DataMessage()
+		data.portnum = .routingApp
+		data.requestID = requestID
+		data.payload = try routing.serializedData()
+		var packet = MeshPacket()
+		packet.from = 1
+		packet.to = 42
+		packet.decoded = data
+		var fromRadio = FromRadio()
+		fromRadio.packet = packet
+
+		await manager.didReceive(.data(fromRadio))
+		#expect((try? await request.value) == nil)
+		#expect(rejectedTarget.sessionPasskey == nil)
+		#expect(rejectedTarget.sessionExpiration == nil)
+		#expect(unaffectedTarget.sessionPasskey == Data([0x5A]))
 	}
 
 	@Test func relaySuccessIsIgnoredUntilTargetConfirms() throws {

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -84,6 +84,52 @@ struct RemoteAdminConfigTrackerTests {
 		#expect(tracker.operations[operationID]?.result == .failed("No route"))
 	}
 
+	@Test func routingRejectionInvalidatesOnlyRejectedTargetSession() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let rejectedTarget = NodeInfoEntity()
+		rejectedTarget.num = 42
+		rejectedTarget.sessionPasskey = Data([0xA5])
+		rejectedTarget.sessionExpiration = Date().addingTimeInterval(300)
+		let unaffectedTarget = NodeInfoEntity()
+		unaffectedTarget.num = 99
+		unaffectedTarget.sessionPasskey = Data([0x5A])
+		unaffectedTarget.sessionExpiration = Date().addingTimeInterval(300)
+		context.insert(rejectedTarget)
+		context.insert(unaffectedTarget)
+		try context.save()
+
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		manager.context = context
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .save, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+
+		var routing = Routing()
+		routing.errorReason = .adminBadSessionKey
+		var data = DataMessage()
+		data.portnum = .routingApp
+		data.requestID = 100
+		data.payload = try routing.serializedData()
+		var packet = MeshPacket()
+		packet.from = 1
+		packet.to = 42
+		packet.decoded = data
+		var fromRadio = FromRadio()
+		fromRadio.packet = packet
+
+		await manager.didReceive(.data(fromRadio))
+
+		#expect(rejectedTarget.sessionPasskey == nil)
+		#expect(rejectedTarget.sessionExpiration == nil)
+		#expect(unaffectedTarget.sessionPasskey == Data([0x5A]))
+		#expect(unaffectedTarget.sessionExpiration != nil)
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.result == .failed("Remote node rejected the request: adminBadSessionKey"))
+	}
+
 	@Test func relaySuccessIsIgnoredUntilTargetConfirms() throws {
 		let tracker = RemoteAdminConfigTracker()
 		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Combine
+import Testing
+@testable import Meshtastic
+import MeshtasticProtobufs
+
+private actor RemoteAdminReceiveConnection: Connection {
+	let type: TransportType = .ble
+	var isConnected = true
+	func send(_ data: ToRadio) async throws {}
+	func connect() async throws -> AsyncStream<ConnectionEvent> { AsyncStream { $0.finish() } }
+	func disconnect(withError: Error?, shouldReconnect: Bool) async throws {}
+	func drainPendingPackets() async throws {}
+	func startDrainPendingPackets() throws {}
+	func appDidEnterBackground() {}
+	func appDidBecomeActive() {}
+}
+
+@Suite("Remote admin configuration operation tracking")
+@MainActor
+struct RemoteAdminConfigTrackerTests {
+	private func makeManager(connection: RemoteAdminReceiveConnection) -> AccessoryManager {
+		let manager = AccessoryManager(transports: [])
+		let device = Device(id: UUID(), name: "Test Radio", transportType: .ble, identifier: "remote-admin-test", connectionState: .connected, num: 1)
+		manager.activeConnection = (device: device, connection: connection)
+		manager.activeDeviceNum = 1
+		manager.updateState(.subscribed)
+		return manager
+	}
+
+	@Test func encodedAdminResponseResolvesThroughReceivePath() async throws {
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+
+		var admin = AdminMessage()
+		admin.getModuleConfigResponse = ModuleConfig()
+		var data = DataMessage()
+		data.portnum = .adminApp
+		data.requestID = 100
+		data.payload = try admin.serializedData()
+		var packet = MeshPacket()
+		packet.from = 42
+		packet.to = 1
+		packet.decoded = data
+		var fromRadio = FromRadio()
+		fromRadio.packet = packet
+
+		await manager.didReceive(.data(fromRadio))
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+		#expect(manager.remoteAdminConfigTracker.finish(operationID) == .succeeded)
+	}
+	@Test func unrelatedPacketsCannotEnroll() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(!tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: nil))
+		#expect(tracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+	}
+
+	@Test func responseMustMatchPacketIDAndTarget() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+		#expect(tracker.resolveAdminResponse(packetID: 101, sourceNodeNum: 42) == nil)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 43) == nil)
+		#expect(tracker.operations[operationID]?.result == nil)
+	}
+
+	@Test func targetResponseSucceeds() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .request, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == operationID)
+		#expect(tracker.finish(operationID) == .succeeded)
+	}
+
+	@Test func routingFailurePropagatesByPacketID() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.resolveRouting(packetID: 100, sourceNodeNum: 99, reason: "No route", isFailure: true)
+		#expect(tracker.operations[operationID]?.result == .failed("No route"))
+	}
+
+	@Test func relaySuccessIsIgnoredUntilTargetConfirms() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 99, reason: nil, isFailure: false) == nil)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 42, reason: nil, isFailure: false) == operationID)
+	}
+
+	@Test func requestRequiresAdminResponseInsteadOfRoutingSuccess() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Ambient Lighting"))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(tracker.resolveRouting(packetID: 100, sourceNodeNum: 42, reason: nil, isFailure: false) == nil)
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == operationID)
+	}
+
+	@Test func multiPacketOperationWaitsForEveryPacket() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.registerPacket(packetID: 200, targetNodeNum: 42, operationID: operationID)
+		tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42)
+		#expect(tracker.finish(operationID) == .timedOut)
+		tracker.resolveAdminResponse(packetID: 200, sourceNodeNum: 42)
+		#expect(tracker.finish(operationID) == .succeeded)
+	}
+
+	@Test func packetTimeoutIsRetainedAsTimeout() async throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		#expect(await tracker.waitForPacket(packetID: 100, operationID: operationID, timeout: .milliseconds(1)) == .timedOut)
+		#expect(tracker.operations[operationID]?.result == .timedOut)
+		#expect(tracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
+	}
+
+	@Test func duplicateSaveIsBlockedAndRetryGetsNewSequence() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let first = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.begin(kind: .save, targetNodeNum: 42) == nil)
+		tracker.fail(first, with: "failed")
+		let retry = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		#expect(tracker.latest(for: 42, kind: .save, section: "save")?.id == retry)
+	}
+
+	@Test func requestStateIsScopedToConfigurationSection() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let device = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Device"))
+		let bluetooth = try #require(tracker.begin(kind: .request, targetNodeNum: 42, section: "Bluetooth"))
+		#expect(tracker.latest(for: 42, kind: .request, section: "Device")?.id == device)
+		#expect(tracker.latest(for: 42, kind: .request, section: "Bluetooth")?.id == bluetooth)
+	}
+
+	@Test func managerPublishesNestedTrackerMutations() {
+		let manager = AccessoryManager(transports: [])
+		var changeCount = 0
+		let cancellable = manager.objectWillChange.sink { _ in changeCount += 1 }
+		_ = manager.remoteAdminConfigTracker.begin(kind: .request, targetNodeNum: 42, section: "Device")
+		#expect(changeCount > 0)
+		cancellable.cancel()
+	}
+
+	@Test func disconnectInvalidatesPendingPacketsAndLateAck() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
+		tracker.failAll(with: "disconnected")
+		#expect(tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42) == nil)
+		#expect(tracker.operations[operationID]?.result == .failed("disconnected"))
+	}
+}

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -314,6 +314,11 @@ struct RemoteAdminConfigTrackerTests {
 		#expect(requests == 1)
 	}
 
+	@Test func configFormKeepsRetryEnabledWhenTheConfigIsMissing() {
+		#expect(!ConfigFormAvailability.isDisabled(isConnected: true))
+		#expect(ConfigFormAvailability.isDisabled(isConnected: false))
+	}
+
 	@Test func managerPublishesNestedTrackerMutations() {
 		let manager = AccessoryManager(transports: [])
 		var changeCount = 0

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -60,6 +60,72 @@ struct RemoteAdminConfigTrackerTests {
 		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.pendingPacketIDs.isEmpty == true)
 		#expect(manager.remoteAdminConfigTracker.finish(operationID) == .succeeded)
 	}
+
+	@Test func replyIDCannotResolveRemoteAdminOperationWithoutRequestID() async throws {
+		let connection = RemoteAdminReceiveConnection()
+		let manager = makeManager(connection: connection)
+		let operationID = try #require(manager.beginRemoteAdminConfigOperation(kind: .request, targetNodeNum: 42))
+		#expect(manager.remoteAdminConfigTracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID))
+
+		var admin = AdminMessage()
+		admin.getModuleConfigResponse = ModuleConfig()
+		var data = DataMessage()
+		data.portnum = .adminApp
+		data.replyID = 100
+		data.payload = try admin.serializedData()
+		var packet = MeshPacket()
+		packet.from = 42
+		packet.to = 1
+		packet.decoded = data
+		var fromRadio = FromRadio()
+		fromRadio.packet = packet
+
+		await manager.didReceive(.data(fromRadio))
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.pendingPacketIDs == [100])
+		#expect(manager.remoteAdminConfigTracker.operations[operationID]?.result == nil)
+	}
+
+	@Test func connectedNodeMissingDeviceConfigRequestsIt() async throws {
+		let container = try ModelContainer(
+			for: Schema(MeshtasticSchema.allModels),
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+		let local = NodeInfoEntity(); local.num = 1; local.id = 1
+		let user = UserEntity(); user.num = 1; user.userNode = local
+		local.user = user
+		context.insert(local); context.insert(user)
+		try context.save()
+
+		let manager = AccessoryManager(transports: [])
+		manager.context = context
+		manager.activeDeviceNum = 1
+		manager.updateState(.subscribed)
+
+		var requests = 0
+		requestRemoteConfig(
+			node: local,
+			context: context,
+			accessoryManager: manager,
+			configIsNil: { $0.deviceConfig == nil },
+			section: "Device",
+			request: { _, _ in requests += 1 },
+			requestForConnectedNode: true)
+		for _ in 0..<20 where requests == 0 {
+			try await Task.sleep(for: .milliseconds(10))
+		}
+		#expect(requests == 1)
+	}
+
+	@Test func requestFeedbackIsScopedAwayFromSaveButton() {
+		let manager = AccessoryManager(transports: [])
+		manager.remoteAdminConfigFeedback = RemoteAdminConfigFeedback(
+			targetNodeNum: 42,
+			kind: .request,
+			message: "request failed")
+		#expect(manager.remoteAdminConfigFeedback(for: 42, kind: .save) == nil)
+		#expect(manager.remoteAdminConfigFeedback(for: 42, kind: .request) == "request failed")
+	}
 	@Test func unrelatedPacketsCannotEnroll() throws {
 		let tracker = RemoteAdminConfigTracker()
 		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -302,7 +302,7 @@ struct RemoteAdminConfigTrackerTests {
 		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: operationID)
 		tracker.registerPacket(packetID: 200, targetNodeNum: 42, operationID: operationID)
 		tracker.resolveAdminResponse(packetID: 100, sourceNodeNum: 42)
-		#expect(tracker.finish(operationID) == .timedOut)
+		#expect(tracker.operations[operationID]?.pendingPacketIDs == [200])
 		tracker.resolveAdminResponse(packetID: 200, sourceNodeNum: 42)
 		#expect(tracker.finish(operationID) == .succeeded)
 	}

--- a/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
+++ b/MeshtasticTests/RemoteAdminConfigTrackerTests.swift
@@ -241,6 +241,16 @@ struct RemoteAdminConfigTrackerTests {
 		#expect(tracker.finish(operationID) == .succeeded)
 	}
 
+	@Test func finishingWithPendingPacketsTimesOutAndAllowsRetry() throws {
+		let tracker = RemoteAdminConfigTracker()
+		let first = try #require(tracker.begin(kind: .save, targetNodeNum: 42))
+		tracker.registerPacket(packetID: 100, targetNodeNum: 42, operationID: first)
+
+		#expect(tracker.finish(first) == .timedOut)
+		#expect(tracker.operations[first]?.result == .timedOut)
+		#expect(tracker.begin(kind: .save, targetNodeNum: 42) != nil)
+	}
+
 	@Test func packetTimeoutIsRetainedAsTimeout() async throws {
 		let tracker = RemoteAdminConfigTracker()
 		let operationID = try #require(tracker.begin(kind: .save, targetNodeNum: 42))

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -22,10 +22,12 @@ struct RemoteAdminEntryTests {
 
 	@Test @MainActor func orchestrator_staleSessionSendsAndWaits() async {
 		var sends = 0
+		var waits = 0
 		var fresh = false
-		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { fresh ? .active : .timedOut })
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { waits += 1; return fresh ? .active : .timedOut })
 		#expect(result == .active)
 		#expect(sends == 1)
+		#expect(waits == 1)
 	}
 
 	@Test @MainActor func orchestrator_identityChangeAfterSendCannotActivate() async {
@@ -96,7 +98,7 @@ struct RemoteAdminEntryTests {
 	@Test func sessionWaiter_stopsWhenConnectionDrops() async {
 		let result = await RemoteAdminSessionWaiter.wait(
 			timeout: .seconds(30),
-			pollInterval: .zero,
+			pollInterval: .milliseconds(1),
 			isLive: { false },
 			isConnected: { false },
 			targetIsCurrent: { true }
@@ -107,7 +109,7 @@ struct RemoteAdminEntryTests {
 	@Test func sessionWaiter_stopsWhenTargetChanges() async {
 		let result = await RemoteAdminSessionWaiter.wait(
 			timeout: .seconds(30),
-			pollInterval: .zero,
+			pollInterval: .milliseconds(1),
 			isLive: { false },
 			isConnected: { true },
 			targetIsCurrent: { false }
@@ -115,11 +117,38 @@ struct RemoteAdminEntryTests {
 		#expect(result == .targetChanged)
 	}
 
-	@Test @MainActor func routerStoresPendingSettingsNodeUntilSettingsAppears() {
-		let router = Router()
-		router.navigateToSettings(nodeNum: 42)
-		#expect(router.selectedTab == .settings)
-		#expect(router.settingsNodeNum == 42)
-		#expect(router.settingsPath.isEmpty)
+	@Test func sessionWaiter_rejectsNonPositivePollInterval() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { true }
+		)
+		#expect(result == .timedOut)
+	}
+
+	@Test @MainActor func remoteSettingsSelectionRequiresActiveDevice() {
+		#expect(Settings.remoteSettingsSelection(
+			requestedNodeNum: 42,
+			activeDeviceNum: nil,
+			availableNodeNums: [42],
+			isConnected: true
+		) == nil)
+		#expect(Settings.remoteSettingsSelection(
+			requestedNodeNum: 42,
+			activeDeviceNum: 7,
+			availableNodeNums: [42],
+			isConnected: true
+		)?.preferredNodeNum == 7)
+	}
+	@Test func remoteSettingsDestinationRejectsSourceReplacement() {
+		let connection = NSObject()
+		let replacement = NSObject()
+		let destination = RemoteAdminSettingsDestination(nodeNum: 42, radioNum: 7, connectionID: ObjectIdentifier(connection))
+		#expect(destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(connection), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 8, connectionID: ObjectIdentifier(connection), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(replacement), isConnected: true))
+		#expect(!destination.isCurrent(radioNum: 7, connectionID: ObjectIdentifier(connection), isConnected: false))
 	}
 }

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -57,6 +57,22 @@ struct RemoteAdminEntryTests {
 		#expect(result == .requestFailed)
 	}
 
+	@Test @MainActor func sameRadioWithReplacementConnectionCannotActivate() async {
+		let initial = NSObject()
+		let replacement = NSObject()
+		let capturedID = ObjectIdentifier(initial)
+		var connectionID = capturedID
+		let radioNum = 42
+		let result = await RemoteAdminSessionOrchestrator.establish(
+			allowed: { true },
+			attemptIsCurrent: { radioNum == 42 && connectionID == capturedID },
+			fresh: { false },
+			request: { connectionID = ObjectIdentifier(replacement) },
+			wait: { .active }
+		)
+		#expect(result == .targetChanged)
+	}
+
 	@Test func sessionFreshness_requiresPasskeyAndFutureExpiration() {
 		let now = Date(timeIntervalSince1970: 100)
 		#expect(RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now.addingTimeInterval(1), now: now))

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import Meshtastic
+
+@Suite("Remote admin entry")
+struct RemoteAdminEntryTests {
+
+	@Test @MainActor func orchestrator_disabledSendsZero() async {
+		var sends = 0
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { false }, attemptIsCurrent: { true }, fresh: { false }, request: { sends += 1 }, wait: { .active })
+		#expect(result == .requestFailed)
+		#expect(sends == 0)
+	}
+
+	@Test @MainActor func orchestrator_freshSessionSendsZero() async {
+		var sends = 0
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { true }, request: { sends += 1 }, wait: { .active })
+		#expect(result == .active)
+		#expect(sends == 0)
+	}
+
+	@Test @MainActor func orchestrator_staleSessionSendsAndWaits() async {
+		var sends = 0
+		var fresh = false
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { fresh }, request: { sends += 1; fresh = true }, wait: { fresh ? .active : .timedOut })
+		#expect(result == .active)
+		#expect(sends == 1)
+	}
+
+	@Test @MainActor func orchestrator_identityChangeAfterSendCannotActivate() async {
+		var current = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { current }, fresh: { false }, request: { current = false }, wait: { .active })
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func orchestrator_sendErrorIsRequestFailed() async {
+		struct SendError: Error {}
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { false }, request: { throw SendError() }, wait: { .active })
+		#expect(result == .requestFailed)
+	}
+
+	@Test @MainActor func orchestrator_cancelledSendDoesNotActivate() async {
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { true }, fresh: { false }, request: { throw CancellationError() }, wait: { .active })
+		#expect(result == .cancelled)
+	}
+
+	@Test @MainActor func orchestrator_postWaitIdentityChangeCannotActivate() async {
+		var current = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { true }, attemptIsCurrent: { current }, fresh: { false }, request: {}, wait: { current = false; return .active })
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func orchestrator_postWaitDisableCannotActivate() async {
+		var allowed = true
+		let result = await RemoteAdminSessionOrchestrator.establish(allowed: { allowed }, attemptIsCurrent: { true }, fresh: { false }, request: {}, wait: { allowed = false; return .active })
+		#expect(result == .requestFailed)
+	}
+
+	@Test func sessionFreshness_requiresPasskeyAndFutureExpiration() {
+		let now = Date(timeIntervalSince1970: 100)
+		#expect(RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: nil, expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: Data(), expiration: now.addingTimeInterval(1), now: now))
+		#expect(!RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now, now: now.addingTimeInterval(1)))
+	}
+
+	@Test func sessionWaiter_timesOutWhenResponseNeverArrives() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .milliseconds(1),
+			pollInterval: .milliseconds(1),
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { true },
+			sleep: { _ in }
+		)
+		#expect(result == .timedOut)
+	}
+
+	@Test func sessionWaiter_stopsWhenConnectionDrops() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { false },
+			targetIsCurrent: { true }
+		)
+		#expect(result == .disconnected)
+	}
+
+	@Test func sessionWaiter_stopsWhenTargetChanges() async {
+		let result = await RemoteAdminSessionWaiter.wait(
+			timeout: .seconds(30),
+			pollInterval: .zero,
+			isLive: { false },
+			isConnected: { true },
+			targetIsCurrent: { false }
+		)
+		#expect(result == .targetChanged)
+	}
+
+	@Test @MainActor func routerStoresPendingSettingsNodeUntilSettingsAppears() {
+		let router = Router()
+		router.navigateToSettings(nodeNum: 42)
+		#expect(router.selectedTab == .settings)
+		#expect(router.settingsNodeNum == 42)
+		#expect(router.settingsPath.isEmpty)
+	}
+}

--- a/MeshtasticTests/RemoteAdminEntryTests.swift
+++ b/MeshtasticTests/RemoteAdminEntryTests.swift
@@ -75,6 +75,12 @@ struct RemoteAdminEntryTests {
 		#expect(result == .targetChanged)
 	}
 
+	@Test func activeSessionIsResetWhenTheActiveRadioChanges() {
+		var state = RemoteAdminSessionState.active
+		state.invalidateForActiveRadioReplacement()
+		#expect(state == .stale)
+	}
+
 	@Test func sessionFreshness_requiresPasskeyAndFutureExpiration() {
 		let now = Date(timeIntervalSince1970: 100)
 		#expect(RemoteAdminSessionFreshness.isFresh(passkey: Data([1]), expiration: now.addingTimeInterval(1), now: now))

--- a/MeshtasticTests/RemoteChannelsTests.swift
+++ b/MeshtasticTests/RemoteChannelsTests.swift
@@ -120,6 +120,27 @@ struct RemoteChannelsTests {
 	}
 
 	@MainActor
+	@Test("coordinator refreshes a rejected session before retrying a channel read")
+	func coordinatorRefreshesAfterRejectedRead() async throws {
+		let transport = TestRemoteChannelsTransport()
+		transport.session = true
+		transport.rejectNextRequest = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: channel))
+		}
+
+		var primary = Channel()
+		primary.index = 0
+		primary.role = .primary
+		transport.channels[0] = primary
+		try await coordinator.load()
+
+		#expect(transport.refreshCount == 1)
+		#expect(coordinator.channels[0]?.role == .primary)
+	}
+
+	@MainActor
 	@Test("coordinator reports a real no reply timeout")
 	func coordinatorNoReplyTimesOut() async {
 		let transport = TestRemoteChannelsTransport(); transport.session = true
@@ -182,6 +203,7 @@ private final class TestRemoteChannelsTransport: RemoteChannelsTransport {
 	var session = false
 	var refreshCount = 0
 	var saveCount = 0
+	var rejectNextRequest = false
 	var channels: [Int32: Channel] = [:]
 	var onRequest: ((UInt32, Channel) -> Void)?
 	private var nextID: UInt32 = 100
@@ -192,7 +214,13 @@ private final class TestRemoteChannelsTransport: RemoteChannelsTransport {
 
 	func refreshMetadata() async throws { refreshCount += 1; session = true }
 	func requestChannel(index: Int32) async throws -> UInt32 {
+		guard session else { throw AccessoryError.ioFailed("Remote admin session expired") }
 		let id = nextID; nextID += 1
+		if rejectNextRequest {
+			rejectNextRequest = false
+			session = false
+			throw AccessoryError.ioFailed("Remote node rejected the request: adminBadSessionKey")
+		}
 		var channel = channels[index] ?? Channel()
 		channel.index = index
 		onRequest?(id, channel)

--- a/MeshtasticTests/RemoteChannelsTests.swift
+++ b/MeshtasticTests/RemoteChannelsTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+import MeshtasticProtobufs
+@testable import Meshtastic
+
+@Suite("Remote Channels")
+struct RemoteChannelsTests {
+    @Test("channel read requests use one based wire indexes")
+    func channelReadRequestUsesOneBasedWireIndex() throws {
+        let packet = try RemoteChannelsPacketBuilder.getRequest(
+            index: 0, from: 0x1111, to: 0x2222, sessionPasskey: Data([1, 2, 3]), id: 42
+        )
+        let admin = try AdminMessage(serializedBytes: packet.decoded.payload)
+
+        #expect(admin.getChannelRequest == 1)
+        #expect(packet.to == 0x2222)
+        #expect(packet.from == 0x1111)
+        #expect(admin.sessionPasskey == Data([1, 2, 3]))
+        #expect(packet.decoded.wantResponse)
+    }
+
+    @Test("response matching isolates target and request index")
+    func responseMatchingIsTargetScoped() throws {
+        var channel = Channel()
+        channel.index = 3
+        var response = AdminMessage()
+        response.getChannelResponse = channel
+
+        var packet = MeshPacket()
+        packet.from = 0x2222
+        packet.to = 0x1111
+        packet.decoded.requestID = 99
+
+        #expect(RemoteChannelsPacketBuilder.matchesResponse(
+            packet: packet, response: response, requestID: 99, target: 0x2222, index: 3
+        ))
+        #expect(!RemoteChannelsPacketBuilder.matchesResponse(
+            packet: packet, response: response, requestID: 99, target: 0x3333, index: 3
+        ))
+        #expect(!RemoteChannelsPacketBuilder.matchesResponse(
+            packet: packet, response: response, requestID: 99, target: 0x2222, index: 2
+        ))
+    }
+
+    @Test("ordered writes stop at the first failure")
+    func orderedWritesStopAtFirstFailure() async throws {
+        let channels = [0, 1, 2].map { index in
+            var channel = Channel()
+            channel.index = Int32(index)
+            return channel
+        }
+        var attempted: [Int32] = []
+        let result = try await RemoteChannelsWritePlan.execute(channels) { channel in
+            attempted.append(channel.index)
+            if channel.index == 1 { throw AccessoryError.ioFailed("failed") }
+        }
+
+        #expect(attempted == [0, 1])
+        #expect(result == .failure(index: 1))
+    }
+
+    @Test("remote reads retry once and surface timeout when every attempt fails")
+    func remoteReadsRetryAndSurfaceTimeout() async {
+        var attempts = 0
+        let value = try? await RemoteChannelsReadPlan.retry(retries: 1) {
+            attempts += 1
+            if attempts == 1 { throw AccessoryError.timeout }
+            return "confirmed"
+        }
+        #expect(value == "confirmed")
+        #expect(attempts == 2)
+
+        let timedOut = try? await RemoteChannelsReadPlan.retry(retries: 1) {
+            throw AccessoryError.timeout
+        }
+        #expect(timedOut == nil)
+    }
+
+	@MainActor
+	@Test("coordinator confirms editable fields and stops after a mismatch")
+	func coordinatorReadbackMismatchStopsWrites() async throws {
+		let transport = TestRemoteChannelsTransport()
+		transport.session = true
+		var first = Channel(); first.index = 0; first.role = .primary; first.settings.name = "Before"
+		transport.channels[0] = first
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			var response = channel
+			if channel.index == 0 { response.settings.name = "Different" }
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: response))
+		}
+		var desired = first; desired.settings.name = "After"
+		await #expect(throws: AccessoryError.self) { try await coordinator.save([desired]) }
+		#expect(transport.saveCount == 1)
+	}
+
+	@MainActor
+	@Test("coordinator refreshes initial PKI session before loading")
+	func coordinatorRefreshesBeforeLoad() async throws {
+		let transport = TestRemoteChannelsTransport()
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: channel))
+		}
+		var primary = Channel(); primary.index = 0; primary.role = .primary; primary.settings.name = "Primary"; primary.settings.moduleSettings.isMuted = true
+		transport.channels[0] = primary
+		try await coordinator.load()
+		#expect(transport.refreshCount == 1)
+		#expect(coordinator.channels[0]?.role == .primary)
+		#expect(coordinator.channels[0]?.settings.name == "Primary")
+		#expect(coordinator.channels[0]?.settings.moduleSettings.isMuted == true)
+	}
+
+	@MainActor
+	@Test("coordinator reports a real no reply timeout")
+	func coordinatorNoReplyTimesOut() async {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		await #expect(throws: AccessoryError.self) { try await coordinator.load() }
+	}
+
+	@MainActor
+	@Test("coordinator aborts when the connected identity switches")
+	func coordinatorAbortsOnIdentitySwitch() async {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { _, _ in transport.switchConnection() }
+		await #expect(throws: AccessoryError.self) { try await coordinator.load() }
+	}
+
+	@MainActor
+	@Test("coordinator confirms a successful save with semantic fields")
+	func coordinatorConfirmsSuccessfulSave() async throws {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: channel))
+		}
+		var channel = Channel(); channel.index = 1; channel.role = .secondary
+		channel.settings.name = "Remote"; channel.settings.psk = Data(repeating: 7, count: 16)
+		channel.settings.uplinkEnabled = true; channel.settings.downlinkEnabled = true
+		channel.settings.moduleSettings.positionPrecision = 14; channel.settings.moduleSettings.isMuted = true
+		try await coordinator.save([channel])
+		#expect(transport.saveCount == 1)
+		#expect(coordinator.channels[1]?.settings.moduleSettings.isMuted == true)
+	}
+
+	@MainActor
+	@Test("disabled channel writes clear settings and invalid roles are rejected")
+	func disabledAndInvalidRoles() async throws {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		transport.onRequest = { [weak coordinator] id, channel in
+			coordinator?.receive(TestRemoteChannelsTransport.notification(id: id, source: 2, destination: 1, channel: channel))
+		}
+		var disabled = Channel(); disabled.index = 1; disabled.role = .disabled; disabled.settings.name = "old"
+		try await coordinator.save([disabled])
+		#expect(transport.channels[1]?.hasSettings == false)
+		var primaryOnSecondary = Channel(); primaryOnSecondary.index = 1; primaryOnSecondary.role = .primary
+		await #expect(throws: AccessoryError.self) { try await coordinator.save([primaryOnSecondary]) }
+		var disabledPrimary = Channel(); disabledPrimary.index = 0; disabledPrimary.role = .disabled
+		await #expect(throws: AccessoryError.self) { try await coordinator.save([disabledPrimary]) }
+	}
+}
+
+private final class IdentityToken {}
+
+@MainActor
+private final class TestRemoteChannelsTransport: RemoteChannelsTransport {
+	var isConnected = true
+	var connectedDeviceNum: Int64? = 1
+	var identityToken = IdentityToken()
+	var connectionID: ObjectIdentifier? { ObjectIdentifier(identityToken) }
+	var session = false
+	var refreshCount = 0
+	var saveCount = 0
+	var channels: [Int32: Channel] = [:]
+	var onRequest: ((UInt32, Channel) -> Void)?
+	private var nextID: UInt32 = 100
+	var hasLiveSession: Bool { session }
+	func switchConnection() { identityToken = IdentityToken() }
+	var responseTimeout: Duration { .milliseconds(50) }
+	var sessionTimeout: Duration { .milliseconds(50) }
+
+	func refreshMetadata() async throws { refreshCount += 1; session = true }
+	func requestChannel(index: Int32) async throws -> UInt32 {
+		let id = nextID; nextID += 1
+		var channel = channels[index] ?? Channel()
+		channel.index = index
+		onRequest?(id, channel)
+		return id
+	}
+	func saveChannel(_ channel: Channel) async throws { saveCount += 1; channels[channel.index] = channel }
+
+	static func notification(id: UInt32, source: UInt32, destination: UInt32, channel: Channel) -> Foundation.Notification {
+		var response = AdminMessage(); response.getChannelResponse = channel
+		var packet = MeshPacket(); packet.from = source; packet.to = destination; packet.decoded.requestID = id
+		return Foundation.Notification(name: .remoteChannelResponse, object: nil, userInfo: ["packet": packet, "response": response])
+	}
+}

--- a/MeshtasticTests/RemoteChannelsTests.swift
+++ b/MeshtasticTests/RemoteChannelsTests.swift
@@ -5,6 +5,14 @@ import MeshtasticProtobufs
 
 @Suite("Remote Channels")
 struct RemoteChannelsTests {
+	@Test("remote channel identity includes the target name and node number")
+	func remoteTargetIdentityIsAccessible() {
+		let label = RemoteTargetIdentity.accessibilityLabel(name: "Relay Alpha", nodeNum: 0x1234)
+
+		#expect(label.contains("Relay Alpha"))
+		#expect(label.contains("4660"))
+	}
+
     @Test("channel read requests use one based wire indexes")
     func channelReadRequestUsesOneBasedWireIndex() throws {
         let packet = try RemoteChannelsPacketBuilder.getRequest(

--- a/MeshtasticTests/RemoteChannelsTests.swift
+++ b/MeshtasticTests/RemoteChannelsTests.swift
@@ -175,6 +175,20 @@ struct RemoteChannelsTests {
 	}
 
 	@MainActor
+	@Test("coordinator reports an in-progress save")
+	func coordinatorReportsInProgressSave() async throws {
+		let transport = TestRemoteChannelsTransport(); transport.session = true
+		transport.saveDelay = .milliseconds(100)
+		let coordinator = RemoteChannelsCoordinator(transport: transport, sourceNum: 1, targetNum: 2)
+		var channel = Channel(); channel.index = 1; channel.role = .secondary
+		let firstSave = Task { try await coordinator.save([channel]) }
+		while !transport.saveStarted { try await Task.sleep(for: .milliseconds(1)) }
+
+		await #expect(throws: AccessoryError.self) { try await coordinator.save([channel]) }
+		_ = try await firstSave.value
+	}
+
+	@MainActor
 	@Test("disabled channel writes clear settings and invalid roles are rejected")
 	func disabledAndInvalidRoles() async throws {
 		let transport = TestRemoteChannelsTransport(); transport.session = true
@@ -203,6 +217,8 @@ private final class TestRemoteChannelsTransport: RemoteChannelsTransport {
 	var session = false
 	var refreshCount = 0
 	var saveCount = 0
+	var saveStarted = false
+	var saveDelay: Duration?
 	var rejectNextRequest = false
 	var channels: [Int32: Channel] = [:]
 	var onRequest: ((UInt32, Channel) -> Void)?
@@ -226,7 +242,12 @@ private final class TestRemoteChannelsTransport: RemoteChannelsTransport {
 		onRequest?(id, channel)
 		return id
 	}
-	func saveChannel(_ channel: Channel) async throws { saveCount += 1; channels[channel.index] = channel }
+	func saveChannel(_ channel: Channel) async throws {
+		saveCount += 1
+		saveStarted = true
+		if let saveDelay { try await Task.sleep(for: saveDelay) }
+		channels[channel.index] = channel
+	}
 
 	static func notification(id: UInt32, source: UInt32, destination: UInt32, channel: Channel) -> Foundation.Notification {
 		var response = AdminMessage(); response.getChannelResponse = channel

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -111,6 +111,12 @@ Long-press any node in the list to access quick actions:
 - **Ignore / Remove from ignored** — hide this node from normal views
 - **Remove** — remove the node from your local database
 
+## Remote Admin
+
+Remote Admin pushes a Settings page for that node within the Nodes navigation stack. Open a configuration section and use Back to return to the node’s Settings; use Back again to return to the node details. The target stays fixed while this page is open.
+
+On a node's detail screen, **Remote Admin** requires a connected radio and **Administration** enabled in App Settings. When the target has no live admin session, the app requests device metadata through the connected radio and waits for the session to become active before opening the target's configuration. If the request fails, the radio disconnects, the target changes, the request is cancelled, or the 30-second wait expires, the screen shows the reason and a **Retry Remote Admin** action. Retry after restoring the connection, selecting the intended target, or enabling Administration.
+
 ## Display Names
 
 You can give any node a local nickname that's shown throughout the app instead of its device long name — in the node list, node details, and messages. Set it from the node's long-press menu ("Display name") or from the **Name** row in Node Detail. The avatar circle always shows the node's actual short code, unaffected by the nickname.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -45,6 +45,10 @@ The Remote Admin page stays inside node navigation: Back from a configuration se
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.
 
+### Remote configuration
+
+When you configure another node, Settings shows progress while the request or save is being confirmed by that node. A timeout or delivery error keeps your edits on screen and provides a **Retry** action, so you can check the node and try again without re-entering the values.
+
 ### LoRa
 
 LoRa settings control how your radio communicates on the mesh:

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -39,6 +39,8 @@ Radio configuration requires a connected node. Select your node from the **Confi
 
 From a node's detail screen, **Remote Admin** opens that node's configuration directly. If the app does not have a current admin session, it requests fresh device metadata first and shows the target name while the session is established. A disconnected radio, changed target, or 30-second timeout leaves the screen in an error state with a **Retry Remote Admin** action; Settings is opened only after the session becomes active.
 
+The Remote Admin page stays inside node navigation: Back from a configuration section returns to the remote Settings page, and Back from that page returns to the node. It does not switch to the app’s Settings tab.
+
 ### Node selection
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -49,6 +49,8 @@ The Configure picker lists live nodes from the current node database, with favor
 
 When you configure another node, Settings shows progress while the request or save is being confirmed by that node. A timeout or delivery error keeps your edits on screen and provides a **Retry** action, so you can check the node and try again without re-entering the values.
 
+Remote **Set Time**, **Factory Reset**, and **NodeDB Reset** actions are sent only while the connected radio and live administration session still match the selected target. If the connection changes or the session expires, Settings stops the action and reports the failure rather than applying it to a stale target.
+
 ### LoRa
 
 LoRa settings control how your radio communicates on the mesh:

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -35,6 +35,10 @@ Turning a toggle off suppresses only the alert — messages, reactions, waypoint
 
 Radio configuration requires a connected node. Select your node from the **Configure** section if you have multiple nodes.
 
+### Remote administration
+
+From a node's detail screen, **Remote Admin** opens that node's configuration directly. If the app does not have a current admin session, it requests fresh device metadata first and shows the target name while the session is established. A disconnected radio, changed target, or 30-second timeout leaves the screen in an error state with a **Retry Remote Admin** action; Settings is opened only after the session becomes active.
+
 ### Node selection
 
 The Configure picker lists live nodes from the current node database, with favorites first. If the node database is reset or the selected node disappears, Settings clears that selection instead of opening configuration for a stale node. Reconnect to a radio or choose a currently listed node to continue configuring it.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -70,6 +70,8 @@ Saving LoRa settings may reboot the radio and briefly disconnect it. If the radi
 
 Manage up to 8 channels (0–7). Channel 0 is the primary broadcast channel. Additional channels create isolated messaging groups with their own encryption keys.
 
+When a remote administered node is selected in Settings, Channels loads that node's eight slots through the connected radio. Remote edits are sent in slot order and confirmed by reading each slot back; progress and the first failed slot are shown in the screen. Remote channel responses stay scoped to the selected node and are not copied into the connected radio's local channel database.
+
 When sharing channels, the share screen shows a QR code and link, and — on iPhones with NFC hardware (iOS 18 or later) — a **Write to NFC Tag** button. Hold a writable NFC tag near the top of your iPhone to save the channel link to it, replacing any content the tag already held; tapping that tag on another phone opens the same add-or-replace channels flow the QR code does.
 
 ### Security


### PR DESCRIPTION
## Summary

Adds target-aware Remote Admin actions to the direct-to-`main` implementation for Android parity. It covers time setting and destructive reset actions while making the outcome visible and truthful to the operator.

This branch includes prerequisite Remote Admin entry, session, feedback, and channel work so it can be reviewed and merged independently. It has no GitHub stacked-PR dependency and supersedes #2412.

## Design

Implements the [Remote Administration design issue](https://github.com/meshtastic/design/issues/144): destructive actions name the target, wait for the target’s administrative response, and distinguish acknowledged, verified, unconfirmed, and failed outcomes.

## Safety details

- Factory Reset and NodeDB Reset await the target’s routing ACK/error instead of reporting success when dispatch is merely queued.
- Reset packets request a response; NodeDB Reset uses the actual local radio as its source address.
- Local-node resets retain their existing immediate behavior.
- UI guards verify the live connection, selected target, and active session before dispatching.

## Validation and evidence

- `RemoteAdminActionsTests`: passed with `xcodebuild test -quiet`.
- Added coverage for packet construction, routing ACK, relay race, failure, timeout, and target UI guards.
- `git diff --check`: passed.
- [Real-mesh Remote Admin navigation video](https://github.com/user-attachments/assets/0a5da430-eb2a-49c4-a8c6-68358d9df6df): simulator → TCP radio → RF target, including requesting and entering target settings.
- Target-settings navigation after a nested screen: [screenshot](https://private-user-images.githubusercontent.com/119711889/646685000-75652dee-5910-4a89-b32b-0b0a7439a35c.png).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added remote administration for non-connected nodes, including Set Time, Factory Reset, and Node Database Reset actions.
  - Added remote settings access with channel viewing and editing.
  - Added remote configuration retrieval, saving, progress feedback, failure messages, and retry controls.
- **Bug Fixes**
  - Improved tracking of remote responses, timeouts, routing errors, and disconnections.
  - Prevented empty session passkeys from being stored.
  - Improved remote channel response handling and session validation.
- **Tests**
  - Expanded coverage for remote administration, configuration, sessions, and channel management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->