### PR TITLE
Never send a contact with an empty public key, and make favoriting on send stick

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -213,61 +213,72 @@ extension AccessoryManager {
 		}
 
 		let decodedString = base64UrlString.base64urlToBase64()
-		if let decodedData = Data(base64Encoded: decodedString) {
-			do {
-				let contact: SharedContact = try SharedContact(serializedBytes: decodedData)
-				guard contact.carriesPublicKey else {
-					Logger.services.error("addContactFromURL: refusing a contact for \(contact.nodeNum, privacy: .public) with no public key; applying it would erase the key the radio holds")
-					throw AccessoryError.ioFailed("addContactFromURL: Contact has no public key")
-				}
-				var adminPacket = AdminMessage()
-				adminPacket.addContact = contact
-				var meshPacket: MeshPacket = MeshPacket()
-				meshPacket.to = UInt32(deviceNum)
-				meshPacket.from	= UInt32(deviceNum)
-				meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
-				meshPacket.priority =  MeshPacket.Priority.reliable
-				meshPacket.wantAck = true
-				meshPacket.channel = 0
-				var dataMessage = DataMessage()
-				guard let adminData: Data = try? adminPacket.serializedData() else {
-					throw AccessoryError.ioFailed("addContactFromURL: Unable to serialize admin packet")
-				}
-				dataMessage.payload = adminData
-				dataMessage.portnum = PortNum.adminApp
-				meshPacket.decoded = dataMessage
-				var toRadio: ToRadio!
-				toRadio = ToRadio()
-				toRadio.packet = meshPacket
-
-				let logString = String.localizedStringWithFormat("Added contact %@ to device".localized, contact.user.longName)
-				try await send(toRadio, debugDescription: logString)
-
-				// Create a NodeInfo (User) packet for the newly added contact
-				var dataNodeMessage = DataMessage()
-				if let nodeInfoData = try? contact.user.serializedData() {
-					dataNodeMessage.payload = nodeInfoData
-					dataNodeMessage.portnum = PortNum.nodeinfoApp
-					var nodeMeshPacket = MeshPacket()
-					nodeMeshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
-					nodeMeshPacket.to = UInt32.max
-					nodeMeshPacket.from = UInt32(contact.nodeNum)
-					nodeMeshPacket.decoded = dataNodeMessage
-
-					// Update local database with the new node info
-					// Do not auto-favorite when using CLIENT_BASE role to avoid creating routing issues
-					let shouldFavorite = connectedDeviceRole != .clientBase
-					await MeshPackets.shared.upsertNodeInfoPacket(packet: nodeMeshPacket, favorite: shouldFavorite, overTheMesh: false)
-				}
-			} catch {
-				Logger.data.error("Failed to decode contact data: \(error.localizedDescription, privacy: .public)")
-				throw AccessoryError.appError("Unable to decode contact data from QR code.")
-			}
-		} else {
+		guard let decodedData = Data(base64Encoded: decodedString) else {
 			// Without this the method returned normally on undecodable input, so
 			// callers treated a failed import as a success.
 			Logger.data.error("Contact payload is not valid base64url data.")
 			throw AccessoryError.appError("Unable to decode contact data from QR code.")
+		}
+
+		let contact: SharedContact
+		do {
+			contact = try SharedContact(serializedBytes: decodedData)
+		} catch {
+			Logger.data.error("Failed to decode contact data: \(error.localizedDescription, privacy: .public)")
+			throw AccessoryError.appError("Unable to decode contact data from QR code.")
+		}
+
+		// Checked out here rather than alongside the radio work below, so a keyless contact is not
+		// reported to the caller as malformed QR data.
+		guard contact.carriesPublicKey else {
+			Logger.services.error("addContactFromURL: refusing a contact for \(contact.nodeNum, privacy: .public) with no public key; applying it would erase the key the radio holds")
+			throw AccessoryError.appError("This contact does not include a public key, so it cannot be added.")
+		}
+
+		do {
+			var adminPacket = AdminMessage()
+			adminPacket.addContact = contact
+			var meshPacket: MeshPacket = MeshPacket()
+			meshPacket.to = UInt32(deviceNum)
+			meshPacket.from	= UInt32(deviceNum)
+			meshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+			meshPacket.priority =  MeshPacket.Priority.reliable
+			meshPacket.wantAck = true
+			meshPacket.channel = 0
+			var dataMessage = DataMessage()
+			guard let adminData: Data = try? adminPacket.serializedData() else {
+				throw AccessoryError.ioFailed("addContactFromURL: Unable to serialize admin packet")
+			}
+			dataMessage.payload = adminData
+			dataMessage.portnum = PortNum.adminApp
+			meshPacket.decoded = dataMessage
+			var toRadio: ToRadio!
+			toRadio = ToRadio()
+			toRadio.packet = meshPacket
+
+			let logString = String.localizedStringWithFormat("Added contact %@ to device".localized, contact.user.longName)
+			try await send(toRadio, debugDescription: logString)
+
+			// Create a NodeInfo (User) packet for the newly added contact
+			var dataNodeMessage = DataMessage()
+			if let nodeInfoData = try? contact.user.serializedData() {
+				dataNodeMessage.payload = nodeInfoData
+				dataNodeMessage.portnum = PortNum.nodeinfoApp
+				var nodeMeshPacket = MeshPacket()
+				nodeMeshPacket.id = UInt32.random(in: UInt32(UInt8.max)..<UInt32.max)
+				nodeMeshPacket.to = UInt32.max
+				nodeMeshPacket.from = UInt32(contact.nodeNum)
+				nodeMeshPacket.decoded = dataNodeMessage
+
+				// Update local database with the new node info
+				// Do not auto-favorite when using CLIENT_BASE role to avoid creating routing issues
+				let shouldFavorite = connectedDeviceRole != .clientBase
+				await MeshPackets.shared.upsertNodeInfoPacket(packet: nodeMeshPacket, favorite: shouldFavorite, overTheMesh: false)
+			}
+		} catch {
+			// The contact decoded fine and carries a key; this is the radio send failing.
+			Logger.data.error("Failed to add contact: \(error.localizedDescription, privacy: .public)")
+			throw AccessoryError.appError("Unable to add this contact.")
 		}
 	}
 	
@@ -436,7 +447,14 @@ extension AccessoryManager {
 									// take that as the node's key. Skip the contact rather than erase it.
 									if contact.carriesPublicKey {
 										let contactString = try contact.serializedData().base64EncodedString()
-										try? await am.addContactFromURL(base64UrlString: contactString)
+										do {
+											try await am.addContactFromURL(base64UrlString: contactString)
+										} catch {
+											// Best effort. The message still goes out, and the radio may
+											// already hold the key, so a failure here is not fatal — but it
+											// should not vanish either.
+											Logger.services.warning("Could not refresh the contact for \(user.num, privacy: .public) before a direct message: \(error.localizedDescription, privacy: .public)")
+										}
 									} else {
 										Logger.services.info("Skipping the pre-message contact for \(user.num, privacy: .public); no public key on file")
 									}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -216,6 +216,10 @@ extension AccessoryManager {
 		if let decodedData = Data(base64Encoded: decodedString) {
 			do {
 				let contact: SharedContact = try SharedContact(serializedBytes: decodedData)
+				guard contact.carriesPublicKey else {
+					Logger.services.error("addContactFromURL: refusing a contact for \(contact.nodeNum, privacy: .public) with no public key; applying it would erase the key the radio holds")
+					throw AccessoryError.ioFailed("addContactFromURL: Contact has no public key")
+				}
 				var adminPacket = AdminMessage()
 				adminPacket.addContact = contact
 				var meshPacket: MeshPacket = MeshPacket()
@@ -429,8 +433,14 @@ extension AccessoryManager {
 								user.userNode?.favorite = user.userNode?.deviceConfig?.role ?? 0 != DeviceRoles.clientBase.rawValue
 								contact.user = user.toProto()
 								do {
-									let contactString = try contact.serializedData().base64EncodedString()
-									try? await am.addContactFromURL(base64UrlString: contactString)
+									// toProto() emits an empty key when we hold none, and the radio would
+									// take that as the node's key. Skip the contact rather than erase it.
+									if contact.carriesPublicKey {
+										let contactString = try contact.serializedData().base64EncodedString()
+										try? await am.addContactFromURL(base64UrlString: contactString)
+									} else {
+										Logger.services.info("Skipping the pre-message contact for \(user.num, privacy: .public); no public key on file")
+									}
 									try context.save()
 								} catch {
 									Logger.services.error("Error inserting new contact and resending encrypted send failed message: \(error)")

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -430,7 +430,6 @@ extension AccessoryManager {
 								var contact = SharedContact()
 								contact.manuallyVerified = false
 								contact.nodeNum = UInt32(truncatingIfNeeded: user.num)
-								user.userNode?.favorite = user.userNode?.deviceConfig?.role ?? 0 != DeviceRoles.clientBase.rawValue
 								contact.user = user.toProto()
 								do {
 									// toProto() emits an empty key when we hold none, and the radio would
@@ -440,6 +439,24 @@ extension AccessoryManager {
 										try? await am.addContactFromURL(base64UrlString: contactString)
 									} else {
 										Logger.services.info("Skipping the pre-message contact for \(user.num, privacy: .public); no public key on file")
+									}
+									// Pin the node we are messaging so it does not age out of the radio's
+									// node db mid conversation. It has to go to the radio as an admin
+									// message: setting the local flag alone is overwritten by the next
+									// NodeInfo, so the star would appear and then quietly revert.
+									if let node = user.userNode,
+									   let connectedNodeNum = am.activeDeviceNum,
+									   AutoFavoriteRule.shouldFavorite(
+										destinationRole: node.deviceConfig?.role,
+										connectedRole: am.connectedDeviceRole,
+										isAlreadyFavorite: node.favorite
+									   ) {
+										do {
+											try await am.setFavoriteNode(node: node, connectedNodeNum: Int64(connectedNodeNum))
+											node.favorite = true
+										} catch {
+											Logger.services.error("Could not favorite \(user.num, privacy: .public) while sending a direct message: \(error.localizedDescription, privacy: .public)")
+										}
 									}
 									try context.save()
 								} catch {

--- a/Meshtastic/Helpers/AutoFavoriteRule.swift
+++ b/Meshtastic/Helpers/AutoFavoriteRule.swift
@@ -1,0 +1,30 @@
+//
+//  AutoFavoriteRule.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import Foundation
+
+/// Decides whether sending a direct message should favorite the node it is addressed to.
+///
+/// Favoriting pins the node in the radio's node db so it does not age out from under an ongoing
+/// conversation. Client base is excluded at both ends: a client base should only favorite nodes its
+/// operator controls, and a client base is infrastructure rather than a contact worth pinning.
+enum AutoFavoriteRule {
+
+	static func shouldFavorite(
+		destinationRole: Int32?,
+		connectedRole: DeviceRoles?,
+		isAlreadyFavorite: Bool
+	) -> Bool {
+		// Already pinned, so there is nothing to send.
+		if isAlreadyFavorite { return false }
+		// Never auto favorite from a client base, whatever it is messaging.
+		if connectedRole == .clientBase { return false }
+		// Never auto favorite a client base, whoever is messaging it.
+		if let destinationRole, Int(destinationRole) == DeviceRoles.clientBase.rawValue { return false }
+		return true
+	}
+}

--- a/Meshtastic/Helpers/SharedContactKeyGuard.swift
+++ b/Meshtastic/Helpers/SharedContactKeyGuard.swift
@@ -1,0 +1,22 @@
+//
+//  SharedContactKeyGuard.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import Foundation
+import MeshtasticProtobufs
+
+extension SharedContact {
+	/// Whether this contact carries a public key.
+	///
+	/// Firmware applies an `add_contact` through `CopyUserToNodeInfoLite`, which assigns
+	/// `public_key` unconditionally. A contact with no key therefore erases the key the radio
+	/// already holds for that node, and the next direct message to it fails with
+	/// `PKI_SEND_FAIL_PUBLIC_KEY` instead of falling back to channel encryption. Nothing we send
+	/// to the radio should be able to do that, so contacts without a key are refused.
+	var carriesPublicKey: Bool {
+		!user.publicKey.isEmpty
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/AddContactConfirmationView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/AddContactConfirmationView.swift
@@ -22,6 +22,12 @@ struct AddContactConfirmationView: View {
 		return name.isEmpty ? "?" : name
 	}
 
+	/// A contact with no public key would clear the key the node already holds, so there is
+	/// nothing safe to import. See `SharedContact.carriesPublicKey`.
+	private var canAdd: Bool {
+		pendingContact.contact.carriesPublicKey
+	}
+
 	var body: some View {
 		VStack(spacing: 20) {
 			Text("Add Contact")
@@ -38,6 +44,12 @@ struct AddContactConfirmationView: View {
 				.font(.subheadline)
 				.multilineTextAlignment(.center)
 				.foregroundColor(.secondary)
+			if !canAdd {
+				Text("This contact does not include a public key, so it cannot be added.")
+					.font(.subheadline)
+					.multilineTextAlignment(.center)
+					.foregroundColor(.red)
+			}
 			if let failureMessage {
 				Text(failureMessage)
 					.font(.subheadline)
@@ -50,7 +62,7 @@ struct AddContactConfirmationView: View {
 				Label("Add Contact", systemImage: "person.crop.circle.badge.plus")
 			}
 			.buttonStyle(.borderedProminent)
-			.disabled(isAdding)
+			.disabled(isAdding || !canAdd)
 			Button("Cancel") { dismiss() }
 				.padding(.bottom)
 		}

--- a/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
+++ b/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
@@ -15,12 +15,18 @@ import OSLog
 enum ShareContactQR {
 	static let urlPrefix = "https://meshtastic.org/v/#"
 
+	/// Whether there is anything worth sharing for this node.
+	///
+	/// Carrying the public key is the point of a shared contact — it is what lets the receiving radio
+	/// direct message the node. A contact with no key is worse than useless: firmware assigns
+	/// `public_key` unconditionally when it applies one, so it clears the key the receiving radio
+	/// already held. We refuse those on import, so we must not hand them out either.
 	static func canShareContact(for node: NodeInfoEntity) -> Bool {
-		node.user?.unmessagable == false
+		node.user?.unmessagable == false && node.user?.publicKey?.isEmpty == false
 	}
 
 	static func canShareContact(for node: NodeInfo) -> Bool {
-		node.hasUser && !node.user.isUnmessagable
+		node.hasUser && !node.user.isUnmessagable && !node.user.publicKey.isEmpty
 	}
 
 	static func urlString(for node: NodeInfo, manuallyVerified: Bool) -> String? {

--- a/MeshtasticTests/AutoFavoriteRuleTests.swift
+++ b/MeshtasticTests/AutoFavoriteRuleTests.swift
@@ -1,0 +1,63 @@
+//
+//  AutoFavoriteRuleTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import Testing
+import Foundation
+@testable import Meshtastic
+
+/// Covers `AutoFavoriteRule` — whether sending a direct message pins the destination in the
+/// radio's node db. Client base is excluded at both ends.
+@Suite("AutoFavoriteRule")
+struct AutoFavoriteRuleTests {
+
+	private let client = Int32(DeviceRoles.client.rawValue)
+	private let clientBase = Int32(DeviceRoles.clientBase.rawValue)
+
+	@Test("favorites an ordinary node from an ordinary node")
+	func favoritesOrdinaryNode() {
+		#expect(AutoFavoriteRule.shouldFavorite(destinationRole: client, connectedRole: .client, isAlreadyFavorite: false))
+	}
+
+	@Test("never favorites when the connected node is a client base")
+	func neverFavoritesFromClientBase() {
+		#expect(!AutoFavoriteRule.shouldFavorite(destinationRole: client, connectedRole: .clientBase, isAlreadyFavorite: false))
+	}
+
+	@Test("never favorites a client base destination")
+	func neverFavoritesClientBaseDestination() {
+		#expect(!AutoFavoriteRule.shouldFavorite(destinationRole: clientBase, connectedRole: .client, isAlreadyFavorite: false))
+	}
+
+	@Test("never favorites client base to client base")
+	func neverFavoritesClientBaseBothEnds() {
+		#expect(!AutoFavoriteRule.shouldFavorite(destinationRole: clientBase, connectedRole: .clientBase, isAlreadyFavorite: false))
+	}
+
+	@Test("skips a node that is already a favorite")
+	func skipsExistingFavorite() {
+		// Nothing to send, and re-sending would put an admin message on the mesh for every message.
+		#expect(!AutoFavoriteRule.shouldFavorite(destinationRole: client, connectedRole: .client, isAlreadyFavorite: true))
+	}
+
+	@Test("favorites when the destination role is unknown")
+	func favoritesUnknownDestinationRole() {
+		// A node we have no device config for is treated as an ordinary contact.
+		#expect(AutoFavoriteRule.shouldFavorite(destinationRole: nil, connectedRole: .client, isAlreadyFavorite: false))
+	}
+
+	@Test("favorites when the connected role is unknown")
+	func favoritesUnknownConnectedRole() {
+		#expect(AutoFavoriteRule.shouldFavorite(destinationRole: client, connectedRole: nil, isAlreadyFavorite: false))
+	}
+
+	@Test("router and repeater destinations are still favorited")
+	func favoritesInfrastructureThatIsNotClientBase() {
+		// Only client base is carved out; the rule must not quietly widen to other roles.
+		#expect(AutoFavoriteRule.shouldFavorite(destinationRole: Int32(DeviceRoles.router.rawValue), connectedRole: .client, isAlreadyFavorite: false))
+		#expect(AutoFavoriteRule.shouldFavorite(destinationRole: Int32(DeviceRoles.repeater.rawValue), connectedRole: .client, isAlreadyFavorite: false))
+	}
+}

--- a/MeshtasticTests/EntityTests.swift
+++ b/MeshtasticTests/EntityTests.swift
@@ -336,6 +336,7 @@ struct ShareContactQRTests {
 		let node = NodeInfoEntity()
 		let user = UserEntity()
 		user.unmessagable = false
+		user.publicKey = Data(repeating: 0x2B, count: 32)
 		node.user = user
 
 		#expect(ShareContactQR.canShareContact(for: node))
@@ -345,6 +346,37 @@ struct ShareContactQRTests {
 
 		node.user = nil
 		#expect(!ShareContactQR.canShareContact(for: node))
+	}
+
+	@Test @MainActor func availabilityRequiresAPublicKey() {
+		// The key is what makes a shared contact worth anything, and firmware assigns public_key
+		// unconditionally when it applies one, so a keyless contact clears the key the receiving radio
+		// already held.
+		let node = NodeInfoEntity()
+		let user = UserEntity()
+		user.unmessagable = false
+		node.user = user
+
+		#expect(!ShareContactQR.canShareContact(for: node))
+
+		user.publicKey = Data()
+		#expect(!ShareContactQR.canShareContact(for: node))
+
+		user.publicKey = Data(repeating: 0x2B, count: 32)
+		#expect(ShareContactQR.canShareContact(for: node))
+	}
+
+	@Test func contactURLUnavailableWithoutAPublicKey() {
+		var user = User()
+		user.id = "!1234abcd"
+		user.longName = "Node Alpha"
+		user.shortName = "ALFA"
+		var node = NodeInfo()
+		node.num = 0x1234_ABCD
+		node.user = user
+
+		#expect(!ShareContactQR.canShareContact(for: node))
+		#expect(ShareContactQR.urlString(for: node, manuallyVerified: true) == nil)
 	}
 
 	@Test @MainActor func nodeProtoPreservesUnmessagableStateForQRAvailability() {

--- a/MeshtasticTests/SharedContactKeyGuardTests.swift
+++ b/MeshtasticTests/SharedContactKeyGuardTests.swift
@@ -1,0 +1,59 @@
+//
+//  SharedContactKeyGuardTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import Testing
+import Foundation
+import MeshtasticProtobufs
+@testable import Meshtastic
+
+/// Covers `SharedContact.carriesPublicKey` — the guard that keeps a keyless contact from reaching
+/// the radio, where it would overwrite the key already in the node db.
+@Suite("SharedContact.carriesPublicKey")
+struct SharedContactKeyGuardTests {
+
+	private func contact(key: Data?) -> SharedContact {
+		var user = User()
+		user.id = "!47ea4b5a"
+		user.longName = "Test Node"
+		user.shortName = "test"
+		if let key { user.publicKey = key }
+
+		var contact = SharedContact()
+		contact.nodeNum = 1_206_537_050
+		contact.user = user
+		return contact
+	}
+
+	@Test("accepts a contact carrying a full key")
+	func acceptsFullKey() {
+		#expect(contact(key: Data(repeating: 0x2B, count: 32)).carriesPublicKey)
+	}
+
+	@Test("refuses a contact whose key field was never set")
+	func refusesUnsetKey() {
+		#expect(!contact(key: nil).carriesPublicKey)
+	}
+
+	@Test("refuses a contact carrying an explicitly empty key")
+	func refusesEmptyKey() {
+		// This is what UserEntity.toProto() produces for a node we hold no key for, and what would
+		// blank the radio's stored key if it were applied.
+		#expect(!contact(key: Data()).carriesPublicKey)
+	}
+
+	@Test("survives a serialize and decode round trip")
+	func survivesRoundTrip() throws {
+		// addContactFromURL decodes from base64 before the guard runs, so the check has to hold on
+		// the decoded value rather than the one we built.
+		let encoded = try contact(key: Data()).serializedData()
+		let decoded = try SharedContact(serializedBytes: encoded)
+		#expect(!decoded.carriesPublicKey)
+
+		let keyed = try contact(key: Data(repeating: 0x2B, count: 32)).serializedData()
+		#expect(try SharedContact(serializedBytes: keyed).carriesPublicKey)
+	}
+}

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -180,6 +180,8 @@ Opening a Meshtastic contact link — by scanning a QR code, tapping a shared li
 
 If the import fails — most often because the radio disconnected — the sheet stays open and shows the reason so you can reconnect and tap **Add Contact** again. It closes only once the contact has actually been sent to your node. A link that is damaged or truncated is reported as an invalid format instead of being imported.
 
+A contact that carries no public key cannot be added. **Add Contact** is disabled and the sheet says the contact does not include one. The key is the point of a shared contact — it is what lets your node send direct messages to that contact — and applying a keyless one would clear the key your node already held, breaking direct messages that used to work. For the same reason, a node you have no public key for cannot be shared from this app.
+
 Importing a contact requires firmware 2.6.9 or later on the connected node.
 
 ### Air Quality


### PR DESCRIPTION
## Summary

Firmware applies `add_contact` through `CopyUserToNodeInfoLite`, which assigns `public_key` unconditionally. A contact carrying no key therefore erases the key the radio already holds for that node, and the next direct message to it fails with `PKI_SEND_FAIL_PUBLIC_KEY` instead of falling back to channel encryption. Firmware has since gained a guard that keeps the stored key, but only builds carrying it are protected.

We had two ways to send one. We push a contact to the radio before every PKI direct message, built from `UserEntity.toProto()`, which emits an empty key when we hold none. And `addContactFromURL` forwarded any scanned, tapped or pasted contact straight through without looking at it.

While in that block, the favoriting next to it turned out not to work.

## What changed

Both contact paths go through `addContactFromURL`, so the check lives there and it now throws rather than sending. The pre-message push checks before calling instead of relying on the throw, since it uses `try?` and would swallow it. The import sheet says the contact has no public key rather than blaming the connection.

Favoriting the destination on send only set the SwiftData flag. Real favoriting goes to the radio as a `setFavoriteNode` admin message, so the radio never learned about it and the next NodeInfo from that node overwrote the flag, which made the star appear and then revert. It also cleared the flag when its check failed, so messaging a client base you had deliberately favorited unfavorited it. And it gated on the destination's role, while the client base guard on the favorite button gates on the connected node's role, which is the end that matters for a client base collecting favorites.

`AutoFavoriteRule` now decides, excluding client base at both ends and skipping nodes already favorited so a message does not put a redundant admin packet on the mesh. When it says yes, the admin message goes first and the local flag is set after it succeeds, matching `FavoriteNodeButton`. Favoriting is never cleared as a side effect of sending a message.

## Notes

Keyless contacts are refused outright rather than only when they would overwrite something. Firmware can be smarter here because it knows its own node db; from the app we do not, and a keyless node cannot take a direct message anyway. The cost is that a genuinely keyless contact can no longer be imported.

Android does not gate favoriting and the contact push the same way we do, which is raised as an open question in [design#145](https://github.com/meshtastic/design/issues/145) rather than settled here.

## Testing

- Built for the iOS Simulator and for device.
- `SharedContact.carriesPublicKey` and `AutoFavoriteRule` suites, 12 tests, all passing.
- Run on device alongside #2417. Exchange User Info on a node we held no key for brought its NodeInfo in and the direct message then went through in both directions.
- Not exercised on device: importing a keyless contact, since producing one takes a hand-built URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards to prevent importing contacts without public keys.
  * Added automatic favorite handling for eligible direct-message contacts.
  * Favorite status is now synchronized with the connected radio.

* **Bug Fixes**
  * Prevented empty keys from overwriting valid keys stored on the radio.
  * Added clearer validation feedback and disabled contact addition when required key information is missing.

* **Tests**
  * Added coverage for public-key validation, key preservation, and automatic favorite rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->