### PR TITLE
Drop the redundant Signed node row from the node list

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -101,13 +101,19 @@ struct NodeListRowSummary {
 	/// a mismatch warning at any version. Derived from the snapshot so the row never re-reads
 	/// `node.user` at render time.
 	func keyStatus(isConnectedNode: Bool = false) -> (image: String, color: Color) {
+		securityIndicator(isConnectedNode: isConnectedNode).glyph
+	}
+
+	/// The indicator state itself — the single contract the glyph and the VoiceOver
+	/// description both read, so the two can never disagree about signing.
+	func securityIndicator(isConnectedNode: Bool = false) -> NodeSecurityIndicator {
 		NodeSecurityIndicator.status(
 			firmwareVersion: firmwareVersion,
 			pkiEncrypted: pkiEncrypted,
 			keyMatch: keyMatch,
 			verified: isKeyManuallyVerified,
 			isOwnNode: isConnectedNode
-		).glyph
+		)
 	}
 }
 
@@ -198,10 +204,13 @@ struct NodeListItem: View {
 			}
 			desc += ", " + signalString
 		}
-		// The security glyph beside the name carries signing state visually; name it for VoiceOver
-		// too, since a glyph alone announces nothing. Affirmative only, never for unsigned nodes.
-		if summary.hasXeddsaSigned {
+		// Announce signing the way the glyph shows it — both read securityIndicator(), so
+		// VoiceOver can never claim "Signed node" on a row drawing a lock. Affirmative only.
+		switch summary.securityIndicator() {
+		case .signed, .verified:
 			desc += ", " + "Signed node".localized
+		default:
+			break
 		}
 		return desc
 	}

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -198,8 +198,8 @@ struct NodeListItem: View {
 			}
 			desc += ", " + signalString
 		}
-		// Mirror the visual "Signed node" trust signal (see the shield row below) so VoiceOver
-		// announces it too — affirmative only, never for unsigned nodes.
+		// The security glyph beside the name carries signing state visually; name it for VoiceOver
+		// too, since a glyph alone announces nothing. Affirmative only, never for unsigned nodes.
 		if summary.hasXeddsaSigned {
 			desc += ", " + "Signed node".localized
 		}
@@ -284,15 +284,6 @@ struct NodeListItem: View {
 							Image(systemName: "star.fill")
 								.symbolRenderingMode(.multicolor)
 						}
-					}
-					// Signed node = XEdDSA-signed NodeInfo broadcast → identity verified by the radio.
-					// Affirmative only; never shown for unsigned nodes. Mirrors the Node Detail row.
-					// A person badge rather than a bare shield: what was verified is who this node
-					// says it is, not that the traffic is encrypted, which the lock already covers.
-					if summary.hasXeddsaSigned {
-						IconAndText(systemName: SignedNodeIcon.symbolName,
-									imageColor: .green,
-									text: "Signed node".localized)
 					}
 					// User-authored status broadcast by the node — shown directly beneath the
 					// name, clamped to 2 lines so it can never grow the card unbounded. Omitted

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -112,7 +112,7 @@ struct NodeListItemCompact: View {
 			}
 			desc += ", " + signalString
 		}
-		// Mirror the visual "Signed node" shield (rendered below) so VoiceOver announces it in the
+		// The security glyph beside the name carries signing state visually; name it for VoiceOver in the
 		// compact list too — affirmative only, never for unsigned nodes.
 		if summary.hasXeddsaSigned {
 			desc += ", " + "Signed node".localized
@@ -144,20 +144,13 @@ struct NodeListItemCompact: View {
 		return nil
 	}
 	
-	private func lineNums(hasXeddsaSigned: Bool) -> Int {
+	private func lineNums() -> Int {
 		var lines = 1
 		if shouldShowRole || shouldShowLocation || shouldShowTelemetry || shouldShowChannel || shouldShowHops || shouldShowSignal {
 			lines += 1
 		}
 
 		if shouldShowLastHeard {
-			lines += 1
-		}
-
-		// The signed-node ("Signed node") row renders on its own line whenever the node is signed,
-		// so reserve space for it too — otherwise the avatar circle is sized too short for signed
-		// nodes, most visibly when last-heard / telemetry rows are disabled.
-		if hasXeddsaSigned {
 			lines += 1
 		}
 
@@ -190,7 +183,7 @@ struct NodeListItemCompact: View {
 	@ViewBuilder private func rowContent(_ summary: NodeListRowSummary) -> some View {
 		// Resolve the status once per render; reused for the row, circle sizing, and a11y.
 		let statusMessage = summary.statusMessage
-		let circleSize = max(minCircle, min(maxCircle, baseUnit * CGFloat(lineNums(hasXeddsaSigned: summary.hasXeddsaSigned) + (statusMessage != nil ? 1 : 0))))
+		let circleSize = max(minCircle, min(maxCircle, baseUnit * CGFloat(lineNums() + (statusMessage != nil ? 1 : 0))))
 		let cachedBatteryLevel = (shouldShowPower || shouldShowTelemetry) ? summary.batteryLevel : nil
 		let needsLatestPosition = shouldShowTelemetry || (shouldShowLocation && connectedNode != summary.num)
 		let cachedLatestNodeCoordinate = needsLatestPosition ? summary.latestNodeCoordinate : nil
@@ -228,15 +221,6 @@ struct NodeListItemCompact: View {
 							Image(systemName: "star.fill")
 								.symbolRenderingMode(.multicolor)
 						}
-					}
-					// Signed node = XEdDSA-signed NodeInfo broadcast → identity verified by the radio.
-					// Affirmative only; never shown for unsigned nodes. Mirrors the Node Detail row.
-					// A person badge rather than a bare shield: what was verified is who this node
-					// says it is, not that the traffic is encrypted, which the lock already covers.
-					if summary.hasXeddsaSigned {
-						IconAndText(systemName: SignedNodeIcon.symbolName,
-									imageColor: .green,
-									text: "Signed node".localized)
 					}
 					// User-authored status broadcast by the node, directly beneath the name.
 					// Single-line clamp keeps the compact row dense; omitted when empty.

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItemCompact.swift
@@ -112,10 +112,13 @@ struct NodeListItemCompact: View {
 			}
 			desc += ", " + signalString
 		}
-		// The security glyph beside the name carries signing state visually; name it for VoiceOver in the
-		// compact list too — affirmative only, never for unsigned nodes.
-		if summary.hasXeddsaSigned {
+		// Announce signing the way the glyph shows it — both read securityIndicator(), the
+		// same contract the visual indicator uses. Affirmative only.
+		switch summary.securityIndicator() {
+		case .signed, .verified:
 			desc += ", " + "Signed node".localized
+		default:
+			break
 		}
 		return desc
 	}


### PR DESCRIPTION
## Summary

Node list rows showed signing twice: the security glyph beside the name, and a separate "Signed node" row underneath. The two can disagree, because they read different things. The glyph goes through `NodeSecurityIndicator`, which is gated on the node reporting firmware 2.8 or newer, while the row read `hasXeddsaSigned` directly with no version gate. A node that has signed but reports an older or unknown version therefore showed a green lock beside its name and "Signed node" below it.

The glyph already carries the state, so the row is redundant as well as contradictory.

## What changed

Removes the "Signed node" `IconAndText` row from `NodeListItem` and `NodeListItemCompact`.

In the compact row, `lineNums` reserved an extra line for it when sizing the avatar circle. That branch goes too, so the circle is no longer sized for a row that does not render, and the parameter it needed goes with it.

The VoiceOver descriptions stay. A glyph announces nothing on its own, so those strings are now the only thing naming signing state for screen reader users. Their comments referred to "the shield row below" and have been corrected.

## Testing

Built for a connected iPhone and installed. Node detail is untouched and still shows its own signed row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Updated VoiceOver descriptions for signed-node announcements.
  - Signed-node status remains available through accessibility text.

- **UI Changes**
  - Removed the visual “Signed node” badge from standard and compact node list rows.
  - Compact rows no longer reserve space for the removed badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->