### PR TITLE
Settle the startup cascade test on every request, not just images

### DIFF
--- a/MeshtasticTests/MeshtasticAPIBundledSeedTests.swift
+++ b/MeshtasticTests/MeshtasticAPIBundledSeedTests.swift
@@ -244,6 +244,12 @@ final class MeshtasticAPIBundledSeedTests {
 
 	/// Polls until the detached startup cascade stops issuing image requests, then returns them.
 	/// The cascade is unstructured `Task.detached` work with no completion handle to await.
+	///
+	/// Settles on the count of ALL recorded requests, not just images: the cascade's tail —
+	/// orphan cleanup, then the msh.to link import — runs after the last image fetch, and a
+	/// settle that only watched images could return while that tail was still in flight. On a
+	/// slow runner the straggling link fetch then landed inside the NEXT test's recording
+	/// window, which counted it as a duplicate. CI caught that; local machines never did.
 	private func settledImageRequests(
 		timeout: Duration = .seconds(30),
 		quietPolls: Int = 5,
@@ -254,13 +260,13 @@ final class MeshtasticAPIBundledSeedTests {
 		let deadline = ContinuousClock.now.advanced(by: timeout)
 		while ContinuousClock.now < deadline {
 			try await Task.sleep(for: pollInterval)
-			let current = imageRequests(from: RequestRecordingURLProtocol.recordedURLs)
-			if current.count == lastCount && !current.isEmpty {
+			let all = RequestRecordingURLProtocol.recordedURLs
+			if all.count == lastCount && !imageRequests(from: all).isEmpty {
 				stablePolls += 1
-				if stablePolls >= quietPolls { return current }
+				if stablePolls >= quietPolls { return imageRequests(from: all) }
 			} else {
 				stablePolls = 0
-				lastCount = current.count
+				lastCount = all.count
 			}
 		}
 		return imageRequests(from: RequestRecordingURLProtocol.recordedURLs)

--- a/MeshtasticTests/MeshtasticAPIBundledSeedTests.swift
+++ b/MeshtasticTests/MeshtasticAPIBundledSeedTests.swift
@@ -261,7 +261,11 @@ final class MeshtasticAPIBundledSeedTests {
 		while ContinuousClock.now < deadline {
 			try await Task.sleep(for: pollInterval)
 			let all = RequestRecordingURLProtocol.recordedURLs
-			if all.count == lastCount && !imageRequests(from: all).isEmpty {
+			// The link import is the cascade's last network call, so the record is only
+			// complete once it is present — a quiet stretch between the images and the
+			// link fetch must not count as settled.
+			let tailArrived = all.contains { $0.absoluteString.contains("msh.to/api/urls") }
+			if all.count == lastCount && tailArrived && !imageRequests(from: all).isEmpty {
 				stablePolls += 1
 				if stablePolls >= quietPolls { return imageRequests(from: all) }
 			} else {
@@ -297,6 +301,10 @@ final class MeshtasticAPIBundledSeedTests {
 			images.count == expected.count,
 			"startup should issue one request per unique image (\(expected.count)), got \(images.count)"
 		)
+		// The regression this suite caught on CI: the cascade's trailing link import must be in
+		// the record before the helper returns, or it lands in the next test's window instead.
+		let linkImports = RequestRecordingURLProtocol.recordedURLs.filter { $0.absoluteString.contains("msh.to/api/urls") }
+		#expect(linkImports.count == 1, "the cascade imports the link catalog exactly once, inside this test's window")
 	}
 
 	/// The API-driven pass must cover hardware that exists only in the live API list (which the


### PR DESCRIPTION
## Summary

unit-tests failed on main's tip with apiRefreshCoversApiOnlyHardwareWithoutDuplicating seeing two msh.to/api/urls requests where it expects one. The extra request is a straggler from the previous test in the suite, not a real double import.

## What changed

startupCascadeRunsOneImagePass launches the full detached startup cascade, which has no completion handle, and settled by waiting for image requests to go quiet. The cascade's tail — orphan cleanup, then the msh.to link import — runs after the last image fetch, so on a slow runner the link fetch landed after the settle, drifted past the next test's reset, and was recorded inside its window. Fast machines finish the tail inside the settle window, which is why this never failed locally.

The settle now watches the count of all recorded requests rather than only images, so the helper cannot return while the cascade is still talking to the network.

## Testing

- The suite run five times in a row: 10 tests passing each time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup settling to wait for all recorded requests, including cleanup and link requests, to complete.
  * Image results continue to be returned once request activity has stabilized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->