### PR TITLE
Point backup tests at their own store instead of the live one

### DIFF
--- a/Meshtastic/Persistence/NodeBackupManager.swift
+++ b/Meshtastic/Persistence/NodeBackupManager.swift
@@ -36,12 +36,15 @@ final class NodeBackupManager: NodeBackupManaging {
 
 	private var backupIndex: BackupIndex
 	private let backupBaseURL: URL
+	/// Test-only redirect for the store `createBackup` copies from. Nil in production.
+	private var activeStoreURLOverride: URL?
 	private let fileManager = FileManager.default
 
 	// MARK: - Initialization
 
 	private init() {
 		backupBaseURL = Self.resolveBackupBaseURL()
+		activeStoreURLOverride = nil
 
 		// Ensure backup directory exists
 		try? FileManager.default.createDirectory(at: backupBaseURL, withIntermediateDirectories: true)
@@ -108,8 +111,14 @@ final class NodeBackupManager: NodeBackupManaging {
 	}
 
 	/// Initializer for testing with a custom base URL.
-	init(baseURL: URL) {
+	///
+	/// `activeStoreURL` points `createBackup` at a store the test owns. Without it the manager reads
+	/// the live Application Support store, which the schema-history tests open and replace through
+	/// the real `PersistenceController` — so a full parallel run could catch it mid-manipulation and
+	/// fail tests that pass in isolation.
+	init(baseURL: URL, activeStoreURL: URL? = nil) {
 		backupBaseURL = baseURL
+		self.activeStoreURLOverride = activeStoreURL
 		try? FileManager.default.createDirectory(at: backupBaseURL, withIntermediateDirectories: true)
 		backupIndex = Self.loadIndex(from: backupBaseURL)
 		validateIndexConsistency()
@@ -641,6 +650,7 @@ final class NodeBackupManager: NodeBackupManaging {
 
 	/// Returns the URL to the active SQLite database file.
 	private func activeDatabaseURL() -> URL {
+		if let activeStoreURLOverride { return activeStoreURLOverride }
 		let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
 		return appSupport.appendingPathComponent("Meshtastic.store")
 	}

--- a/MeshtasticTests/NodeBackupManagerTests.swift
+++ b/MeshtasticTests/NodeBackupManagerTests.swift
@@ -77,18 +77,19 @@ struct NodeBackupManagerTests {
 		let tempDir = try makeTempDir()
 		defer { cleanup(tempDir) }
 
-		// Setup: Create a fake active database
+		// Setup: Create a fake active database and point the manager at it, so the test never
+		// touches the live Application Support store other suites open and replace.
 		let dbDir = tempDir.appendingPathComponent("ActiveDB", isDirectory: true)
-		_ = try createFakeDatabase(at: dbDir)
+		let storeURL = try createFakeDatabase(at: dbDir)
 
-		// Create manager with custom base
 		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
-		let manager = NodeBackupManager(baseURL: backupDir)
+		let manager = NodeBackupManager(baseURL: backupDir, activeStoreURL: storeURL)
 
 		// Act
 		let result = await manager.createBackup(forNode: 12345, deviceId: nil, nodeName: "TestNode")
 
-		// Assert
+		// Assert — no tolerance for .skipped: the source store is guaranteed to exist now, so a
+		// skip is a real failure rather than a test-environment shrug.
 		switch result {
 		case .success(let entry):
 			#expect(entry.nodeNum == 12345)
@@ -96,10 +97,10 @@ struct NodeBackupManagerTests {
 			#expect(entry.fileSize > 0)
 			#expect(entry.checksum.count == 64) // SHA-256 hex digest
 			#expect(manager.hasBackup(forNode: 12345))
-		case .skipped, .noBackupFound:
-			// In test environment, database file may not exist at expected path
-			// This verifies the retry logic works (skipped after retry)
-			break
+		case .skipped(let reason):
+			Issue.record("createBackup skipped with a guaranteed source store: \(reason)")
+		case .noBackupFound:
+			Issue.record("createBackup should never return .noBackupFound")
 		}
 	}
 
@@ -111,27 +112,25 @@ struct NodeBackupManagerTests {
 		let tempDir = try makeTempDir()
 		defer { cleanup(tempDir) }
 
+		let storeURL = try createFakeDatabase(at: tempDir.appendingPathComponent("ActiveDB", isDirectory: true))
 		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
-		let manager = NodeBackupManager(baseURL: backupDir)
+		let manager = NodeBackupManager(baseURL: backupDir, activeStoreURL: storeURL)
 
 		// First backup
-		let result1 = await manager.createBackup(forNode: 99999, deviceId: nil, nodeName: "NodeV1")
+		_ = await manager.createBackup(forNode: 99999, deviceId: nil, nodeName: "NodeV1")
 
 		// Second backup (overwrite)
 		let result2 = await manager.createBackup(forNode: 99999, deviceId: nil, nodeName: "NodeV2")
 
-		// Only one backup should exist for this node
-		let backups = manager.listBackups()
-		let nodeBackups = backups.filter { $0.nodeNum == 99999 }
-		#expect(nodeBackups.count <= 1) // At most 1 backup per node
-
-		// If both succeeded, name should be updated
-		if case .success(let entry) = result2 {
-			#expect(entry.nodeName == "NodeV2")
+		// Exactly one backup for this node, carrying the second name. With a guaranteed source
+		// store there is nothing to hedge: both saves succeed or the test should fail.
+		let nodeBackups = manager.listBackups().filter { $0.nodeNum == 99999 }
+		#expect(nodeBackups.count == 1)
+		guard case .success(let entry) = result2 else {
+			Issue.record("second backup did not succeed: \(result2)")
+			return
 		}
-
-		// Suppress unused variable warnings
-		_ = result1
+		#expect(entry.nodeName == "NodeV2")
 	}
 
 	// MARK: - T012: createBackup Failure and Retry
@@ -143,18 +142,19 @@ struct NodeBackupManagerTests {
 		defer { cleanup(tempDir) }
 
 		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
-		let manager = NodeBackupManager(baseURL: backupDir)
+		// A source path that is guaranteed missing, so the failure is deterministic instead of
+		// depending on whether the test host happens to have a live store.
+		let missingStore = tempDir.appendingPathComponent("Nowhere", isDirectory: true)
+			.appendingPathComponent("Meshtastic.store")
+		let manager = NodeBackupManager(baseURL: backupDir, activeStoreURL: missingStore)
 
-		// The active database path won't exist in test environment,
-		// so backup should fail and return .skipped after retry
 		let result = await manager.createBackup(forNode: 77777, deviceId: nil, nodeName: "FailNode")
 
 		switch result {
 		case .skipped(let reason):
 			#expect(reason.contains("failed") || reason.contains("Failed") || reason.contains("No such file"))
 		case .success:
-			// If somehow it succeeded (environment has the file), that's also acceptable
-			break
+			Issue.record("createBackup succeeded with a missing source store")
 		case .noBackupFound:
 			Issue.record("createBackup should never return .noBackupFound")
 		}
@@ -308,8 +308,9 @@ struct NodeBackupManagerTests {
 		let tempDir = try makeTempDir()
 		defer { cleanup(tempDir) }
 
+		let storeURL = try createFakeDatabase(at: tempDir.appendingPathComponent("ActiveDB", isDirectory: true))
 		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
-		let manager = NodeBackupManager(baseURL: backupDir)
+		let manager = NodeBackupManager(baseURL: backupDir, activeStoreURL: storeURL)
 
 		// The manager is @MainActor-isolated, but file I/O runs via Task.detached
 		// We verify that calling createBackup is async (doesn't synchronously block)
@@ -729,9 +730,9 @@ struct NodeBackupManagerTests {
 		defer { cleanup(tempDir) }
 		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
 		let dbDir = tempDir.appendingPathComponent("ActiveDB", isDirectory: true)
-		_ = try createFakeDatabase(at: dbDir)
+		let storeURL = try createFakeDatabase(at: dbDir)
 
-		let manager = NodeBackupManager(baseURL: backupDir)
+		let manager = NodeBackupManager(baseURL: backupDir, activeStoreURL: storeURL)
 		_ = await manager.createBackup(forNode: 4242, deviceId: Data([0xAB, 0xCD]), nodeName: "First")
 
 		// The caller resolves the device id from the store, which can come back nil part way through

--- a/MeshtasticTests/NodeBackupManagerTests.swift
+++ b/MeshtasticTests/NodeBackupManagerTests.swift
@@ -116,8 +116,12 @@ struct NodeBackupManagerTests {
 		let backupDir = tempDir.appendingPathComponent("Backups", isDirectory: true)
 		let manager = NodeBackupManager(baseURL: backupDir, activeStoreURL: storeURL)
 
-		// First backup
-		_ = await manager.createBackup(forNode: 99999, deviceId: nil, nodeName: "NodeV1")
+		// First backup — must succeed, or the overwrite below is never actually exercised.
+		let result1 = await manager.createBackup(forNode: 99999, deviceId: nil, nodeName: "NodeV1")
+		guard case .success = result1 else {
+			Issue.record("first backup did not succeed: \(result1)")
+			return
+		}
 
 		// Second backup (overwrite)
 		let result2 = await manager.createBackup(forNode: 99999, deviceId: nil, nodeName: "NodeV2")


### PR DESCRIPTION
## Summary

`NodeBackupManagerTests` can fail in a full-suite run while passing in isolation. #2433's description documented it: three assertion failures in "a backup with no device id joins the one already keyed by device", reproducible locally, full suite only. That test is mine, and so is the underlying problem.

## What changed

The `createBackup` tests read the real Application Support store — `activeDatabaseURL()` is hard-coded, and the "fake active database" the tests set up was never wired to anything. That held up for as long as nothing else touched the live store during a test run. #2423's schema-history tests open and replace it through the real `PersistenceController`, so a parallel full run can catch a backup test mid-manipulation. Timing-dependent, which is why it shows on one machine and not another.

The test initializer now takes the store to copy from, and all five `createBackup` tests own theirs. Production behavior is unchanged — the override is nil outside tests.

Making them hermetic also let three hedges become hard failures, since they existed only because the source store was not guaranteed:

- the success test tolerated `.skipped` "in case the database file may not exist"
- the overwrite test asserted `count <= 1` and checked the name only "if both succeeded"
- the retry test accepted an unexpected success as "also acceptable", and now pins an explicitly missing path instead of hoping the environment lacks one

## Testing

- `NodeBackupManagerTests` in isolation: 26 tests, all passing.
- Full `MeshtasticTests` target: 3,093 tests in 537 suites, all passing.
- The full-suite run is a smoke check rather than the proof — the interference was timing-dependent, so the real argument is by construction: these tests no longer touch the shared store at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved backup test reliability by isolating tests from the live application data store.
  - Strengthened backup creation and overwrite assertions to verify expected outcomes.
  - Made retry and device-related test scenarios more deterministic.
- **User Impact**
  - No user-visible functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->