### PR TITLE
docs: use Wi-Fi with the dash

### DIFF
--- a/Meshtastic/Resources/docs/index.json
+++ b/Meshtastic/Resources/docs/index.json
@@ -192,7 +192,7 @@
             "started",
             "setup"
         ],
-        "charCount": 2899
+        "charCount": 2900
     },
     {
         "id": "lockdown",
@@ -699,7 +699,7 @@
             "only",
             "docs"
         ],
-        "charCount": 7437
+        "charCount": 7438
     },
     {
         "id": "adding-features",

--- a/Meshtastic/Resources/docs/markdown/user/getting-started.md
+++ b/Meshtastic/Resources/docs/markdown/user/getting-started.md
@@ -37,7 +37,7 @@ The first time you open the app, a short guided setup walks you through the perm
 
 ![Bluetooth permission screen](../assets/screenshots/onboarding_bluetooth.png)
 
-**2. Local Network** — lets the app find radios connected over WiFi or Ethernet.
+**2. Local Network** — lets the app find radios connected over Wi-Fi or Ethernet.
 
 ![Local Network permission screen](../assets/screenshots/onboarding_localNetwork.png)
 

--- a/Meshtastic/Resources/docs/markdown/user/whats-new.md
+++ b/Meshtastic/Resources/docs/markdown/user/whats-new.md
@@ -54,7 +54,7 @@ Show roughly the last 12 months of changes; archive entries older than a year by
 
 **May 2026** — [Settings](settings.md) — Neighbor Info Module Config: neighbor info broadcasting with configurable update interval (4–72 hours).
 
-**May 2026** — [Settings](settings.md) — Pax Counter: added WiFi and BLE RSSI threshold fields for device counting sensitivity.
+**May 2026** — [Settings](settings.md) — Pax Counter: added Wi-Fi and BLE RSSI threshold fields for device counting sensitivity.
 
 **May 2026** — [Settings](settings.md) — Compass Orientation: new 8-option picker in Display config for radios mounted at non-standard angles.
 

--- a/Meshtastic/Resources/docs/user/getting-started.html
+++ b/Meshtastic/Resources/docs/user/getting-started.html
@@ -30,7 +30,7 @@
 <p>The first time you open the app, a short guided setup walks you through the permissions Meshtastic uses, in order. Each screen explains what the permission is for, and you can change any of these later in iOS Settings. Granting a permission or tapping <strong>Continue</strong> advances to the next step.</p>
 <p><strong>1. Bluetooth</strong> — required to discover and connect to your radio.</p>
 <p><img src="../assets/screenshots/onboarding_bluetooth.png" alt="Bluetooth permission screen" /></p>
-<p><strong>2. Local Network</strong> — lets the app find radios connected over WiFi or Ethernet.</p>
+<p><strong>2. Local Network</strong> — lets the app find radios connected over Wi-Fi or Ethernet.</p>
 <p><img src="../assets/screenshots/onboarding_localNetwork.png" alt="Local Network permission screen" /></p>
 <p><strong>3. Notifications</strong> — toggle which alerts you want before granting permission: incoming messages, new nodes, low battery, and critical alerts that bypass silent mode and Do Not Disturb.</p>
 <p><img src="../assets/screenshots/onboarding_notifications.png" alt="Notifications permission screen" /></p>

--- a/Meshtastic/Resources/docs/user/whats-new.html
+++ b/Meshtastic/Resources/docs/user/whats-new.html
@@ -34,7 +34,7 @@ Show roughly the last 12 months of changes; archive entries older than a year by
 <p><strong>Jun 2026</strong> — <a href="settings.html">Settings</a> — Packet Stream: watch mesh packets cross the network live in the Debug Logs view, paced for readability, with collapsible Categories and Log Levels filters.</p>
 <p><strong>May 2026</strong> — <a href="settings.html">Settings</a> — Audio Module Config: Codec2 voice communication settings, only available on 2.4 GHz radios (LORA_24 region).</p>
 <p><strong>May 2026</strong> — <a href="settings.html">Settings</a> — Neighbor Info Module Config: neighbor info broadcasting with configurable update interval (4–72 hours).</p>
-<p><strong>May 2026</strong> — <a href="settings.html">Settings</a> — Pax Counter: added WiFi and BLE RSSI threshold fields for device counting sensitivity.</p>
+<p><strong>May 2026</strong> — <a href="settings.html">Settings</a> — Pax Counter: added Wi-Fi and BLE RSSI threshold fields for device counting sensitivity.</p>
 <p><strong>May 2026</strong> — <a href="settings.html">Settings</a> — Compass Orientation: new 8-option picker in Display config for radios mounted at non-standard angles.</p>
 <p><strong>May 2026</strong> — <a href="translate.html">Translate</a> — Docs Translation Pipeline: community-sourced translations shared via CDN so future users get instant localized docs.</p>
 <p><strong>May 2026</strong> — <a href="translate.html">Translate</a> — Automatic Documentation Translation: on iOS 26+, in-app docs are translated into your device language using the Apple Translation framework.</p>

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -37,7 +37,7 @@ The first time you open the app, a short guided setup walks you through the perm
 
 ![Bluetooth permission screen](../assets/screenshots/onboarding_bluetooth.png)
 
-**2. Local Network** — lets the app find radios connected over WiFi or Ethernet.
+**2. Local Network** — lets the app find radios connected over Wi-Fi or Ethernet.
 
 ![Local Network permission screen](../assets/screenshots/onboarding_localNetwork.png)
 

--- a/docs/user/whats-new.md
+++ b/docs/user/whats-new.md
@@ -54,7 +54,7 @@ Show roughly the last 12 months of changes; archive entries older than a year by
 
 **May 2026** — [Settings](settings.md) — Neighbor Info Module Config: neighbor info broadcasting with configurable update interval (4–72 hours).
 
-**May 2026** — [Settings](settings.md) — Pax Counter: added WiFi and BLE RSSI threshold fields for device counting sensitivity.
+**May 2026** — [Settings](settings.md) — Pax Counter: added Wi-Fi and BLE RSSI threshold fields for device counting sensitivity.
 
 **May 2026** — [Settings](settings.md) — Compass Orientation: new 8-option picker in Display config for radios mounted at non-standard angles.
 


### PR DESCRIPTION
## Summary

Wi-Fi takes the dash, matching the Wi-Fi Alliance and the word lists in the other Meshtastic clients. The Android docs guide already requires it, and the docs site is standardizing on it in meshtastic/meshtastic#2667, so this brings the app docs in line rather than leaving three spellings across the clients.

## What changed

Two prose occurrences under `docs/user/`: the Local Network description in `getting-started.md` and the Pax Counter entry in `whats-new.md`.

One occurrence is deliberately left as `WiFi`. In `settings.md` the phrase "Configure WiFi Threshold (dBm)" quotes the in-app label from `PaxCounterConfig.swift`. Changing the doc on its own would stop it matching what the app shows, so the label is the thing to fix first — happy to follow up with that if you want it, and the doc line can change with it.

Bundled HTML under `Meshtastic/Resources/docs/` regenerated with `scripts/build-docs.sh --output Meshtastic/Resources/docs`, as `docs/developer/contributing.md` requires. That accounts for five of the seven changed files, including two keyword entries in `index.json`.

## Testing

Not applicable, documentation only. Ran `scripts/build-docs.sh`, which reported 31 pages built and an 8.0 MB bundle, and confirmed the regenerated `index.json` parses and still holds 31 entries.

One thing worth knowing from running that script: on Python 3.14 the `python3 -m json.tool` call at the end writes ANSI color escapes into `index.json`, producing invalid JSON about 42% larger than it should be. `PYTHON_COLORS=0` avoids it. Might be worth pinning in the script so a regeneration on a newer Python cannot silently corrupt the bundled search index.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Standardized the spelling of “Wi-Fi” across the Getting Started and What’s New documentation.
  - Updated documentation metadata to reflect the revised character counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->