### PR TITLE
Key database backups by device id instead of node number

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+FromRadio.swift
@@ -197,9 +197,20 @@ extension AccessoryManager {
 		// connecting one. A backup restored for this radio always contains its own MyInfo row,
 		// so a legitimate switch+restore never trips this — including legacy backups that may
 		// carry extra foreign rows from the pre-fix bleed era.
-		await defensiveResetIfForeignDatabase(incomingNodeNum: Int64(myNodeInfo.myNodeNum))
+		await defensiveResetIfForeignDatabase(
+			incomingNodeNum: Int64(myNodeInfo.myNodeNum),
+			incomingDeviceId: myNodeInfo.deviceID
+		)
 
 		let myInfoId = await MeshPackets.shared.myInfoPacket(myInfo: myNodeInfo, peripheralId: connectedDeviceId)
+
+		// Move this radio's backup onto its device id if it is still filed under a node number, and
+		// collapse anything left behind by earlier renumbers. Cheap after the first connect.
+		await NodeBackupManager.shared.adoptLegacyBackups(
+			deviceId: myNodeInfo.deviceID,
+			nodeNum: Int64(myNodeInfo.myNodeNum),
+			peripheralId: connectedDeviceId
+		)
 
 		// Resolve on a throwaway context, NOT the long-lived main context. After a database clear
 		// (manual reset, or the clear inside a device switch) the main context can still hold an
@@ -241,7 +252,7 @@ extension AccessoryManager {
 	/// so nothing is lost, clear the store, repoint the container, and refresh the UI. See the
 	/// call site in `handleMyInfo` for when this can happen. No-ops for a fresh install (no
 	/// MyInfo rows) and for reconnects/restores (a MyInfo row for the incoming node exists).
-	private func defensiveResetIfForeignDatabase(incomingNodeNum: Int64) async {
+	private func defensiveResetIfForeignDatabase(incomingNodeNum: Int64, incomingDeviceId: Data) async {
 		// Fresh throwaway context: no stale registrations, and this runs before any ingest for
 		// the new radio, so what it sees is exactly what the previous session left behind.
 		let checkContext = ModelContext(context.container)
@@ -254,12 +265,21 @@ extension AccessoryManager {
 		}
 
 		// Same radio, new number. A firmware upgrade to 2.8 changes the node number a radio
-		// reports, and everything the app stored is keyed to the old one. The MyInfo row records
-		// the peripheral it came from, so a match means this is that radio under a new number
-		// rather than a different radio — renumber the store instead of throwing it away.
+		// reports, and everything the app stored is keyed to the old one. A match means this is that
+		// radio under a new number rather than a different radio — renumber the store instead of
+		// throwing it away.
+		//
+		// device_id is the radio's own hardware identifier, so it holds over TCP and serial where
+		// there is no BLE identifier, and it survives a re-pair. The MyInfo row also records the
+		// peripheral it came from, which is the fallback for radios that report no device id.
+		if !incomingDeviceId.isEmpty,
+		   let sameRadio = myInfos.first(where: { $0.deviceId == incomingDeviceId }) {
+			await renumberStore(from: sameRadio.myNodeNum, to: incomingNodeNum, deviceId: incomingDeviceId)
+			return
+		}
 		if let connectedDeviceId = activeConnection?.device.id.uuidString,
 		   let sameRadio = myInfos.first(where: { $0.peripheralId == connectedDeviceId }) {
-			await renumberStore(from: sameRadio.myNodeNum, to: incomingNodeNum)
+			await renumberStore(from: sameRadio.myNodeNum, to: incomingNodeNum, deviceId: incomingDeviceId)
 			return
 		}
 
@@ -270,7 +290,13 @@ extension AccessoryManager {
 		await MeshPackets.shared.flushDebouncedSaves()
 		if let previousNum = nums.first {
 			let previousName = devices.first(where: { $0.num == previousNum })?.longName
-			_ = await NodeBackupManager.shared.createBackup(forNode: previousNum, nodeName: previousName)
+			// The outgoing radio's own device id, not the one now connected.
+			let previousDeviceId = myInfos.first(where: { $0.myNodeNum == previousNum })?.deviceId
+			_ = await NodeBackupManager.shared.createBackup(
+				forNode: previousNum,
+				deviceId: previousDeviceId,
+				nodeName: previousName
+			)
 		}
 
 		let cleared = await MeshPackets.shared.clearDatabase(includeRoutes: false)
@@ -288,14 +314,15 @@ extension AccessoryManager {
 	/// Rewrites the store from the node number this radio used to report to the one it reports
 	/// now. Runs before any data for the new number is ingested, so what it rewrites is exactly
 	/// what the previous session left behind.
-	private func renumberStore(from oldNum: Int64, to newNum: Int64) async {
+	private func renumberStore(from oldNum: Int64, to newNum: Int64, deviceId: Data) async {
 		Logger.data.warning("💾 [Database] Node \(oldNum.toHex(), privacy: .public) now reports \(newNum.toHex(), privacy: .public) — same radio, renumbering the store")
 
 		// The backup is the safety net if the rewrite goes wrong, so flush first — it copies the
 		// store files, and anything still waiting on a debounced save would not be in them yet.
 		await MeshPackets.shared.flushDebouncedSaves()
 		let previousName = devices.first(where: { $0.num == oldNum })?.longName
-		_ = await NodeBackupManager.shared.createBackup(forNode: oldNum, nodeName: previousName)
+		// Same physical radio either side of the renumber, so the backup keys on the id it reports now.
+		_ = await NodeBackupManager.shared.createBackup(forNode: oldNum, deviceId: deviceId, nodeName: previousName)
 
 		// Detail views bound to the old node have to unmount before its identity changes
 		// underneath them, the same reason the reset path pops first.

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -1241,6 +1241,16 @@ extension AccessoryManager {
 		return activeConnection?.device.firmwareVersion
 	}
 
+	/// The connected radio's `MyNodeInfo.device_id`, which is what backups are keyed on. Nil before
+	/// MyInfo lands, and for a radio whose firmware reports none.
+	var connectedDeviceId: Data? {
+		guard let connectedNodeNum = activeDeviceNum else { return nil }
+		let descriptor = FetchDescriptor<MyInfoEntity>(
+			predicate: #Predicate { $0.myNodeNum == connectedNodeNum }
+		)
+		return try? context.fetch(descriptor).first?.deviceId
+	}
+
 	var connectedDeviceRole: DeviceRoles? {
 		guard let connectedNodeNum = activeDeviceNum else { return nil }
 		guard let connectedNode = getNodeInfo(id: connectedNodeNum, context: context) else { return nil }

--- a/Meshtastic/Helpers/MeshPackets.swift
+++ b/Meshtastic/Helpers/MeshPackets.swift
@@ -742,6 +742,12 @@ actor MeshPackets {
 				if !myInfo.pioEnv.isEmpty {
 					fetchedMyInfo[0].pioEnv = myInfo.pioEnv
 				}
+				// Only set on insert before, so a row first written when the radio reported no device
+				// id never gained one. Backups key on this. Guarded like pioEnv: an empty value never
+				// clears a stored one.
+				if !myInfo.deviceID.isEmpty {
+					fetchedMyInfo[0].deviceId = myInfo.deviceID
+				}
 
 				Logger.data.info("💾 Updated myInfo for node: \(myInfo.myNodeNum.toHex(), privacy: .public)")
 				savePendingChanges()

--- a/Meshtastic/Persistence/BackupModels.swift
+++ b/Meshtastic/Persistence/BackupModels.swift
@@ -30,8 +30,12 @@ enum BackupKey {
 	}
 
 	/// Whether this key is still waiting to be re-keyed to a device id.
+	///
+	/// The suffix has to parse as a node number. The backup folder is visible in Files, so anything
+	/// the user drops in there could otherwise look like one of ours and be swept as an orphan.
 	static func isNodeNumberKey(_ key: String) -> Bool {
-		key.hasPrefix(nodeNumberPrefix)
+		guard key.hasPrefix(nodeNumberPrefix) else { return false }
+		return Int64(key.dropFirst(nodeNumberPrefix.count)) != nil
 	}
 }
 

--- a/Meshtastic/Persistence/BackupModels.swift
+++ b/Meshtastic/Persistence/BackupModels.swift
@@ -7,10 +7,41 @@
 
 import Foundation
 
+/// Identifies a backup, both as its index key and as its directory name.
+///
+/// Node numbers change when a radio upgrades to 2.8, so they cannot key a backup that has to survive
+/// the upgrade — each renumber orphans the previous backup and starts a new one. `MyNodeInfo.device_id`
+/// is the radio's hardware identifier and does not change, so it is the key wherever we have one. A
+/// radio that reports no device id keeps the old node-number key and behaves as it always has.
+enum BackupKey {
+	/// Marks a key that is still a node number, so the two forms can be told apart on sight and in
+	/// the backup folder listing.
+	static let nodeNumberPrefix = "node-"
+
+	/// The key for a radio that reported a device id. Nil for an empty id, which is what firmware
+	/// sends when it has none, so callers fall through to `forNode`.
+	static func forDevice(_ deviceId: Data?) -> String? {
+		guard let deviceId, !deviceId.isEmpty else { return nil }
+		return deviceId.map { String(format: "%02x", $0) }.joined()
+	}
+
+	static func forNode(_ nodeNum: Int64) -> String {
+		"\(nodeNumberPrefix)\(nodeNum)"
+	}
+
+	/// Whether this key is still waiting to be re-keyed to a device id.
+	static func isNodeNumberKey(_ key: String) -> Bool {
+		key.hasPrefix(nodeNumberPrefix)
+	}
+}
+
 /// Represents a single node's backup snapshot metadata.
 struct BackupEntry: Codable, Sendable {
 	/// Unique node identifier (from `NodeInfoEntity.num`)
 	let nodeNum: Int64
+	/// Lowercase hex of the radio's `MyNodeInfo.device_id`, once we have connected to it and learned
+	/// one. Nil for backups taken before this was recorded, and for radios that report no device id.
+	var deviceId: String?
 	/// Human-readable node display name at time of backup
 	var nodeName: String?
 	/// Timestamp when backup was created
@@ -21,16 +52,48 @@ struct BackupEntry: Codable, Sendable {
 	var checksum: String
 	/// Relative path from `NodeBackups/` to backup directory
 	var backupPath: String
+
+	/// Where this entry belongs in the index.
+	var key: String {
+		deviceId ?? BackupKey.forNode(nodeNum)
+	}
 }
 
 /// Top-level container for all backup metadata, stored as JSON.
 struct BackupIndex: Codable, Sendable {
+	/// Version 1 keyed entries by node number. Version 2 keys them by device id where one is known,
+	/// and by node number otherwise, so the two forms coexist for as long as it takes to reconnect to
+	/// every radio.
+	static let currentVersion = 2
+
 	/// Schema version of the index format
-	var version: Int = 1
-	/// Map of node number to backup metadata
-	var entries: [Int64: BackupEntry] = [:]
+	var version: Int = currentVersion
+	/// Map of backup key to metadata. Treat the key as opaque; use `BackupKey` to build one.
+	var entries: [String: BackupEntry] = [:]
 	/// Timestamp of last index modification
 	var lastModified: Date = .now
+
+	init() {}
+
+	init(from decoder: any Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		lastModified = try container.decodeIfPresent(Date.self, forKey: .lastModified) ?? .now
+
+		if let keyed = try? container.decode([String: BackupEntry].self, forKey: .entries) {
+			entries = keyed
+		} else {
+			// Version 1. A dictionary with a non-String key encodes as a flat [key, value, key, value]
+			// array rather than an object, so it has to be decoded in that shape before re-keying.
+			// This is the whole of the format migration: no files are opened, renamed or deleted.
+			// Entries move to their device id later, one radio at a time, as each is reconnected.
+			let legacy = try container.decode([Int64: BackupEntry].self, forKey: .entries)
+			entries = Dictionary(
+				uniqueKeysWithValues: legacy.map { (BackupKey.forNode($0.key), $0.value) }
+			)
+		}
+
+		version = Self.currentVersion
+	}
 }
 
 /// Represents the outcome of a backup or restore operation.

--- a/Meshtastic/Persistence/NodeBackupManager.swift
+++ b/Meshtastic/Persistence/NodeBackupManager.swift
@@ -569,8 +569,16 @@ final class NodeBackupManager: NodeBackupManaging {
 	/// reading them, so that only runs when the cheap match fails.
 	func adoptLegacyBackups(deviceId: Data?, nodeNum: Int64, peripheralId: String?) async {
 		guard let deviceKey = BackupKey.forDevice(deviceId) else { return }
-		// Already re-keyed. This is the common path on every connect after the first.
-		guard backupIndex.entries[deviceKey] == nil else { return }
+		// Already re-keyed — the common path on every connect after the first. Still worth looking for
+		// a node-number entry for the same radio: a backup taken while the device id lookup was
+		// coming back nil left one sitting beside the device-keyed backup. Clearing it here means a
+		// connect is enough to tidy up, rather than waiting for whatever takes the next backup.
+		if backupIndex.entries[deviceKey] != nil {
+			if removeBackup(forKey: BackupKey.forNode(nodeNum), reason: "duplicate of \(deviceKey)") {
+				saveIndex()
+			}
+			return
+		}
 
 		var candidateKeys: [String] = []
 		let nodeKey = BackupKey.forNode(nodeNum)

--- a/Meshtastic/Persistence/NodeBackupManager.swift
+++ b/Meshtastic/Persistence/NodeBackupManager.swift
@@ -146,7 +146,7 @@ final class NodeBackupManager: NodeBackupManaging {
 	private func validateIndexConsistency() {
 		var modified = false
 		for (key, entry) in backupIndex.entries {
-			let nodeDir = backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
+			guard let nodeDir = backupDirectory(for: entry) else { continue }
 			let sqliteFile = nodeDir.appendingPathComponent(Self.storeFileName)
 			if !fileManager.fileExists(atPath: sqliteFile.path) {
 				Logger.backup.warning("Orphaned index entry for \(key, privacy: .public) — backup file missing, removing entry")
@@ -188,6 +188,27 @@ final class NodeBackupManager: NodeBackupManaging {
 	}
 
 	// MARK: - T006: SHA-256 Checksum
+
+	/// The directory an entry lives in, or nil when its recorded path is not a plain folder name.
+	///
+	/// `backup-index.json` sits in Documents and is visible in Files, so a hand-edited `backupPath`
+	/// could carry `..` components or an absolute path, and every delete, move and read here would
+	/// follow it out of the backup folder. Paths we write are always a single component.
+	private func backupDirectory(for entry: BackupEntry) -> URL? {
+		guard Self.isPlainBackupPath(entry.backupPath) else {
+			Logger.backup.error("Refusing to use backup path \(entry.backupPath, privacy: .public) — not a plain folder name")
+			return nil
+		}
+		return backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
+	}
+
+	nonisolated static func isPlainBackupPath(_ path: String) -> Bool {
+		!path.isEmpty
+		&& path != "."
+		&& path != ".."
+		&& !path.contains("/")
+		&& !path.contains("\\")
+	}
 
 	/// Computes SHA-256 checksum of the file at the given URL.
 	private func computeChecksum(for fileURL: URL) async throws -> String {
@@ -248,7 +269,12 @@ final class NodeBackupManager: NodeBackupManaging {
 	}
 
 	private func performBackup(forNode nodeNum: Int64, deviceId: Data?, nodeName: String?) async throws -> BackupEntry {
+		// Fall back to the device id already recorded for this node. Callers resolve it from the
+		// store, which can come back nil part way through a connect or a radio switch, and minting a
+		// node-number key then would sit a second backup beside the device-keyed one for the same
+		// radio — which is exactly what happened on my phone before this.
 		let deviceKey = BackupKey.forDevice(deviceId)
+			?? backupIndex.entries.values.first { $0.nodeNum == nodeNum }?.deviceId
 		let nodeDirName = deviceKey ?? BackupKey.forNode(nodeNum)
 		let nodeBackupDir = backupBaseURL.appendingPathComponent(nodeDirName, isDirectory: true)
 
@@ -419,8 +445,9 @@ final class NodeBackupManager: NodeBackupManaging {
 			.prefix(max(0, backupIndex.entries.count - Self.maximumBackupCount))
 
 		for (overflowKey, entry) in overflow {
-			let nodeBackupDir = backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
-			try? fileManager.removeItem(at: nodeBackupDir)
+			if let nodeBackupDir = backupDirectory(for: entry) {
+				try? fileManager.removeItem(at: nodeBackupDir)
+			}
 			backupIndex.entries.removeValue(forKey: overflowKey)
 			Logger.backup.info("Pruned oldest backup for node \(entry.nodeNum) to enforce limit of \(Self.maximumBackupCount)")
 		}
@@ -430,8 +457,9 @@ final class NodeBackupManager: NodeBackupManaging {
 	@discardableResult
 	private func removeBackup(forKey key: String, reason: String) -> Bool {
 		guard let entry = backupIndex.entries[key] else { return false }
-		let dir = backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
-		try? fileManager.removeItem(at: dir)
+		if let dir = backupDirectory(for: entry) {
+			try? fileManager.removeItem(at: dir)
+		}
 		backupIndex.entries.removeValue(forKey: key)
 		Logger.backup.info("Removed backup for node \(entry.nodeNum) (\(entry.fileSize) bytes): \(reason, privacy: .public)")
 		return true
@@ -560,20 +588,19 @@ final class NodeBackupManager: NodeBackupManaging {
 			return
 		}
 
-		for (key, _) in candidates where key != survivingKey {
-			removeBackup(forKey: key, reason: "duplicate of \(deviceKey) from an earlier node number")
-		}
-
-		let oldDir = backupBaseURL.appendingPathComponent(surviving.backupPath, isDirectory: true)
+		guard let oldDir = backupDirectory(for: surviving) else { return }
 		let newDir = backupBaseURL.appendingPathComponent(deviceKey, isDirectory: true)
 		if fileManager.fileExists(atPath: newDir.path) {
 			try? fileManager.removeItem(at: newDir)
 		}
+
+		// The survivor moves first. Deleting the duplicates before this meant a transient move
+		// failure destroyed them and re-keyed nothing, turning a retryable hiccup into permanent
+		// backup loss. Nothing is deleted until the one we are keeping is safely in place.
 		do {
 			try fileManager.moveItem(at: oldDir, to: newDir)
 		} catch {
-			Logger.backup.error("Could not move backup \(survivingKey, privacy: .public) to its device id: \(error.localizedDescription, privacy: .public)")
-			saveIndex()
+			Logger.backup.error("Could not move backup \(survivingKey, privacy: .public) to its device id, leaving it and its duplicates alone: \(error.localizedDescription, privacy: .public)")
 			return
 		}
 
@@ -582,6 +609,10 @@ final class NodeBackupManager: NodeBackupManaging {
 		adopted.backupPath = deviceKey
 		backupIndex.entries.removeValue(forKey: survivingKey)
 		backupIndex.entries[deviceKey] = adopted
+
+		for (key, _) in candidates where key != survivingKey {
+			removeBackup(forKey: key, reason: "duplicate of \(deviceKey) from an earlier node number")
+		}
 		saveIndex()
 
 		Logger.backup.info("Re-keyed the backup for node \(surviving.nodeNum) onto its device id, dropping \(candidates.count - 1) duplicate(s)")

--- a/Meshtastic/Persistence/NodeBackupManager.swift
+++ b/Meshtastic/Persistence/NodeBackupManager.swift
@@ -28,7 +28,7 @@ final class NodeBackupManager: NodeBackupManaging {
 	private static let storeFileName = "Meshtastic.store"
 	private static let walFileName = "Meshtastic.store-wal"
 	private static let shmFileName = "Meshtastic.store-shm"
-	private static let maximumBackupCount = 50
+	private static let maximumBackupCount = 100
 	/// Minimum free disk space required for backup (50 MB)
 	private static let minimumFreeDiskSpace: Int64 = 50 * 1024 * 1024
 
@@ -145,25 +145,28 @@ final class NodeBackupManager: NodeBackupManaging {
 	/// Validates backup index consistency on launch. Removes entries for orphaned or missing files.
 	private func validateIndexConsistency() {
 		var modified = false
-		for (nodeNum, entry) in backupIndex.entries {
+		for (key, entry) in backupIndex.entries {
 			let nodeDir = backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
 			let sqliteFile = nodeDir.appendingPathComponent(Self.storeFileName)
 			if !fileManager.fileExists(atPath: sqliteFile.path) {
-				Logger.backup.warning("Orphaned index entry for node \(nodeNum) — backup file missing, removing entry")
-				backupIndex.entries.removeValue(forKey: nodeNum)
+				Logger.backup.warning("Orphaned index entry for \(key, privacy: .public) — backup file missing, removing entry")
+				backupIndex.entries.removeValue(forKey: key)
 				modified = true
 			}
 		}
 
-		// Check for orphaned directories without index entries
+		// Check for orphaned directories without index entries. Match on the paths the index actually
+		// references rather than on the directory name: names are node numbers on older installs and
+		// device ids once a radio has been reconnected, and parsing them would delete every re-keyed
+		// directory the first time this ran.
+		let referencedPaths = Set(backupIndex.entries.values.map(\.backupPath))
 		if let contents = try? fileManager.contentsOfDirectory(at: backupBaseURL, includingPropertiesForKeys: nil) {
 			for item in contents {
 				let name = item.lastPathComponent
 				// Skip index file
 				if name == Self.indexFileName { continue }
-				// If it's a directory with a numeric name but no index entry, clean it up
-				if let nodeNum = Int64(name), backupIndex.entries[nodeNum] == nil {
-					Logger.backup.warning("Orphaned backup directory for node \(nodeNum) — removing")
+				if !referencedPaths.contains(name), Self.isBackupDirectoryName(name) {
+					Logger.backup.warning("Orphaned backup directory \(name, privacy: .public) — removing")
 					try? fileManager.removeItem(at: item)
 					modified = true
 				}
@@ -173,6 +176,15 @@ final class NodeBackupManager: NodeBackupManaging {
 		if modified {
 			saveIndex()
 		}
+	}
+
+	/// Whether a directory in the backup folder is one of ours, so the orphan sweep leaves anything
+	/// else alone. Covers the bare node numbers written before this change, the `node-` form, and a
+	/// device id.
+	private static func isBackupDirectoryName(_ name: String) -> Bool {
+		if Int64(name) != nil { return true }
+		if BackupKey.isNodeNumberKey(name) { return true }
+		return name.count == 32 && name.allSatisfy { $0.isHexDigit && !$0.isUppercase }
 	}
 
 	// MARK: - T006: SHA-256 Checksum
@@ -204,7 +216,10 @@ final class NodeBackupManager: NodeBackupManaging {
 
 	// MARK: - T007: Create Backup
 
-	func createBackup(forNode nodeNum: Int64, nodeName: String?) async -> NodeBackupResult {
+	/// - Parameter deviceId: The radio's `MyNodeInfo.device_id`, which keys the backup. Node numbers
+	///   change when a radio upgrades to 2.8, so a backup keyed on one is orphaned by the upgrade.
+	///   Pass nil for a radio that reports none and the backup keeps the old node-number key.
+	func createBackup(forNode nodeNum: Int64, deviceId: Data?, nodeName: String?) async -> NodeBackupResult {
 		Logger.backup.info("Creating backup for node \(nodeNum)")
 
 		// T026: Check disk space
@@ -216,7 +231,7 @@ final class NodeBackupManager: NodeBackupManaging {
 		// Retry-once logic (FR-004)
 		for attempt in 1...2 {
 			do {
-				let entry = try await performBackup(forNode: nodeNum, nodeName: nodeName)
+				let entry = try await performBackup(forNode: nodeNum, deviceId: deviceId, nodeName: nodeName)
 				Logger.backup.info("Backup created for node \(nodeNum): \(entry.fileSize) bytes, checksum: \(entry.checksum, privacy: .public)")
 				return .success(entry)
 			} catch {
@@ -232,8 +247,9 @@ final class NodeBackupManager: NodeBackupManaging {
 		return .skipped(reason: "Backup failed unexpectedly")
 	}
 
-	private func performBackup(forNode nodeNum: Int64, nodeName: String?) async throws -> BackupEntry {
-		let nodeDirName = "\(nodeNum)"
+	private func performBackup(forNode nodeNum: Int64, deviceId: Data?, nodeName: String?) async throws -> BackupEntry {
+		let deviceKey = BackupKey.forDevice(deviceId)
+		let nodeDirName = deviceKey ?? BackupKey.forNode(nodeNum)
 		let nodeBackupDir = backupBaseURL.appendingPathComponent(nodeDirName, isDirectory: true)
 
 		// Create or clean destination directory
@@ -286,14 +302,23 @@ final class NodeBackupManager: NodeBackupManaging {
 		// Update index
 		let entry = BackupEntry(
 			nodeNum: nodeNum,
+			deviceId: deviceKey,
 			nodeName: nodeName,
 			createdAt: .now,
 			fileSize: fileSize,
 			checksum: checksum,
 			backupPath: nodeDirName
 		)
-		backupIndex.entries[nodeNum] = entry
-		enforceBackupLimit(keeping: nodeNum)
+		backupIndex.entries[nodeDirName] = entry
+
+		// A radio backed up under its node number before we knew its device id leaves an entry behind
+		// once it is keyed by device. Drop it here so the same radio is not listed twice; anything
+		// filed under an *earlier* node number is cleaned up by adoptLegacyBackups on connect.
+		if deviceKey != nil {
+			removeBackup(forKey: BackupKey.forNode(nodeNum), reason: "superseded by the device id backup")
+		}
+
+		enforceBackupLimit(keeping: nodeDirName)
 		saveIndex()
 		scheduleBackupCompaction(for: entry)
 
@@ -305,10 +330,10 @@ final class NodeBackupManager: NodeBackupManaging {
 			do {
 				let compactedEntry = try Self.compactBackupSnapshot(entry, backupBaseURL: backupBaseURL)
 				await MainActor.run {
-					guard self.backupIndex.entries[entry.nodeNum]?.createdAt == entry.createdAt else {
+					guard self.backupIndex.entries[entry.key]?.createdAt == entry.createdAt else {
 						return
 					}
-					self.backupIndex.entries[entry.nodeNum] = compactedEntry
+					self.backupIndex.entries[entry.key] = compactedEntry
 					self.saveIndex()
 					Logger.backup.info("Compacted backup for node \(entry.nodeNum) to \(compactedEntry.fileSize) bytes")
 				}
@@ -385,30 +410,92 @@ final class NodeBackupManager: NodeBackupManaging {
 		return digest.map { String(format: "%02x", $0) }.joined()
 	}
 
-	private func enforceBackupLimit(keeping nodeNum: Int64) {
+	private func enforceBackupLimit(keeping key: String) {
 		guard backupIndex.entries.count > Self.maximumBackupCount else { return }
 
-		let overflowEntries = backupIndex.entries.values
-			.filter { $0.nodeNum != nodeNum }
-			.sorted { $0.createdAt < $1.createdAt }
+		let overflow = backupIndex.entries
+			.filter { $0.key != key }
+			.sorted { $0.value.createdAt < $1.value.createdAt }
 			.prefix(max(0, backupIndex.entries.count - Self.maximumBackupCount))
 
-		for entry in overflowEntries {
+		for (overflowKey, entry) in overflow {
 			let nodeBackupDir = backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
 			try? fileManager.removeItem(at: nodeBackupDir)
-			backupIndex.entries.removeValue(forKey: entry.nodeNum)
+			backupIndex.entries.removeValue(forKey: overflowKey)
 			Logger.backup.info("Pruned oldest backup for node \(entry.nodeNum) to enforce limit of \(Self.maximumBackupCount)")
 		}
+	}
+
+	/// Deletes a backup's directory and its index entry. Returns whether there was one to remove.
+	@discardableResult
+	private func removeBackup(forKey key: String, reason: String) -> Bool {
+		guard let entry = backupIndex.entries[key] else { return false }
+		let dir = backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
+		try? fileManager.removeItem(at: dir)
+		backupIndex.entries.removeValue(forKey: key)
+		Logger.backup.info("Removed backup for node \(entry.nodeNum) (\(entry.fileSize) bytes): \(reason, privacy: .public)")
+		return true
 	}
 
 	// MARK: - T009: Query Methods
 
 	func hasBackup(forNode nodeNum: Int64) -> Bool {
-		backupIndex.entries[nodeNum] != nil
+		// The caller knows a node number, which may be keyed either way depending on whether we have
+		// connected to that radio since it started reporting a device id.
+		backupIndex.entries.values.contains { $0.nodeNum == nodeNum }
 	}
 
 	func listBackups() -> [BackupEntry] {
 		Array(backupIndex.entries.values).sorted { $0.createdAt > $1.createdAt }
+	}
+
+	/// Whether a backup belongs to the given peripheral, read from the backup itself.
+	///
+	/// Staged copy: a pending schema migration cannot run on a read-only store, and the backup itself
+	/// must never be mutated. See `stagedBackupContainer` (staging dirs are swept at launch, never
+	/// removed while live).
+	nonisolated private static func backupBelongs(
+		to peripheralId: String,
+		storeURL: URL,
+		schema: Schema
+	) throws -> Int64? {
+		let backupContainer = try stagedBackupContainer(for: storeURL, schema: schema)
+		let backupContext = ModelContext(backupContainer)
+		backupContext.autosaveEnabled = false
+
+		let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.peripheralId == peripheralId })
+		return try backupContext.fetch(descriptor).first?.myNodeNum
+	}
+
+	/// Index keys whose backup was taken from the given peripheral. Only searches entries still keyed
+	/// by node number, since anything already keyed by device id has been identified.
+	private func legacyKeys(forPeripheralId peripheralId: String) async -> [String] {
+		let candidates = backupIndex.entries
+			.filter { BackupKey.isNodeNumberKey($0.key) }
+			.map { ($0.key, $0.value.backupPath) }
+		guard !candidates.isEmpty else { return [] }
+
+		let baseURL = backupBaseURL
+		return await Task.detached(priority: .userInitiated) {
+			let fileManager = FileManager.default
+			let schema = Schema(versionedSchema: MeshtasticSchema.current)
+			var matches: [String] = []
+
+			for (key, backupPath) in candidates {
+				let storeURL = baseURL
+					.appendingPathComponent(backupPath, isDirectory: true)
+					.appendingPathComponent(Self.storeFileName)
+				guard fileManager.fileExists(atPath: storeURL.path) else { continue }
+				do {
+					if try Self.backupBelongs(to: peripheralId, storeURL: storeURL, schema: schema) != nil {
+						matches.append(key)
+					}
+				} catch {
+					Logger.backup.warning("Could not read backup \(key, privacy: .public) while matching a peripheral: \(error.localizedDescription, privacy: .public)")
+				}
+			}
+			return matches
+		}.value
 	}
 
 	/// Resolves a node number for a device peripheral identifier by inspecting existing backups.
@@ -417,49 +504,93 @@ final class NodeBackupManager: NodeBackupManaging {
 		let entries = listBackups()
 		guard !entries.isEmpty else { return nil }
 
-		do {
-			return try await Task.detached(priority: .userInitiated) {
-				let fileManager = FileManager.default
-				let schema = Schema(versionedSchema: MeshtasticSchema.current)
+		let baseURL = backupBaseURL
+		return await Task.detached(priority: .userInitiated) {
+			let fileManager = FileManager.default
+			let schema = Schema(versionedSchema: MeshtasticSchema.current)
 
-				for entry in entries {
-					let nodeBackupDir = self.backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
-					let backupStoreURL = nodeBackupDir.appendingPathComponent(Self.storeFileName)
-					guard fileManager.fileExists(atPath: backupStoreURL.path) else { continue }
-
-					// Staged copy: a pending schema migration cannot run on a read-only store,
-					// and the backup itself must never be mutated. See stagedBackupContainer
-					// (staging dirs are swept at launch, never removed while live).
-					let backupContainer = try Self.stagedBackupContainer(for: backupStoreURL, schema: schema)
-					let backupContext = ModelContext(backupContainer)
-					backupContext.autosaveEnabled = false
-
-					let descriptor = FetchDescriptor<MyInfoEntity>(predicate: #Predicate { $0.peripheralId == peripheralId })
-					if let myInfo = try backupContext.fetch(descriptor).first {
-						return myInfo.myNodeNum
+			for entry in entries {
+				let storeURL = baseURL
+					.appendingPathComponent(entry.backupPath, isDirectory: true)
+					.appendingPathComponent(Self.storeFileName)
+				guard fileManager.fileExists(atPath: storeURL.path) else { continue }
+				do {
+					if let nodeNum = try Self.backupBelongs(to: peripheralId, storeURL: storeURL, schema: schema) {
+						return nodeNum
 					}
+				} catch {
+					Logger.backup.error("💾 Failed to read backup while resolving peripheral \(peripheralId, privacy: .public): \(error.localizedDescription, privacy: .public)")
 				}
-
-				return nil
-			}.value
-		} catch {
-			Logger.backup.error("💾 Failed to resolve node for peripheral \(peripheralId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+			}
 			return nil
+		}.value
+	}
+
+	// MARK: - Re-keying backups to the device id
+
+	/// Moves this radio's backup from a node-number key onto its device id.
+	///
+	/// Called on connect, when the device id, node number and peripheral id are all known. Node
+	/// numbers change on the 2.8 upgrade, so a backup keyed on one is orphaned by the upgrade and a
+	/// fresh one starts alongside it. Re-keying happens a radio at a time rather than as one pass over
+	/// every backup, so nothing expensive or destructive runs at launch and radios that are never
+	/// reconnected keep working exactly as they do now.
+	///
+	/// Matching on the current node number is free but only finds a backup taken since the last
+	/// renumber. Backups filed under *earlier* node numbers are found by peripheral id, which means
+	/// reading them, so that only runs when the cheap match fails.
+	func adoptLegacyBackups(deviceId: Data?, nodeNum: Int64, peripheralId: String?) async {
+		guard let deviceKey = BackupKey.forDevice(deviceId) else { return }
+		// Already re-keyed. This is the common path on every connect after the first.
+		guard backupIndex.entries[deviceKey] == nil else { return }
+
+		var candidateKeys: [String] = []
+		let nodeKey = BackupKey.forNode(nodeNum)
+		if backupIndex.entries[nodeKey] != nil {
+			candidateKeys.append(nodeKey)
 		}
+		if let peripheralId {
+			for key in await legacyKeys(forPeripheralId: peripheralId) where !candidateKeys.contains(key) {
+				candidateKeys.append(key)
+			}
+		}
+
+		let candidates = candidateKeys.compactMap { key in backupIndex.entries[key].map { (key, $0) } }
+		guard let (survivingKey, surviving) = candidates.max(by: { $0.1.createdAt < $1.1.createdAt }) else {
+			return
+		}
+
+		for (key, _) in candidates where key != survivingKey {
+			removeBackup(forKey: key, reason: "duplicate of \(deviceKey) from an earlier node number")
+		}
+
+		let oldDir = backupBaseURL.appendingPathComponent(surviving.backupPath, isDirectory: true)
+		let newDir = backupBaseURL.appendingPathComponent(deviceKey, isDirectory: true)
+		if fileManager.fileExists(atPath: newDir.path) {
+			try? fileManager.removeItem(at: newDir)
+		}
+		do {
+			try fileManager.moveItem(at: oldDir, to: newDir)
+		} catch {
+			Logger.backup.error("Could not move backup \(survivingKey, privacy: .public) to its device id: \(error.localizedDescription, privacy: .public)")
+			saveIndex()
+			return
+		}
+
+		var adopted = surviving
+		adopted.deviceId = deviceKey
+		adopted.backupPath = deviceKey
+		backupIndex.entries.removeValue(forKey: survivingKey)
+		backupIndex.entries[deviceKey] = adopted
+		saveIndex()
+
+		Logger.backup.info("Re-keyed the backup for node \(surviving.nodeNum) onto its device id, dropping \(candidates.count - 1) duplicate(s)")
 	}
 
 	@discardableResult
-	func deleteBackup(forNode nodeNum: Int64) -> Bool {
-		guard let entry = backupIndex.entries[nodeNum] else {
-			return false
-		}
-
-		let nodeBackupDir = backupBaseURL.appendingPathComponent(entry.backupPath, isDirectory: true)
-		try? fileManager.removeItem(at: nodeBackupDir)
-		backupIndex.entries.removeValue(forKey: nodeNum)
+	func deleteBackup(forKey key: String) -> Bool {
+		guard removeBackup(forKey: key, reason: "deleted by the user") else { return false }
 		saveIndex()
-
-		Logger.backup.info("Deleted backup for node \(nodeNum)")
 		return true
 	}
 
@@ -493,7 +624,9 @@ final class NodeBackupManager: NodeBackupManaging {
 	func restoreFromBackup(forNode nodeNum: Int64, into container: ModelContainer) async -> NodeBackupResult {
 		Logger.backup.info("💾 Restoring full backup for node \(nodeNum)")
 
-		guard let entry = backupIndex.entries[nodeNum] else {
+		// Looked up by node number rather than by key: a backup for this radio may still be keyed by
+		// node number, or already re-keyed onto its device id.
+		guard let entry = backupIndex.entries.values.first(where: { $0.nodeNum == nodeNum }) else {
 			Logger.backup.debug("💾 No backup found for node \(nodeNum)")
 			return .noBackupFound
 		}
@@ -561,7 +694,7 @@ final class NodeBackupManager: NodeBackupManaging {
 		let currentChecksum = try await computeChecksum(for: backupStoreURL)
 		guard currentChecksum == entry.checksum else {
 			Logger.backup.error("Checksum mismatch for node \(entry.nodeNum) — backup is corrupt, deleting")
-			deleteBackup(forNode: entry.nodeNum)
+			deleteBackup(forKey: entry.key)
 			throw BackupError.checksumMismatch
 		}
 	}

--- a/Meshtastic/Persistence/NodeBackupManaging.swift
+++ b/Meshtastic/Persistence/NodeBackupManaging.swift
@@ -17,10 +17,22 @@ protocol NodeBackupManaging: Sendable {
 	///
 	/// - Parameters:
 	///   - nodeNum: The unique node number (`NodeInfoEntity.num`) to associate with the backup
+	///   - deviceId: The radio's `MyNodeInfo.device_id`, which keys the backup. Node numbers change
+	///     when a radio upgrades to 2.8; a device id does not. Nil keeps the node-number key.
 	///   - nodeName: Optional display name for the node (for UI purposes)
 	/// - Returns: Result indicating success or skip reason
 	/// - Note: Retries once automatically on failure before returning `.skipped`
-	func createBackup(forNode nodeNum: Int64, nodeName: String?) async -> NodeBackupResult
+	func createBackup(forNode nodeNum: Int64, deviceId: Data?, nodeName: String?) async -> NodeBackupResult
+
+	/// Moves this radio's backup from a node-number key onto its device id, collapsing any duplicates
+	/// left behind by earlier renumbers. Call on connect; it is cheap once a radio has been adopted.
+	///
+	/// - Parameters:
+	///   - deviceId: The connected radio's `MyNodeInfo.device_id`. Nil does nothing.
+	///   - nodeNum: The node number the radio reports now
+	///   - peripheralId: The connection's identifier, which is how backups filed under *earlier* node
+	///     numbers are found
+	func adoptLegacyBackups(deviceId: Data?, nodeNum: Int64, peripheralId: String?) async
 
 	/// Restores a full backup by importing all entities from the backup SQLite into the live container.
 	/// Call after `clearDatabase()` has emptied the live database.
@@ -42,12 +54,13 @@ protocol NodeBackupManaging: Sendable {
 	/// - Returns: Array of backup entries sorted by most recent first
 	func listBackups() -> [BackupEntry]
 
-	/// Deletes the backup for the specified node, freeing storage.
+	/// Deletes a backup, freeing storage.
 	///
-	/// - Parameter nodeNum: The node number whose backup should be deleted
+	/// - Parameter key: The entry's `BackupEntry.key`. Treat it as opaque — it is a device id for a
+	///   radio we have connected to since this change, and a node number otherwise.
 	/// - Returns: `true` if backup was found and deleted, `false` if no backup existed
 	@discardableResult
-	func deleteBackup(forNode nodeNum: Int64) -> Bool
+	func deleteBackup(forKey key: String) -> Bool
 
 	/// Returns the total disk space consumed by all backups in bytes.
 	var totalBackupSize: Int64 { get }

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -1044,6 +1044,7 @@ func backupCurrentDatabase(forTargetNode targetNodeNum: Int64?, currentNodeNum: 
 		Logger.backup.info("💾 Creating backup for current node \(currentNodeNum) before restore")
 		let backupResult = await NodeBackupManager.shared.createBackup(
 			forNode: currentNodeNum,
+			deviceId: accessoryManager.connectedDeviceId,
 			nodeName: currentNodeName
 		)
 		switch backupResult {

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -200,7 +200,7 @@ struct AppSettings: View {
 								
 								/// Delete any node database backups too.
 								for entry in NodeBackupManager.shared.listBackups() {
-									_ = NodeBackupManager.shared.deleteBackup(forNode: entry.nodeNum)
+									_ = NodeBackupManager.shared.deleteBackup(forKey: entry.key)
 								}
 								await MeshPackets.shared.flushDebouncedSaves()
 								await MeshPackets.shared.clearDatabase(includeRoutes: true)

--- a/Meshtastic/Views/Settings/BackupManagement/BackupManagement.swift
+++ b/Meshtastic/Views/Settings/BackupManagement/BackupManagement.swift
@@ -60,7 +60,7 @@ struct BackupManagement: View {
 						.foregroundColor(.secondary)
 						.italic()
 				} else {
-					ForEach(backups, id: \.nodeNum) { entry in
+					ForEach(backups, id: \.key) { entry in
 						BackupRowView(
 							entry: entry,
 							showRestoreButton: showsInlineRestoreButton,
@@ -160,7 +160,7 @@ struct BackupManagement: View {
 		.alert("Delete Backup?", isPresented: $showDeleteConfirmation, presenting: entryToDelete) { entry in
 			Button("Delete", role: .destructive) {
 				Task { @MainActor in
-					NodeBackupManager.shared.deleteBackup(forNode: entry.nodeNum)
+					NodeBackupManager.shared.deleteBackup(forKey: entry.key)
 					refreshBackups()
 				}
 			}
@@ -229,7 +229,11 @@ struct BackupManagement: View {
 		isBackingUp = true
 		defer { isBackingUp = false }
 
-		let result = await NodeBackupManager.shared.createBackup(forNode: nodeNum, nodeName: nodeName)
+		let result = await NodeBackupManager.shared.createBackup(
+			forNode: nodeNum,
+			deviceId: accessoryManager.connectedDeviceId,
+			nodeName: nodeName
+		)
 		switch result {
 		case .success:
 			refreshBackups()

--- a/Meshtastic/Views/Settings/BackupManagement/BackupRowView.swift
+++ b/Meshtastic/Views/Settings/BackupManagement/BackupRowView.swift
@@ -26,20 +26,34 @@ struct BackupRowView: View {
 			VStack(alignment: .leading, spacing: 4) {
 				Text(entry.nodeName ?? entry.nodeNum.toHex())
 					.font(.headline)
+
+				// Both identifiers, because they answer different questions. The node number is what
+				// the radio reports now and changes on the 2.8 upgrade; the device id is the hardware
+				// identifier the backup is filed under and does not. An entry with no device id has
+				// not been reconnected since this changed and is still keyed by node number.
+				HStack(spacing: 4) {
+					Text(entry.nodeNum.toHex())
+					if let deviceId = entry.deviceId {
+						Text("•")
+						Image(systemName: "checkmark.seal")
+						Text(deviceId)
+							.lineLimit(1)
+							.truncationMode(.middle)
+					}
+				}
+				.font(.caption.monospaced())
+				.foregroundColor(.secondary)
+				.accessibilityElement(children: .combine)
+				.accessibilityLabel(
+					entry.deviceId == nil
+					? String(localized: "Node \(entry.nodeNum.toHex()), keyed by node number")
+					: String(localized: "Node \(entry.nodeNum.toHex()), keyed by device \(entry.deviceId ?? "")")
+				)
+
 				HStack {
 					Text(entry.createdAt, style: .date)
 					Text("•")
 					Text(entry.createdAt, style: .time)
-					Text("•")
-					// Node numbers change on the 2.8 upgrade, so a backup keyed on one is orphaned by
-					// the upgrade. Showing which entries are keyed by device and which are still
-					// waiting to be is the only way to see that from here.
-					if entry.deviceId == nil {
-						Text(entry.nodeNum.toHex())
-					} else {
-						Label(entry.nodeNum.toHex(), systemImage: "checkmark.seal")
-							.labelStyle(.titleAndIcon)
-					}
 				}
 				.font(.caption)
 				.foregroundColor(.secondary)

--- a/Meshtastic/Views/Settings/BackupManagement/BackupRowView.swift
+++ b/Meshtastic/Views/Settings/BackupManagement/BackupRowView.swift
@@ -15,6 +15,14 @@ struct BackupRowView: View {
 	var onRestore: (() -> Void)?
 	var onDelete: (() -> Void)?
 
+	/// Spoken form of the identity line — two bare hex strings read aloud are meaningless.
+	private var identityDescription: String {
+		if let deviceId = entry.deviceId {
+			return String(localized: "Node \(entry.nodeNum.toHex()), keyed by device \(deviceId)")
+		}
+		return String(localized: "Node \(entry.nodeNum.toHex()), keyed by node number")
+	}
+
 	var body: some View {
 		HStack {
 			Image(systemName: "cylinder.split.1x2")
@@ -23,40 +31,44 @@ struct BackupRowView: View {
 				.foregroundColor(.accentColor)
 				.frame(width: 35)
 
-			VStack(alignment: .leading, spacing: 4) {
+			VStack(alignment: .leading, spacing: 2) {
 				Text(entry.nodeName ?? entry.nodeNum.toHex())
 					.font(.headline)
+					.lineLimit(1)
 
-				// Both identifiers, because they answer different questions. The node number is what
-				// the radio reports now and changes on the 2.8 upgrade; the device id is the hardware
-				// identifier the backup is filed under and does not. An entry with no device id has
-				// not been reconnected since this changed and is still keyed by node number.
-				HStack(spacing: 4) {
+				// The two identifiers answer different questions: the node number is what the radio
+				// reports now and changes on the 2.8 upgrade, the device id is what the backup is
+				// filed under and does not. The node number only repeats here when the headline shows
+				// a name instead.
+				if entry.nodeName != nil {
 					Text(entry.nodeNum.toHex())
-					if let deviceId = entry.deviceId {
-						Text("•")
+						.font(.caption.monospaced())
+						.foregroundColor(.secondary)
+						.lineLimit(1)
+				}
+
+				// Its own line and never truncated — a partial device id cannot be checked against
+				// anything, which is the only reason to show it. Scales down to fit instead.
+				// No device id means this radio has not been reconnected since backups moved off
+				// node numbers, so it is still keyed by one.
+				if let deviceId = entry.deviceId {
+					HStack(spacing: 4) {
 						Image(systemName: "checkmark.seal")
 						Text(deviceId)
 							.lineLimit(1)
-							.truncationMode(.middle)
+							.minimumScaleFactor(0.5)
 					}
+					.font(.caption2.monospaced())
+					.foregroundColor(.secondary)
+					.accessibilityElement(children: .combine)
+					.accessibilityLabel(identityDescription)
 				}
-				.font(.caption.monospaced())
-				.foregroundColor(.secondary)
-				.accessibilityElement(children: .combine)
-				.accessibilityLabel(
-					entry.deviceId == nil
-					? String(localized: "Node \(entry.nodeNum.toHex()), keyed by node number")
-					: String(localized: "Node \(entry.nodeNum.toHex()), keyed by device \(entry.deviceId ?? "")")
-				)
 
-				HStack {
-					Text(entry.createdAt, style: .date)
-					Text("•")
-					Text(entry.createdAt, style: .time)
-				}
-				.font(.caption)
-				.foregroundColor(.secondary)
+				// One string rather than date and time as separate views, which wrapped mid-line.
+				Text(entry.createdAt.formatted(date: .abbreviated, time: .shortened))
+					.font(.caption)
+					.foregroundColor(.secondary)
+					.lineLimit(1)
 			}
 
 			Spacer()

--- a/Meshtastic/Views/Settings/BackupManagement/BackupRowView.swift
+++ b/Meshtastic/Views/Settings/BackupManagement/BackupRowView.swift
@@ -30,6 +30,16 @@ struct BackupRowView: View {
 					Text(entry.createdAt, style: .date)
 					Text("•")
 					Text(entry.createdAt, style: .time)
+					Text("•")
+					// Node numbers change on the 2.8 upgrade, so a backup keyed on one is orphaned by
+					// the upgrade. Showing which entries are keyed by device and which are still
+					// waiting to be is the only way to see that from here.
+					if entry.deviceId == nil {
+						Text(entry.nodeNum.toHex())
+					} else {
+						Label(entry.nodeNum.toHex(), systemImage: "checkmark.seal")
+							.labelStyle(.titleAndIcon)
+					}
 				}
 				.font(.caption)
 				.foregroundColor(.secondary)

--- a/MeshtasticTests/NodeBackupManagerTests.swift
+++ b/MeshtasticTests/NodeBackupManagerTests.swift
@@ -697,4 +697,79 @@ struct NodeBackupManagerTests {
 		#expect(FileManager.default.fileExists(atPath: backupDir.appendingPathComponent("abcd").path))
 	}
 
+
+	// MARK: - Review fixes
+
+	@Test("a node- key needs a real node number, so user folders are not swept")
+	func testNodeKeyRequiresNumber() {
+		#expect(BackupKey.isNodeNumberKey("node-1373366617"))
+		// The backup folder shows up in Files, so anything can land in it.
+		#expect(!BackupKey.isNodeNumberKey("node-notes"))
+		#expect(!BackupKey.isNodeNumberKey("node-"))
+		#expect(!BackupKey.isNodeNumberKey("notes"))
+	}
+
+	@Test("a recorded backup path has to be a plain folder name")
+	func testBackupPathMustBePlain() {
+		// backup-index.json is user-writable, so a hand-edited path could walk out of the folder.
+		#expect(NodeBackupManager.isPlainBackupPath("18f062fc2c5525e37635701f8442a5a4"))
+		#expect(NodeBackupManager.isPlainBackupPath("node-1373366617"))
+		#expect(!NodeBackupManager.isPlainBackupPath(".."))
+		#expect(!NodeBackupManager.isPlainBackupPath("."))
+		#expect(!NodeBackupManager.isPlainBackupPath(""))
+		#expect(!NodeBackupManager.isPlainBackupPath("../../Library/Application Support"))
+		#expect(!NodeBackupManager.isPlainBackupPath("/tmp/elsewhere"))
+		#expect(!NodeBackupManager.isPlainBackupPath("nested/path"))
+	}
+
+	@Test("a backup with no device id joins the one already keyed by device")
+	@MainActor
+	func testBackupReusesKnownDeviceId() async throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
+		let dbDir = tempDir.appendingPathComponent("ActiveDB", isDirectory: true)
+		_ = try createFakeDatabase(at: dbDir)
+
+		let manager = NodeBackupManager(baseURL: backupDir)
+		_ = await manager.createBackup(forNode: 4242, deviceId: Data([0xAB, 0xCD]), nodeName: "First")
+
+		// The caller resolves the device id from the store, which can come back nil part way through
+		// a connect or a radio switch. That must not sit a second backup beside the first.
+		_ = await manager.createBackup(forNode: 4242, deviceId: nil, nodeName: "Second")
+
+		let backups = manager.listBackups()
+		#expect(backups.count == 1)
+		#expect(backups.first?.deviceId == "abcd")
+		#expect(backups.first?.nodeName == "Second")
+	}
+
+	@Test("a failed re-key leaves every backup alone")
+	@MainActor
+	func testFailedAdoptionKeepsDuplicates() async throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
+
+		let older = try makeBackup(
+			in: backupDir, dirName: "node-1000", nodeNum: 1000, peripheralId: "PERIPHERAL-A",
+			createdAt: Date(timeIntervalSince1970: 1000), makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		let newer = try makeBackup(
+			in: backupDir, dirName: "node-2000", nodeNum: 2000, peripheralId: "PERIPHERAL-A",
+			createdAt: Date(timeIntervalSince1970: 2000), makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		try writeIndex(entries: [older, newer], to: backupDir)
+
+		let manager = NodeBackupManager(baseURL: backupDir)
+		// Pull the survivor's directory out from under the move. Duplicates used to be deleted
+		// before the move ran, so a failure here destroyed them and re-keyed nothing.
+		try FileManager.default.removeItem(at: backupDir.appendingPathComponent("node-2000"))
+
+		await manager.adoptLegacyBackups(deviceId: Data([0x18, 0xF0]), nodeNum: 2000, peripheralId: "PERIPHERAL-A")
+
+		#expect(manager.listBackups().contains { $0.nodeNum == 1000 })
+		#expect(FileManager.default.fileExists(atPath: backupDir.appendingPathComponent("node-1000").path))
+	}
+
 }

--- a/MeshtasticTests/NodeBackupManagerTests.swift
+++ b/MeshtasticTests/NodeBackupManagerTests.swift
@@ -772,4 +772,36 @@ struct NodeBackupManagerTests {
 		#expect(FileManager.default.fileExists(atPath: backupDir.appendingPathComponent("node-1000").path))
 	}
 
+
+	@Test("connecting clears a duplicate left beside a device-keyed backup")
+	@MainActor
+	func testConnectClearsStrayNodeKeyedBackup() async throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
+
+		// The state my phone was actually in: one backup keyed by device id, and a second for the
+		// same radio keyed by node number, written while the device id lookup was returning nil.
+		var keyed = try makeBackup(
+			in: backupDir, dirName: "abcd", nodeNum: 4242, peripheralId: "PERIPHERAL-A",
+			createdAt: Date(timeIntervalSince1970: 2000), makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		keyed.deviceId = "abcd"
+		let stray = try makeBackup(
+			in: backupDir, dirName: "node-4242", nodeNum: 4242, peripheralId: "PERIPHERAL-A",
+			createdAt: Date(timeIntervalSince1970: 1000), makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		try writeIndex(entries: [keyed, stray], to: backupDir)
+
+		let manager = NodeBackupManager(baseURL: backupDir)
+		#expect(manager.listBackups().count == 2)
+
+		await manager.adoptLegacyBackups(deviceId: Data([0xAB, 0xCD]), nodeNum: 4242, peripheralId: "PERIPHERAL-A")
+
+		let backups = manager.listBackups()
+		#expect(backups.count == 1)
+		#expect(backups.first?.deviceId == "abcd")
+		#expect(!FileManager.default.fileExists(atPath: backupDir.appendingPathComponent("node-4242").path))
+	}
+
 }

--- a/MeshtasticTests/NodeBackupManagerTests.swift
+++ b/MeshtasticTests/NodeBackupManagerTests.swift
@@ -64,7 +64,7 @@ struct NodeBackupManagerTests {
 
 	private func writeIndex(entry: BackupEntry, to backupDir: URL) throws {
 		var index = BackupIndex()
-		index.entries[entry.nodeNum] = entry
+		index.entries[entry.key] = entry
 		let indexData = try JSONEncoder().encode(index)
 		try indexData.write(to: backupDir.appendingPathComponent("backup-index.json"))
 	}
@@ -86,7 +86,7 @@ struct NodeBackupManagerTests {
 		let manager = NodeBackupManager(baseURL: backupDir)
 
 		// Act
-		let result = await manager.createBackup(forNode: 12345, nodeName: "TestNode")
+		let result = await manager.createBackup(forNode: 12345, deviceId: nil, nodeName: "TestNode")
 
 		// Assert
 		switch result {
@@ -115,10 +115,10 @@ struct NodeBackupManagerTests {
 		let manager = NodeBackupManager(baseURL: backupDir)
 
 		// First backup
-		let result1 = await manager.createBackup(forNode: 99999, nodeName: "NodeV1")
+		let result1 = await manager.createBackup(forNode: 99999, deviceId: nil, nodeName: "NodeV1")
 
 		// Second backup (overwrite)
-		let result2 = await manager.createBackup(forNode: 99999, nodeName: "NodeV2")
+		let result2 = await manager.createBackup(forNode: 99999, deviceId: nil, nodeName: "NodeV2")
 
 		// Only one backup should exist for this node
 		let backups = manager.listBackups()
@@ -147,7 +147,7 @@ struct NodeBackupManagerTests {
 
 		// The active database path won't exist in test environment,
 		// so backup should fail and return .skipped after retry
-		let result = await manager.createBackup(forNode: 77777, nodeName: "FailNode")
+		let result = await manager.createBackup(forNode: 77777, deviceId: nil, nodeName: "FailNode")
 
 		switch result {
 		case .skipped(let reason):
@@ -314,7 +314,7 @@ struct NodeBackupManagerTests {
 		// The manager is @MainActor-isolated, but file I/O runs via Task.detached
 		// We verify that calling createBackup is async (doesn't synchronously block)
 		let startTime = Date()
-		_ = await manager.createBackup(forNode: 88888, nodeName: "AsyncTest")
+		_ = await manager.createBackup(forNode: 88888, deviceId: nil, nodeName: "AsyncTest")
 		let elapsed = Date().timeIntervalSince(startTime)
 
 		// The operation should complete quickly (< 5s per SC-001)
@@ -343,14 +343,14 @@ struct NodeBackupManagerTests {
 		// Write index
 		let entry = BackupEntry(nodeNum: nodeNum, nodeName: "DeleteMe", createdAt: .now, fileSize: 4, checksum: "abc", backupPath: nodeDirName)
 		var index = BackupIndex()
-		index.entries[nodeNum] = entry
+		index.entries[entry.key] = entry
 		let indexData = try JSONEncoder().encode(index)
 		try indexData.write(to: backupDir.appendingPathComponent("backup-index.json"))
 
 		let manager = NodeBackupManager(baseURL: backupDir)
 		#expect(manager.hasBackup(forNode: nodeNum))
 
-		let deleted = manager.deleteBackup(forNode: nodeNum)
+		let deleted = manager.deleteBackup(forKey: BackupKey.forNode(nodeNum))
 		#expect(deleted)
 		#expect(!manager.hasBackup(forNode: nodeNum))
 	}
@@ -366,9 +366,9 @@ struct NodeBackupManagerTests {
 
 		// Create index with multiple entries
 		var index = BackupIndex()
-		index.entries[1] = BackupEntry(nodeNum: 1, nodeName: "Old", createdAt: Date(timeIntervalSince1970: 1000), fileSize: 100, checksum: "aaa", backupPath: "1")
-		index.entries[2] = BackupEntry(nodeNum: 2, nodeName: "New", createdAt: Date(timeIntervalSince1970: 2000), fileSize: 200, checksum: "bbb", backupPath: "2")
-		index.entries[3] = BackupEntry(nodeNum: 3, nodeName: "Mid", createdAt: Date(timeIntervalSince1970: 1500), fileSize: 150, checksum: "ccc", backupPath: "3")
+		index.entries[BackupKey.forNode(1)] = BackupEntry(nodeNum: 1, deviceId: nil, nodeName: "Old", createdAt: Date(timeIntervalSince1970: 1000), fileSize: 100, checksum: "aaa", backupPath: "1")
+		index.entries[BackupKey.forNode(2)] = BackupEntry(nodeNum: 2, deviceId: nil, nodeName: "New", createdAt: Date(timeIntervalSince1970: 2000), fileSize: 200, checksum: "bbb", backupPath: "2")
+		index.entries[BackupKey.forNode(3)] = BackupEntry(nodeNum: 3, deviceId: nil, nodeName: "Mid", createdAt: Date(timeIntervalSince1970: 1500), fileSize: 150, checksum: "ccc", backupPath: "3")
 
 		// Create directories so validation doesn't remove them
 		for n in 1...3 {
@@ -399,8 +399,8 @@ struct NodeBackupManagerTests {
 		try FileManager.default.createDirectory(at: backupDir, withIntermediateDirectories: true)
 
 		var index = BackupIndex()
-		index.entries[1] = BackupEntry(nodeNum: 1, nodeName: "A", createdAt: .now, fileSize: 1000, checksum: "a", backupPath: "1")
-		index.entries[2] = BackupEntry(nodeNum: 2, nodeName: "B", createdAt: .now, fileSize: 2000, checksum: "b", backupPath: "2")
+		index.entries[BackupKey.forNode(1)] = BackupEntry(nodeNum: 1, deviceId: nil, nodeName: "A", createdAt: .now, fileSize: 1000, checksum: "a", backupPath: "1")
+		index.entries[BackupKey.forNode(2)] = BackupEntry(nodeNum: 2, deviceId: nil, nodeName: "B", createdAt: .now, fileSize: 2000, checksum: "b", backupPath: "2")
 
 		// Create directories so validation doesn't remove them
 		for n in 1...2 {
@@ -509,4 +509,192 @@ struct NodeBackupManagerTests {
 		// No migration was attempted into the blocked location; the backup is intact where it was.
 		#expect(FileManager.default.fileExists(atPath: nodeDir.appendingPathComponent("Meshtastic.store").path))
 	}
+
+	// MARK: - Keying backups by device id
+
+	private func makeBackup(
+		in backupDir: URL,
+		dirName: String,
+		nodeNum: Int64,
+		peripheralId: String?,
+		createdAt: Date,
+		makeContainer: (URL) throws -> ModelContainer
+	) throws -> BackupEntry {
+		let dir = backupDir.appendingPathComponent(dirName, isDirectory: true)
+		try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+		let storeURL = dir.appendingPathComponent("Meshtastic.store")
+		let container = try makeContainer(storeURL)
+		let context = ModelContext(container)
+		context.autosaveEnabled = false
+		let myInfo = MyInfoEntity()
+		myInfo.myNodeNum = nodeNum
+		myInfo.peripheralId = peripheralId
+		context.insert(myInfo)
+		try context.save()
+
+		let data = try Data(contentsOf: storeURL)
+		return BackupEntry(
+			nodeNum: nodeNum,
+			deviceId: nil,
+			nodeName: "Node \(nodeNum)",
+			createdAt: createdAt,
+			fileSize: Int64(data.count),
+			checksum: "unused",
+			backupPath: dirName
+		)
+	}
+
+	private func writeIndex(entries: [BackupEntry], to backupDir: URL) throws {
+		try FileManager.default.createDirectory(at: backupDir, withIntermediateDirectories: true)
+		var index = BackupIndex()
+		for entry in entries {
+			index.entries[entry.key] = entry
+		}
+		let data = try JSONEncoder().encode(index)
+		try data.write(to: backupDir.appendingPathComponent("backup-index.json"))
+	}
+
+	@Test("BackupKey uses the device id when there is one and the node number otherwise")
+	func testBackupKeyDerivation() {
+		#expect(BackupKey.forDevice(Data([0x18, 0xF0, 0x62])) == "18f062")
+		#expect(BackupKey.forDevice(Data()) == nil)
+		#expect(BackupKey.forDevice(nil) == nil)
+		#expect(BackupKey.forNode(1_373_366_617) == "node-1373366617")
+		#expect(BackupKey.isNodeNumberKey("node-1373366617"))
+		#expect(!BackupKey.isNodeNumberKey("18f062fc2c5525e37635701f8442a5a4"))
+	}
+
+	@Test("a version 1 index decodes to node-number keys without touching any files")
+	func testVersionOneIndexDecodes() throws {
+		// Version 1 keyed by Int64, which Swift encodes as a flat [key, value] array rather than an
+		// object, so this is the shape the decoder has to recognize.
+		let json = """
+		{"version":1,"lastModified":768000000,"entries":[1373366617,{"nodeNum":1373366617,\
+		"nodeName":"cebc","createdAt":768000000,"fileSize":120,"checksum":"abc","backupPath":"1373366617"}]}
+		"""
+		let index = try JSONDecoder().decode(BackupIndex.self, from: Data(json.utf8))
+
+		#expect(index.version == BackupIndex.currentVersion)
+		#expect(index.entries.count == 1)
+		#expect(index.entries["node-1373366617"]?.nodeNum == 1_373_366_617)
+		#expect(index.entries["node-1373366617"]?.deviceId == nil)
+	}
+
+	@Test("adopting a radio re-keys the backup filed under its current node number")
+	@MainActor
+	func testAdoptRekeysByNodeNum() async throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
+
+		let entry = try makeBackup(
+			in: backupDir, dirName: "node-4242", nodeNum: 4242, peripheralId: "PERIPHERAL-A",
+			createdAt: .now, makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		try writeIndex(entries: [entry], to: backupDir)
+
+		let manager = NodeBackupManager(baseURL: backupDir)
+		let deviceId = Data([0xAB, 0xCD])
+		await manager.adoptLegacyBackups(deviceId: deviceId, nodeNum: 4242, peripheralId: "PERIPHERAL-A")
+
+		let backups = manager.listBackups()
+		#expect(backups.count == 1)
+		#expect(backups.first?.deviceId == "abcd")
+		#expect(backups.first?.backupPath == "abcd")
+		#expect(FileManager.default.fileExists(atPath: backupDir.appendingPathComponent("abcd").path))
+		#expect(!FileManager.default.fileExists(atPath: backupDir.appendingPathComponent("node-4242").path))
+	}
+
+	@Test("adopting a renumbered radio keeps the newest backup and deletes the rest")
+	@MainActor
+	func testAdoptCollapsesRenumberDuplicates() async throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
+
+		// One radio, three node numbers — what a pair of 2.8 upgrades leaves behind. Only the last is
+		// findable by the number the radio reports now; the others are found by peripheral id.
+		let old = try makeBackup(
+			in: backupDir, dirName: "node-1373366617", nodeNum: 1_373_366_617, peripheralId: "PERIPHERAL-A",
+			createdAt: Date(timeIntervalSince1970: 1000), makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		let middle = try makeBackup(
+			in: backupDir, dirName: "node-1658900156", nodeNum: 1_658_900_156, peripheralId: "PERIPHERAL-A",
+			createdAt: Date(timeIntervalSince1970: 2000), makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		let newest = try makeBackup(
+			in: backupDir, dirName: "node-3177266887", nodeNum: 3_177_266_887, peripheralId: "PERIPHERAL-A",
+			createdAt: Date(timeIntervalSince1970: 3000), makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		// A different radio, which must be left alone.
+		let other = try makeBackup(
+			in: backupDir, dirName: "node-999", nodeNum: 999, peripheralId: "PERIPHERAL-B",
+			createdAt: Date(timeIntervalSince1970: 4000), makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		try writeIndex(entries: [old, middle, newest, other], to: backupDir)
+
+		let manager = NodeBackupManager(baseURL: backupDir)
+		await manager.adoptLegacyBackups(
+			deviceId: Data([0x18, 0xF0]), nodeNum: 3_177_266_887, peripheralId: "PERIPHERAL-A"
+		)
+
+		let backups = manager.listBackups()
+		#expect(backups.count == 2)
+		let adopted = backups.first { $0.deviceId == "18f0" }
+		#expect(adopted?.nodeNum == 3_177_266_887)
+		#expect(adopted?.createdAt == Date(timeIntervalSince1970: 3000))
+
+		let fm = FileManager.default
+		#expect(fm.fileExists(atPath: backupDir.appendingPathComponent("18f0").path))
+		#expect(!fm.fileExists(atPath: backupDir.appendingPathComponent("node-1373366617").path))
+		#expect(!fm.fileExists(atPath: backupDir.appendingPathComponent("node-1658900156").path))
+		#expect(!fm.fileExists(atPath: backupDir.appendingPathComponent("node-3177266887").path))
+		// The other radio is untouched and still keyed by node number.
+		#expect(fm.fileExists(atPath: backupDir.appendingPathComponent("node-999").path))
+		#expect(backups.contains { $0.nodeNum == 999 && $0.deviceId == nil })
+	}
+
+	@Test("a radio reporting no device id is left keyed by node number")
+	@MainActor
+	func testAdoptIgnoresRadioWithoutDeviceId() async throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
+
+		let entry = try makeBackup(
+			in: backupDir, dirName: "node-4242", nodeNum: 4242, peripheralId: "PERIPHERAL-A",
+			createdAt: .now, makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		try writeIndex(entries: [entry], to: backupDir)
+
+		let manager = NodeBackupManager(baseURL: backupDir)
+		await manager.adoptLegacyBackups(deviceId: Data(), nodeNum: 4242, peripheralId: "PERIPHERAL-A")
+
+		#expect(manager.listBackups().first?.deviceId == nil)
+		#expect(FileManager.default.fileExists(atPath: backupDir.appendingPathComponent("node-4242").path))
+	}
+
+	@Test("re-keyed directories survive the orphan sweep")
+	@MainActor
+	func testRekeyedDirectorySurvivesSweep() async throws {
+		let tempDir = try makeTempDir()
+		defer { cleanup(tempDir) }
+		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
+
+		let entry = try makeBackup(
+			in: backupDir, dirName: "node-4242", nodeNum: 4242, peripheralId: "PERIPHERAL-A",
+			createdAt: .now, makeContainer: { try makeContainer(inMemory: false, storeURL: $0) }
+		)
+		try writeIndex(entries: [entry], to: backupDir)
+
+		let manager = NodeBackupManager(baseURL: backupDir)
+		await manager.adoptLegacyBackups(deviceId: Data([0xAB, 0xCD]), nodeNum: 4242, peripheralId: "PERIPHERAL-A")
+
+		// The sweep used to parse directory names as node numbers, which would have deleted this one.
+		let reopened = NodeBackupManager(baseURL: backupDir)
+		#expect(reopened.listBackups().count == 1)
+		#expect(FileManager.default.fileExists(atPath: backupDir.appendingPathComponent("abcd").path))
+	}
+
 }


### PR DESCRIPTION
## Summary

Backups are filed under the radio's node number. Node numbers change when a radio upgrades to 2.8, so every renumber orphans the previous backup and starts a new one.

On my phone, one radio had three backups under three different node numbers — eight backup folders for six actual radios. The restore list shows the same radio several times with nothing to tell them apart, and the duplicates count toward the backup limit, so a radio that renumbers repeatedly can prune other radios' backups.

`MyNodeInfo.device_id` is the radio's hardware identifier and does not change. The app already stores it on `MyInfoEntity`.

## What changed

Two migrations, split so nothing expensive or destructive happens at launch.

The index moves from `Int64` keys to strings as it decodes — `1373366617` becomes `node-1373366617`. No files are opened, renamed or deleted.

Backups move onto a device id one radio at a time, the first time we connect to it and can ask who it is. Matching on the current node number is free but only finds a backup taken since the last renumber, so anything filed under an earlier number is found by peripheral id, which means reading those backups — that only runs when the cheap match fails. Several matches collapse to the newest and the rest are deleted, with each deletion logged. A radio that reports no device id keeps its node-number key and behaves exactly as it does now, so keys stay mixed for as long as it takes to reconnect to everything.

Same-radio detection in the renumber path matches on `device_id` first, falling back to the peripheral id. `device_id` holds over TCP and serial, where there is no BLE identifier, and survives a re-pair.

Two things that would have broken quietly:

- The orphan sweep parsed directory names as node numbers, so it would have deleted every re-keyed directory on the next launch. It now matches the paths the index references.
- `BackupManagement` keyed its `ForEach` on `nodeNum`. Duplicate ForEach ids corrupt the List diff, which is the crash class this repo has hit before, so it keys on the entry now.

`maximumBackupCount` goes from 50 to 100. Backup rows show the node number, with a seal on entries already keyed by device.

## Testing

- Built for the iOS Simulator.
- `NodeBackupManagerTests`: 21 tests, all executed and passing. Seven are new — a v1 index decoding to `node-` keys without touching files, re-keying by current node number, three backups under different node numbers collapsing to the newest while a second radio is left alone, a radio with no device id being left alone, and a re-keyed directory surviving the orphan sweep.
- The compaction errors in the test log are pre-existing fixture noise: those tests write fake non-SQLite content, and compaction is best-effort and logged rather than thrown.

Run on device against my real ten-backup store, which is where this earned its keep:

- **cebc collapsed correctly** — three backups under three node numbers became one keyed by device id, confirmed from `backup-index.json` on the phone rather than from the screen.
- **It surfaced a duplicate no test would have.** A radio ended up with a device-keyed backup and a node-keyed one side by side, because `myInfoPacket` only stored `deviceId` when inserting a `MyInfoEntity`. Fixed at the source, plus `performBackup` now falls back to the device id already in the index so a failed lookup cannot mint a duplicate, and adoption clears a stray entry on connect so existing ones heal themselves.

Still unverified: whether 2.5 and 2.6 firmware actually populate `device_id`. The field predates the app's 2.5.18 minimum, but every radio I have is recent, so the node-number fallback has only ever run in tests.
