### PR TITLE
Stop the Add Contact sheet truncating its explanation

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/AddContactConfirmationView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/AddContactConfirmationView.swift
@@ -44,8 +44,8 @@ struct AddContactConfirmationView: View {
 				.font(.subheadline)
 				.multilineTextAlignment(.center)
 				.foregroundColor(.secondary)
-				// The sheet's medium detent compresses flexible text into an ellipsis while the
-				// spacer below keeps the leftover room. Fixed vertical size keeps every line.
+				// The sheet's medium detent compresses flexible text into an ellipsis even with
+				// room left in the sheet. Fixed vertical size keeps every line.
 				.fixedSize(horizontal: false, vertical: true)
 			if !canAdd {
 				Text("This contact does not include a public key, so it cannot be added.")

--- a/Meshtastic/Views/Nodes/Helpers/AddContactConfirmationView.swift
+++ b/Meshtastic/Views/Nodes/Helpers/AddContactConfirmationView.swift
@@ -44,26 +44,34 @@ struct AddContactConfirmationView: View {
 				.font(.subheadline)
 				.multilineTextAlignment(.center)
 				.foregroundColor(.secondary)
+				// The sheet's medium detent compresses flexible text into an ellipsis while the
+				// spacer below keeps the leftover room. Fixed vertical size keeps every line.
+				.fixedSize(horizontal: false, vertical: true)
 			if !canAdd {
 				Text("This contact does not include a public key, so it cannot be added.")
 					.font(.subheadline)
 					.multilineTextAlignment(.center)
 					.foregroundColor(.red)
+					.fixedSize(horizontal: false, vertical: true)
 			}
 			if let failureMessage {
 				Text(failureMessage)
 					.font(.subheadline)
 					.multilineTextAlignment(.center)
 					.foregroundColor(.red)
+					.fixedSize(horizontal: false, vertical: true)
 			}
 			Button {
 				addContact()
 			} label: {
 				Label("Add Contact", systemImage: "person.crop.circle.badge.plus")
+					.frame(maxWidth: .infinity)
 			}
 			.buttonStyle(.borderedProminent)
+			.controlSize(.large)
 			.disabled(isAdding || !canAdd)
 			Button("Cancel") { dismiss() }
+				.controlSize(.large)
 				.padding(.bottom)
 		}
 		.padding()


### PR DESCRIPTION
## Summary

The Add Contact sheet cut its explanation off mid-sentence — "so you can message them sec…" — with visible empty space right below it, and its buttons were small.

## What changed

The sheet presents at `.presentationDetents([.medium, .large])`. At the medium detent SwiftUI compresses flexible `Text` into an ellipsis while the `Spacer` below keeps the leftover room, which is how a sheet truncates text and shows blank space at the same time. The explanation and both error texts now use `.fixedSize(horizontal: false, vertical: true)` — the same remedy `UpdateWarningSheet` already uses for the same layout.

Add Contact is now `.controlSize(.large)` with a full-width label and Cancel is `.controlSize(.large)`, matching the button treatment in the update sheets and clearing the minimum touch target.

## Testing

- Built and installed on an iPhone 17 Pro. Not yet looked at on screen — opening the sheet needs a contact QR scan, so the truncation fix is by-analysis (the same `fixedSize` remedy `UpdateWarningSheet` uses for the same detent behavior) until someone scans one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Add Contact confirmation sheet layout so informational and warning messages display fully without truncation.
  - Expanded the “Add Contact” button label and increased the size of both action buttons for better readability and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->