### PR TITLE
Close the Share Contact sheet the way the other sheets do

### DIFF
--- a/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
+++ b/Meshtastic/Views/Nodes/Helpers/ShareContactQRDialog.swift
@@ -79,7 +79,6 @@ struct ShareContactQRDialog: View {
 				.resizable()
 				.scaledToFit()
 				.background(Color(.systemBackground))
-				.cornerRadius(16)
 				.shadow(radius: 4)
 			Text("Scan this QR code to add \(node.user.longName) to another device.")
 				.font(.subheadline)
@@ -102,18 +101,33 @@ struct ShareContactQRDialog: View {
 				)
 			}
 			#endif
-			Button("Done") { dismiss() }
-				.buttonStyle(.borderedProminent)
-				// A filled accent shape under a white label, so it keeps the dark fill accent
-				// rather than the lighter on-surface one the plain buttons above need.
-				.tint(.accentColor)
-				.padding(.bottom)
 		}
 		.padding()
 		.frame(maxWidth: 350)
 		// Share and the NFC button are plain labels on the sheet, so they read as text and need
 		// the on-surface accent; the inherited fill accent is close to unreadable here in dark.
 		.tint(.accentTint)
+		#if targetEnvironment(macCatalyst)
+		// Catalyst has no drag-to-dismiss, so it gets the close button the other sheets use.
+		// Widened first, or the overlay would anchor to the 350pt content rather than the sheet.
+		.frame(maxWidth: .infinity)
+		.overlay(alignment: .topLeading) {
+			Button {
+				dismiss()
+			} label: {
+				Image(systemName: "xmark.circle.fill")
+					.font(.system(size: 34))
+					.symbolRenderingMode(.palette)
+					.foregroundStyle(.white, Color(.systemGray3))
+			}
+			.accessibilityLabel(String(localized: "Close", comment: "VoiceOver: dismiss this sheet"))
+			.buttonStyle(.plain)
+			.padding(.top, 12)
+			.padding(.leading, 14)
+		}
+		#else
+		.presentationDragIndicator(.visible)
+		#endif
 	}
 }
 


### PR DESCRIPTION
## Summary

The Share Contact sheet had its own Done button, which no other sheet in the app has, and the QR code was drawn with rounded corners.

## What changed

- Dropped `.cornerRadius(16)` from the QR code. A QR code needs its quiet zone intact to the corners, and rounding clipped it.
- Removed the Done button.
- Added the close treatment the rest of the app uses: the `xmark.circle.fill` button at `.topLeading` on Mac Catalyst, which has no drag-to-dismiss, and `.presentationDragIndicator(.visible)` everywhere else. Same glyph, sizing and VoiceOver label as `NodeListHelp`, `MetricsColumnDetail`, `MapLegend` and the other sheets.

The content is widened to full width before the overlay, otherwise the button would anchor to the 350pt content column rather than the sheet's corner.

## Testing

- Full `MeshtasticTests` suite: 3109 tests in 538 suites pass.
- Built for Mac Catalyst as well as iOS, since the close button is behind `#if targetEnvironment(macCatalyst)` and an iOS build never compiles it.
- Installed on an iPhone 17 Pro to check the sheet.

## Note

Touches the same view as #2467, which tints the buttons in this sheet — including the Done button removed here. Whichever lands second needs a one-hunk resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the contact QR code presentation to display without rounded corners.

* **UI Improvements**
  * Removed the bottom “Done” button.
  * Added platform-specific dismissal controls, including a close button on Catalyst and a drag indicator on other platforms.
  * Adjusted the Catalyst layout to use the available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->