### PR TITLE
Use the filled person badge for a verified contact

### DIFF
--- a/Meshtastic/Helpers/NodeSecurityIndicator.swift
+++ b/Meshtastic/Helpers/NodeSecurityIndicator.swift
@@ -32,7 +32,7 @@ enum NodeSecurityIndicator: Equatable {
 	var glyph: (image: String, color: Color) {
 		switch self {
 		case .verified:
-			return ("person.badge.shield.checkmark", .green)
+			return ("person.badge.shield.checkmark.fill", .green)
 		case .signed:
 			// Custom symbol: the mesh radio with a shield-checkmark badge — verified by the
 			// radio over the mesh, as opposed to the person badge for in-person verification.


### PR DESCRIPTION
## Summary

The verified-contact indicator used `person.badge.shield.checkmark` while `SignedNodeIcon` used `person.badge.shield.checkmark.fill` for the same fact. A node list row and node detail could therefore show the outline and the filled badge for the same verified contact.

## What changed

`NodeSecurityIndicator.verified` returns the `.fill` variant, so both places draw the same glyph.

The custom `radio.badge.shield.checkmark` used for mesh-verified nodes has no fill variant — the symbolset holds a single SVG — so it is unchanged.

## Testing

`NodeSecurityIndicatorTests` asserts state selection, not symbol names, so it is unaffected. `SignedNodeIconTests` already asserts the `.fill` name resolves through `UIImage(systemName:)` on the deployment target, so the symbol is known good. Not built locally; this is a symbol-name constant with no branching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the verified node security indicator to use a filled shield-and-checkmark icon while retaining its green color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->