### PR TITLE
End the reconnect loop on a lost BLE bond

### DIFF
--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -108,8 +108,16 @@ extension AccessoryManager {
 					// The mesh-traffic monitor (map flyover gate) self-starts its decay timer on the
 					// first inbound packet and is cleared by Step 0's closeConnection() reset(), so
 					// there's no explicit start to make here — it stays correct across connect retries.
-				} catch let error as CBError where error.code == .peerRemovedPairingInformation {
-					await self.connectionStepper?.cancelCurrentlyExecutingStep(withError: AccessoryError.coreBluetoothError(error), cancelFullProcess: true)
+				} catch let error where BLEConnection.terminatesConnectRetries(error) {
+					// A lost bond cannot be fixed by retrying or reconnecting — the user has to
+					// forget the device in iOS Settings. The old catch matched only the raw CBError,
+					// but the transport maps that into AccessoryError.bondLost before throwing, so
+					// the mapped error fell through to retryAll and looped. Kill auto-reconnect
+					// before cancelling or discovery immediately starts the loop again.
+					self.shouldAutomaticallyConnectToPreferredPeripheralAfterError = false
+					self.autoReconnectSuspendedForSession = true
+					self.lastConnectionError = AccessoryError.bondLost
+					await self.connectionStepper?.cancelCurrentlyExecutingStep(withError: AccessoryError.bondLost, cancelFullProcess: true)
 				}
 			}
 			

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Connect.swift
@@ -331,7 +331,7 @@ extension AccessoryManager {
 			try await self.closeConnection()
 			updateState(.discovering)
 		} catch {
-			Logger.transport.error("🔗 [Connect] Error returned by connectionStepper: \(error)")
+			Logger.transport.error("🔗 [Connect] Error returned by connectionStepper: \(error, privacy: .public)")
 			try await self.closeConnection()
 			updateState(.discovering)
 			self.lastConnectionError = error

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Discovery.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager+Discovery.swift
@@ -65,6 +65,7 @@ extension AccessoryManager {
 						// connect must be the only one running, or its database clear/restore
 						// races a second node dump (nodes bleeding between radios).
 						if self.shouldAutomaticallyConnectToPreferredPeripheralAfterError, !userRequestedConnectionCancellation,
+						   !self.autoReconnectSuspendedForSession,
 						   !self.isSwitchingDevices,
 						   UserDefaults.autoconnectOnDiscovery, UserDefaults.preferredPeripheralId == newDevice.id.uuidString {
 							Logger.transport.debug("🔎 [Discovery] Found preferred peripheral \(newDevice.name)")

--- a/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
+++ b/Meshtastic/Accessory/Accessory Manager/AccessoryManager.swift
@@ -277,6 +277,11 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 	public var wantRangeTestPackets = false
 	var wantStoreAndForwardPackets = false
 	var shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
+	/// Set when a lost bond ends a connect. Auto-reconnect stays off for the rest of the app
+	/// session — reconnecting can never fix a lost bond, and any later transient error would
+	/// otherwise re-arm it and restart the loop. Manual connects are always allowed; only a
+	/// fresh app launch clears this.
+	var autoReconnectSuspendedForSession = false
 	var userRequestedConnectionCancellation = false
 
 	/// True while a device switch (backup → clear → restore → connect) is in flight.
@@ -829,7 +834,9 @@ class AccessoryManager: ObservableObject, MqttClientProxyManagerDelegate {
 				if case .errorWithoutReconnect = event {
 					shouldAutomaticallyConnectToPreferredPeripheralAfterError = false
 				} else {
-					shouldAutomaticallyConnectToPreferredPeripheralAfterError = true
+					// A suspended session stays suspended: a transient error after a lost bond
+					// must not re-arm the reconnect loop the suspension exists to end.
+					shouldAutomaticallyConnectToPreferredPeripheralAfterError = !autoReconnectSuspendedForSession
 				}
 				
 				Logger.transport.info("🚨 [Accessory] didReceive with failure: \(error.localizedDescription, privacy: .public) (willReconnect = \(self.shouldAutomaticallyConnectToPreferredPeripheralAfterError, privacy: .public))")

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLEConnection.swift
@@ -723,7 +723,26 @@ extension BLEConnection {
 		guard isPairingFailure(error) else { return error }
 		let hadBond = UserDefaults.isPairedPeripheral(peripheralID)
 		UserDefaults.forgetPairedPeripheral(peripheralID)
+		// Peer-removed-pairing is the radio saying outright that it dropped the bond — there is
+		// nothing to disambiguate, so it is a lost bond with or without the hint. Relying on the
+		// hint here made the classification one-shot: the first failure cleared it, and every
+		// retry after that saw a raw, retryable-looking error. Reconnecting can never fix this;
+		// only forgetting the device in iOS Settings can.
+		if let cbError = error as? CBError, cbError.code == .peerRemovedPairingInformation {
+			return AccessoryError.bondLost
+		}
 		return hadBond ? AccessoryError.bondLost : error
+	}
+
+	/// Whether a connect failure can never be fixed by trying again.
+	///
+	/// A lost bond needs the user to forget the device in iOS Settings > Bluetooth — every retry
+	/// re-fails the same way, and retrying it is the reconnect loop this exists to end. Pure so the
+	/// policy is testable without a peripheral.
+	static func terminatesConnectRetries(_ error: Error) -> Bool {
+		if case AccessoryError.bondLost = error { return true }
+		if let cbError = error as? CBError, cbError.code == .peerRemovedPairingInformation { return true }
+		return false
 	}
 
 	private func logPeripheralError(_ error: Error) {

--- a/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
+++ b/Meshtastic/Accessory/Transports/Bluetooth Low Energy/BLETransport.swift
@@ -442,19 +442,19 @@ actor BLETransport: Transport {
 			case .connectionTimeout: // 6
 				// Happens when the node goes out of range or the shutdown or reset buttons are presses
 				// Should disconnect, show error, and retry when re-advertised
-				Logger.transport.error("🛜 [BLETransport] Disconnected with CBError code: \(cbError.code.rawValue) - \(cbError.localizedDescription)")
+				Logger.transport.error("🛜 [BLETransport] Disconnected with CBError code: \(cbError.code.rawValue, privacy: .public) - \(cbError.localizedDescription, privacy: .public)")
 				shouldReconnect = true
 			case .peripheralDisconnected: // 7
 				// Happens when the node reboots or shuts down intentionally via the firmware or app
 				// Should disconnect, show error, and retry when re-advertised
-				Logger.transport.error("🛜 [BLETransport] Disconnected with CBError code: \(cbError.code.rawValue) - \(cbError.localizedDescription)")
+				Logger.transport.error("🛜 [BLETransport] Disconnected with CBError code: \(cbError.code.rawValue, privacy: .public) - \(cbError.localizedDescription, privacy: .public)")
 				shouldReconnect = true
 			default:
 				// Fallback for other CBError codes
-				Logger.transport.error("🛜 [BLETransport] Disconnected with CBError code: \(cbError.code.rawValue) - \(cbError.localizedDescription)")
+				Logger.transport.error("🛜 [BLETransport] Disconnected with CBError code: \(cbError.code.rawValue, privacy: .public) - \(cbError.localizedDescription, privacy: .public)")
 			}
 		case let otherError:
-			Logger.transport.error("🛜 [BLETransport] Disconnected with non-CBError: \(otherError.localizedDescription)")
+			Logger.transport.error("🛜 [BLETransport] Disconnected with non-CBError: \(otherError.localizedDescription, privacy: .public)")
 		}
 		
 		if let continuation = self.connectContinuation {
@@ -677,7 +677,7 @@ class BLEDelegate: NSObject, CBCentralManagerDelegate {
 
 	func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
 		if let error = error as? NSError {
-			Logger.transport.error("🛜 [BLETransport] Error while disconnecting peripheral: \(peripheral.name ?? ""): \(error)")
+			Logger.transport.error("🛜 [BLETransport] Error while disconnecting peripheral: \(peripheral.name ?? "", privacy: .public): \(error, privacy: .public)")
 			Task { await transport?.handlePeripheralDisconnectError(peripheral: peripheral, error: error) }
 		} else {
 			Logger.transport.error("🛜 [BLETransport] Did succesfully disconnect peripheral: \(peripheral.name ?? "")")

--- a/MeshtasticTests/BLEPairingHintTests.swift
+++ b/MeshtasticTests/BLEPairingHintTests.swift
@@ -255,4 +255,47 @@ final class LostBondTests {
 		#expect(message == AccessoryError.coreBluetoothError(CBError(.peerRemovedPairingInformation)).errorDescription,
 				"however it arrives, it reads the same")
 	}
+
+	// MARK: - The reconnect loop (regression)
+
+	@Test func peerRemovedPairingIsALostBondWithoutAnyHint() {
+		// The radio said outright that it removed the pairing — no hint needed. Relying on the
+		// hint made this one-shot: the first failure cleared it and every retry after saw a raw
+		// error, which the connect flow retried forever.
+		let radio = UUID()
+		#expect(!UserDefaults.isPairedPeripheral(radio))
+		let reported = BLEConnection.bondLostError(for: radio, error: CBError(.peerRemovedPairingInformation))
+		guard case AccessoryError.bondLost = reported else {
+			Issue.record("peer-removed-pairing without a hint reported \(reported) instead of bondLost")
+			return
+		}
+	}
+
+	@Test func theClassificationSurvivesRepeatedFailures() {
+		// The loop's signature: the same failure arriving again after the hint is gone must get
+		// the same terminal answer, not degrade to a retryable-looking error.
+		let radio = UUID()
+		UserDefaults.rememberPairedPeripheral(radio)
+		for attempt in 1...3 {
+			let reported = BLEConnection.bondLostError(for: radio, error: CBError(.peerRemovedPairingInformation))
+			guard case AccessoryError.bondLost = reported else {
+				Issue.record("attempt \(attempt) reported \(reported) instead of bondLost")
+				return
+			}
+		}
+	}
+
+	@Test func lostBondsTerminateConnectRetries() {
+		#expect(BLEConnection.terminatesConnectRetries(AccessoryError.bondLost))
+		#expect(BLEConnection.terminatesConnectRetries(CBError(.peerRemovedPairingInformation)))
+	}
+
+	@Test func recoverableErrorsKeepRetrying() {
+		// Timeouts and reboots recover on their own; a wrong PIN deserves another attempt.
+		#expect(!BLEConnection.terminatesConnectRetries(CBError(.connectionTimeout)))
+		#expect(!BLEConnection.terminatesConnectRetries(CBError(.peripheralDisconnected)))
+		#expect(!BLEConnection.terminatesConnectRetries(CBATTError(.insufficientAuthentication)))
+		#expect(!BLEConnection.terminatesConnectRetries(AccessoryError.disconnected("x")))
+	}
+
 }


### PR DESCRIPTION
## Summary

When a radio removes its pairing — a factory erase, a firmware wipe, a bond cleared on the device — the app looped forever: retry, fail, rediscover, auto-reconnect, fail. The user never saw the lost-bond message with the instructions to forget the device in iOS Settings, which is the only recovery. Urgent regression, reproduced live on a phone stuck in the loop.

## What changed

Two bugs made the loop, introduced across #2400 and the year-older connect flow it grafted onto.

`bondLostError` classified a failure as a lost bond only when a paired hint existed, and cleared the hint as it answered. The first failure got the terminal answer; every retry after saw a raw, retryable-looking error. But peer-removed-pairing is the radio saying outright that the bond is gone — there is nothing to disambiguate — so it is now a lost bond with or without the hint. The hint still separates the ATT errors, where no-hint plausibly means a mistyped PIN and a retry is right.

Step 1's escape hatch caught only the raw `CBError`, but the transport maps that into `AccessoryError.bondLost` before throwing — the mapped error fell straight through to the step's `retryAll`. The catch now matches terminal errors through a pure `terminatesConnectRetries`, disables auto-reconnect before cancelling, and surfaces `bondLost` so the UI shows the forget-device instructions.

A lost bond also suspends auto-reconnect for the rest of the app session. Any plain error event used to set the reconnect flag back to true, so one transient hiccup after the stop restarted the loop. Manual connects are always allowed; only a fresh app launch re-enables automatic ones.

## Why no test caught it

The suite tested the classifier, not the policy — and partly tested the wrong policy in: `aFirstPairingAttemptKeepsItsOwnError` pinned raw-error-without-hint as correct, which is right for ATT errors and wrong for peer-removed-pairing. The connect-retry path had no test seam at all. `terminatesConnectRetries` is that seam now.

## Testing

- Built for the iOS Simulator and installed on device.
- 25 tests in the three BLE pairing suites, all passing — four new, including the loop's signature: the same failure arriving repeatedly keeps getting the terminal answer, instead of degrading to retryable after the hint clears.
- Verified on hardware: the loop was observed live on a phone before the fix, and with the fixed build the error now surfaces with the forget-device instructions instead of looping, confirmed on both the phone and a Mac Catalyst build.
- The disconnect and stepper error log lines now use privacy: .public — they showed <private> exactly where the CBError code was needed to diagnose this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bluetooth connection handling when device pairing information is lost.
  - Prevented repeated connection attempts and automatic reconnect loops after a lost Bluetooth bond.
  - Ensured lost-bond errors are identified consistently, even when pairing information is unavailable.
  - Recoverable connection errors continue to support retry behavior.
  - Improved connection state and error reporting following lost pairing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
