### PR TITLE
Clean up the unheard-nodes removal flow

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
+++ b/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
@@ -166,6 +166,7 @@ struct UnheardNodesBanner: View {
 			do {
 				try await accessoryManager.removeNode(node: node, connectedNodeNum: connectedNodeNum)
 				removed += 1
+				unheardNodes.removeAll { $0.num == node.num }
 			} catch {
 				// Keep going: one node the radio refuses should not strand the rest.
 				failed += 1

--- a/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
+++ b/Meshtastic/Views/Nodes/Helpers/UnheardNodesBanner.swift
@@ -58,25 +58,35 @@ struct UnheardNodesBanner: View {
 					.font(.caption)
 					.foregroundStyle(.secondary)
 
-				HStack(spacing: 12) {
-					Button(role: .destructive) {
-						isConfirming = true
-					} label: {
-						Text("Remove Them")
-							.frame(minWidth: 48, minHeight: 48)
+				if isRemoving {
+					// One admin message per node, so a large cleanup takes a while. The count in the
+					// headline ticks down as nodes are removed.
+					HStack(spacing: 8) {
+						ProgressView()
+						Text("Removing…")
+							.font(.callout)
+							.foregroundStyle(.secondary)
 					}
-					.buttonStyle(.borderedProminent)
-					.disabled(isRemoving)
+					.frame(minHeight: 48)
+				} else {
+					HStack(spacing: 12) {
+						Button(role: .destructive) {
+							isConfirming = true
+						} label: {
+							Text("Remove Them")
+								.frame(minWidth: 48, minHeight: 48)
+						}
+						.buttonStyle(.borderedProminent)
 
-					Button {
-						LoRaConfigChange.dismissOffer(forNode: connectedNodeNum)
-						refresh()
-					} label: {
-						Text("Keep")
-							.frame(minWidth: 48, minHeight: 48)
+						Button {
+							LoRaConfigChange.dismissOffer(forNode: connectedNodeNum)
+							refresh()
+						} label: {
+							Text("Keep")
+								.frame(minWidth: 48, minHeight: 48)
+						}
+						.buttonStyle(.bordered)
 					}
-					.buttonStyle(.bordered)
-					.disabled(isRemoving)
 				}
 			}
 			Spacer(minLength: 0)
@@ -86,7 +96,9 @@ struct UnheardNodesBanner: View {
 		.padding(.horizontal)
 		.padding(.bottom, 4)
 		.confirmationDialog(
-			Text("Remove ^[\(unheardNodes.count) node](inflect: true)?", comment: "Confirmation title for removing nodes not heard since the settings changed"),
+			// Resolved through String(localized:) first: the Text(_:comment:) initializer showed the
+			// inflection markup literally in the dialog title on device — "^[117 node](inflect: true)".
+			Text(verbatim: String(localized: "Remove ^[\(unheardNodes.count) node](inflect: true)?", comment: "Confirmation title for removing nodes not heard since the settings changed")),
 			isPresented: $isConfirming,
 			titleVisibility: .visible
 		) {


### PR DESCRIPTION
## Summary

Two problems from running #2429's cleanup against a real 117-node store.

## What changed

The confirmation title rendered its inflection markup literally — "Remove ^[117 node](inflect: true)?" on screen. The banner headline resolves the identical markup correctly; the `Text(_:comment:)` initializer as a `confirmationDialog` title does not. The title is now resolved through `String(localized:)` first, which processes the inflection, and passed as verbatim text.

While removing, the banner showed its two buttons greyed and nothing else. Removal sends one admin message per node, so clearing a hundred-node store takes a while — the buttons are now replaced by a spinner and "Removing…", and the headline count ticks down live as nodes are removed.

## Testing

- Built and installed on an iPhone 17 Pro. The title bug and the mute removing state were both found on device against a real store; the fixed build is installed but the dialog has not been reopened on screen yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Displayed a clear “Removing…” progress indicator while nodes are being removed.
  * Fixed the confirmation dialog title so localized text displays correctly on devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->