### PR TITLE
Let a verified signature outrank the version gate

### DIFF
--- a/Meshtastic/Helpers/NodeSecurityIndicator.swift
+++ b/Meshtastic/Helpers/NodeSecurityIndicator.swift
@@ -63,13 +63,17 @@ enum NodeSecurityIndicator: Equatable {
 	}
 
 	/// Decides the indicator for one row from snapshot fields alone (no live model access).
-	static func status(firmwareVersion: String?, pkiEncrypted: Bool, keyMatch: Bool, verified: Bool = false, isOwnNode: Bool = false) -> NodeSecurityIndicator {
+	static func status(firmwareVersion: String?, pkiEncrypted: Bool, keyMatch: Bool, verified: Bool = false, isOwnNode: Bool = false, hasXeddsaSigned: Bool = false) -> NodeSecurityIndicator {
 		// A stored key that stopped matching is a warning regardless of firmware version —
 		// most of all for a contact the user personally verified.
 		if pkiEncrypted && !keyMatch {
 			return .keyMismatch
 		}
-		if supportsSigning(firmwareVersion: firmwareVersion) {
+		// A verified signature is direct evidence the node signs, and outranks the version
+		// gate, which is only the proxy "every 2.8 node signs". A node can report a stale or
+		// empty version — DeviceMetadata that never arrived, or arrived before an update —
+		// and still be signing; showing it a lock contradicts what the radio has proven.
+		if hasXeddsaSigned || supportsSigning(firmwareVersion: firmwareVersion) {
 			// Every 2.8 node signs its broadcasts, so a 2.8 node is signed by definition.
 			// The connected radio is the user's own device: they hold its key, so its
 			// identity needs no third-party verification. Sharing your own contact QR

--- a/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeListItem.swift
@@ -106,7 +106,8 @@ struct NodeListRowSummary {
 			pkiEncrypted: pkiEncrypted,
 			keyMatch: keyMatch,
 			verified: isKeyManuallyVerified,
-			isOwnNode: isConnectedNode
+			isOwnNode: isConnectedNode,
+			hasXeddsaSigned: hasXeddsaSigned
 		).glyph
 	}
 }

--- a/MeshtasticTests/NodeSecurityIndicatorTests.swift
+++ b/MeshtasticTests/NodeSecurityIndicatorTests.swift
@@ -49,6 +49,16 @@ struct NodeSecurityIndicatorTests {
 		#expect(NodeSecurityIndicator.status(firmwareVersion: "2.7.26", pkiEncrypted: true, keyMatch: true, isOwnNode: true) == .publicKey)
 	}
 
+	@Test("a verified signature shows signed even when the version gate says no")
+	func signatureEvidenceBeatsVersionGate() {
+		// The radio verified this node's signature, so it signs — whatever version it reports.
+		#expect(NodeSecurityIndicator.status(firmwareVersion: "2.7.26", pkiEncrypted: true, keyMatch: true, hasXeddsaSigned: true) == .signed)
+		#expect(NodeSecurityIndicator.status(firmwareVersion: nil, pkiEncrypted: false, keyMatch: false, hasXeddsaSigned: true) == .signed)
+		// In-person verification still outranks it, and a mismatch still wins.
+		#expect(NodeSecurityIndicator.status(firmwareVersion: "2.7.26", pkiEncrypted: true, keyMatch: true, verified: true, hasXeddsaSigned: true) == .verified)
+		#expect(NodeSecurityIndicator.status(firmwareVersion: "2.7.26", pkiEncrypted: true, keyMatch: false, hasXeddsaSigned: true) == .keyMismatch)
+	}
+
 	@Test("an in-person verified contact outranks signing on 2.8")
 	func verifiedOutranksSigned() {
 		#expect(NodeSecurityIndicator.status(firmwareVersion: "2.8.0", pkiEncrypted: true, keyMatch: true, verified: true) == .verified)


### PR DESCRIPTION
## Summary

A node the radio has verified signatures from could still show a lock. `NodeSecurityIndicator` decided signing purely from the reported firmware version, and never looked at `hasXeddsaSigned`. A node reporting a stale or empty version — DeviceMetadata that never arrived, or arrived before an update — fell to the lock branch even though the radio had proven it signs. Visible in the field as a green lock beside the name of a node the app knows is signed.

The version gate is a proxy: every 2.8 node signs. A verified signature is the fact itself, so it outranks the proxy.

## What changed

`status` gains `hasXeddsaSigned`, defaulting to false, checked alongside `supportsSigning`. Either is enough for the signing display. A key mismatch still wins at any version, and in-person verification still outranks over-the-mesh within the signing display.

`keyStatus` on the row summary passes the flag through — the summary already carried it for the VoiceOver description.

The strict version gate is unchanged for nodes with no verified signature: an unknown version with no evidence still keeps the locks.

## Testing

New test covers signature evidence beating the gate on old and unknown versions, in-person verification still winning inside it, and a mismatch still winning over everything. Existing suite unaffected — the parameter defaults to false. Built for a connected iPhone and installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Security indicators now correctly recognize verified XEdDSA signatures, even when a node’s firmware version is missing, outdated, or unavailable.
  - Nodes with valid signature evidence no longer incorrectly display legacy lock indicators.
  - Existing verified and key-mismatch indicator behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->