### PR TITLE
Rename Share Contact QR to Share Contact

### DIFF
--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -302,7 +302,7 @@ struct Connect: View {
 											shareContactNode = live.toProto()
 											showingShareContactQR = true
 										} label: {
-											Label("Share Contact QR", systemImage: "qrcode")
+											Label("Share Contact", systemImage: "qrcode")
 										}
 									}
 									if accessoryManager.allowDisconnect {

--- a/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeDetail.swift
@@ -822,7 +822,7 @@ struct NodeDetail: View {
 					Button {
 						showingShareContactQR = true
 					} label: {
-						Label("Share Contact QR", systemImage: "qrcode")
+						Label("Share Contact", systemImage: "qrcode")
 					}
 				}
 			}

--- a/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
+++ b/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
@@ -69,7 +69,7 @@ struct ShareContactQRDialog: View {
 
 	var body: some View {
 		VStack(spacing: 20) {
-			Text("Share Contact QR")
+			Text("Share Contact")
 				.font(.title2)
 				.padding(.top)
 			Text(node.user.longName)


### PR DESCRIPTION
## Summary

The share sheet offers a QR code, a copyable link, and NFC tag writing, so the menu item naming only the QR undersold it.

## What changed

The menu option on the node detail screen and the Connect long-press reads Share Contact, and the dialog title matches.

## Testing

- Full suite on the iOS Simulator: 3109 tests in 538 suites, all passing.
- Installed on a phone for the menu and dialog text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Renamed “Share Contact QR” to “Share Contact” across the contact-sharing menu, action button, and dialog title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->