### PR TITLE
Move the affiliate disclosure under the product links

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/DeviceLinksSection.swift
+++ b/Meshtastic/Views/Nodes/Helpers/DeviceLinksSection.swift
@@ -52,10 +52,6 @@ struct DeviceLinksSection: View {
 					}
 				}
 				if isExpanded {
-					// The disclosure sits above the links it covers.
-					Text("Product links may be affiliate links — purchases may earn Meshtastic a commission.")
-						.font(.subheadline)
-						.foregroundStyle(.secondary)
 					ForEach(matchingLinks, id: \.shortCode) { link in
 						Button {
 							if let url = URL(string: "https://msh.to/\(link.shortCode)") {
@@ -73,6 +69,9 @@ struct DeviceLinksSection: View {
 							}
 						}
 					}
+					Text("Product links may be affiliate links — purchases may earn Meshtastic a commission.")
+						.font(.footnote)
+						.foregroundStyle(.secondary)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

The affiliate disclosure in the node detail I want one section sat above the links, reading like a warning before the list instead of the fine print it is.

## What changed

The disclosure moves below the links and drops from subheadline to footnote. The links themselves are unchanged.

## Testing

- Full suite on the iOS Simulator: 3108 tests in 538 suites, all passing.
- Installed on a phone to check the expanded section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Moved the affiliate disclosure below the device links.
  * Updated the disclosure text size from subheadline to footnote.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->