### PR TITLE
Describe where the affiliate disclosure sits now

### DIFF
--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -133,17 +133,17 @@
             "bootloader",
             "screen",
             "meshtastic",
+            "from",
             "version",
             "image",
-            "from",
             "tap",
+            "shows",
+            "connected",
             "connect",
             "artwork",
             "target",
-            "shows",
             "install",
             "erase",
-            "connected",
             "ble",
             "transfer",
             "stable",
@@ -153,7 +153,7 @@
             "nrf52",
             "notification"
         ],
-        "charCount": 7251
+        "charCount": 7481
     },
     {
         "id": "getting-started",
@@ -366,8 +366,8 @@
             "only",
             "name",
             "messages",
-            "firmware",
             "shows",
+            "firmware",
             "shown",
             "radio",
             "links",
@@ -387,7 +387,7 @@
             "map",
             "local"
         ],
-        "charCount": 12606
+        "charCount": 12656
     },
     {
         "id": "settings",

--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -145,15 +145,15 @@
             "install",
             "erase",
             "ble",
+            "without",
             "transfer",
             "stable",
             "settings",
             "radios",
             "progress",
-            "nrf52",
-            "notification"
+            "nrf52"
         ],
-        "charCount": 7481
+        "charCount": 7633
     },
     {
         "id": "getting-started",

--- a/Meshtastic/Resources/docs/markdown/user/firmware.md
+++ b/Meshtastic/Resources/docs/markdown/user/firmware.md
@@ -94,6 +94,9 @@ The metadata feed is informational. The app does not download or install firmwar
 **Firmware below the supported minimum**
 The radio stays connected and the app shows the firmware update screen, with everything else blocked until the radio is updated. Update from that screen, or disconnect to use a different radio.
 
+**Security update recommended**
+Firmware before 2.6 works but has known security fixes available, so the app recommends updating without blocking anything.
+
 ![Security update recommended](../assets/screenshots/securityVersionNag.png)
 
 **Radio not appearing in firmware list**

--- a/Meshtastic/Resources/docs/markdown/user/nodes.md
+++ b/Meshtastic/Resources/docs/markdown/user/nodes.md
@@ -224,7 +224,7 @@ For devices with known purchase links, an **I want one** section appears below t
 
 Marketplace links are filtered to your device region, so only stores that ship to your area are shown. Vendor links (directly from the device manufacturer) are always shown regardless of region.
 
-Some of these are affiliate links. The app says so above the links, in both the **I want one** section and the full directory at **Settings → Device Links**: product links may be affiliate links, and purchases may earn Meshtastic a commission.
+Some of these are affiliate links. The app says so — product links may be affiliate links, and purchases may earn Meshtastic a commission. In the **I want one** section the disclosure sits in small print below the links; the full directory at **Settings → Device Links** shows it above them.
 
 > **Tip — No purchase links shown**
 > Purchase links require an internet connection on first launch and after clearing app data. Connect the app to update the device catalog.

--- a/Meshtastic/Resources/docs/user/firmware.html
+++ b/Meshtastic/Resources/docs/user/firmware.html
@@ -111,6 +111,8 @@
 </ul>
 <p><strong>Firmware below the supported minimum</strong>
 The radio stays connected and the app shows the firmware update screen, with everything else blocked until the radio is updated. Update from that screen, or disconnect to use a different radio.</p>
+<p><strong>Security update recommended</strong>
+Firmware before 2.6 works but has known security fixes available, so the app recommends updating without blocking anything.</p>
 <p><img src="../assets/screenshots/securityVersionNag.png" alt="Security update recommended" /></p>
 <p><strong>Radio not appearing in firmware list</strong></p>
 <ul>

--- a/Meshtastic/Resources/docs/user/firmware.html
+++ b/Meshtastic/Resources/docs/user/firmware.html
@@ -109,7 +109,8 @@
 <li>Keep the radio within 1–2 meters of your phone during the update.</li>
 <li>If the radio appears bricked after a failed update, it can usually be recovered using the <a href="https://flasher.meshtastic.org/">Meshtastic Flasher</a> on a computer.</li>
 </ul>
-<p><img src="../assets/screenshots/invalidVersion.png" alt="Incompatible firmware version warning" /></p>
+<p><strong>Firmware below the supported minimum</strong>
+The radio stays connected and the app shows the firmware update screen, with everything else blocked until the radio is updated. Update from that screen, or disconnect to use a different radio.</p>
 <p><img src="../assets/screenshots/securityVersionNag.png" alt="Security update recommended" /></p>
 <p><strong>Radio not appearing in firmware list</strong></p>
 <ul>

--- a/Meshtastic/Resources/docs/user/nodes.html
+++ b/Meshtastic/Resources/docs/user/nodes.html
@@ -343,7 +343,7 @@ Key</strong> in place of the public key row for those nodes, and they are left o
 <h3>Where to Buy</h3>
 <p>For devices with known purchase links, an <strong>I want one</strong> section appears below the hardware info. It shows the official vendor link and regional marketplace options (Amazon, Rokland, AliExpress, and others) sourced from <a href="https://msh.to">msh.to</a>.</p>
 <p>Marketplace links are filtered to your device region, so only stores that ship to your area are shown. Vendor links (directly from the device manufacturer) are always shown regardless of region.</p>
-<p>Some of these are affiliate links. The app says so above the links, in both the <strong>I want one</strong> section and the full directory at <strong>Settings → Device Links</strong>: product links may be affiliate links, and purchases may earn Meshtastic a commission.</p>
+<p>Some of these are affiliate links. The app says so — product links may be affiliate links, and purchases may earn Meshtastic a commission. In the <strong>I want one</strong> section the disclosure sits in small print below the links; the full directory at <strong>Settings → Device Links</strong> shows it above them.</p>
 <div class="tips-callout"><strong>Tip — No purchase links shown</strong>
 Purchase links require an internet connection on first launch and after clearing app data. Connect the app to update the device catalog.</div>
 <p><a href="https://meshtastic.org/docs/configuration/radio/device/">Device Configuration Docs →</a></p>

--- a/docs/user/firmware.md
+++ b/docs/user/firmware.md
@@ -94,6 +94,9 @@ The metadata feed is informational. The app does not download or install firmwar
 **Firmware below the supported minimum**
 The radio stays connected and the app shows the firmware update screen, with everything else blocked until the radio is updated. Update from that screen, or disconnect to use a different radio.
 
+**Security update recommended**
+Firmware before 2.6 works but has known security fixes available, so the app recommends updating without blocking anything.
+
 ![Security update recommended](../assets/screenshots/securityVersionNag.png)
 
 **Radio not appearing in firmware list**

--- a/docs/user/nodes.md
+++ b/docs/user/nodes.md
@@ -224,7 +224,7 @@ For devices with known purchase links, an **I want one** section appears below t
 
 Marketplace links are filtered to your device region, so only stores that ship to your area are shown. Vendor links (directly from the device manufacturer) are always shown regardless of region.
 
-Some of these are affiliate links. The app says so above the links, in both the **I want one** section and the full directory at **Settings → Device Links**: product links may be affiliate links, and purchases may earn Meshtastic a commission.
+Some of these are affiliate links. The app says so — product links may be affiliate links, and purchases may earn Meshtastic a commission. In the **I want one** section the disclosure sits in small print below the links; the full directory at **Settings → Device Links** shows it above them.
 
 > **Tip — No purchase links shown**
 > Purchase links require an internet connection on first launch and after clearing app data. Connect the app to update the device catalog.


### PR DESCRIPTION
## Summary

Follow-up to #2460, which moved the affiliate disclosure in the node detail I want one section below the links. The nodes doc still said the disclosure appears above the links in both places.

## What changed

docs/user/nodes.md says which surface shows the disclosure where: below the links in small print on node detail, above them in the Settings → Device Links directory. Bundled docs regenerated with build-docs.sh, which also picked up a stale firmware.html left behind by an earlier docs edit.

## Testing

- Regenerated the bundle; only the touched pages and the index changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified firmware troubleshooting guidance for radios running below the supported minimum, including available update and disconnect options.
  - Updated affiliate-link disclosure wording and placement details across the “Where to Buy” and Device Links sections.
  - Refreshed documentation search indexing for firmware and node-related content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->