### PR TITLE
Give the dark theme the palette's own dark blues

### DIFF
--- a/Meshtastic/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Meshtastic/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,38 +1,38 @@
 {
-  "colors" : [
+  "colors": [
     {
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.157",
-          "green" : "0.333",
-          "blue" : "0.659",
-          "alpha" : "1.000"
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.157",
+          "green": "0.333",
+          "blue": "0.659",
+          "alpha": "1.000"
         }
       },
-      "idiom" : "universal"
+      "idiom": "universal"
     },
     {
-      "appearances" : [
+      "appearances": [
         {
-          "appearance" : "luminosity",
-          "value" : "dark"
+          "appearance": "luminosity",
+          "value": "dark"
         }
       ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.157",
-          "green" : "0.333",
-          "blue" : "0.659",
-          "alpha" : "1.000"
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.690",
+          "green": "0.749",
+          "blue": "0.941",
+          "alpha": "1.000"
         }
       },
-      "idiom" : "universal"
+      "idiom": "universal"
     }
   ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
+  "info": {
+    "author": "xcode",
+    "version": 1
   }
 }

--- a/Meshtastic/Assets.xcassets/Colors/MeshtasticLink.colorset/Contents.json
+++ b/Meshtastic/Assets.xcassets/Colors/MeshtasticLink.colorset/Contents.json
@@ -1,38 +1,38 @@
 {
-  "colors" : [
+  "colors": [
     {
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.608",
-          "green" : "0.659",
-          "blue" : "0.878",
-          "alpha" : "1.000"
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.361",
+          "green": "0.420",
+          "blue": "0.753",
+          "alpha": "1.000"
         }
       },
-      "idiom" : "universal"
+      "idiom": "universal"
     },
     {
-      "appearances" : [
+      "appearances": [
         {
-          "appearance" : "luminosity",
-          "value" : "dark"
+          "appearance": "luminosity",
+          "value": "dark"
         }
       ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.608",
-          "green" : "0.659",
-          "blue" : "0.878",
-          "alpha" : "1.000"
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0.608",
+          "green": "0.659",
+          "blue": "0.878",
+          "alpha": "1.000"
         }
       },
-      "idiom" : "universal"
+      "idiom": "universal"
     }
   ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
+  "info": {
+    "author": "xcode",
+    "version": 1
   }
 }


### PR DESCRIPTION
## Summary

Addresses the contrast half of #2322. The map node menu in dark mode draws its actions in dark blue on dark gray — measured from the reporter's screenshot at **1.8:1**, below even the 3:1 floor for UI components, never mind the 4.5:1 the design standards require. "The options are active, believe it or not" is what 1.8:1 looks like.

## What changed

`AccentColor` shipped Blue 700 `#2855A8` in **both** appearances — the dark entry existed and held the byte-identical value. The design standards already assign Blue 300 `#B0BFF0` as the dark-mode tertiary, so the dark appearance now uses it: 7.1:1 on those menus, 9.4:1 on the standards' dark background. Light mode is unchanged at 7.1:1 on white.

`MeshtasticLink` had the mirror problem — Blue 400 `#9BA8E0` in both appearances, fine on dark (5.5:1) and 2.3:1 on white. Light mode now uses Blue 600 `#5C6BC0` (4.9:1 on white), per [meshtastic/design#148](https://github.com/meshtastic/design/pull/148), which splits the standards' Link color per mode — the previous single-value spec could not pass 4.5:1 on both grounds.

Every ratio is WCAG relative luminance, computed against the reporter's sampled pixels for the menu case and the standards' named backgrounds otherwise.

## What this does not fix

#2322's first item — the un-resizable macOS node detail window — is separate work and stays open.

## Testing

- Built for the iOS Simulator.
- Ratios verified by computation; the menu background was sampled from the issue's screenshot rather than assumed.
- Not yet looked at on a dark-mode device. The accent tints every control in the app, so this deserves eyes on real screens before merge.