### PR TITLE
Share the connected node's contact QR from Connect

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -290,8 +290,12 @@ struct Connect: View {
 									if ShareContactQR.canShareContact(for: node) {
 										Button {
 											// Same liveness re-check as Power Off below: the node captured
-											// when the menu opened can fault before the tap lands.
-											guard let live = Connect.liveNode(node) else { return }
+											// when the menu opened can fault before the tap lands. Share
+											// eligibility is re-checked too — the menu condition ran when the
+											// menu was built, and a node that loses its key or turns
+											// unmessagable in between would produce a QR of an empty string.
+											guard let live = Connect.liveNode(node),
+												  ShareContactQR.canShareContact(for: live) else { return }
 											shareContactNode = live.toProto()
 											showingShareContactQR = true
 										} label: {

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -10,6 +10,7 @@ import MapKit
 @preconcurrency import SwiftData
 import CoreLocation
 import CoreBluetooth
+import MeshtasticProtobufs
 import OSLog
 import TipKit
 #if canImport(ActivityKit)
@@ -43,6 +44,11 @@ struct Connect: View {
 	@State private var pendingNymeaDevice: NymeaDiscoveredDevice?
 	@State private var isSwitchingRadio = false
 	@State private var showingShutdownConfirm = false
+	@State private var showingShareContactQR = false
+	/// The connected node as a plain protobuf value, copied when the share menu item is tapped.
+	/// The sheet outlives the row it was opened from, and reading a faulted @Model after a
+	/// reconnect traps, so nothing SwiftData-backed is held here.
+	@State private var shareContactNode: NodeInfo?
 	/// Stable identity of the node whose context menu opened the shutdown dialog, captured at tap
 	/// time so the confirmation can't drift to a different node if the connection changes first.
 	@State private var pendingShutdownNodeNum: Int64?
@@ -281,6 +287,17 @@ struct Connect: View {
 										}
 									}
 #endif
+									if ShareContactQR.canShareContact(for: node) {
+										Button {
+											// Same liveness re-check as Power Off below: the node captured
+											// when the menu opened can fault before the tap lands.
+											guard let live = Connect.liveNode(node) else { return }
+											shareContactNode = live.toProto()
+											showingShareContactQR = true
+										} label: {
+											Label("Share Contact QR", systemImage: "qrcode")
+										}
+									}
 									if accessoryManager.allowDisconnect {
 										Button(role: .destructive) {
 											if accessoryManager.allowDisconnect {
@@ -538,6 +555,15 @@ struct Connect: View {
 							Logger.mesh.error("Shutdown Failed: \(error)")
 						}
 					}
+				}
+			}
+			// Attached here for the same reason as the dialog above: the connected-device
+			// row unmounts on disconnect, which would tear the sheet down with it.
+			.sheet(isPresented: $showingShareContactQR) {
+				if let shareContactNode {
+					// This menu only ever shows on the connected radio, which is verified by
+					// definition.
+					ShareContactQRDialog(manuallyVerified: true, node: shareContactNode)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Sharing your own contact meant going to the node list or node detail first. The Connect screen already shows the connected radio, so the action belongs in its long-press menu too.

## What changed

Added **Share Contact QR** to the context menu on the connected device row in Connect, between Mesh Live Activity and Disconnect. It presents the existing `ShareContactQRDialog`; no new QR code, sharing or URL work.

The item is hidden when `ShareContactQR.canShareContact` says no, the same gate the other share entry points use.

Two details that follow this file's existing conventions rather than the node list's:

- The node is copied to a plain protobuf at tap time via `toProto()`, behind the same `Connect.liveNode` liveness check the Power Off action uses. Connect holds `node` across disconnects, and reading a faulted `@Model` traps.
- The sheet hangs off the root `VStack` next to the shutdown dialog, not off the row, because the connected-device row unmounts on disconnect and would take a row-attached sheet with it.

`manuallyVerified` is true: this menu only appears on the connected radio, so it is your own contact, which matches what node detail computes and what Tools already passes.

The Catalyst manual-connection menu further down is left alone. Its subject is a transport entry with no user record or key, so there is nothing to put in a `SharedContact`.

## Testing

- Built for the iOS Simulator.
- `ShareContactURLTests` (6 functions, 17 parameterized cases) and `ShareContactQRTests` (9 tests), all passing.
- Not yet exercised on device.

## Note

Rebased onto main after [#2422](https://github.com/meshtastic/Meshtastic-Apple/pull/2422), which added the public key requirement to `canShareContact`. This entry point inherits it, so it will not generate a QR for a node with an empty key.