### PR TITLE
Show the signed-node badge in green

### DIFF
--- a/Meshtastic/Helpers/NodeSecurityIndicator.swift
+++ b/Meshtastic/Helpers/NodeSecurityIndicator.swift
@@ -36,7 +36,9 @@ enum NodeSecurityIndicator: Equatable {
 		case .signed:
 			// Custom symbol: the mesh radio with a shield-checkmark badge — verified by the
 			// radio over the mesh, as opposed to the person badge for in-person verification.
-			return ("radio.badge.shield.checkmark", .secondary)
+			// Green like .verified: both are a verified identity, and the glyph carries which
+			// route earned it. A muted color read as a weaker or partial state, which it is not.
+			return ("radio.badge.shield.checkmark", .green)
 		case .publicKey:
 			return ("lock.fill", .green)
 		case .sharedKey:


### PR DESCRIPTION
## Summary

The signed-node badge rendered in `.secondary`, which read as a weaker or partial state next to the green person badge. Both are a verified identity. Only the route differs, and the glyph already carries that: a person badge for in-person verification, the mesh radio badge for verification the radio did itself.

## What changed

`NodeSecurityIndicator.signed` returns `.green` instead of `.secondary`. One line, plus a comment saying why the two verified states share a color.

`.verified` stays green, the locks stay green and yellow, and `keyMismatch` stays red.

## Testing

`NodeSecurityIndicatorTests` asserts state selection rather than colors, so it is unaffected and still covers the 2.8 gate, unknown and empty versions, signing replacing the locks, and a mismatch winning at any version. Not run locally — this is a one-line color change with no branching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the signed security indicator to use a green color for improved visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->