### PR TITLE
Stop assuming a LoRa save reboots the radio

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+ToRadio.swift
@@ -783,11 +783,12 @@ extension AccessoryManager {
 			}
 		}
 
-		// Re-sync after the change. When we sent a LoRa config the device reboots
-		// and the connection drops, so the follow-up wantConfig is expected to fail
-		// — treat that as success since the channels/config were already delivered.
-		// When no reboot is expected, let wantConfig errors surface normally.
-		if didSendLoRaConfig {
+		// Re-sync after the change. On firmware before 2.8 a LoRa config write reboots the device and
+		// the connection drops, so the follow-up wantConfig is expected to fail — treat that as
+		// success since the channels/config were already delivered. 2.8 applies LoRa changes live
+		// (firmware #9962), so the connection survives and a wantConfig failure there is a real
+		// failure worth surfacing rather than shrugging off as a reboot.
+		if didSendLoRaConfig && !appliesLoRaConfigWithoutReboot {
 			do {
 				Logger.transport.debug("[AccessoryManager] sending wantConfig after channel set (device may reboot)")
 				try await sendWantConfig()
@@ -795,7 +796,7 @@ extension AccessoryManager {
 				Logger.transport.warning("[AccessoryManager] wantConfig after channel set did not complete; device is likely rebooting: \(error.localizedDescription, privacy: .public)")
 			}
 		} else {
-			Logger.transport.debug("[AccessoryManager] sending wantConfig for saveChannelSet")
+			Logger.transport.debug("[AccessoryManager] sending wantConfig for saveChannelSet (no reboot expected)")
 			try await sendWantConfig()
 		}
 	}

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -1340,14 +1340,22 @@ extension AccessoryManager {
 	/// skipped the reboot only when no radio field actually changed, which a real edit never
 	/// satisfies.
 	///
-	/// Deliberately conservative where the other gates here are permissive. `checkIsVersionSupported`
-	/// returns true for an unknown version, and assuming "no reboot" when we do not know is the
-	/// direction that hurts: it warns nobody before a reboot they did not expect, and it turns a real
-	/// post-save failure into a shrug. Unknown means assume it may reboot.
+	/// Deliberately conservative where the other gates here are permissive, and read from the live
+	/// connection only. `UserDefaults.firmwareVersion` is global rather than per radio, so falling
+	/// back to it right after switching radios answers for the *previous* radio — and assuming
+	/// "no reboot" on the wrong radio is the direction that hurts: it warns nobody before a reboot
+	/// they did not expect, and turns a real post-save failure into a shrug. No live version means
+	/// assume it may reboot, which merely restores the old forgiving behavior for that window.
 	var appliesLoRaConfigWithoutReboot: Bool {
-		let live = connectedVersion ?? ""
-		let known = !live.isEmpty || UserDefaults.firmwareVersion != "0.0.0"
-		return known && checkIsVersionSupported(forVersion: "2.8.0")
+		Self.appliesLoRaConfigWithoutReboot(liveVersion: connectedVersion)
+	}
+
+	/// Pure core of the gate, split out so tests exercise the decision without a live connection
+	/// or the global stored version.
+	nonisolated static func appliesLoRaConfigWithoutReboot(liveVersion: String?) -> Bool {
+		guard let liveVersion, !liveVersion.isEmpty else { return false }
+		let comparison = "2.8.0".compare(liveVersion, options: .numeric)
+		return comparison == .orderedAscending || comparison == .orderedSame
 	}
 }
 

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -1333,6 +1333,22 @@ extension AccessoryManager {
 	var supportsStatusMessage: Bool {
 		checkIsVersionSupported(forVersion: "2.8.0")
 	}
+
+	/// Whether a LoRa config save lands without dropping the connection.
+	///
+	/// Firmware 2.8 applies every LoRa change live (firmware #9962). Before that, `set_config(lora)`
+	/// skipped the reboot only when no radio field actually changed, which a real edit never
+	/// satisfies.
+	///
+	/// Deliberately conservative where the other gates here are permissive. `checkIsVersionSupported`
+	/// returns true for an unknown version, and assuming "no reboot" when we do not know is the
+	/// direction that hurts: it warns nobody before a reboot they did not expect, and it turns a real
+	/// post-save failure into a shrug. Unknown means assume it may reboot.
+	var appliesLoRaConfigWithoutReboot: Bool {
+		let live = connectedVersion ?? ""
+		let known = !live.isEmpty || UserDefaults.firmwareVersion != "0.0.0"
+		return known && checkIsVersionSupported(forVersion: "2.8.0")
+	}
 }
 
 extension AccessoryManager {

--- a/MeshtasticTests/LoRaRebootCapabilityTests.swift
+++ b/MeshtasticTests/LoRaRebootCapabilityTests.swift
@@ -1,0 +1,54 @@
+//
+//  LoRaRebootCapabilityTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/5/26.
+//
+
+import Testing
+import Foundation
+@testable import Meshtastic
+
+/// Covers `AccessoryManager.appliesLoRaConfigWithoutReboot`.
+///
+/// Firmware 2.8 applies LoRa changes live, so the connection survives a save. The gate has to stay
+/// conservative when the firmware version is unknown: assuming no reboot there drops the warning
+/// before a reboot the user did not expect, and turns a genuine post-save failure into a shrug.
+@Suite("LoRa save reboot capability")
+@MainActor
+struct LoRaRebootCapabilityTests {
+
+	private func withFirmwareVersion(_ version: String?, _ body: () -> Void) {
+		let previous = UserDefaults.firmwareVersion
+		UserDefaults.firmwareVersion = version ?? "0.0.0"
+		defer { UserDefaults.firmwareVersion = previous }
+		body()
+	}
+
+	@Test("2.8 and later apply LoRa config without a reboot")
+	func liveApplyOnTwoEight() {
+		for version in ["2.8.0", "2.8.1", "2.9.0", "3.0.0"] {
+			withFirmwareVersion(version) {
+				#expect(AccessoryManager.shared.appliesLoRaConfigWithoutReboot, "expected no reboot on \(version)")
+			}
+		}
+	}
+
+	@Test("firmware before 2.8 still reboots on a LoRa save")
+	func rebootsBeforeTwoEight() {
+		for version in ["2.7.21", "2.7.0", "2.6.17"] {
+			withFirmwareVersion(version) {
+				#expect(!AccessoryManager.shared.appliesLoRaConfigWithoutReboot, "expected a reboot on \(version)")
+			}
+		}
+	}
+
+	@Test("an unknown firmware version assumes a reboot")
+	func unknownAssumesReboot() {
+		// The other capability gates are permissive when the version is unknown, because showing a
+		// feature early is cheap. Here the permissive answer is the harmful one.
+		withFirmwareVersion(nil) {
+			#expect(!AccessoryManager.shared.appliesLoRaConfigWithoutReboot)
+		}
+	}
+}

--- a/MeshtasticTests/LoRaRebootCapabilityTests.swift
+++ b/MeshtasticTests/LoRaRebootCapabilityTests.swift
@@ -9,46 +9,49 @@ import Testing
 import Foundation
 @testable import Meshtastic
 
-/// Covers `AccessoryManager.appliesLoRaConfigWithoutReboot`.
+/// Covers `AccessoryManager.appliesLoRaConfigWithoutReboot(liveVersion:)`.
 ///
-/// Firmware 2.8 applies LoRa changes live, so the connection survives a save. The gate has to stay
-/// conservative when the firmware version is unknown: assuming no reboot there drops the warning
-/// before a reboot the user did not expect, and turns a genuine post-save failure into a shrug.
+/// Firmware 2.8 applies LoRa changes live, so the connection survives a save. The gate reads only
+/// the live connection's version: `UserDefaults.firmwareVersion` is global rather than per radio,
+/// so consulting it right after a radio switch would answer for the previous radio.
 @Suite("LoRa save reboot capability")
-@MainActor
 struct LoRaRebootCapabilityTests {
-
-	private func withFirmwareVersion(_ version: String?, _ body: () -> Void) {
-		let previous = UserDefaults.firmwareVersion
-		UserDefaults.firmwareVersion = version ?? "0.0.0"
-		defer { UserDefaults.firmwareVersion = previous }
-		body()
-	}
 
 	@Test("2.8 and later apply LoRa config without a reboot")
 	func liveApplyOnTwoEight() {
-		for version in ["2.8.0", "2.8.1", "2.9.0", "3.0.0"] {
-			withFirmwareVersion(version) {
-				#expect(AccessoryManager.shared.appliesLoRaConfigWithoutReboot, "expected no reboot on \(version)")
-			}
+		for version in ["2.8.0", "2.8.1", "2.8.1.3a0c08b", "2.9.0", "3.0.0"] {
+			#expect(AccessoryManager.appliesLoRaConfigWithoutReboot(liveVersion: version),
+					"expected no reboot on \(version)")
 		}
 	}
 
 	@Test("firmware before 2.8 still reboots on a LoRa save")
 	func rebootsBeforeTwoEight() {
-		for version in ["2.7.21", "2.7.0", "2.6.17"] {
-			withFirmwareVersion(version) {
-				#expect(!AccessoryManager.shared.appliesLoRaConfigWithoutReboot, "expected a reboot on \(version)")
-			}
+		for version in ["2.7.21", "2.7.21.abc123f", "2.7.0", "2.6.17"] {
+			#expect(!AccessoryManager.appliesLoRaConfigWithoutReboot(liveVersion: version),
+					"expected a reboot on \(version)")
 		}
 	}
 
-	@Test("an unknown firmware version assumes a reboot")
+	@Test("no live version assumes a reboot")
 	func unknownAssumesReboot() {
-		// The other capability gates are permissive when the version is unknown, because showing a
-		// feature early is cheap. Here the permissive answer is the harmful one.
-		withFirmwareVersion(nil) {
-			#expect(!AccessoryManager.shared.appliesLoRaConfigWithoutReboot)
-		}
+		// The reconnect window after switching radios is exactly when this is nil. Assuming no
+		// reboot there answers for whatever radio was connected before; assuming a reboot merely
+		// restores the old forgiving behavior until metadata arrives.
+		#expect(!AccessoryManager.appliesLoRaConfigWithoutReboot(liveVersion: nil))
+		#expect(!AccessoryManager.appliesLoRaConfigWithoutReboot(liveVersion: ""))
+	}
+
+	@Test("the stored global version has no influence")
+	func storedVersionDoesNotLeakAcrossRadios() {
+		// The switching-radio regression: a 2.8 radio was connected, its version persisted, then a
+		// pre-2.8 radio connects and the live version is briefly unknown. The stored value must not
+		// make the gate claim the new radio applies LoRa config live.
+		let previous = UserDefaults.firmwareVersion
+		defer { UserDefaults.firmwareVersion = previous }
+
+		UserDefaults.firmwareVersion = "2.8.1"
+		#expect(!AccessoryManager.appliesLoRaConfigWithoutReboot(liveVersion: nil))
+		#expect(!AccessoryManager.appliesLoRaConfigWithoutReboot(liveVersion: "2.7.21"))
 	}
 }


### PR DESCRIPTION
## Summary

Firmware 2.8 applies every LoRa config change live ([firmware #9962](https://github.com/meshtastic/firmware/pull/9962)), so saving LoRa settings no longer drops the connection. Before 2.8, `set_config(lora)` skipped the reboot only when no radio field actually changed, which a real edit never satisfies.

The app still assumed the reboot in one place where it mattered.

## What changed

`saveChannelSet` swallowed `wantConfig` failures whenever it had sent a LoRa config, because the connection was expected to drop and the channels had already been delivered. On 2.8 the connection stays up, so that turned a genuine post-save failure into a shrug logged as "device is likely rebooting". It now only forgives the failure on firmware that actually reboots.

`appliesLoRaConfigWithoutReboot` is the gate. It is deliberately conservative where the other capability gates in that file are permissive: `checkIsVersionSupported` returns true for an unknown version, which is the right default when the cost of being wrong is showing a feature slightly early. Here the permissive answer is the harmful one — it drops the warning before a reboot the user did not expect, and hides a real failure — so an unknown version assumes a reboot.

Left alone deliberately: `DeviceProfileImport.mayReboot` stays `true` for `loraConfig`. Its own comment explains why version-gating it changes nothing — the import commits inside `commit_edit_settings`, which always saves and reboots regardless of the per-item flags.

## Testing

- Built for the iOS Simulator.
- `LoRaRebootCapabilityTests` — 3 tests, all passing: 2.8 and later apply live, pre-2.8 reboots, and an unknown version assumes a reboot.
- Not exercised against hardware. [#2403](https://github.com/meshtastic/Meshtastic-Apple/pull/2403) verified the live-apply behavior on firmware 2.8.1, which is the observation this builds on.

## Note

Related to #2403, which fixes the region banner for the same underlying change. That one clears cached state when the connection survives; this one stops treating a survived connection as a failure to ignore. They do not overlap in code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LoRa configuration saving for supported firmware versions that apply changes without restarting.
  - Configuration save errors are now reported accurately when the device can apply changes immediately.
  - Older or unknown firmware versions continue to be handled conservatively, including expected connection interruptions during LoRa updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->