### PR TITLE
Say what the NFC sheet is scanning for

### DIFF
--- a/Meshtastic/Helpers/NFCReader.swift
+++ b/Meshtastic/Helpers/NFCReader.swift
@@ -34,7 +34,9 @@ final class NFCReader: NSObject, ObservableObject, NFCNDEFReaderSessionDelegate 
 	}
 
 	/// Starts a session that writes `payload` to the next tag presented.
-	func write(payload: String) {
+	/// - Parameter message: Shown under the system sheet's Ready to Scan title, so it can say
+	///   what is being written — a contact, channels — rather than "the NFC tag".
+	func write(payload: String, message: String? = nil) {
 		// Tear down any in-flight session so a stale one can't race the new mode.
 		session?.invalidate()
 		mode = .write(payload: payload)
@@ -45,13 +47,14 @@ final class NFCReader: NSObject, ObservableObject, NFCNDEFReaderSessionDelegate 
 			invalidateAfterFirstRead: false
 		)
 
-		session?.alertMessage = String(localized: "Hold your iPhone near the NFC tag.")
+		session?.alertMessage = message ?? String(localized: "Hold your iPhone near the NFC tag.")
 		session?.begin()
 	}
 
 	/// Starts a read session and calls `onURL` (on the main actor) with the
 	/// first https/meshtastic URL found on the tag.
-	func scanToRead(onURL: @escaping (URL) -> Void) {
+	/// - Parameter message: Shown under the system sheet's Ready to Scan title.
+	func scanToRead(message: String? = nil, onURL: @escaping (URL) -> Void) {
 		// Tear down any in-flight session so a stale one can't race the new mode.
 		session?.invalidate()
 		mode = .read(onURL: onURL)
@@ -62,7 +65,7 @@ final class NFCReader: NSObject, ObservableObject, NFCNDEFReaderSessionDelegate 
 			invalidateAfterFirstRead: true
 		)
 
-		session?.alertMessage = String(localized: "Hold your iPhone near the Meshtastic NFC tag.")
+		session?.alertMessage = message ?? String(localized: "Hold your iPhone near the Meshtastic NFC tag.")
 		session?.begin()
 	}
 

--- a/Meshtastic/Views/Settings/Tools.swift
+++ b/Meshtastic/Views/Settings/Tools.swift
@@ -64,7 +64,10 @@ struct Tools: View {
 						if let node = connectedNode {
 							Text("Node Name: \(node.user?.longName ?? "Unknown".localized)")
 							Button {
-								nfcReader.write(payload: qrString)
+								nfcReader.write(
+									payload: qrString,
+									message: String(localized: "Hold your iPhone near a writable tag to save your contact to it.")
+								)
 							} label: {
 								Label("Write Contact to NFC Tag", systemImage: "tag")
 							}
@@ -74,7 +77,9 @@ struct Tools: View {
 								.foregroundStyle(.secondary)
 						}
 						Button {
-							nfcReader.scanToRead { url in
+							nfcReader.scanToRead(
+								message: String(localized: "Hold your iPhone near a Meshtastic tag to add the contact or channels it holds.")
+							) { url in
 								handleScannedURL(url)
 							}
 						} label: {


### PR DESCRIPTION
## Summary

The system Ready to Scan sheet showed the same generic "Hold your iPhone near the NFC tag" line whether the app was writing a contact or reading a tag. The title is fixed by iOS, but the line under it is the session's alert message, so it can say what is actually happening.

## What changed

NFCReader's write and scan methods take an optional message for the sheet, keeping the old lines as defaults. The Tools screen passes content-specific text: writing says the tag will hold your contact, scanning says the tag's contact or channels will be added.

## Testing

- Builds for iOS device; installed on a phone for the sheet text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * NFC tag writing and scanning now display contextual, localized instructions in the system scanning prompt.
  * Existing default messages remain available when no custom instruction is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->