### PR TITLE
Use the palette's light blue for tinted labels in dark mode

### DIFF
--- a/Meshtastic/Extensions/Color+Brand.swift
+++ b/Meshtastic/Extensions/Color+Brand.swift
@@ -19,6 +19,16 @@ extension Color {
 	/// Cobalt #2855A8 both modes
 	static var accentColor: Color { Color("Colors/MeshtasticAccent") }
 
+	/// The accent for text and glyphs that sit *on* a surface: the `AccentColor` asset, Cobalt
+	/// #2855A8 light / Blue 300 #B0BFF0 dark.
+	///
+	/// Separate from `accentColor` because the two roles need opposite things in dark mode.
+	/// `accentColor` is a *fill* drawn under white text — message bubbles, prominent buttons —
+	/// so it has to stay dark. A tinted label is the reverse: cobalt on a dark sheet is about
+	/// 1.7:1, so it needs the palette's light blue. Using one color for both is what made the
+	/// save confirmation unreadable in dark mode.
+	static let accentTint = Color("AccentColor")
+
 	/// Branded primary text — shadows SwiftUI `Color.primary`
 	/// Neutral 700 #3D3E50 light / Neutral 50 #F5F6FA dark
 	static let primary = Color("Colors/MeshtasticPrimary")

--- a/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
+++ b/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
@@ -104,10 +104,16 @@ struct ShareContactQRDialog: View {
 			#endif
 			Button("Done") { dismiss() }
 				.buttonStyle(.borderedProminent)
+				// A filled accent shape under a white label, so it keeps the dark fill accent
+				// rather than the lighter on-surface one the plain buttons above need.
+				.tint(.accentColor)
 				.padding(.bottom)
 		}
 		.padding()
 		.frame(maxWidth: 350)
+		// Share and the NFC button are plain labels on the sheet, so they read as text and need
+		// the on-surface accent; the inherited fill accent is close to unreadable here in dark.
+		.tint(.accentTint)
 	}
 }
 

--- a/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
+++ b/Meshtastic/Views/Settings/Config/SaveConfigButton.swift
@@ -31,6 +31,7 @@ struct SaveConfigButton: View {
 				.padding(.bottom)
 				.controlSize(.large)
 				.buttonStyle(.borderedProminent)
+				.tint(.accentColor)
 				.confirmationDialog(
 					"Are you sure?",
 					isPresented: $isPresentingSaveConfirm,
@@ -44,6 +45,10 @@ struct SaveConfigButton: View {
 				} message: {
 					Text(confirmationMessage)
 				}
+				// After the dialog modifier, so this tints the dialog's actions rather than the
+				// Save button. The button above is a filled accent shape and keeps `accentColor`;
+				// the dialog's action is plain text on glass and needs the on-surface accent.
+				.tint(.accentTint)
 			} else {
 				Button {
 					isPresentingSaveConfirm = true

--- a/MeshtasticTests/AccentTintTests.swift
+++ b/MeshtasticTests/AccentTintTests.swift
@@ -18,9 +18,17 @@ import UIKit
 struct AccentTintTests {
 
 	#if canImport(UIKit)
-	private func resolved(_ name: String, dark: Bool) -> UIColor? {
-		guard let color = UIColor(named: name) else { return nil }
-		return color.resolvedColor(with: UITraitCollection(userInterfaceStyle: dark ? .dark : .light))
+	/// The fill accent by asset name rather than through `Color.accentColor`. The brand extension
+	/// shadows SwiftUI's `accentColor`, which resolves inside the app but is ambiguous from here,
+	/// where both declarations are visible. `accentTint` has no such clash and is read directly.
+	private static let fillAccentAsset = "Colors/MeshtasticAccent"
+
+	private func resolved(_ color: Color, dark: Bool) -> UIColor {
+		UIColor(color).resolvedColor(with: UITraitCollection(userInterfaceStyle: dark ? .dark : .light))
+	}
+
+	private func resolved(asset: String, dark: Bool) -> UIColor? {
+		UIColor(named: asset)?.resolvedColor(with: UITraitCollection(userInterfaceStyle: dark ? .dark : .light))
 	}
 
 	private func luminance(_ color: UIColor) -> CGFloat {
@@ -30,19 +38,13 @@ struct AccentTintTests {
 		return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
 	}
 
-	@Test("both accent assets resolve")
-	func assetsExist() {
-		#expect(UIColor(named: "AccentColor") != nil)
-		#expect(UIColor(named: "Colors/MeshtasticAccent") != nil)
-	}
-
 	@Test("the fill accent stays dark in both appearances")
 	func fillAccentDoesNotLighten() {
-		// Message bubbles and prominent buttons paint white text on this, so it has to stay dark
-		// in dark mode. Lightening it is the tempting one-line fix that breaks them.
-		guard let light = resolved("Colors/MeshtasticAccent", dark: false),
-			  let dark = resolved("Colors/MeshtasticAccent", dark: true) else {
-			Issue.record("Colors/MeshtasticAccent missing"); return
+		// Message bubbles and prominent buttons paint white text on this, so it has to stay dark in
+		// dark mode. Lightening it is the tempting one-line fix that breaks them.
+		guard let light = resolved(asset: Self.fillAccentAsset, dark: false),
+			  let dark = resolved(asset: Self.fillAccentAsset, dark: true) else {
+			Issue.record("\(Self.fillAccentAsset) missing"); return
 		}
 		#expect(abs(luminance(light) - luminance(dark)) < 0.01)
 		#expect(luminance(dark) < 0.2)
@@ -50,14 +52,24 @@ struct AccentTintTests {
 
 	@Test("the on-surface accent lightens in dark so tinted labels stay readable")
 	func tintAccentLightensInDark() {
-		// What `Color.accentTint` reads. Cobalt on a dark sheet measures about 1.7:1, which is why
-		// the save confirmation action was unreadable; the palette's Blue 300 is the fix.
-		guard let light = resolved("AccentColor", dark: false),
-			  let dark = resolved("AccentColor", dark: true) else {
-			Issue.record("AccentColor missing"); return
+		// Reads Color.accentTint itself, so repointing it at another asset fails here. Cobalt on a
+		// dark sheet measures about 1.7:1, which is why the save confirmation was unreadable.
+		let light = luminance(resolved(.accentTint, dark: false))
+		let dark = luminance(resolved(.accentTint, dark: true))
+		#expect(dark > light)
+		#expect(dark > 0.4)
+	}
+
+	@Test("the tint token agrees with the fill accent in light and diverges in dark")
+	func accentsSplitOnlyInDark() {
+		// The whole point of the split, and the assertion that catches `accentTint` being pointed
+		// back at the fill accent: the dark values would collapse together.
+		guard let fillLight = resolved(asset: Self.fillAccentAsset, dark: false),
+			  let fillDark = resolved(asset: Self.fillAccentAsset, dark: true) else {
+			Issue.record("\(Self.fillAccentAsset) missing"); return
 		}
-		#expect(luminance(dark) > luminance(light))
-		#expect(luminance(dark) > 0.4)
+		#expect(abs(luminance(resolved(.accentTint, dark: false)) - luminance(fillLight)) < 0.01)
+		#expect(luminance(resolved(.accentTint, dark: true)) > luminance(fillDark) + 0.2)
 	}
 	#endif
 }

--- a/MeshtasticTests/AccentTintTests.swift
+++ b/MeshtasticTests/AccentTintTests.swift
@@ -1,0 +1,63 @@
+//
+//  AccentTintTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/8/26.
+//
+
+import Testing
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+@testable import Meshtastic
+
+/// The app carries two accents on purpose: one to fill a shape under white text, one to draw text
+/// on a surface. They agree in light mode and must not in dark.
+@Suite("Accent tint")
+struct AccentTintTests {
+
+	#if canImport(UIKit)
+	private func resolved(_ name: String, dark: Bool) -> UIColor? {
+		guard let color = UIColor(named: name) else { return nil }
+		return color.resolvedColor(with: UITraitCollection(userInterfaceStyle: dark ? .dark : .light))
+	}
+
+	private func luminance(_ color: UIColor) -> CGFloat {
+		var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+		color.getRed(&r, green: &g, blue: &b, alpha: &a)
+		func lin(_ c: CGFloat) -> CGFloat { c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4) }
+		return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+	}
+
+	@Test("both accent assets resolve")
+	func assetsExist() {
+		#expect(UIColor(named: "AccentColor") != nil)
+		#expect(UIColor(named: "Colors/MeshtasticAccent") != nil)
+	}
+
+	@Test("the fill accent stays dark in both appearances")
+	func fillAccentDoesNotLighten() {
+		// Message bubbles and prominent buttons paint white text on this, so it has to stay dark
+		// in dark mode. Lightening it is the tempting one-line fix that breaks them.
+		guard let light = resolved("Colors/MeshtasticAccent", dark: false),
+			  let dark = resolved("Colors/MeshtasticAccent", dark: true) else {
+			Issue.record("Colors/MeshtasticAccent missing"); return
+		}
+		#expect(abs(luminance(light) - luminance(dark)) < 0.01)
+		#expect(luminance(dark) < 0.2)
+	}
+
+	@Test("the on-surface accent lightens in dark so tinted labels stay readable")
+	func tintAccentLightensInDark() {
+		// What `Color.accentTint` reads. Cobalt on a dark sheet measures about 1.7:1, which is why
+		// the save confirmation action was unreadable; the palette's Blue 300 is the fix.
+		guard let light = resolved("AccentColor", dark: false),
+			  let dark = resolved("AccentColor", dark: true) else {
+			Issue.record("AccentColor missing"); return
+		}
+		#expect(luminance(dark) > luminance(light))
+		#expect(luminance(dark) > 0.4)
+	}
+	#endif
+}


### PR DESCRIPTION
## Summary

The Save Config confirmation action and the Share Contact buttons are plain labels drawn in the accent color. The accent is cobalt #2855A8 in both appearances, so on a dark sheet those labels measure roughly 1.7:1.

## What changed

The tempting fix is to give the accent a lighter dark-mode value, but that breaks other things: message bubbles ([MessageText.swift:122-123](Meshtastic/Views/Messages/MessageText.swift#L122-L123)), `MessagePreview` and the AI doc assistant all paint **white text on the accent as a background**, so it has to stay dark.

Filling a shape and drawing a label are different roles that want opposite things in dark mode, so this separates them:

- `Color.accentTint` reads the `AccentColor` asset, which already carries the palette's Blue 300 (#B0BFF0) in dark from #2439. Used where the accent *is* the text.
- `Color.accentColor` is unchanged and stays the dark fill.
- Light mode is unchanged in both roles — the two assets agree there.

Applied in `SaveConfigButton` (after the `confirmationDialog` modifier, so it tints the dialog's action and not the Save button, which keeps the fill accent) and in the Share Contact sheet (Share and the NFC button take the on-surface accent; Done stays a filled accent shape).

## Testing

- New `AccentTintTests` pins the premise: both assets resolve, the fill accent does not lighten in dark, and the on-surface accent does. Had the fill accent been lightened instead, the second test would fail.
- Full `MeshtasticTests` suite: 3112 tests in 539 suites pass.
- Built and installed on an iPhone 17 Pro.

## Note

This overlaps with #2395, which fixes the same dialog with adaptive primary (white) rather than a brand color, and also adds snapshot coverage for the presented dialog. Whichever approach is preferred, only one should land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated accent colors across contact sharing and configuration-saving dialogs for clearer contrast and improved readability in dark mode.
  - Save buttons retain their filled accent styling, while confirmation actions use a surface-appropriate tint.
- **Quality Improvements**
  - Added automated coverage to verify accent colors remain readable across light and dark appearances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->