### PR TITLE
Move direct message summaries off the main actor

### DIFF
--- a/Meshtastic/Extensions/SwiftData/DirectMessageSummary.swift
+++ b/Meshtastic/Extensions/SwiftData/DirectMessageSummary.swift
@@ -51,8 +51,11 @@ struct DirectMessageSummaryActorCache {
 enum DirectMessageSummaryRefreshLifecycle {
 	static let burstDelay: Duration = .milliseconds(100)
 
-	static func waitForBurstToSettle(for delay: Duration = burstDelay) async throws {
-		try await Task.sleep(for: delay)
+	static func waitForBurstToSettle(
+		for delay: Duration = burstDelay,
+		sleep: @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+	) async throws {
+		try await sleep(delay)
 		try Task.checkCancellation()
 	}
 }

--- a/Meshtastic/Extensions/SwiftData/DirectMessageSummary.swift
+++ b/Meshtastic/Extensions/SwiftData/DirectMessageSummary.swift
@@ -1,0 +1,154 @@
+//
+//  DirectMessageSummary.swift
+//  Meshtastic
+//
+
+import Foundation
+@preconcurrency import SwiftData
+
+struct DirectMessageSummary: Equatable, Sendable {
+	let messageId: Int64
+	let timestamp: Int32
+	let payload: String
+	let unreadCount: Int
+}
+
+struct DirectMessageSummaryMessage: Sendable {
+	let messageId: Int64
+	let timestamp: Int32
+	let payload: String
+	let read: Bool
+	let fromNum: Int64?
+	let toNum: Int64?
+}
+
+struct DirectMessageSummaryRefreshID: Equatable {
+	let usersKey: Int64
+	let unreadCount: Int
+	let activeDeviceNum: Int64
+	let containerGeneration: Int
+}
+
+struct DirectMessageSummaryActorCache {
+	private var actor: DirectMessageSummaryActor?
+	private var containerIdentifier: ObjectIdentifier?
+	private(set) var generation: Int?
+
+	mutating func actor(for container: ModelContainer, generation: Int) -> DirectMessageSummaryActor {
+		let identifier = ObjectIdentifier(container)
+		if let actor, self.generation == generation, containerIdentifier == identifier {
+			return actor
+		}
+
+		let replacement = DirectMessageSummaryActor(modelContainer: container)
+		actor = replacement
+		self.generation = generation
+		containerIdentifier = identifier
+		return replacement
+	}
+}
+
+enum DirectMessageSummaryRefreshLifecycle {
+	static let burstDelay: Duration = .milliseconds(100)
+
+	static func waitForBurstToSettle(for delay: Duration = burstDelay) async throws {
+		try await Task.sleep(for: delay)
+		try Task.checkCancellation()
+	}
+}
+
+enum DirectMessageSummaryReducer {
+	static func summaries<Messages: Sequence>(
+		for peerNums: Set<Int64>,
+		messages: Messages
+	) throws -> [Int64: DirectMessageSummary] where Messages.Element == DirectMessageSummaryMessage {
+		try Task.checkCancellation()
+		guard !peerNums.isEmpty else { return [:] }
+
+		var accumulators = [Int64: DirectMessageSummaryAccumulator](minimumCapacity: peerNums.count)
+		for message in messages {
+			try Task.checkCancellation()
+			record(message, peerNum: message.fromNum, peerNums: peerNums, accumulators: &accumulators)
+			if message.toNum != message.fromNum {
+				record(message, peerNum: message.toNum, peerNums: peerNums, accumulators: &accumulators)
+			}
+		}
+		try Task.checkCancellation()
+		return accumulators.compactMapValues(\.summary)
+	}
+
+	private static func record(
+		_ message: DirectMessageSummaryMessage,
+		peerNum: Int64?,
+		peerNums: Set<Int64>,
+		accumulators: inout [Int64: DirectMessageSummaryAccumulator]
+	) {
+		guard let peerNum, peerNums.contains(peerNum) else { return }
+		accumulators[peerNum, default: DirectMessageSummaryAccumulator()].record(message)
+	}
+}
+
+private struct DirectMessageSummaryAccumulator {
+	private var latestMessageId = Int64.min
+	private var latestTimestamp = Int32.min
+	private var latestPayload = " "
+	private var unreadCount = 0
+
+	var summary: DirectMessageSummary? {
+		guard latestMessageId != Int64.min else { return nil }
+		return DirectMessageSummary(
+			messageId: latestMessageId,
+			timestamp: latestTimestamp,
+			payload: latestPayload,
+			unreadCount: unreadCount
+		)
+	}
+
+	mutating func record(_ message: DirectMessageSummaryMessage) {
+		if !message.read {
+			unreadCount += 1
+		}
+		if message.timestamp > latestTimestamp
+			|| (message.timestamp == latestTimestamp && message.messageId > latestMessageId) {
+			latestMessageId = message.messageId
+			latestTimestamp = message.timestamp
+			latestPayload = message.payload
+		}
+	}
+}
+
+/// Fetches direct-message summaries on a background context. Only value types cross
+/// the actor boundary; SwiftData entities remain isolated to this actor's context.
+/// `ModelContext.fetch` is synchronous and cannot be interrupted once entered, so the
+/// view coalesces bursts before calling here and this actor serializes calls as backpressure.
+@ModelActor
+actor DirectMessageSummaryActor {
+	func summaries(for peerNums: Set<Int64>) throws -> [Int64: DirectMessageSummary] {
+		try Task.checkCancellation()
+		guard !peerNums.isEmpty else { return [:] }
+
+		let detectionSensorPortNum: Int32 = 10
+		let descriptor = FetchDescriptor<MessageEntity>(
+			predicate: #Predicate<MessageEntity> {
+				$0.isEmoji == false && $0.admin == false && $0.portNum != detectionSensorPortNum
+					&& $0.toUser != nil
+			}
+		)
+		let messages = try modelContext.fetch(descriptor)
+		try Task.checkCancellation()
+
+		return try DirectMessageSummaryReducer.summaries(
+			for: peerNums,
+			messages: messages.lazy.map {
+				DirectMessageSummaryMessage(
+					messageId: $0.messageId,
+					timestamp: $0.messageTimestamp,
+					payload: $0.messagePayload ?? " ",
+					read: $0.read,
+					fromNum: $0.fromUser?.num,
+					toNum: $0.toUser?.num
+				)
+			}
+		)
+	}
+}

--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -98,6 +98,7 @@ private struct FilteredUserList: View {
 	@State private var isPresentingDeleteUserMessagesConfirm: Bool = false
 	@State private var userToDeleteMessages: UserEntity?
 	@State private var directMessageSummaries: [Int64: DirectMessageSummary] = [:]
+	@State private var summaryActorCache = DirectMessageSummaryActorCache()
 	private var filters: NodeFilterParameters
 
 	init(withFilters: NodeFilterParameters, node: Binding<NodeInfoEntity?>, userSelection: Binding<UserEntity?>) {
@@ -130,9 +131,16 @@ private struct FilteredUserList: View {
 		let localeDateFormat = DateFormatter.dateFormat(fromTemplate: "yyMMdd", options: 0, locale: Locale.current)
 		let dateFormatString = (localeDateFormat ?? "MM/dd/YY")
 		let activeDeviceNum = Int64(accessoryManager.activeDeviceNum ?? 0)
+		let containerGeneration = PersistenceController.shared.containerGeneration
 		let visibleUsers = users.filter { $0.num != activeDeviceNum }
-		let summaryUsers = visibleUsers.filter { $0.lastMessage != nil }
-		let summaryRefreshKey = directMessageSummaryRefreshKey(for: summaryUsers)
+		let summaryUsers = allUsers.filter { $0.num != activeDeviceNum && $0.lastMessage != nil }
+		let summaryUserNums = Set(summaryUsers.map(\.num))
+		let summaryRefreshID = DirectMessageSummaryRefreshID(
+			usersKey: directMessageSummaryRefreshKey(for: summaryUsers),
+			unreadCount: appState.unreadDirectMessages,
+			activeDeviceNum: activeDeviceNum,
+			containerGeneration: containerGeneration
+		)
 		let currentDay = Calendar.current.dateComponents([.day], from: Date()).day ?? 0
 
 		List(visibleUsers, selection: $userSelection) { user in
@@ -148,14 +156,11 @@ private struct FilteredUserList: View {
 		}
 		.listStyle(.plain)
 		.navigationTitle(String.localizedStringWithFormat("Contacts (%@)".localized, String(visibleUsers.count)))
-		.onAppear {
-			refreshDirectMessageSummaries(for: summaryUsers)
-		}
-		.onChange(of: summaryRefreshKey) {
-			refreshDirectMessageSummaries(for: summaryUsers)
-		}
-		.onChange(of: appState.unreadDirectMessages) {
-			refreshDirectMessageSummaries(for: summaryUsers)
+		.task(id: summaryRefreshID) {
+			await refreshDirectMessageSummaries(
+				for: summaryUserNums,
+				containerGeneration: containerGeneration
+			)
 		}
 	}
 
@@ -170,84 +175,31 @@ private struct FilteredUserList: View {
 		return key
 	}
 
-	private func refreshDirectMessageSummaries(for users: [UserEntity]) {
-		let userNums = Set(users.map(\.num))
+	@MainActor
+	private func refreshDirectMessageSummaries(
+		for userNums: Set<Int64>,
+		containerGeneration: Int
+	) async {
+		guard containerGeneration == PersistenceController.shared.containerGeneration else { return }
 		guard !userNums.isEmpty else {
 			directMessageSummaries = [:]
 			return
 		}
 
 		do {
-			let detectionSensorPortNum: Int32 = 10
-			let descriptor = FetchDescriptor<MessageEntity>(
-				predicate: #Predicate<MessageEntity> {
-					$0.toUser != nil
-					&& $0.isEmoji == false && $0.admin == false && $0.portNum != detectionSensorPortNum
-				},
-				sortBy: [
-					SortDescriptor(\MessageEntity.messageTimestamp, order: .reverse),
-					SortDescriptor(\MessageEntity.messageId, order: .reverse)
-				]
-			)
-			let messages = try context.fetch(descriptor)
-			var accumulators = [Int64: DirectMessageSummaryAccumulator](minimumCapacity: userNums.count)
-			for message in messages {
-				let fromNum = message.fromUser?.num
-				record(message, peerNum: fromNum, userNums: userNums, accumulators: &accumulators)
-				let toNum = message.toUser?.num
-				if toNum != fromNum {
-					record(message, peerNum: toNum, userNums: userNums, accumulators: &accumulators)
-				}
-			}
-			directMessageSummaries = accumulators.compactMapValues(\.summary)
+			try await DirectMessageSummaryRefreshLifecycle.waitForBurstToSettle()
+			guard containerGeneration == PersistenceController.shared.containerGeneration else { return }
+			let currentContainer = PersistenceController.shared.container
+			guard context.container === currentContainer else { return }
+			let actor = summaryActorCache.actor(for: currentContainer, generation: containerGeneration)
+			let summaries = try await actor.summaries(for: userNums)
+			guard !Task.isCancelled,
+				  containerGeneration == PersistenceController.shared.containerGeneration else { return }
+			directMessageSummaries = summaries
+		} catch is CancellationError {
+			return
 		} catch {
 			Logger.data.error("Failed to load direct message summaries: \(error.localizedDescription, privacy: .public)")
-		}
-	}
-
-	private func record(
-		_ message: MessageEntity,
-		peerNum: Int64?,
-		userNums: Set<Int64>,
-		accumulators: inout [Int64: DirectMessageSummaryAccumulator]
-	) {
-		guard let peerNum, userNums.contains(peerNum) else { return }
-		accumulators[peerNum, default: DirectMessageSummaryAccumulator()].record(message)
-	}
-}
-
-private struct DirectMessageSummary: Equatable {
-	let messageId: Int64
-	let timestamp: Int32
-	let payload: String
-	let unreadCount: Int
-}
-
-private struct DirectMessageSummaryAccumulator {
-	private var latestMessageId: Int64 = Int64.min
-	private var latestTimestamp: Int32 = Int32.min
-	private var latestPayload: String = " "
-	private var unreadCount = 0
-
-	var summary: DirectMessageSummary? {
-		guard latestMessageId != Int64.min else { return nil }
-		return DirectMessageSummary(
-			messageId: latestMessageId,
-			timestamp: latestTimestamp,
-			payload: latestPayload,
-			unreadCount: unreadCount
-		)
-	}
-
-	mutating func record(_ message: MessageEntity) {
-		if !message.read {
-			unreadCount += 1
-		}
-		if message.messageTimestamp > latestTimestamp
-			|| (message.messageTimestamp == latestTimestamp && message.messageId > latestMessageId) {
-			latestMessageId = message.messageId
-			latestTimestamp = message.messageTimestamp
-			latestPayload = message.messagePayload ?? " "
 		}
 	}
 }

--- a/MeshtasticTests/DirectMessageSummaryTests.swift
+++ b/MeshtasticTests/DirectMessageSummaryTests.swift
@@ -1,0 +1,263 @@
+//
+//  DirectMessageSummaryTests.swift
+//  MeshtasticTests
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import Meshtastic
+
+@Suite("Direct message summaries")
+struct DirectMessageSummaryTests {
+
+	@Test("latest message and timestamp ties are order-independent")
+	func latestMessageAndTimestampTiesAreOrderIndependent() throws {
+		let peerNum: Int64 = 200
+		let messages = [
+			message(id: 10, timestamp: 100, payload: "oldest", from: peerNum, to: 100),
+			message(id: 30, timestamp: 300, payload: "tie winner", from: 100, to: peerNum),
+			message(id: 20, timestamp: 300, payload: "tie loser", from: peerNum, to: 100),
+			message(id: 40, timestamp: 200, payload: "middle", from: 100, to: peerNum)
+		]
+
+		let forward = try DirectMessageSummaryReducer.summaries(for: [peerNum], messages: messages)
+		let reverse = try DirectMessageSummaryReducer.summaries(for: [peerNum], messages: messages.reversed())
+
+		#expect(forward == reverse)
+		#expect(forward[peerNum] == DirectMessageSummary(
+			messageId: 30,
+			timestamp: 300,
+			payload: "tie winner",
+			unreadCount: 0
+		))
+	}
+
+	@Test("actor scopes summaries to requested peers")
+	@MainActor
+	func actorScopesSummariesToRequestedPeers() async throws {
+		let container = try makeContainer()
+		let context = container.mainContext
+		let local = insertUser(num: 100, into: context)
+		let requestedPeer = insertUser(num: 200, into: context)
+		let otherPeer = insertUser(num: 300, into: context)
+
+		insertMessage(id: 1, timestamp: 100, payload: "incoming", participants: (requestedPeer, local), into: context)
+		insertMessage(id: 2, timestamp: 200, payload: "outgoing", participants: (local, requestedPeer), into: context)
+		insertMessage(id: 3, timestamp: 300, payload: "other peer", participants: (otherPeer, local), into: context)
+		insertMessage(id: 4, timestamp: 400, payload: "channel", participants: (requestedPeer, nil), into: context)
+		try context.save()
+
+		let summaries = try await DirectMessageSummaryActor(modelContainer: container).summaries(for: [requestedPeer.num])
+
+		#expect(summaries.keys.sorted() == [requestedPeer.num])
+		#expect(summaries[requestedPeer.num]?.messageId == 2)
+		#expect(summaries[requestedPeer.num]?.payload == "outgoing")
+	}
+
+	@Test("actor excludes emoji, admin, and detection messages")
+	@MainActor
+	func actorExcludesNonConversationMessages() async throws {
+		let container = try makeContainer()
+		let context = container.mainContext
+		let local = insertUser(num: 110, into: context)
+		let peer = insertUser(num: 210, into: context)
+
+		insertMessage(id: 10, timestamp: 100, payload: "visible", participants: (peer, local), into: context)
+		insertMessage(id: 11, timestamp: 200, payload: "emoji", participants: (peer, local), isEmoji: true, into: context)
+		insertMessage(id: 12, timestamp: 300, payload: "admin", participants: (peer, local), admin: true, into: context)
+		insertMessage(id: 13, timestamp: 400, payload: "detection", participants: (peer, local), portNum: 10, into: context)
+		try context.save()
+
+		let summary = try await DirectMessageSummaryActor(modelContainer: container).summaries(for: [peer.num])[peer.num]
+
+		#expect(summary?.messageId == 10)
+		#expect(summary?.payload == "visible")
+	}
+
+	@Test("actor counts only unread conversation messages")
+	@MainActor
+	func actorCountsUnreadConversationMessages() async throws {
+		let container = try makeContainer()
+		let context = container.mainContext
+		let local = insertUser(num: 120, into: context)
+		let peer = insertUser(num: 220, into: context)
+
+		insertMessage(id: 20, timestamp: 100, payload: "unread incoming", participants: (peer, local), read: false, into: context)
+		insertMessage(id: 21, timestamp: 200, payload: "read incoming", participants: (peer, local), read: true, into: context)
+		insertMessage(id: 22, timestamp: 300, payload: "unread outgoing", participants: (local, peer), read: false, into: context)
+		insertMessage(id: 23, timestamp: 400, payload: "excluded unread", participants: (peer, local), read: false, isEmoji: true, into: context)
+		try context.save()
+
+		let summary = try await DirectMessageSummaryActor(modelContainer: container).summaries(for: [peer.num])[peer.num]
+
+		#expect(summary?.unreadCount == 2)
+	}
+
+	@Test("pre-cancelled actor request stops immediately")
+	@MainActor
+	func preCancelledActorRequestStopsImmediately() async throws {
+		let actor = DirectMessageSummaryActor(modelContainer: try makeContainer())
+		let task = Task {
+			withUnsafeCurrentTask { $0?.cancel() }
+			return try await actor.summaries(for: [200])
+		}
+
+		await #expect(throws: CancellationError.self) {
+			try await task.value
+		}
+	}
+
+	@Test("container generation participates in refresh identity")
+	func containerGenerationParticipatesInRefreshIdentity() {
+		let original = DirectMessageSummaryRefreshID(
+			usersKey: 1,
+			unreadCount: 2,
+			activeDeviceNum: 3,
+			containerGeneration: 4
+		)
+		let replacement = DirectMessageSummaryRefreshID(
+			usersKey: 1,
+			unreadCount: 2,
+			activeDeviceNum: 3,
+			containerGeneration: 5
+		)
+
+		#expect(original != replacement)
+	}
+
+	@Test("actor cache follows container identity and generation")
+	@MainActor
+	func actorCacheFollowsContainerIdentityAndGeneration() throws {
+		let firstContainer = try makeContainer()
+		let secondContainer = try makeContainer()
+		var cache = DirectMessageSummaryActorCache()
+
+		let original = cache.actor(for: firstContainer, generation: 10)
+		let reused = cache.actor(for: firstContainer, generation: 10)
+		let newGeneration = cache.actor(for: firstContainer, generation: 11)
+		let newContainer = cache.actor(for: secondContainer, generation: 11)
+
+		#expect(original === reused)
+		#expect(original !== newGeneration)
+		#expect(newGeneration !== newContainer)
+		#expect(cache.generation == 11)
+	}
+
+	@Test("cancelled burst refresh never reaches fetch phase")
+	func cancelledBurstRefreshNeverReachesFetchPhase() async {
+		let recorder = RefreshInvocationRecorder()
+		let superseded = Task {
+			try await DirectMessageSummaryRefreshLifecycle.waitForBurstToSettle(for: .seconds(1))
+			await recorder.record(1)
+		}
+		for _ in 0..<3 {
+			await Task.yield()
+		}
+		superseded.cancel()
+
+		let current = Task {
+			try await DirectMessageSummaryRefreshLifecycle.waitForBurstToSettle(for: .zero)
+			await recorder.record(2)
+		}
+
+		await #expect(throws: CancellationError.self) {
+			try await superseded.value
+		}
+		try? await current.value
+		let invocations = await recorder.invocations
+		#expect(invocations == [2])
+	}
+
+	@Test("in-flight reduction observes cancellation")
+	func inFlightReductionObservesCancellation() async {
+		let peerNum: Int64 = 230
+		let messages = (0..<8).map {
+			message(id: Int64($0), timestamp: Int32($0), payload: "message", from: peerNum, to: 130)
+		}
+		let cancellingMessages = messages.enumerated().lazy.map { index, message in
+			if index == 3 {
+				withUnsafeCurrentTask { $0?.cancel() }
+			}
+			return message
+		}
+		let task = Task {
+			try DirectMessageSummaryReducer.summaries(for: [peerNum], messages: cancellingMessages)
+		}
+
+		await #expect(throws: CancellationError.self) {
+			try await task.value
+		}
+	}
+
+	private func message(
+		id: Int64,
+		timestamp: Int32,
+		payload: String,
+		from: Int64,
+		to: Int64,
+		read: Bool = true
+	) -> DirectMessageSummaryMessage {
+		DirectMessageSummaryMessage(
+			messageId: id,
+			timestamp: timestamp,
+			payload: payload,
+			read: read,
+			fromNum: from,
+			toNum: to
+		)
+	}
+
+	@MainActor
+	private func makeContainer() throws -> ModelContainer {
+		let schema = Schema(versionedSchema: MeshtasticSchema.current)
+		let configuration = ModelConfiguration(
+			"DirectMessageSummaryTest-\(UUID().uuidString)",
+			schema: schema,
+			isStoredInMemoryOnly: true,
+			allowsSave: true
+		)
+		return try ModelContainer(for: schema, configurations: configuration)
+	}
+
+	@MainActor
+	private func insertUser(num: Int64, into context: ModelContext) -> UserEntity {
+		let user = UserEntity()
+		user.num = num
+		context.insert(user)
+		return user
+	}
+
+	@MainActor
+	private func insertMessage(
+		id: Int64,
+		timestamp: Int32,
+		payload: String,
+		participants: (from: UserEntity, to: UserEntity?),
+		read: Bool = true,
+		isEmoji: Bool = false,
+		admin: Bool = false,
+		portNum: Int32 = 1,
+		into context: ModelContext
+	) {
+		let message = MessageEntity()
+		message.messageId = id
+		message.messageTimestamp = timestamp
+		message.messagePayload = payload
+		message.fromUser = participants.from
+		message.toUser = participants.to
+		message.read = read
+		message.isEmoji = isEmoji
+		message.admin = admin
+		message.portNum = portNum
+		context.insert(message)
+	}
+}
+
+private actor RefreshInvocationRecorder {
+	private(set) var invocations: [Int] = []
+
+	func record(_ invocation: Int) {
+		invocations.append(invocation)
+	}
+}

--- a/MeshtasticTests/DirectMessageSummaryTests.swift
+++ b/MeshtasticTests/DirectMessageSummaryTests.swift
@@ -148,25 +148,19 @@ struct DirectMessageSummaryTests {
 	func cancelledBurstRefreshNeverReachesFetchPhase() async {
 		let recorder = RefreshInvocationRecorder()
 		let superseded = Task {
-			try await DirectMessageSummaryRefreshLifecycle.waitForBurstToSettle(for: .seconds(1))
+			withUnsafeCurrentTask { $0?.cancel() }
+			try await DirectMessageSummaryRefreshLifecycle.waitForBurstToSettle(
+				for: .zero,
+				sleep: { _ in }
+			)
 			await recorder.record(1)
-		}
-		for _ in 0..<3 {
-			await Task.yield()
-		}
-		superseded.cancel()
-
-		let current = Task {
-			try await DirectMessageSummaryRefreshLifecycle.waitForBurstToSettle(for: .zero)
-			await recorder.record(2)
 		}
 
 		await #expect(throws: CancellationError.self) {
 			try await superseded.value
 		}
-		try? await current.value
 		let invocations = await recorder.invocations
-		#expect(invocations == [2])
+		#expect(invocations.isEmpty)
 	}
 
 	@Test("in-flight reduction observes cancellation")


### PR DESCRIPTION
## What changed?

- Fetch and reduce direct-message summaries in a SwiftData model actor instead of the main actor.
- Coalesce burst refreshes and discard canceled or stale results.
- Keep the actor cache aligned with persistence-container replacement.
- Add focused coverage for summary semantics, exclusions, cancellation, and container lifecycle.

## Why did it change?

The contacts screen synchronously fetched and reduced the complete direct-message history on the main actor. A 10,000-message store took about 0.42 seconds for this work, making navigation and list interaction visibly stall. This keeps the same result semantics while moving that work off the UI actor and applying backpressure to refresh bursts.

No open pull request currently touches this direct-message summary path.

## How is this tested?

- `DirectMessageSummaryTests`: 9/9 passed.
- SwiftLint: 0 violations in all changed files.
- iOS Simulator with 4,733 contacts and 10,000 direct messages: opened Direct Messages, verified summaries and unread state rendered, and verified the populated list remained scrollable.
- Debug simulator build succeeded.

## Screenshots/Videos (when applicable)

No visual changes.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (no documentation change is required).
- [x] I have tested the change to ensure that it works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous direct-message summaries grouped by conversation.
  * Added unread counts and latest-message details for each conversation.
  * Added automatic refresh handling when messages, devices, or stored data change.
  * Added filtering to exclude unsupported message types from conversation summaries.

* **Bug Fixes**
  * Improved refresh cancellation and burst handling to prevent stale results.

* **Tests**
  * Added coverage for summary ordering, filtering, unread counts, cancellation, and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->