### PR TITLE
Offer to remove nodes that have no channel left in common

### DIFF
--- a/Meshtastic/Helpers/LoRaConfigChange.swift
+++ b/Meshtastic/Helpers/LoRaConfigChange.swift
@@ -1,0 +1,104 @@
+//
+//  LoRaConfigChange.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import Foundation
+
+/// The LoRa settings that decide which channel the radio actually listens on.
+///
+/// Changing any of these moves the radio to a different frequency, and the node db does not move
+/// with it: every node in the list was heard under the old settings and may no longer be reachable.
+/// Firmware will eventually report this per node (`NodeInfo.heard_on_current_lora`), but the app can
+/// already tell, because it stores the settings and the last-heard time for every node.
+struct LoRaChannelSettings: Equatable {
+	let regionCode: Int32
+	let modemPreset: Int32
+	let usePreset: Bool
+	let channelNum: Int32
+	let overrideFrequency: Float
+	/// Only meaningful when `usePreset` is false — a custom setup is defined by these three.
+	let bandwidth: Int32
+	let spreadFactor: Int32
+	let codingRate: Int32
+
+	/// Whether moving from `other` to this puts the radio on a different channel.
+	///
+	/// The custom radio parameters only count when the radio is actually using them; editing
+	/// bandwidth while `usePreset` is true changes a stored value the radio is ignoring.
+	func movesOffChannel(from other: LoRaChannelSettings) -> Bool {
+		if regionCode != other.regionCode { return true }
+		if usePreset != other.usePreset { return true }
+		if channelNum != other.channelNum { return true }
+		if overrideFrequency != other.overrideFrequency { return true }
+
+		if usePreset {
+			return modemPreset != other.modemPreset
+		}
+		return bandwidth != other.bandwidth
+			|| spreadFactor != other.spreadFactor
+			|| codingRate != other.codingRate
+	}
+}
+
+/// Records when the connected radio last moved to a different channel, so nodes heard before that
+/// can be marked — and offered up for deletion, since they have no channel in common any more.
+enum LoRaConfigChange {
+
+	/// Kept in `UserDefaults` rather than the store: it is one timestamp per radio, and
+	/// `MeshtasticSchemaV1` is frozen, so a persisted model change would force a new schema version
+	/// and a migration stage for a single date.
+	static func key(forNode nodeNum: Int64) -> String {
+		"loraChannelChangedAt.\(nodeNum)"
+	}
+
+	static func changedAt(forNode nodeNum: Int64, store: UserDefaults = .standard) -> Date? {
+		store.object(forKey: key(forNode: nodeNum)) as? Date
+	}
+
+	static func recordChange(forNode nodeNum: Int64, at date: Date = .now, store: UserDefaults = .standard) {
+		store.set(date, forKey: key(forNode: nodeNum))
+	}
+
+	static func clear(forNode nodeNum: Int64, store: UserDefaults = .standard) {
+		store.removeObject(forKey: key(forNode: nodeNum))
+		store.removeObject(forKey: dismissedKey(forNode: nodeNum))
+	}
+
+	// MARK: - Offer to clean up
+
+	private static func dismissedKey(forNode nodeNum: Int64) -> String {
+		"loraChannelChangeDismissedAt.\(nodeNum)"
+	}
+
+	/// Records that the user has seen the offer for this change and does not want it again.
+	///
+	/// Stored as the change's own timestamp rather than a flag, so the next channel change offers
+	/// again instead of staying silent forever.
+	static func dismissOffer(forNode nodeNum: Int64, store: UserDefaults = .standard) {
+		guard let changedAt = changedAt(forNode: nodeNum, store: store) else { return }
+		store.set(changedAt, forKey: dismissedKey(forNode: nodeNum))
+	}
+
+	/// Whether to offer the cleanup for this radio's most recent channel change.
+	static func shouldOfferCleanup(forNode nodeNum: Int64, store: UserDefaults = .standard) -> Bool {
+		guard let changedAt = changedAt(forNode: nodeNum, store: store) else { return false }
+		let dismissed = store.object(forKey: dismissedKey(forNode: nodeNum)) as? Date
+		return dismissed != changedAt
+	}
+
+	/// Whether this node has not been heard since the radio changed channel.
+	///
+	/// A node heard over MQTT arrived over the internet rather than this radio's channel, so hearing
+	/// it says nothing about whether the two share a channel. A node with no last-heard time at all
+	/// has never been heard, so there is nothing to compare and it is left unflagged — that is a
+	/// different problem from having gone quiet.
+	static func isUnheard(lastHeard: Date?, viaMqtt: Bool, changedAt: Date?) -> Bool {
+		guard let changedAt else { return false }
+		guard !viaMqtt else { return false }
+		guard let lastHeard, lastHeard > Date(timeIntervalSince1970: 0) else { return false }
+		return lastHeard < changedAt
+	}
+}

--- a/Meshtastic/Helpers/LoRaConfigChange.swift
+++ b/Meshtastic/Helpers/LoRaConfigChange.swift
@@ -54,12 +54,19 @@ enum LoRaConfigChange {
 		"loraChannelChangedAt.\(nodeNum)"
 	}
 
+	/// Stored as epoch seconds rather than a `Date`: it reads back from the argument domain, so a
+	/// launch argument can stand in for a real channel change when driving the app in a simulator,
+	/// and the value is legible in the preferences plist.
 	static func changedAt(forNode nodeNum: Int64, store: UserDefaults = .standard) -> Date? {
-		store.object(forKey: key(forNode: nodeNum)) as? Date
+		// double(forKey:) rather than object(forKey:) as? Double: it coerces, so the value reads back
+		// whether it was written as a number or arrived as a string from the argument domain.
+		let seconds = store.double(forKey: key(forNode: nodeNum))
+		guard seconds > 0 else { return nil }
+		return Date(timeIntervalSince1970: seconds)
 	}
 
 	static func recordChange(forNode nodeNum: Int64, at date: Date = .now, store: UserDefaults = .standard) {
-		store.set(date, forKey: key(forNode: nodeNum))
+		store.set(date.timeIntervalSince1970, forKey: key(forNode: nodeNum))
 	}
 
 	static func clear(forNode nodeNum: Int64, store: UserDefaults = .standard) {
@@ -79,14 +86,14 @@ enum LoRaConfigChange {
 	/// again instead of staying silent forever.
 	static func dismissOffer(forNode nodeNum: Int64, store: UserDefaults = .standard) {
 		guard let changedAt = changedAt(forNode: nodeNum, store: store) else { return }
-		store.set(changedAt, forKey: dismissedKey(forNode: nodeNum))
+		store.set(changedAt.timeIntervalSince1970, forKey: dismissedKey(forNode: nodeNum))
 	}
 
 	/// Whether to offer the cleanup for this radio's most recent channel change.
 	static func shouldOfferCleanup(forNode nodeNum: Int64, store: UserDefaults = .standard) -> Bool {
 		guard let changedAt = changedAt(forNode: nodeNum, store: store) else { return false }
-		let dismissed = store.object(forKey: dismissedKey(forNode: nodeNum)) as? Date
-		return dismissed != changedAt
+		let dismissed = store.double(forKey: dismissedKey(forNode: nodeNum))
+		return dismissed != changedAt.timeIntervalSince1970
 	}
 
 	/// Whether this node has not been heard since the radio changed channel.

--- a/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
+++ b/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
@@ -1,0 +1,135 @@
+//
+//  UnheardNodesBanner.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import SwiftUI
+import SwiftData
+import OSLog
+
+/// Offered after the radio's LoRa settings move it to a different channel.
+///
+/// The node db does not move with the radio: every node in the list was heard on the old channel and
+/// has no channel in common with this radio any more. Sends to them fail, and for channel broadcasts
+/// they fail silently, because a broadcast carries no ack.
+///
+/// Only ever an offer. The client node db is deliberately a superset of the radio's, so nothing is
+/// removed without the user asking — a node may simply be out of range rather than on another preset,
+/// and it comes back on its own when it is next heard.
+struct UnheardNodesBanner: View {
+	let connectedNodeNum: Int64
+	@Environment(\.modelContext) private var context
+	@EnvironmentObject private var accessoryManager: AccessoryManager
+
+	@State private var unheardNodes: [NodeInfoEntity] = []
+	@State private var isConfirming = false
+	@State private var isRemoving = false
+
+	var body: some View {
+		Group {
+			if !unheardNodes.isEmpty, LoRaConfigChange.shouldOfferCleanup(forNode: connectedNodeNum) {
+				content
+			}
+		}
+		.onAppear(perform: refresh)
+		.onChange(of: accessoryManager.activeDeviceNum) { _, _ in refresh() }
+	}
+
+	private var content: some View {
+		HStack(alignment: .top, spacing: 12) {
+			Image(systemName: "antenna.radiowaves.left.and.right.slash")
+				.font(.title3)
+				.foregroundStyle(.orange)
+
+			VStack(alignment: .leading, spacing: 6) {
+				// The honest claim: we know we have not heard them since the settings changed. We
+				// cannot know they moved to another preset — a radio cannot observe a channel it is
+				// not tuned to.
+				Text("^[\(unheardNodes.count) node](inflect: true) not heard since you changed settings")
+					.font(.callout.weight(.semibold))
+				Text("They were heard on the old channel and cannot be reached from this one. Favorites and the connected node are kept.")
+					.font(.caption)
+					.foregroundStyle(.secondary)
+
+				HStack {
+					Button(role: .destructive) {
+						isConfirming = true
+					} label: {
+						Text("Remove Them")
+					}
+					.buttonStyle(.borderedProminent)
+					.disabled(isRemoving)
+
+					Button {
+						LoRaConfigChange.dismissOffer(forNode: connectedNodeNum)
+						refresh()
+					} label: {
+						Text("Keep")
+					}
+					.buttonStyle(.bordered)
+					.disabled(isRemoving)
+				}
+				.controlSize(.small)
+			}
+			Spacer(minLength: 0)
+		}
+		.padding(12)
+		.background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+		.padding(.horizontal)
+		.padding(.bottom, 4)
+		.confirmationDialog(
+			Text("Remove ^[\(unheardNodes.count) node](inflect: true)?", comment: "Confirmation title for removing nodes not heard since the settings changed"),
+			isPresented: $isConfirming,
+			titleVisibility: .visible
+		) {
+			Button(role: .destructive) {
+				Task { await removeUnheardNodes() }
+			} label: {
+				Text("Remove", comment: "Confirms removing nodes not heard since the settings changed")
+			}
+			Button(role: .cancel) { } label: {
+				Text("Cancel")
+			}
+		} message: {
+			Text("They are removed from this app and from the radio. Any that are still out there come back when they are next heard.")
+		}
+	}
+
+	/// Nodes heard before the change and not since, excluding favorites and the radio itself.
+	private func refresh() {
+		guard let changedAt = LoRaConfigChange.changedAt(forNode: connectedNodeNum) else {
+			unheardNodes = []
+			return
+		}
+		let descriptor = FetchDescriptor<NodeInfoEntity>(
+			predicate: #Predicate { $0.favorite == false && $0.num != connectedNodeNum }
+		)
+		let candidates = (try? context.fetch(descriptor)) ?? []
+		unheardNodes = candidates.filter {
+			LoRaConfigChange.isUnheard(lastHeard: $0.lastHeard, viaMqtt: $0.viaMqtt, changedAt: changedAt)
+		}
+	}
+
+	private func removeUnheardNodes() async {
+		isRemoving = true
+		defer { isRemoving = false }
+
+		var removed = 0
+		for node in unheardNodes {
+			do {
+				try await accessoryManager.removeNode(node: node, connectedNodeNum: connectedNodeNum)
+				removed += 1
+			} catch {
+				// Keep going: one node the radio refuses should not strand the rest, and whatever
+				// survives is still listed and offered again.
+				Logger.data.error("Could not remove unheard node \(node.num.toHex(), privacy: .public): \(error.localizedDescription, privacy: .public)")
+			}
+		}
+		Logger.data.info("Removed \(removed, privacy: .public) of \(unheardNodes.count, privacy: .public) nodes not heard since the channel changed")
+
+		LoRaConfigChange.dismissOffer(forNode: connectedNodeNum)
+		refresh()
+	}
+}

--- a/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
+++ b/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
@@ -103,10 +103,20 @@ struct UnheardNodesBanner: View {
 			unheardNodes = []
 			return
 		}
+		// Bound to a local first: a #Predicate that reaches through self for the node number throws
+		// at fetch time, and the failure is invisible — it just yields no nodes and no banner.
+		let excludedNum = connectedNodeNum
 		let descriptor = FetchDescriptor<NodeInfoEntity>(
-			predicate: #Predicate { $0.favorite == false && $0.num != connectedNodeNum }
+			predicate: #Predicate { $0.favorite == false && $0.num != excludedNum }
 		)
-		let candidates = (try? context.fetch(descriptor)) ?? []
+		let candidates: [NodeInfoEntity]
+		do {
+			candidates = try context.fetch(descriptor)
+		} catch {
+			Logger.data.error("Could not read nodes to flag after a channel change: \(error.localizedDescription, privacy: .public)")
+			unheardNodes = []
+			return
+		}
 		unheardNodes = candidates.filter {
 			LoRaConfigChange.isUnheard(lastHeard: $0.lastHeard, viaMqtt: $0.viaMqtt, changedAt: changedAt)
 		}

--- a/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
+++ b/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
@@ -19,7 +19,6 @@ import OSLog
 /// removed without the user asking — a node may simply be out of range rather than on another preset,
 /// and it comes back on its own when it is next heard.
 struct UnheardNodesBanner: View {
-	let connectedNodeNum: Int64
 	@Environment(\.modelContext) private var context
 	@EnvironmentObject private var accessoryManager: AccessoryManager
 
@@ -27,17 +26,23 @@ struct UnheardNodesBanner: View {
 	@State private var isConfirming = false
 	@State private var isRemoving = false
 
+	/// Resolved here rather than passed in. A parent that only builds this view once a radio is
+	/// connected has to be re-evaluated when one arrives, and inside a `safeAreaInset` that
+	/// evaluates during layout — before the connection is established — it simply stays empty.
+	private var connectedNodeNum: Int64? { accessoryManager.activeDeviceNum }
+
 	var body: some View {
 		Group {
-			if !unheardNodes.isEmpty, LoRaConfigChange.shouldOfferCleanup(forNode: connectedNodeNum) {
-				content
+			if let connectedNodeNum, !unheardNodes.isEmpty,
+			   LoRaConfigChange.shouldOfferCleanup(forNode: connectedNodeNum) {
+				content(connectedNodeNum: connectedNodeNum)
 			}
 		}
 		.onAppear(perform: refresh)
 		.onChange(of: accessoryManager.activeDeviceNum) { _, _ in refresh() }
 	}
 
-	private var content: some View {
+	private func content(connectedNodeNum: Int64) -> some View {
 		HStack(alignment: .top, spacing: 12) {
 			Image(systemName: "antenna.radiowaves.left.and.right.slash")
 				.font(.title3)
@@ -53,11 +58,12 @@ struct UnheardNodesBanner: View {
 					.font(.caption)
 					.foregroundStyle(.secondary)
 
-				HStack {
+				HStack(spacing: 12) {
 					Button(role: .destructive) {
 						isConfirming = true
 					} label: {
 						Text("Remove Them")
+							.frame(minWidth: 48, minHeight: 48)
 					}
 					.buttonStyle(.borderedProminent)
 					.disabled(isRemoving)
@@ -67,11 +73,11 @@ struct UnheardNodesBanner: View {
 						refresh()
 					} label: {
 						Text("Keep")
+							.frame(minWidth: 48, minHeight: 48)
 					}
 					.buttonStyle(.bordered)
 					.disabled(isRemoving)
 				}
-				.controlSize(.small)
 			}
 			Spacer(minLength: 0)
 		}
@@ -85,7 +91,7 @@ struct UnheardNodesBanner: View {
 			titleVisibility: .visible
 		) {
 			Button(role: .destructive) {
-				Task { await removeUnheardNodes() }
+				Task { await removeUnheardNodes(connectedNodeNum: connectedNodeNum) }
 			} label: {
 				Text("Remove", comment: "Confirms removing nodes not heard since the settings changed")
 			}
@@ -99,6 +105,10 @@ struct UnheardNodesBanner: View {
 
 	/// Nodes heard before the change and not since, excluding favorites and the radio itself.
 	private func refresh() {
+		guard let connectedNodeNum else {
+			unheardNodes = []
+			return
+		}
 		guard let changedAt = LoRaConfigChange.changedAt(forNode: connectedNodeNum) else {
 			unheardNodes = []
 			return
@@ -122,24 +132,41 @@ struct UnheardNodesBanner: View {
 		}
 	}
 
-	private func removeUnheardNodes() async {
+	private func removeUnheardNodes(connectedNodeNum: Int64) async {
 		isRemoving = true
 		defer { isRemoving = false }
 
+		// The list was built when the banner appeared. A node can be heard again between then and the
+		// confirmation, and removing one that has just come back is the one outcome worth avoiding
+		// here — so each is re-checked against the current lastHeard rather than trusted.
+		let changedAt = LoRaConfigChange.changedAt(forNode: connectedNodeNum)
 		var removed = 0
+		var failed = 0
+		var recovered = 0
+
 		for node in unheardNodes {
+			guard LoRaConfigChange.isUnheard(
+				lastHeard: node.lastHeard, viaMqtt: node.viaMqtt, changedAt: changedAt
+			) else {
+				recovered += 1
+				continue
+			}
 			do {
 				try await accessoryManager.removeNode(node: node, connectedNodeNum: connectedNodeNum)
 				removed += 1
 			} catch {
-				// Keep going: one node the radio refuses should not strand the rest, and whatever
-				// survives is still listed and offered again.
+				// Keep going: one node the radio refuses should not strand the rest.
+				failed += 1
 				Logger.data.error("Could not remove unheard node \(node.num.toHex(), privacy: .public): \(error.localizedDescription, privacy: .public)")
 			}
 		}
-		Logger.data.info("Removed \(removed, privacy: .public) of \(unheardNodes.count, privacy: .public) nodes not heard since the channel changed")
+		Logger.data.info("Removed \(removed, privacy: .public) nodes not heard since the channel changed, \(failed, privacy: .public) failed, \(recovered, privacy: .public) heard again before removal")
 
-		LoRaConfigChange.dismissOffer(forNode: connectedNodeNum)
+		// Only stand the offer down once nothing is left to remove. Dismissing after a partial
+		// failure would hide the banner and take the retry with it.
+		if failed == 0 {
+			LoRaConfigChange.dismissOffer(forNode: connectedNodeNum)
+		}
 		refresh()
 	}
 }

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -95,6 +95,14 @@ struct NodeList: View {
 		.sheet(isPresented: $showingHelp) {
 			NodeListHelp()
 		}
+		.safeAreaInset(edge: .top) {
+			// Shown after the radio's LoRa settings move it to a different channel. A banner rather
+			// than an alert on the settings screen: a LoRa write reboots the radio, so anything modal
+			// at save time competes with the reconnect, and this needs to survive being missed.
+			if let connectedNodeNum = accessoryManager.activeDeviceNum {
+				UnheardNodesBanner(connectedNodeNum: connectedNodeNum)
+			}
+		}
 		.safeAreaInset(edge: .bottom, alignment: .leading) {
 			HStack {
 				Button(action: {

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -99,9 +99,7 @@ struct NodeList: View {
 			// Shown after the radio's LoRa settings move it to a different channel. A banner rather
 			// than an alert on the settings screen: a LoRa write reboots the radio, so anything modal
 			// at save time competes with the reconnect, and this needs to survive being missed.
-			if let connectedNodeNum = accessoryManager.activeDeviceNum {
-				UnheardNodesBanner(connectedNodeNum: connectedNodeNum)
-			}
+			UnheardNodesBanner()
 		}
 		.safeAreaInset(edge: .bottom, alignment: .leading) {
 			HStack {

--- a/Meshtastic/Views/Settings/Config/LoRaConfig.swift
+++ b/Meshtastic/Views/Settings/Config/LoRaConfig.swift
@@ -300,7 +300,33 @@ struct LoRaConfig: View {
 			   connectedNode.num == node?.user?.num ?? 0 {
 				UserDefaults.modemPreset = modemPreset
 			}
+
+			// Read the stored settings before the save: the radio reboots on a LoRa write and echoes
+			// the new config back, so afterwards there is nothing left to compare against.
+			let previous = node?.loRaConfig.map {
+				LoRaChannelSettings(
+					regionCode: $0.regionCode, modemPreset: $0.modemPreset, usePreset: $0.usePreset,
+					channelNum: $0.channelNum, overrideFrequency: $0.overrideFrequency,
+					bandwidth: $0.bandwidth, spreadFactor: $0.spreadFactor, codingRate: $0.codingRate
+				)
+			}
+			let updated = LoRaChannelSettings(
+				regionCode: Int32(region), modemPreset: Int32(modemPreset), usePreset: usePreset,
+				channelNum: Int32(channelNum), overrideFrequency: overrideFrequency,
+				bandwidth: Int32(bandwidth), spreadFactor: Int32(spreadFactor),
+				codingRate: Int32(normalizedCodingRate)
+			)
+
 			_ = try await accessoryManager.saveLoRaConfig(config: lc, fromUser: fromUser, toUser: toUser)
+
+			// Only when the radio actually moved channel, and only for a change made here. The
+			// beacon join flow writes the same config to follow a mesh it has just found, where every
+			// node in the list is expected to be on the old channel and there is nothing to offer.
+			if let previous, updated.movesOffChannel(from: previous),
+			   let targetNum = node?.user?.num {
+				LoRaConfigChange.recordChange(forNode: targetNum)
+				Logger.mesh.info("📡 LoRa settings moved node \(targetNum.toHex(), privacy: .public) to a different channel; flagging nodes not heard since")
+			}
 		}
 	}
 

--- a/MeshtasticTests/LoRaConfigChangeTests.swift
+++ b/MeshtasticTests/LoRaConfigChangeTests.swift
@@ -1,0 +1,135 @@
+//
+//  LoRaConfigChangeTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import Testing
+import Foundation
+@testable import Meshtastic
+
+@Suite("LoRa channel change")
+struct LoRaConfigChangeTests {
+
+	private func settings(
+		region: Int32 = 1,
+		preset: Int32 = 3,
+		usePreset: Bool = true,
+		channelNum: Int32 = 0,
+		overrideFrequency: Float = 0,
+		bandwidth: Int32 = 250,
+		spreadFactor: Int32 = 11,
+		codingRate: Int32 = 5
+	) -> LoRaChannelSettings {
+		LoRaChannelSettings(
+			regionCode: region, modemPreset: preset, usePreset: usePreset,
+			channelNum: channelNum, overrideFrequency: overrideFrequency,
+			bandwidth: bandwidth, spreadFactor: spreadFactor, codingRate: codingRate
+		)
+	}
+
+	@Test("an unchanged config does not move the radio")
+	func unchangedStaysPut() {
+		#expect(!settings().movesOffChannel(from: settings()))
+	}
+
+	@Test("region, preset, slot and override frequency each move the radio")
+	func channelDefiningFieldsMove() {
+		#expect(settings(region: 2).movesOffChannel(from: settings()))
+		#expect(settings(preset: 5).movesOffChannel(from: settings()))
+		#expect(settings(channelNum: 20).movesOffChannel(from: settings()))
+		#expect(settings(overrideFrequency: 906.875).movesOffChannel(from: settings()))
+		#expect(settings(usePreset: false).movesOffChannel(from: settings()))
+	}
+
+	@Test("custom radio parameters only count when the radio is using them")
+	func customParametersOnlyCountWhenActive() {
+		// usePreset true: the radio derives its channel from the preset and ignores these, so
+		// editing them changes a stored value with no effect on what it listens to.
+		#expect(!settings(bandwidth: 125).movesOffChannel(from: settings()))
+		#expect(!settings(spreadFactor: 12).movesOffChannel(from: settings()))
+		#expect(!settings(codingRate: 8).movesOffChannel(from: settings()))
+
+		// usePreset false: now they define the channel.
+		let custom = settings(usePreset: false)
+		#expect(settings(usePreset: false, bandwidth: 125).movesOffChannel(from: custom))
+		#expect(settings(usePreset: false, spreadFactor: 12).movesOffChannel(from: custom))
+		#expect(settings(usePreset: false, codingRate: 8).movesOffChannel(from: custom))
+	}
+
+	@Test("changing the preset while on custom parameters does not move the radio")
+	func presetIgnoredWhileCustom() {
+		let custom = settings(usePreset: false)
+		#expect(!settings(preset: 5, usePreset: false).movesOffChannel(from: custom))
+	}
+
+	@Test("a node heard before the change is flagged, one heard after is not")
+	func flagsNodesHeardBeforeTheChange() {
+		let changedAt = Date(timeIntervalSince1970: 2000)
+		#expect(LoRaConfigChange.isUnheard(
+			lastHeard: Date(timeIntervalSince1970: 1000), viaMqtt: false, changedAt: changedAt))
+		#expect(!LoRaConfigChange.isUnheard(
+			lastHeard: Date(timeIntervalSince1970: 3000), viaMqtt: false, changedAt: changedAt))
+	}
+
+	@Test("MQTT hears do not clear the flag")
+	func mqttDoesNotCount() {
+		// Heard over the internet, not over this radio's channel, so it says nothing about whether
+		// the two still share one.
+		#expect(!LoRaConfigChange.isUnheard(
+			lastHeard: Date(timeIntervalSince1970: 3000), viaMqtt: true,
+			changedAt: Date(timeIntervalSince1970: 2000)))
+	}
+
+	@Test("nothing is flagged before a change has been recorded")
+	func noChangeMeansNoFlags() {
+		#expect(!LoRaConfigChange.isUnheard(
+			lastHeard: Date(timeIntervalSince1970: 1000), viaMqtt: false, changedAt: nil))
+	}
+
+	@Test("a node that has never been heard is not flagged")
+	func neverHeardIsNotFlagged() {
+		// Never heard is a different problem from gone quiet, and the epoch default is what an
+		// unheard node carries in the store.
+		let changedAt = Date(timeIntervalSince1970: 2000)
+		#expect(!LoRaConfigChange.isUnheard(lastHeard: nil, viaMqtt: false, changedAt: changedAt))
+		#expect(!LoRaConfigChange.isUnheard(
+			lastHeard: Date(timeIntervalSince1970: 0), viaMqtt: false, changedAt: changedAt))
+	}
+
+	@Test("the recorded change is per radio")
+	func changeIsRecordedPerRadio() throws {
+		let store = try #require(UserDefaults(suiteName: "LoRaConfigChangeTests"))
+		defer { store.removePersistentDomain(forName: "LoRaConfigChangeTests") }
+
+		let when = Date(timeIntervalSince1970: 5000)
+		LoRaConfigChange.recordChange(forNode: 4242, at: when, store: store)
+
+		#expect(LoRaConfigChange.changedAt(forNode: 4242, store: store) == when)
+		// A different radio has its own settings and its own history.
+		#expect(LoRaConfigChange.changedAt(forNode: 9999, store: store) == nil)
+
+		LoRaConfigChange.clear(forNode: 4242, store: store)
+		#expect(LoRaConfigChange.changedAt(forNode: 4242, store: store) == nil)
+	}
+
+	@Test("the offer stands until dismissed, and returns on the next change")
+	func offerIsPerChange() throws {
+		let store = try #require(UserDefaults(suiteName: "LoRaConfigChangeOfferTests"))
+		defer { store.removePersistentDomain(forName: "LoRaConfigChangeOfferTests") }
+
+		#expect(!LoRaConfigChange.shouldOfferCleanup(forNode: 7, store: store))
+
+		LoRaConfigChange.recordChange(forNode: 7, at: Date(timeIntervalSince1970: 1000), store: store)
+		#expect(LoRaConfigChange.shouldOfferCleanup(forNode: 7, store: store))
+
+		LoRaConfigChange.dismissOffer(forNode: 7, store: store)
+		#expect(!LoRaConfigChange.shouldOfferCleanup(forNode: 7, store: store))
+
+		// A later change is a new question, not the one they already answered.
+		LoRaConfigChange.recordChange(forNode: 7, at: Date(timeIntervalSince1970: 2000), store: store)
+		#expect(LoRaConfigChange.shouldOfferCleanup(forNode: 7, store: store))
+	}
+
+}

--- a/MeshtasticTests/LoRaConfigChangeTests.swift
+++ b/MeshtasticTests/LoRaConfigChangeTests.swift
@@ -7,6 +7,7 @@
 
 import Testing
 import Foundation
+import SwiftData
 @testable import Meshtastic
 
 @Suite("LoRa channel change")
@@ -130,6 +131,53 @@ struct LoRaConfigChangeTests {
 		// A later change is a new question, not the one they already answered.
 		LoRaConfigChange.recordChange(forNode: 7, at: Date(timeIntervalSince1970: 2000), store: store)
 		#expect(LoRaConfigChange.shouldOfferCleanup(forNode: 7, store: store))
+	}
+
+
+	/// The banner's fetch, which is where the bug was: a `#Predicate` that reached through `self`
+	/// for the node number threw at fetch time, `try?` turned it into an empty result, and the
+	/// banner silently never appeared. Every other test here covers the pure logic and passed
+	/// throughout.
+	@Test("the node fetch excludes favorites and the connected radio")
+	@MainActor
+	func fetchExcludesFavoritesAndConnectedNode() throws {
+		let schema = Schema(versionedSchema: MeshtasticSchema.current)
+		let container = try ModelContainer(
+			for: schema,
+			configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+		)
+		let context = ModelContext(container)
+
+		let connectedNum: Int64 = 4242
+		func makeNode(num: Int64, favorite: Bool) {
+			let node = NodeInfoEntity()
+			node.num = num
+			node.favorite = favorite
+			node.lastHeard = Date(timeIntervalSince1970: 1000)
+			context.insert(node)
+		}
+		makeNode(num: connectedNum, favorite: false)   // the radio itself
+		makeNode(num: 1, favorite: true)               // a favorite
+		makeNode(num: 2, favorite: false)              // eligible
+		makeNode(num: 3, favorite: false)              // eligible
+		try context.save()
+
+		// Bound to a local, exactly as the view does. Reaching through self here is what threw.
+		let excludedNum = connectedNum
+		let descriptor = FetchDescriptor<NodeInfoEntity>(
+			predicate: #Predicate { $0.favorite == false && $0.num != excludedNum }
+		)
+		let candidates = try context.fetch(descriptor)
+
+		#expect(Set(candidates.map(\.num)) == [2, 3])
+
+		let flagged = candidates.filter {
+			LoRaConfigChange.isUnheard(
+				lastHeard: $0.lastHeard, viaMqtt: $0.viaMqtt,
+				changedAt: Date(timeIntervalSince1970: 2000)
+			)
+		}
+		#expect(flagged.count == 2)
 	}
 
 }


### PR DESCRIPTION
## Summary

Changing region, preset, frequency slot or the custom radio parameters moves the radio to a different channel. The node db does not move with it: every node in the list was heard on the old channel and cannot be reached from the new one. Sends to them fail, and for channel broadcasts they fail silently, because a broadcast carries no ack.

After a LoRa save from Settings that actually moved the radio, the node list now offers to remove the nodes that have not been heard since.

Partial, local implementation of [design#146](https://github.com/meshtastic/design/issues/146). The firmware field it specifies (`NodeInfo.heard_on_current_lora`) does not exist yet — meshtastic/protobufs#1060 and meshtastic/firmware#11745 are both still open — but the app already stores everything needed to work it out: the LoRa settings, and the last-heard time for every node.

## What changed

`LoRaChannelSettings.movesOffChannel(from:)` decides whether a save actually moved the radio. The custom bandwidth, spread factor and coding rate only count when `usePreset` is false, and the preset only counts when it is true, so editing a value the radio is ignoring does not trigger anything.

`LoRaConfigChange` records when the radio last moved channel and answers whether a given node has been heard since. A node heard over MQTT does not count, because that arrived over the internet rather than this radio's channel. A node that has never been heard at all is left alone — that is a different problem from having gone quiet.

The node list shows a banner offering to remove the flagged nodes. Favorites and the connected node are always kept. It is only ever an offer: the client node db is deliberately a superset of the radio's, a node may simply be out of range, and it comes back on its own when it is next heard. Answering "Keep" is remembered for that change but not for the next one.

Only the Settings path records a change. The beacon join flow writes the same config through the same transport call to follow a mesh it has just found, where every node in the list is expected to be on the old channel and there is nothing worth offering.

## Notes

A banner on the node list rather than an alert on save. `performConfigSave` dismisses the view on success, so an alert raised there is racing its own dismissal, and a banner survives being missed — which an alert does not. design#146 describes an aggregate banner for the same reason.

An earlier version of this description said a LoRa write reboots the radio and used that as a third reason. That is wrong on 2.8, which applies LoRa changes live (firmware #9962) and keeps the connection up — see #2403. The two reasons above hold either way.

The change timestamp lives in `UserDefaults`, keyed per radio, rather than in the store. `MeshtasticSchemaV1` is frozen by #2423, and a new schema version plus a migration stage for a single `Date` is not a trade worth making.

Removal goes through `accessoryManager.removeNode`, so nodes are removed from the radio as well as the app, matching the existing single-node delete. A node the radio refuses is logged and skipped rather than aborting the rest.

## Testing

- Built for the iOS Simulator.
- `LoRaConfigChangeTests` — 11 tests, all passing: which fields move the radio, custom parameters only counting when active, nodes either side of the change, MQTT hears not counting, never-heard nodes not flagged, per-radio recording, the offer returning on a later change, and the node fetch against an in-memory container.
- Seen rendering in the simulator against the seeded node set: 126 of 144 nodes flagged, the other 18 being favorites, MQTT-heard, or the connected radio.

Getting it on screen turned up three bugs that the tests did not, all now fixed here:

- The fetch used a `#Predicate` reaching through `self` for the connected node number, which SwiftData cannot compile. It threw, `try?` turned it into an empty result, and nothing was logged.
- The banner was built by the parent only once a radio was connected, inside a `safeAreaInset` that evaluates during layout — before the connection exists. It resolved empty and never came back, so none of this ran at all. It resolves the connected node itself now. This would have affected a real cold launch too, where the node list renders before the radio connects.
- A partial removal failure dismissed the offer anyway, hiding the banner and taking the retry with it.

Not yet exercised against a real preset change on hardware.

