### PR TITLE
Start location updates only when needed

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Position.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Position.swift
@@ -16,10 +16,12 @@ extension AccessoryManager {
 	}
 
 	func initializeLocationProvider() {
+		updateLocationProviderDemand()
 		self.locationTask = Task {
 			repeat {
 				let sleepSeconds = Self.locationProviderSleepSeconds(configuredInterval: UserDefaults.provideLocationInterval)
-				try? await Task.sleep(for: .seconds(sleepSeconds)) // Throws if task is cancelled
+				try? await Task.sleep(for: .seconds(sleepSeconds))
+				updateLocationProviderDemand()
 
 				guard let fromNodeNum = activeConnection?.device.num else {
 					return
@@ -29,6 +31,17 @@ extension AccessoryManager {
 					_ = try await sendPosition(channel: 0, destNum: fromNodeNum, wantResponse: false)
 				}
 			} while !Task.isCancelled
+		}
+	}
+
+	func updateLocationProviderDemand() {
+		let shouldRequestUpdates = activeConnection != nil && UserDefaults.provideLocation
+		guard shouldRequestUpdates != locationUpdatesRequestedForPositionSharing else { return }
+		locationUpdatesRequestedForPositionSharing = shouldRequestUpdates
+		if shouldRequestUpdates {
+			LocationsHandler.shared.startLocationUpdates(for: .radioPositionSharing)
+		} else {
+			LocationsHandler.shared.stopLocationUpdates(for: .radioPositionSharing)
 		}
 	}
 

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -298,6 +298,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	var bleStatusTask: Task<Void, Never>?
 	var connectionEventTask: Task <Void, Error>?
 	var locationTask: Task<Void, Error>?
+	var locationUpdatesRequestedForPositionSharing = false
 	/// The detached device image/link pass spawned by connect Step 3b. Held so a disconnect can
 	/// cancel it — otherwise, on a captive portal, its ~78 image HEADs hang ~60s each (no request
 	/// timeout) past teardown, wasting network and pinning the hardware-list spinner.
@@ -623,6 +624,7 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 
 		locationTask?.cancel()
 		locationTask = nil
+		updateLocationProviderDemand()
 
 		// Cancel the detached device image/link pass so its outstanding image HEADs unwind instead of
 		// hanging past teardown. The pass leaves the throttle un-armed when cancelled, so the next

--- a/Meshtastic/Helpers/LocationsHandler.swift
+++ b/Meshtastic/Helpers/LocationsHandler.swift
@@ -9,154 +9,192 @@ import SwiftUI
 import CoreLocation
 import OSLog
 
-// The @MainActor annotation ensures that all state changes and UI updates happen on the main thread,
-// preventing potential race conditions and crashes related to UI updates from background threads.
+enum LocationUpdatePurpose: Hashable {
+	case userInterface
+	case routeRecording
+	case radioPositionSharing
+	case watchSync
+	case continuousBackground
+
+	var requiresBackgroundDelivery: Bool {
+		self == .routeRecording || self == .watchSync || self == .continuousBackground
+	}
+}
+
 @MainActor class LocationsHandler: NSObject, ObservableObject, CLLocationManagerDelegate {
 
-	static let shared = LocationsHandler()  // Create a single, shared instance of the object.
-	public var manager = CLLocationManager()
+	static let shared = LocationsHandler()
+	let manager: CLLocationManager
+	private let backgroundActivitySessionFactory: () -> CLBackgroundActivitySession?
+	private let permissionRequestTimeout: Duration
 	private var background: CLBackgroundActivitySession?
+	private var locationDemandCounts: [LocationUpdatePurpose: Int] = [:]
 	private var locationDeliveryStarted = false
+	private var applicationIsActive = true
 	var enableSmartPosition: Bool = UserDefaults.enableSmartPosition
 
 	@Published var locationsArray: [CLLocation] = [CLLocation]()
 	@Published var isStationary = false
 	@Published var count = 0
 	@Published var isRecording = false {
-		didSet { updateAccuracyForRecordingState() }
+		didSet {
+			guard isRecording != oldValue else { return }
+			updateAccuracyForRecordingState()
+			if isRecording {
+				startLocationUpdates(for: .routeRecording)
+			} else {
+				stopLocationUpdates(for: .routeRecording)
+			}
+		}
 	}
 	@Published var isRecordingPaused = false
 	@Published var recordingStarted: Date?
 	@Published var distanceTraveled = 0.0
 	@Published var elevationGain = 0.0
-	@Published var heading: Double = 0.0 // Current heading in degrees
-	@Published var headingUpdatesStarted: Bool = false // Track heading updates state
+	@Published var heading: Double = 0.0
+	@Published var headingUpdatesStarted: Bool = false
+	@Published private(set) var updatesStarted = false
 
-	@Published
-	var updatesStarted: Bool = UserDefaults.standard.bool(forKey: "liveUpdatesStarted") {
-		didSet { UserDefaults.standard.set(updatesStarted, forKey: "liveUpdatesStarted") }
-	}
-
-	@Published
-	var backgroundActivity: Bool = UserDefaults.standard.bool(forKey: "BGActivitySessionStarted") {
+	@Published var backgroundActivity: Bool {
 		didSet {
-			// Invalidate or create the background activity session based on the new value.
-			backgroundActivity ? self.background = CLBackgroundActivitySession() : self.background?.invalidate()
+			guard backgroundActivity != oldValue else { return }
 			UserDefaults.standard.set(backgroundActivity, forKey: "BGActivitySessionStarted")
+			if backgroundActivity {
+				startLocationUpdates(for: .continuousBackground)
+			} else {
+				stopLocationUpdates(for: .continuousBackground)
+			}
 		}
 	}
 
 	// The continuation we will use to asynchronously ask the user permission to track their location.
 	// This is an Optional to ensure it can be nilled out after use.
 	private var permissionContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
+	private var permissionTimeoutTask: Task<Void, Never>?
 
 	// A flag to prevent multiple concurrent permission requests
 	private var isRequestingPermission = false
 
 	/// Requests "Always" location authorization from the user.
-	/// This method uses Swift's structured concurrency to await the user's decision.
-	/// It includes a timeout to prevent continuation leaks if the delegate method isn't called.
-	/// - Returns: The `CLAuthorizationStatus` reflecting the user's choice.
+	/// It includes a timeout so the request can be retried if no delegate callback arrives.
 	func requestLocationAlwaysPermissions() async -> CLAuthorizationStatus {
-		// If a request is already in progress, return the current status immediately.
-		// This prevents creating multiple continuations and potential leaks.
 		guard !isRequestingPermission else {
 			Logger.services.debug("📍 [App] requestLocationAlwaysPermissions called while a request is already active. Returning current status.")
 			return manager.authorizationStatus
 		}
-		// Set flag to indicate a request is in progress
 		isRequestingPermission = true
 
-		return await withCheckedContinuation { continuation in
-			// Store the continuation.
-			self.permissionContinuation = continuation
-
-			// Request authorization. The response will come via `locationManagerDidChangeAuthorization`.
+		let status = await withCheckedContinuation { continuation in
+			permissionContinuation = continuation
 			manager.requestAlwaysAuthorization()
 
-			// Add a timeout to ensure the continuation is always resumed.
-			// If the delegate method doesn't fire within a reasonable time (e.g., 10 seconds),
-			// we'll resume the continuation with .notDetermined to prevent a leak.
-			Task { @MainActor in // Ensure this task runs on the MainActor
+			permissionTimeoutTask = Task { @MainActor in
 				do {
-					try await Task.sleep(for: .seconds(5)) // Wait for 5 seconds
-					if let currentContinuation = self.permissionContinuation {
-						// If the continuation hasn't been nilled out yet, it means
-						// locationManagerDidChangeAuthorization hasn't been called.
-						Logger.services.warning("📍 [App] Location permission request timed out. Resuming continuation with .notDetermined.")
-						currentContinuation.resume(returning: .denied)
-						self.permissionContinuation = nil // Clear the reference
-					}
-				} catch is CancellationError {
-					// This task was cancelled, likely because the main continuation was already resumed
-					// by locationManagerDidChangeAuthorization. This is expected and safe.
-					Logger.services.debug("📍 [App] Permission timeout task cancelled.")
+					try await Task.sleep(for: permissionRequestTimeout)
 				} catch {
-					Logger.services.error("💥 [App] Error in permission timeout task: \(error.localizedDescription, privacy: .public)")
+					return
 				}
+				guard let continuation = permissionContinuation else { return }
+				Logger.services.warning("📍 [App] Location permission request timed out.")
+				continuation.resume(returning: .denied)
+				permissionContinuation = nil
+				permissionTimeoutTask = nil
 			}
 		}
-		// This defer block ensures `isRequestingPermission` is reset and `permissionContinuation` is nilled out
-		// regardless of how the `withCheckedContinuation` block exits (success, error, or cancellation).
-		// It acts as a final cleanup mechanism.
-		defer {
-			self.isRequestingPermission = false
-			// This nil assignment is somewhat redundant with the one in locationManagerDidChangeAuthorization
-			// and the timeout Task, but it provides an extra layer of safety.
-			self.permissionContinuation = nil
-		}
+		permissionTimeoutTask?.cancel()
+		permissionTimeoutTask = nil
+		isRequestingPermission = false
+		permissionContinuation = nil
+		return status
 	}
 
 	/// Delegate method called when the location authorization status changes.
 	/// - Parameter manager: The CLLocationManager instance.
 	func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-		// Ensure the continuation exists before attempting to resume it.
-		// If it's nil, it means either no request was pending or it was already resumed (e.g., by the timeout).
-		guard let continuation = permissionContinuation else {
-			Logger.services.debug("📍 [App] locationManagerDidChangeAuthorization called but no permissionContinuation is active or it was already handled.")
-			return
+		if let continuation = permissionContinuation {
+			continuation.resume(returning: manager.authorizationStatus)
+			permissionContinuation = nil
+			permissionTimeoutTask?.cancel()
+			permissionTimeoutTask = nil
+		} else {
+			Logger.services.debug("📍 [App] Location authorization changed without an active permission request.")
 		}
-		// Resume the continuation with the current authorization status.
-		continuation.resume(returning: manager.authorizationStatus)
-		// CRUCIAL: Nil out the continuation immediately after resuming it.
-		// This prevents attempting to resume the same continuation multiple times,
-		// which would lead to a runtime crash.
-		self.permissionContinuation = nil
-		self.isRequestingPermission = false // Reset the flag as the request has completed
+		reconcileLocationDelivery()
 	}
 
-	override init() {
+	init(
+		manager: CLLocationManager = CLLocationManager(),
+		backgroundActivity: Bool = UserDefaults.standard.bool(forKey: "BGActivitySessionStarted"),
+		backgroundActivitySessionFactory: @escaping () -> CLBackgroundActivitySession? = { CLBackgroundActivitySession() },
+		permissionRequestTimeout: Duration = .seconds(5)
+	) {
+		self.manager = manager
+		self.backgroundActivity = backgroundActivity
+		self.backgroundActivitySessionFactory = backgroundActivitySessionFactory
+		self.permissionRequestTimeout = permissionRequestTimeout
 		super.init()
 		self.manager.delegate = self
-		// Allow background location updates for continuous tracking.
-		self.manager.allowsBackgroundLocationUpdates = true
-		// Set desired accuracy for location updates.
-		// Use HundredMeters by default to save battery; escalate to Best during route recording.
+		self.manager.allowsBackgroundLocationUpdates = false
 		self.manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
-		// Only deliver updates when the device has moved at least 10 meters.
 		self.manager.distanceFilter = 10
 		if CLLocationManager.headingAvailable() {
-				self.manager.headingFilter = 1 // Update heading when it changes by 1 degree
-				self.manager.headingOrientation = .portrait // Adjust based on device orientation
-			}
-	}
-
-	func startLocationUpdates() {
-		let status = self.manager.authorizationStatus
-		// Guard against starting updates without proper authorization.
-		guard status == .authorizedAlways || status == .authorizedWhenInUse else {
-			Logger.services.warning("📍 [App] Cannot start location updates: insufficient authorization status: \(status.rawValue)")
-			return
+			self.manager.headingFilter = 1
+			self.manager.headingOrientation = .portrait
 		}
-		guard !locationDeliveryStarted else { return }
-		Logger.services.info("📍 [App] Starting location updates")
-		updatesStarted = true
-		beginLocationDelivery()
+		if backgroundActivity {
+			startLocationUpdates(for: .continuousBackground)
+		}
 	}
 
-	func beginLocationDelivery() {
-		locationDeliveryStarted = true
-		manager.startUpdatingLocation()
+	func startLocationUpdates(for purpose: LocationUpdatePurpose) {
+		locationDemandCounts[purpose, default: 0] += 1
+		reconcileLocationDelivery()
+	}
+
+	func stopLocationUpdates(for purpose: LocationUpdatePurpose) {
+		guard let count = locationDemandCounts[purpose] else { return }
+		if count == 1 {
+			locationDemandCounts.removeValue(forKey: purpose)
+		} else {
+			locationDemandCounts[purpose] = count - 1
+		}
+		reconcileLocationDelivery()
+	}
+
+	func setApplicationActive(_ isActive: Bool) {
+		guard applicationIsActive != isActive else { return }
+		applicationIsActive = isActive
+		reconcileLocationDelivery()
+	}
+
+	func location(for purpose: LocationUpdatePurpose, timeout: Duration = .seconds(10)) async -> CLLocation? {
+		if let location = locationsArray.last {
+			return location
+		}
+
+		startLocationUpdates(for: purpose)
+		defer { stopLocationUpdates(for: purpose) }
+
+		return await withTaskGroup(of: CLLocation?.self) { group in
+			group.addTask { @MainActor [weak self] in
+				guard let self else { return nil }
+				for await locations in self.$locationsArray.values {
+					guard !Task.isCancelled else { return nil }
+					if let location = locations.last {
+						return location
+					}
+				}
+				return nil
+			}
+			group.addTask {
+				try? await Task.sleep(for: timeout)
+				return nil
+			}
+
+			let location = await group.next() ?? nil
+			group.cancelAll()
+			return location
+		}
 	}
 
 	// New method to start heading updates
@@ -200,12 +238,51 @@ import OSLog
 		}
 	}
 
-	/// Stops receiving live location updates.
-	func stopLocationUpdates() {
+	private func reconcileLocationDelivery() {
+		let hasBackgroundDemand = locationDemandCounts.contains { purpose, count in
+			count > 0 && purpose.requiresBackgroundDelivery
+		}
+		let hasForegroundDemand = locationDemandCounts.contains { purpose, count in
+			count > 0 && !purpose.requiresBackgroundDelivery
+		}
+		let status = manager.authorizationStatus
+		let isAuthorized = status == .authorizedAlways || status == .authorizedWhenInUse
+		updateBackgroundDelivery(hasBackgroundDemand && isAuthorized)
+
+		let hasActiveDemand = hasBackgroundDemand || (applicationIsActive && hasForegroundDemand)
+		guard hasActiveDemand && isAuthorized else {
+			stopLocationDelivery()
+			return
+		}
+		guard !locationDeliveryStarted else { return }
+
+		Logger.services.info("📍 [App] Starting location updates")
+		updatesStarted = true
+		locationDeliveryStarted = true
+		manager.startUpdatingLocation()
+	}
+
+	private func stopLocationDelivery() {
+		guard locationDeliveryStarted else {
+			updatesStarted = false
+			return
+		}
 		Logger.services.info("🛑 [App] Stopping location updates")
-		self.updatesStarted = false
-		self.locationDeliveryStarted = false
-		self.manager.stopUpdatingLocation()
+		updatesStarted = false
+		locationDeliveryStarted = false
+		manager.stopUpdatingLocation()
+	}
+
+	private func updateBackgroundDelivery(_ isRequired: Bool) {
+		manager.allowsBackgroundLocationUpdates = isRequired
+		if isRequired {
+			if background == nil {
+				background = backgroundActivitySessionFactory()
+			}
+		} else {
+			background?.invalidate()
+			background = nil
+		}
 	}
 
 	private func recordLocation(_ location: CLLocation, isStationary: Bool) {
@@ -316,5 +393,46 @@ import OSLog
 			}
 		}
 		return sats
+	}
+}
+
+@MainActor
+private struct LocationUpdatesModifier: ViewModifier {
+	let purpose: LocationUpdatePurpose
+	let isEnabled: Bool
+	@State private var isVisible = false
+	@State private var isRequestingUpdates = false
+
+	func body(content: Content) -> some View {
+		content
+			.onAppear {
+				isVisible = true
+				updateDemand()
+			}
+			.onDisappear {
+				isVisible = false
+				updateDemand()
+			}
+			.onChange(of: isEnabled) { _, _ in
+				updateDemand()
+			}
+	}
+
+	private func updateDemand() {
+		let shouldRequestUpdates = isVisible && isEnabled
+		guard shouldRequestUpdates != isRequestingUpdates else { return }
+		isRequestingUpdates = shouldRequestUpdates
+		if shouldRequestUpdates {
+			LocationsHandler.shared.startLocationUpdates(for: purpose)
+		} else {
+			LocationsHandler.shared.stopLocationUpdates(for: purpose)
+		}
+	}
+}
+
+extension View {
+	@MainActor
+	func locationUpdates(for purpose: LocationUpdatePurpose, while isEnabled: Bool = true) -> some View {
+		modifier(LocationUpdatesModifier(purpose: purpose, isEnabled: isEnabled))
 	}
 }

--- a/Meshtastic/Helpers/WatchSessionManager.swift
+++ b/Meshtastic/Helpers/WatchSessionManager.swift
@@ -101,7 +101,7 @@ final class WatchSessionManager: NSObject, ObservableObject {
 	private func performSendNodesToWatch() async {
 		lastWatchSendTime = Date()
 
-		guard let userLocation = LocationsHandler.shared.locationsArray.last else {
+		guard let userLocation = await LocationsHandler.shared.location(for: .watchSync) else {
 			logger.info("No user location available, skipping Watch update")
 			return
 		}

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -272,6 +272,7 @@ struct MeshtasticAppleApp: App {
 			switch newScenePhase {
 			case .background:
 				Logger.services.info("🎬 [App] Scene is in the background")
+				LocationsHandler.shared.setApplicationActive(false)
 				accessoryManager.appDidEnterBackground()
 				// Entity-cap evictions run now, while no view is mid-render on the
 				// doomed entities. Foregrounded, the packet actor defers them.
@@ -287,8 +288,10 @@ struct MeshtasticAppleApp: App {
 				}
 			case .inactive:
 				Logger.services.info("🎬 [App] Scene is inactive")
+				LocationsHandler.shared.setApplicationActive(false)
 			case .active:
 				Logger.services.info("🎬 [App] Scene is active")
+				LocationsHandler.shared.setApplicationActive(true)
 				MeshPackets.appIsActive = true
 				accessoryManager.appDidBecomeActive()
 				appState.refreshBadgeCount(context: persistenceController.container.mainContext)

--- a/Meshtastic/MeshtasticAppDelegate.swift
+++ b/Meshtastic/MeshtasticAppDelegate.swift
@@ -31,12 +31,8 @@ class MeshtasticAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificat
 		}
 #endif
 		UNUserNotificationCenter.current().delegate = self
-		let locationsHandler = LocationsHandler.shared
-		locationsHandler.startLocationUpdates()
-		// If a background activity session was previously active, reinstantiate it after the background launch.
-		if locationsHandler.backgroundActivity {
-			locationsHandler.backgroundActivity = true
-		}
+		// Restore location delivery only when the user enabled continuous background updates.
+		_ = LocationsHandler.shared
 		// Initialize TAK Server if enabled
 		Task { @MainActor in
 			TAKServerManager.shared.initializeOnStartup()

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -25,6 +25,10 @@ struct ContentView: View {
 	/// non-blocking state (.none, .unlocked, .lockNowAcknowledged).
 	private var isLockdownGateActive: Bool { lockdown.isBlockingSession }
 
+	private var selectedTabNeedsLocation: Bool {
+		router.selectedTab == .nodes || router.selectedTab == .map
+	}
+
 	/// Plain view-state mirror of `isLockdownGateActive`, kept in sync from the
 	/// coordinator via `.onChange`. Presenting the lockdown `fullScreenCover`
 	/// through a *computed* `Binding` — getter reading the `lockdown`
@@ -44,6 +48,7 @@ struct ContentView: View {
 
 	var body: some View {
 		gatedContent
+			.locationUpdates(for: .userInterface, while: selectedTabNeedsLocation)
 			.sheet(
 				isPresented: $isShowingDeviceOnboardingFlow,
 				onDismiss: {

--- a/Meshtastic/Views/Helpers/CompassView.swift
+++ b/Meshtastic/Views/Helpers/CompassView.swift
@@ -194,12 +194,11 @@ struct CompassView: View {
 			.statusBar(hidden: true)
 			.onAppear {
 				locationsHandler.startHeadingUpdates()
-				locationsHandler.startLocationUpdates()
 			}
 			.onDisappear {
 				locationsHandler.stopHeadingUpdates()
-				locationsHandler.stopLocationUpdates()
 			}
+			.locationUpdates(for: .userInterface)
 			.navigationTitle("Compass")
 		}
 	}

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -81,6 +81,7 @@ struct UserList: View {
 			.autocorrectionDisabled(true)
 			.scrollDismissesKeyboard(.immediately)
 		}
+		.locationUpdates(for: .userInterface)
 	}
 }
 

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -199,6 +199,7 @@ struct NodeListItem: View {
 	}
 
 	@Bindable var node: NodeInfoEntity
+	@ObservedObject private var locationsHandler = LocationsHandler.shared
 	/// The memoized value-type snapshot the row renders from. Captured while the node is live and
 	/// never re-derived from the live model during a plain re-evaluation, so a retained row can't
 	/// fault on a zombie @Model. Refreshed (guarded) when the node's `lastHeard` changes.
@@ -211,7 +212,7 @@ struct NodeListItem: View {
 		guard let nodeCoordinate else {
 			return nil
 		}
-		guard let currentLocation = LocationsHandler.shared.locationsArray.last else {
+		guard let currentLocation = locationsHandler.locationsArray.last else {
 			return nil
 		}
 

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -121,6 +121,7 @@ struct NodeListItemCompact: View {
 	}
 
 		@Bindable var node: NodeInfoEntity
+		@ObservedObject private var locationsHandler = LocationsHandler.shared
 		// Memoized value-type snapshot; rendered from instead of re-reading the live @Model on every
 		// body re-evaluation, so a retained row can't fault on a deleted/zombie node. See NodeListItem.
 		@State private var rowSummary: NodeListRowSummary?
@@ -132,7 +133,7 @@ struct NodeListItemCompact: View {
 		guard let nodeCoordinate else {
 			return nil
 		}
-		guard let currentLocation = LocationsHandler.shared.locationsArray.last else {
+		guard let currentLocation = locationsHandler.locationsArray.last else {
 			return nil
 		}
 

--- a/Meshtastic/Views/Nodes/MapWindow.swift
+++ b/Meshtastic/Views/Nodes/MapWindow.swift
@@ -24,6 +24,7 @@ struct MapWindow: View {
 					Label("Mesh Map", systemImage: "map")
 				}
 		}
+		.locationUpdates(for: .userInterface)
 		.frame(minWidth: 400, idealWidth: 900, maxWidth: .infinity, minHeight: 300, idealHeight: 700, maxHeight: .infinity)
 		.onChange(of: scenePhase) { _, newPhase in
 			if newPhase == .background {

--- a/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
+++ b/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
@@ -141,6 +141,7 @@ struct DeviceOnboarding: View {
 					.onChange(of: provideLocation) {
 						UserDefaults.provideLocationInterval = 30
 						UserDefaults.enableSmartPosition = true
+						accessoryManager.updateLocationProviderDemand()
 					}
 					makeRow(
 						icon: "location.fill",
@@ -182,6 +183,7 @@ struct DeviceOnboarding: View {
 			.capsuleButtonStyle()
 			.padding(.bottom)
 		}
+		.locationUpdates(for: .userInterface)
 	}
 	
 	var localNetworkView: some View {

--- a/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
+++ b/Meshtastic/Views/Settings/Config/Module/MQTTConfig.swift
@@ -14,6 +14,7 @@ struct MQTTConfig: View {
 	@Environment(\.modelContext) private var context
 	@EnvironmentObject var accessoryManager: AccessoryManager
 	@Environment(\.dismiss) private var goBack
+	@ObservedObject private var locationsHandler = LocationsHandler.shared
 	let node: NodeInfoEntity?
 	@State private var isPresentingSaveConfirm: Bool = false
 	@State var hasChanges: Bool = false
@@ -359,6 +360,12 @@ struct MQTTConfig: View {
 		.onChange(of: accessoryManager.mqttProxyConnected) { _, connected in
 			mqttConnected = connected
 		}
+		.onChange(of: locationsHandler.locationsArray.last) { _, location in
+			if location != nil && nearbyTopics.isEmpty {
+				setMqttValues()
+			}
+		}
+		.locationUpdates(for: .userInterface)
 	}
 }
 
@@ -366,10 +373,10 @@ private extension MQTTConfig {
 	func setMqttValues() {
 		nearbyTopics = []
 		let geocoder = CLGeocoder()
-		if LocationsHandler.shared.locationsArray.count > 0 {
+		if locationsHandler.locationsArray.count > 0 {
 			let region  = RegionCodes(rawValue: Int(node?.loRaConfig?.regionCode ?? 0))
 			defaultTopic = "msh/" + (region?.topic ?? "UNSET")
-			geocoder.reverseGeocodeLocation(LocationsHandler.shared.locationsArray.first!, completionHandler: {(placemarks, error) in
+			geocoder.reverseGeocodeLocation(locationsHandler.locationsArray.first!, completionHandler: {(placemarks, error) in
 				if let error {
 					Logger.services.error("Failed to reverse geocode location: \(error.localizedDescription, privacy: .public)")
 					return

--- a/Meshtastic/Views/Settings/Config/PositionConfig.swift
+++ b/Meshtastic/Views/Settings/Config/PositionConfig.swift
@@ -438,6 +438,7 @@ struct PositionConfig: View {
 		.onChange(of: gpsUpdateInterval) { _, newGpsUpdateInterval in
 			if newGpsUpdateInterval != node?.positionConfig?.gpsUpdateInterval ?? 0 { hasChanges = true }
 		}
+		.locationUpdates(for: .userInterface)
 	}
 	
 	func handlePositionFlagtChanges() {

--- a/Meshtastic/Views/Settings/RouteRecorder.swift
+++ b/Meshtastic/Views/Settings/RouteRecorder.swift
@@ -323,5 +323,6 @@ struct RouteRecorder: View {
 			}
 		}
 		.ignoresSafeArea(.all, edges: [.top, .leading, .trailing])
+		.locationUpdates(for: .userInterface)
 	}
 }

--- a/MeshtasticTests/WatchSessionManagerTests.swift
+++ b/MeshtasticTests/WatchSessionManagerTests.swift
@@ -4,8 +4,18 @@ import Testing
 @testable import Meshtastic
 
 private final class RecordingLocationManager: CLLocationManager {
+	var authorizationStatusOverride: CLAuthorizationStatus = .authorizedAlways
+	var requestAlwaysAuthorizationCallCount = 0
 	var startUpdatingLocationCallCount = 0
 	var stopUpdatingLocationCallCount = 0
+
+	override var authorizationStatus: CLAuthorizationStatus {
+		authorizationStatusOverride
+	}
+
+	override func requestAlwaysAuthorization() {
+		requestAlwaysAuthorizationCallCount += 1
+	}
 
 	override func startUpdatingLocation() {
 		startUpdatingLocationCallCount += 1
@@ -82,27 +92,178 @@ struct LocationProviderCadenceTests {
 	}
 }
 
-@Suite("Location updates energy")
+@Suite("Location demand lifecycle", .serialized)
 @MainActor
-struct LocationUpdatesEnergyTests {
+struct LocationDemandLifecycleTests {
 
-	@Test func beginsStandardLocationManagerUpdates() {
-		let handler = LocationsHandler()
+	private func makeHandler() -> (LocationsHandler, RecordingLocationManager) {
 		let manager = RecordingLocationManager()
-		handler.manager = manager
+		let handler = LocationsHandler(
+			manager: manager,
+			backgroundActivity: false,
+			backgroundActivitySessionFactory: { nil }
+		)
+		return (handler, manager)
+	}
 
-		handler.beginLocationDelivery()
+	@Test func doesNotStartWithoutDemand() {
+		let (_, manager) = makeHandler()
+
+		#expect(manager.startUpdatingLocationCallCount == 0)
+	}
+
+	@Test func startsForFirstDemandAndStopsAfterLastDemand() {
+		let (handler, manager) = makeHandler()
+
+		handler.startLocationUpdates(for: .userInterface)
+		handler.startLocationUpdates(for: .radioPositionSharing)
+		handler.stopLocationUpdates(for: .userInterface)
+
+		#expect(manager.startUpdatingLocationCallCount == 1)
+		#expect(manager.stopUpdatingLocationCallCount == 0)
+
+		handler.stopLocationUpdates(for: .radioPositionSharing)
+
+		#expect(manager.stopUpdatingLocationCallCount == 1)
+	}
+
+	@Test func countsMultipleConsumersOfTheSamePurpose() {
+		let (handler, manager) = makeHandler()
+
+		handler.startLocationUpdates(for: .userInterface)
+		handler.startLocationUpdates(for: .userInterface)
+		handler.stopLocationUpdates(for: .userInterface)
+
+		#expect(manager.stopUpdatingLocationCallCount == 0)
+
+		handler.stopLocationUpdates(for: .userInterface)
+
+		#expect(manager.stopUpdatingLocationCallCount == 1)
+	}
+
+	@Test func pausesForegroundDemandWhileApplicationIsInactive() {
+		let (handler, manager) = makeHandler()
+		handler.startLocationUpdates(for: .userInterface)
+
+		handler.setApplicationActive(false)
+		handler.setApplicationActive(true)
+
+		#expect(manager.stopUpdatingLocationCallCount == 1)
+		#expect(manager.startUpdatingLocationCallCount == 2)
+	}
+
+	@Test func routeRecordingKeepsBackgroundDeliveryActive() {
+		let (handler, manager) = makeHandler()
+
+		handler.isRecording = true
+		handler.setApplicationActive(false)
+
+		#expect(manager.startUpdatingLocationCallCount == 1)
+		#expect(manager.stopUpdatingLocationCallCount == 0)
+		#expect(manager.allowsBackgroundLocationUpdates)
+		#expect(manager.desiredAccuracy == kCLLocationAccuracyBest)
+
+		handler.isRecording = false
+
+		#expect(manager.stopUpdatingLocationCallCount == 1)
+		#expect(!manager.allowsBackgroundLocationUpdates)
+		#expect(manager.desiredAccuracy == kCLLocationAccuracyHundredMeters)
+	}
+
+	@Test func startsPendingDemandAfterAuthorizationChanges() {
+		let (handler, manager) = makeHandler()
+		manager.authorizationStatusOverride = .notDetermined
+
+		handler.startLocationUpdates(for: .userInterface)
+		#expect(manager.startUpdatingLocationCallCount == 0)
+
+		manager.authorizationStatusOverride = .authorizedWhenInUse
+		handler.locationManagerDidChangeAuthorization(manager)
 
 		#expect(manager.startUpdatingLocationCallCount == 1)
 	}
 
-	@Test func endsStandardLocationManagerUpdates() {
-		let handler = LocationsHandler()
-		let manager = RecordingLocationManager()
-		handler.manager = manager
+	@Test func stopsDeliveryAfterAuthorizationIsRevoked() {
+		let (handler, manager) = makeHandler()
+		handler.startLocationUpdates(for: .userInterface)
 
-		handler.stopLocationUpdates()
+		manager.authorizationStatusOverride = .denied
+		handler.locationManagerDidChangeAuthorization(manager)
 
 		#expect(manager.stopUpdatingLocationCallCount == 1)
+	}
+
+	@Test func waitsForFirstLocationAndReleasesDemand() async {
+		let (handler, manager) = makeHandler()
+		handler.enableSmartPosition = false
+		let expected = CLLocation(latitude: 37.3346, longitude: -122.0090)
+		let locationTask = Task { @MainActor in
+			await handler.location(for: .watchSync, timeout: .seconds(1))
+		}
+
+		await Task.yield()
+		#expect(manager.startUpdatingLocationCallCount == 1)
+		handler.locationManager(manager, didUpdateLocations: [expected])
+
+		let location = await locationTask.value
+		#expect(location?.coordinate.latitude == expected.coordinate.latitude)
+		#expect(location?.coordinate.longitude == expected.coordinate.longitude)
+		#expect(manager.stopUpdatingLocationCallCount == 1)
+		#expect(!manager.allowsBackgroundLocationUpdates)
+	}
+
+	@Test func releasesOneShotDemandAfterTimeout() async {
+		let (handler, manager) = makeHandler()
+
+		let location = await handler.location(for: .watchSync, timeout: .milliseconds(1))
+
+		#expect(location == nil)
+		#expect(manager.startUpdatingLocationCallCount == 1)
+		#expect(manager.stopUpdatingLocationCallCount == 1)
+		#expect(!manager.allowsBackgroundLocationUpdates)
+	}
+
+	@Test func permissionRequestCanRetryAfterTimeout() async {
+		let manager = RecordingLocationManager()
+		let handler = LocationsHandler(
+			manager: manager,
+			backgroundActivity: false,
+			backgroundActivitySessionFactory: { nil },
+			permissionRequestTimeout: .milliseconds(1)
+		)
+
+		_ = await handler.requestLocationAlwaysPermissions()
+		_ = await handler.requestLocationAlwaysPermissions()
+
+		#expect(manager.requestAlwaysAuthorizationCallCount == 2)
+	}
+
+	@Test func completedPermissionRequestCancelsItsTimeout() async {
+		let manager = RecordingLocationManager()
+		let handler = LocationsHandler(
+			manager: manager,
+			backgroundActivity: false,
+			backgroundActivitySessionFactory: { nil },
+			permissionRequestTimeout: .milliseconds(200)
+		)
+		let firstRequest = Task { @MainActor in
+			await handler.requestLocationAlwaysPermissions()
+		}
+		await Task.yield()
+		handler.locationManagerDidChangeAuthorization(manager)
+		_ = await firstRequest.value
+
+		try? await Task.sleep(for: .milliseconds(150))
+		let secondRequest = Task { @MainActor in
+			await handler.requestLocationAlwaysPermissions()
+		}
+		await Task.yield()
+		try? await Task.sleep(for: .milliseconds(100))
+
+		_ = await handler.requestLocationAlwaysPermissions()
+		#expect(manager.requestAlwaysAuthorizationCallCount == 2)
+
+		handler.locationManagerDidChangeAuthorization(manager)
+		_ = await secondRequest.value
 	}
 }


### PR DESCRIPTION
## Summary

Core Location now starts when an app feature needs location and stops when that demand ends. Opening the app on the Connect tab without a connected radio no longer starts location updates.

## Background

[PR #441](https://github.com/meshtastic/Meshtastic-Apple/pull/441) changed `MeshtasticAppDelegate` in December 2023 from restarting previously active location updates to starting them at app launch. This made the latest phone location available to features throughout the app.

[Commit d477de80](https://github.com/meshtastic/Meshtastic-Apple/commit/d477de80c2865593c80bbd7f0a7ed0201d88aa0d) last changed that launch call in October 2024 when it removed the iOS 16 availability condition. The unconditional startup behavior otherwise remained the same.

The app now has several location consumers with different lifetimes, including maps, node distances, route recording, Watch sync, and connected-radio position sharing. This change keeps those uses while tying Core Location delivery to current demand.

## What changed

- Track location demand from visible map and distance UI, route recording, connected-radio position sharing, Watch sync, and continuous background updates.
- Pause foreground-only demand while the app is inactive and stop delivery after the last consumer releases it.
- Release connected-radio demand on disconnect and reconcile the sharing toggle immediately.
- Wait for a bounded one-shot location when Watch sync has no cached fix.
- Refresh node distances and nearby MQTT topics after the first phone location arrives.
- Add lifecycle tests for overlapping consumers, app activity, authorization changes, recording, Watch timeouts, and permission retries.

## Testing

- `xcodebuild test -project Meshtastic.xcodeproj -scheme Meshtastic -destination 'platform=iOS Simulator,id=59BB9160-4ED9-4606-8EF3-305BF07AAA88'`: 3,083 tests in 533 suites passed.
- Focused location and Watch suites: 15 tests in 3 suites passed.
- iOS Simulator with a Meshtastic TCP replay radio: no location updates before connection; updates started after the connection reached `Subscribed`; a simulated location arrived; updates stopped when the TCP radio disconnected.
- `git diff --check`

Background route recording and continuous background updates were not exercised on a physical device.
