### PR TITLE
Device link disclosure

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -10,6 +10,9 @@
     "Please do not leave this screen until the update is complete. You can safely play Chirpy Hop while waiting!": {
       "comment": "Notice displayed during OTA firmware update"
     },
+    "Product links may be affiliate links — purchases may earn Meshtastic a commission.": {
+      "comment": "Affiliate disclosure shown above msh.to product links"
+    },
     "Visit meshtastic.org/docs for guides, hardware information, and community tips.": {
       "comment": "OTA update tip: docs website"
     },

--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -370,24 +370,24 @@
             "shows",
             "shown",
             "radio",
+            "links",
             "packets",
             "direct",
             "detail",
+            "one",
             "list",
             "link",
             "hardware",
             "channel",
             "broadcasts",
             "tag",
+            "section",
             "row",
-            "one",
             "mesh",
             "map",
-            "local",
-            "tap",
-            "status"
+            "local"
         ],
-        "charCount": 12368
+        "charCount": 12606
     },
     {
         "id": "settings",

--- a/Meshtastic/Resources/docs/markdown/user/nodes.md
+++ b/Meshtastic/Resources/docs/markdown/user/nodes.md
@@ -224,6 +224,8 @@ For devices with known purchase links, an **I want one** section appears below t
 
 Marketplace links are filtered to your device region, so only stores that ship to your area are shown. Vendor links (directly from the device manufacturer) are always shown regardless of region.
 
+Some of these are affiliate links. The app says so above the links, in both the **I want one** section and the full directory at **Settings → Device Links**: product links may be affiliate links, and purchases may earn Meshtastic a commission.
+
 > **Tip — No purchase links shown**
 > Purchase links require an internet connection on first launch and after clearing app data. Connect the app to update the device catalog.
 

--- a/Meshtastic/Resources/docs/user/nodes.html
+++ b/Meshtastic/Resources/docs/user/nodes.html
@@ -343,6 +343,7 @@ Key</strong> in place of the public key row for those nodes, and they are left o
 <h3>Where to Buy</h3>
 <p>For devices with known purchase links, an <strong>I want one</strong> section appears below the hardware info. It shows the official vendor link and regional marketplace options (Amazon, Rokland, AliExpress, and others) sourced from <a href="https://msh.to">msh.to</a>.</p>
 <p>Marketplace links are filtered to your device region, so only stores that ship to your area are shown. Vendor links (directly from the device manufacturer) are always shown regardless of region.</p>
+<p>Some of these are affiliate links. The app says so above the links, in both the <strong>I want one</strong> section and the full directory at <strong>Settings → Device Links</strong>: product links may be affiliate links, and purchases may earn Meshtastic a commission.</p>
 <div class="tips-callout"><strong>Tip — No purchase links shown</strong>
 Purchase links require an internet connection on first launch and after clearing app data. Connect the app to update the device catalog.</div>
 <p><a href="https://meshtastic.org/docs/configuration/radio/device/">Device Configuration Docs →</a></p>

--- a/Meshtastic/Views/Nodes/Helpers/DeviceLinksSection.swift
+++ b/Meshtastic/Views/Nodes/Helpers/DeviceLinksSection.swift
@@ -52,6 +52,10 @@ struct DeviceLinksSection: View {
 					}
 				}
 				if isExpanded {
+					// The disclosure sits above the links it covers.
+					Text("Product links may be affiliate links — purchases may earn Meshtastic a commission.")
+						.font(.subheadline)
+						.foregroundStyle(.secondary)
 					ForEach(matchingLinks, id: \.shortCode) { link in
 						Button {
 							if let url = URL(string: "https://msh.to/\(link.shortCode)") {

--- a/Meshtastic/Views/Settings/DeviceLinkDirectory.swift
+++ b/Meshtastic/Views/Settings/DeviceLinkDirectory.swift
@@ -13,6 +13,12 @@ struct DeviceLinkDirectory: View {
 
 	var body: some View {
 		List {
+			if !allLinks.isEmpty {
+				// The disclosure sits above the links it covers.
+				Text("Product links may be affiliate links — purchases may earn Meshtastic a commission.")
+					.font(.subheadline)
+					.foregroundStyle(.secondary)
+			}
 			ForEach(allLinks, id: \.shortCode) { link in
 				Button {
 					if let url = URL(string: "https://msh.to/\(link.shortCode)") {

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -224,6 +224,8 @@ For devices with known purchase links, an **I want one** section appears below t
 
 Marketplace links are filtered to your device region, so only stores that ship to your area are shown. Vendor links (directly from the device manufacturer) are always shown regardless of region.
 
+Some of these are affiliate links. The app says so above the links, in both the **I want one** section and the full directory at **Settings → Device Links**: product links may be affiliate links, and purchases may earn Meshtastic a commission.
+
 > **Tip — No purchase links shown**
 > Purchase links require an internet connection on first launch and after clearing app data. Connect the app to update the device catalog.
 


### PR DESCRIPTION
Product links in the app route through msh.to and carry Meshtastic referral
parameters. This states that where the links appear.

Wording is taken from web-flasher
[#415](https://github.com/meshtastic/web-flasher/pull/415) so the line reads the
same on every client.

## Changes

- **`DeviceLinksSection`** — the disclosure sits above the first link, shown
  once "I want one" is expanded.
- **`DeviceLinkDirectory`** — the same line as the first row, shown when there
  are links. It sits in the links' own section rather than a section of its own,
  so it does not read as a tappable group.
- **`Localizable.xcstrings`** — one additive entry, English only.
- **`docs/user/nodes.md`** — the "Where to Buy" section describes both surfaces,
  so it mentions this too. The bundle is regenerated for that page only.

## Notes

- Checked 2026-09-08: the msh.to redirects for RAK, Rokland and AliExpress carry
  referral or partner parameters. The Amazon redirects carry none.
- The line is placed above the links rather than below them so it is read first,
  and at `.subheadline` so it is not smaller than the links it covers.
- `scripts/build-docs.sh` writes a corrupted `index.json` on Python 3.14, where
  `python3 -m json.tool` emits ANSI colour codes into the file. CI runs an older
  Python and is unaffected. This branch ran it with `NO_COLOR=1` and applied only
  the `nodes` entry, so the three entries already stale in the committed bundle
  (`carplay`, `firmware`, `whats-new`) are left as they are.

## Testing

- `xcodebuild build -scheme Meshtastic -destination 'generic/platform=iOS Simulator'` — no errors.
- SwiftLint clean on both files.
- No snapshot reference changes: `NodeDetailSnapshotTests` inserts no
  `DeviceLinkEntity`, so `DeviceLinksSection` renders nothing there, and neither
  view has a snapshot of its own.
- `MeshtasticTests/DeviceLinkTests.swift` covers decoding and visibility only, so
  nothing there needed updating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added affiliate-link disclosures above device links in node details and Settings → Device Links.
  * Clarified that purchases through some links may earn Meshtastic a commission.

* **Documentation**
  * Updated the Nodes guide and related search metadata to reflect the affiliate-link disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->