### PR TITLE
Debounce shared node and contact search

### DIFF
--- a/Meshtastic/Views/Messages/UserList.swift
+++ b/Meshtastic/Views/Messages/UserList.swift
@@ -23,7 +23,12 @@ struct UserList: View {
 
 	var body: some View {
 		VStack {
-			FilteredUserList(withFilters: filters, node: $node, userSelection: $userSelection)
+			FilteredUserList(
+				withFilters: filters,
+				committedSearchText: filters.debouncedSearchText,
+				node: $node,
+				userSelection: $userSelection
+			)
 			.sheet(isPresented: $editingFilters) {
 				NodeListFilter(filterTitle: "Contact Filters", showsEncryptedFilter: false, filters: filters)
 			}
@@ -84,6 +89,15 @@ struct UserList: View {
 	}
 }
 
+func filterContacts<Contact>(
+	_ contacts: [Contact],
+	committedSearchText: String,
+	matches: (Contact, String) -> Bool
+) -> [Contact] {
+	let normalizedSearchText = committedSearchText.lowercased()
+	return contacts.filter { matches($0, normalizedSearchText) }
+}
+
 private struct FilteredUserList: View {
 	@EnvironmentObject var accessoryManager: AccessoryManager
 	@EnvironmentObject var appState: AppState
@@ -99,15 +113,21 @@ private struct FilteredUserList: View {
 	@State private var userToDeleteMessages: UserEntity?
 	@State private var directMessageSummaries: [Int64: DirectMessageSummary] = [:]
 	private var filters: NodeFilterParameters
+	private let committedSearchText: String
 
-	init(withFilters: NodeFilterParameters, node: Binding<NodeInfoEntity?>, userSelection: Binding<UserEntity?>) {
+	init(
+		withFilters: NodeFilterParameters,
+		committedSearchText: String,
+		node: Binding<NodeInfoEntity?>,
+		userSelection: Binding<UserEntity?>
+	) {
 		self.filters = withFilters
+		self.committedSearchText = committedSearchText
 		self._node = node
 		self._userSelection = userSelection
 	}
 
 	private var users: [UserEntity] {
-		let searchText = filters.searchText.lowercased()
 		let onlineThreshold = filters.isOnline ? Date().addingTimeInterval(-7_200) : nil
 		let distanceBounds = filters.currentPreciseDistanceBounds
 		let filterLookup = UserListFilterLookup(
@@ -115,9 +135,9 @@ private struct FilteredUserList: View {
 			distanceBounds: filters.distanceFilter ? distanceBounds : nil,
 			context: context
 		)
-		return allUsers.filter {
+		return filterContacts(allUsers, committedSearchText: committedSearchText) { user, searchText in
 			filters.matches(
-				user: $0,
+				user: user,
 				normalizedSearchText: searchText,
 				onlineThreshold: onlineThreshold,
 				distanceBounds: distanceBounds,

--- a/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
@@ -88,8 +88,12 @@ final class NodeFilterParameters: ObservableObject {
 	}
 
 	/// Search text is intentionally **not** persisted — relaunching into a stale search that hides
-	/// most nodes is confusing. It lives in memory for the app session only.
-	@Published var searchText = ""
+	/// most nodes is confusing. The draft is shared immediately but does not invalidate filtering.
+	var searchText = "" {
+		didSet { debounceSearchText() }
+	}
+	/// The value used by expensive node and contact filtering.
+	@Published private(set) var debouncedSearchText = ""
 
 	// Each filter is `@Published` (so SwiftUI observers update live when it toggles — an
 	// `@AppStorage` property inside an `ObservableObject` reads/writes `UserDefaults` but does NOT
@@ -118,6 +122,8 @@ final class NodeFilterParameters: ObservableObject {
 	/// Backing store for all persisted filter values. Defaults to `.standard`; tests inject an
 	/// isolated suite so they don't read or clobber the shared `UserDefaults.standard` domain.
 	private let store: UserDefaults
+	private let searchDebounceSleep: @MainActor @Sendable (Duration) async throws -> Void
+	private var searchDebounceTask: Task<Void, Never>?
 
 	// Public computed wrappers with enforcement
 	var viaLora: Bool {
@@ -142,8 +148,12 @@ final class NodeFilterParameters: ObservableObject {
 
 	/// - Parameter store: The `UserDefaults` instance backing all persisted filter values.
 	///   Defaults to `.standard`; pass an isolated suite in tests.
-	init(store: UserDefaults = .standard) {
+	init(
+		store: UserDefaults = .standard,
+		searchDebounceSleep: @escaping @MainActor @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+	) {
 		self.store = store
+		self.searchDebounceSleep = searchDebounceSleep
 
 		// Property observers do not fire for assignments made inside `init`, so loading persisted
 		// values here reads from `store` without writing back to it.
@@ -162,6 +172,26 @@ final class NodeFilterParameters: ObservableObject {
 
 		if let storedRoles = store.array(forKey: Keys.deviceRoles) as? [Int] {
 			deviceRoles = Set(storedRoles)
+		}
+	}
+
+	private func debounceSearchText() {
+		searchDebounceTask?.cancel()
+		guard !searchText.isEmpty else {
+			debouncedSearchText = ""
+			return
+		}
+
+		let pendingSearchText = searchText
+		let sleep = searchDebounceSleep
+		searchDebounceTask = Task { @MainActor [weak self] in
+			do {
+				try await sleep(.milliseconds(150))
+			} catch {
+				return
+			}
+			guard !Task.isCancelled, self?.searchText == pendingSearchText else { return }
+			self?.debouncedSearchText = pendingSearchText
 		}
 	}
 

--- a/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
+++ b/Meshtastic/Views/Nodes/Helpers/NodeFilterParameters.swift
@@ -255,7 +255,7 @@ final class NodeFilterParameters: ObservableObject {
 		distanceBounds: NodeDistanceFilterBounds? = nil
 	) -> Bool {
 		// Search text
-		let text = normalizedSearchText ?? searchText.lowercased()
+		let text = normalizedSearchText ?? debouncedSearchText.lowercased()
 		if !text.isEmpty {
 			let matchesSearch = [
 				node.user?.userId,

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -204,7 +204,7 @@ struct MeshMapMK: View {
 
 	/// Positions filtered once per render using the full NodeFilterParameters.
 	private func filteredPositions(from positions: [PositionEntity]) -> [PositionEntity] {
-		let searchText = filters.searchText.lowercased()
+		let searchText = filters.debouncedSearchText.lowercased()
 		let onlineThreshold = filters.isOnline ? Date().addingTimeInterval(-7_200) : nil
 		let distanceBounds = filters.currentDistanceBounds
 		return positions.filter { position in
@@ -246,7 +246,7 @@ struct MeshMapMK: View {
 
 		let eligiblePositions = mapEligiblePositions
 		guard let visibleRegion else {
-			guard filters.isFiltering || !filters.searchText.isEmpty else {
+			guard filters.isFiltering || !filters.debouncedSearchText.isEmpty else {
 				return densityLimitedPositions(eligiblePositions)
 			}
 			return densityLimitedPositions(filteredPositions(from: eligiblePositions))
@@ -255,7 +255,7 @@ struct MeshMapMK: View {
 		// MapKit can briefly report a stale/empty camera region while restoring
 		// the tab or handling deep links. Never blank all pins because of that.
 		let positions = positionsInRegion.isEmpty ? eligiblePositions : positionsInRegion
-		guard filters.isFiltering || !filters.searchText.isEmpty else {
+		guard filters.isFiltering || !filters.debouncedSearchText.isEmpty else {
 			return densityLimitedPositions(positions)
 		}
 		return densityLimitedPositions(filteredPositions(from: positions))
@@ -956,7 +956,7 @@ struct MeshMapMK: View {
 	private var filterRefreshKey: Int64 {
 		var key: Int64 = 0
 		combine(&key, preciseLocationsOnly ? 1 : 0)
-		combine(&key, stableStringKey(filters.searchText.lowercased()))
+		combine(&key, stableStringKey(filters.debouncedSearchText.lowercased()))
 		combine(&key, filters.isOnline ? 1 : 0)
 		combine(&key, filters.isSigned ? 1 : 0)
 		combine(&key, filters.isPkiEncrypted ? 1 : 0)

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -307,7 +307,7 @@ private struct FilteredNodeList: View {
 	}
 
 	private func displayNodes(from allNodes: [NodeInfoEntity], activeNodeNum: Int64?) -> [NodeListEntry] {
-		let searchText = filters.searchText.lowercased()
+		let searchText = filters.debouncedSearchText.lowercased()
 		let onlineThreshold = filters.isOnline ? Date().addingTimeInterval(-7_200) : nil
 		let distanceBounds = filters.currentDistanceBounds
 		let filterLookup = NodeListFilterLookup(

--- a/MeshtasticTests/NodeFilterParametersTests.swift
+++ b/MeshtasticTests/NodeFilterParametersTests.swift
@@ -56,6 +56,21 @@ private func waitForPendingSleeps(_ count: Int, in sleeper: ControlledSearchSlee
 }
 
 @MainActor
+private func resumeNextSleep(
+	in sleeper: ControlledSearchSleeper,
+	for filters: NodeFilterParameters,
+	expecting expectedSearchText: String
+) async {
+	let promotion = Task { @MainActor in
+		for await searchText in filters.$debouncedSearchText.values where searchText == expectedSearchText {
+			return
+		}
+	}
+	sleeper.resumeNext()
+	await promotion.value
+}
+
+@MainActor
 @Suite("NodeFilterParameters", .serialized)
 struct NodeFilterParametersTests {
 
@@ -114,7 +129,7 @@ struct NodeFilterParametersTests {
 	@Test("Rapid search input coalesces to the latest value")
 	func rapidSearchInputCoalesces() async {
 		let sleeper = ControlledSearchSleeper()
-		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+		let filters = NodeFilterParameters(store: defaults) { try await sleeper.sleep(for: $0) }
 
 		filters.searchText = "n"
 		await waitForPendingSleeps(1, in: sleeper)
@@ -132,15 +147,14 @@ struct NodeFilterParametersTests {
 		sleeper.resumeNext()
 		await Task.yield()
 		#expect(filters.debouncedSearchText == "")
-		sleeper.resumeNext()
-		await Task.yield()
+		await resumeNextSleep(in: sleeper, for: filters, expecting: "node")
 		#expect(filters.debouncedSearchText == "node")
 	}
 
 	@Test("Draft search edits do not invoke contact filtering before commit")
 	func draftSearchDoesNotInvokeContactFiltering() async {
 		let sleeper = ControlledSearchSleeper()
-		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+		let filters = NodeFilterParameters(store: defaults) { try await sleeper.sleep(for: $0) }
 		let contacts = ["Node Alpha", "Contact Bravo"]
 		var invalidationCount = 0
 		var matchInvocationCount = 0
@@ -172,8 +186,7 @@ struct NodeFilterParametersTests {
 		#expect(invalidationCount == 0)
 		#expect(matchInvocationCount == 0)
 
-		sleeper.resumeNext()
-		await Task.yield()
+		await resumeNextSleep(in: sleeper, for: filters, expecting: "node")
 		#expect(invalidationCount == 1)
 		#expect(matchInvocationCount == contacts.count)
 		#expect(visibleContacts == ["Node Alpha"])
@@ -185,12 +198,11 @@ struct NodeFilterParametersTests {
 	@Test("Clearing search text applies immediately and cancels pending input")
 	func clearingSearchTextIsImmediate() async {
 		let sleeper = ControlledSearchSleeper()
-		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+		let filters = NodeFilterParameters(store: defaults) { try await sleeper.sleep(for: $0) }
 
 		filters.searchText = "node"
 		await waitForPendingSleeps(1, in: sleeper)
-		sleeper.resumeNext()
-		await Task.yield()
+		await resumeNextSleep(in: sleeper, for: filters, expecting: "node")
 		#expect(filters.debouncedSearchText == "node")
 
 		filters.searchText = "pending"
@@ -208,13 +220,12 @@ struct NodeFilterParametersTests {
 	@Test("Programmatic changes debounce and reset clears immediately")
 	func programmaticChangesAndReset() async {
 		let sleeper = ControlledSearchSleeper()
-		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+		let filters = NodeFilterParameters(store: defaults) { try await sleeper.sleep(for: $0) }
 
 		filters.searchText = "external"
 		await waitForPendingSleeps(1, in: sleeper)
 		#expect(filters.debouncedSearchText == "")
-		sleeper.resumeNext()
-		await Task.yield()
+		await resumeNextSleep(in: sleeper, for: filters, expecting: "external")
 		#expect(filters.debouncedSearchText == "external")
 
 		filters.searchText = "pending"
@@ -231,7 +242,7 @@ struct NodeFilterParametersTests {
 	@Test("Shared search state rejects a stale hidden-tab promotion")
 	func sharedSearchRejectsStalePromotion() async {
 		let sleeper = ControlledSearchSleeper()
-		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+		let filters = NodeFilterParameters(store: defaults) { try await sleeper.sleep(for: $0) }
 		let nodeTabFilters = filters
 		let contactTabFilters = filters
 
@@ -245,8 +256,7 @@ struct NodeFilterParametersTests {
 		#expect(nodeTabFilters.searchText == "contact")
 		#expect(contactTabFilters.debouncedSearchText == "")
 
-		sleeper.resumeNext()
-		await Task.yield()
+		await resumeNextSleep(in: sleeper, for: contactTabFilters, expecting: "contact")
 		#expect(nodeTabFilters.searchText == "contact")
 		#expect(contactTabFilters.debouncedSearchText == "contact")
 	}
@@ -618,6 +628,24 @@ struct NodeFilterParametersMatchesTests {
 	}
 
 	// MARK: Online filter
+
+	@Test("Node matching uses only committed search text")
+	func nodeMatchingUsesCommittedSearchText() async {
+		let sleeper = ControlledSearchSleeper()
+		let filters = NodeFilterParameters(store: defaults) { try await sleeper.sleep(for: $0) }
+		let node = makeNode(sharedModelContainer.mainContext, num: 9_900_001)
+		attachUser(sharedModelContainer.mainContext, to: node)
+		node.user?.longName = "Matching Node"
+
+		filters.searchText = "different"
+		await waitForPendingSleeps(1, in: sleeper)
+
+		#expect(filters.matches(node))
+
+		await resumeNextSleep(in: sleeper, for: filters, expecting: "different")
+
+		#expect(!filters.matches(node))
+	}
 
 	@Test("Online filter matches only recently-heard nodes")
 	func onlineFilter() {

--- a/MeshtasticTests/NodeFilterParametersTests.swift
+++ b/MeshtasticTests/NodeFilterParametersTests.swift
@@ -26,6 +26,36 @@ private func makeIsolatedDefaults(_ suiteName: String) -> UserDefaults {
 }
 
 @MainActor
+private final class ControlledSearchSleeper {
+	private(set) var durations: [Duration] = []
+	private var continuations: [CheckedContinuation<Void, Error>] = []
+
+	var pendingCount: Int { continuations.count }
+
+	func sleep(for duration: Duration) async throws {
+		durations.append(duration)
+		// Deliberately resume cancelled sleeps so tests also exercise stale completion guards.
+		try await withCheckedThrowingContinuation { continuation in
+			continuations.append(continuation)
+		}
+	}
+
+	func resumeNext() {
+		continuations.removeFirst().resume()
+	}
+}
+
+@MainActor
+private func waitForPendingSleeps(_ count: Int, in sleeper: ControlledSearchSleeper) async {
+	var yields = 0
+	while sleeper.pendingCount < count && yields < 20 {
+		yields += 1
+		await Task.yield()
+	}
+	#expect(sleeper.pendingCount == count)
+}
+
+@MainActor
 @Suite("NodeFilterParameters", .serialized)
 struct NodeFilterParametersTests {
 
@@ -79,6 +109,146 @@ struct NodeFilterParametersTests {
 		// searchText is intentionally session-only — a stale search on relaunch hides most nodes.
 		let filters2 = NodeFilterParameters(store: defaults)
 		#expect(filters2.searchText == "")
+	}
+
+	@Test("Rapid search input coalesces to the latest value")
+	func rapidSearchInputCoalesces() async {
+		let sleeper = ControlledSearchSleeper()
+		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+
+		filters.searchText = "n"
+		await waitForPendingSleeps(1, in: sleeper)
+		filters.searchText = "no"
+		await waitForPendingSleeps(2, in: sleeper)
+		filters.searchText = "node"
+		await waitForPendingSleeps(3, in: sleeper)
+
+		#expect(filters.debouncedSearchText == "")
+		#expect(sleeper.durations == [.milliseconds(150), .milliseconds(150), .milliseconds(150)])
+
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(filters.debouncedSearchText == "")
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(filters.debouncedSearchText == "")
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(filters.debouncedSearchText == "node")
+	}
+
+	@Test("Draft search edits do not invoke contact filtering before commit")
+	func draftSearchDoesNotInvokeContactFiltering() async {
+		let sleeper = ControlledSearchSleeper()
+		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+		let contacts = ["Node Alpha", "Contact Bravo"]
+		var invalidationCount = 0
+		var matchInvocationCount = 0
+		var visibleContacts: [String] = []
+		let invalidationCancellable = filters.objectWillChange.sink {
+			invalidationCount += 1
+		}
+		let committedSearchCancellable = filters.$debouncedSearchText.dropFirst().sink { committedSearchText in
+			visibleContacts = filterContacts(contacts, committedSearchText: committedSearchText) { contact, searchText in
+				matchInvocationCount += 1
+				return contact.lowercased().contains(searchText)
+			}
+		}
+
+		filters.searchText = "n"
+		await waitForPendingSleeps(1, in: sleeper)
+		filters.searchText = "no"
+		await waitForPendingSleeps(2, in: sleeper)
+		filters.searchText = "node"
+		await waitForPendingSleeps(3, in: sleeper)
+
+		#expect(invalidationCount == 0)
+		#expect(matchInvocationCount == 0)
+
+		sleeper.resumeNext()
+		await Task.yield()
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(invalidationCount == 0)
+		#expect(matchInvocationCount == 0)
+
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(invalidationCount == 1)
+		#expect(matchInvocationCount == contacts.count)
+		#expect(visibleContacts == ["Node Alpha"])
+
+		invalidationCancellable.cancel()
+		committedSearchCancellable.cancel()
+	}
+
+	@Test("Clearing search text applies immediately and cancels pending input")
+	func clearingSearchTextIsImmediate() async {
+		let sleeper = ControlledSearchSleeper()
+		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+
+		filters.searchText = "node"
+		await waitForPendingSleeps(1, in: sleeper)
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(filters.debouncedSearchText == "node")
+
+		filters.searchText = "pending"
+		await waitForPendingSleeps(1, in: sleeper)
+		filters.searchText = ""
+
+		#expect(filters.searchText == "")
+		#expect(filters.debouncedSearchText == "")
+
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(filters.debouncedSearchText == "")
+	}
+
+	@Test("Programmatic changes debounce and reset clears immediately")
+	func programmaticChangesAndReset() async {
+		let sleeper = ControlledSearchSleeper()
+		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+
+		filters.searchText = "external"
+		await waitForPendingSleeps(1, in: sleeper)
+		#expect(filters.debouncedSearchText == "")
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(filters.debouncedSearchText == "external")
+
+		filters.searchText = "pending"
+		await waitForPendingSleeps(1, in: sleeper)
+		filters.reset()
+
+		#expect(filters.searchText == "")
+		#expect(filters.debouncedSearchText == "")
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(filters.debouncedSearchText == "")
+	}
+
+	@Test("Shared search state rejects a stale hidden-tab promotion")
+	func sharedSearchRejectsStalePromotion() async {
+		let sleeper = ControlledSearchSleeper()
+		let filters = NodeFilterParameters(store: defaults, searchDebounceSleep: sleeper.sleep)
+		let nodeTabFilters = filters
+		let contactTabFilters = filters
+
+		nodeTabFilters.searchText = "node"
+		await waitForPendingSleeps(1, in: sleeper)
+		contactTabFilters.searchText = "contact"
+		await waitForPendingSleeps(2, in: sleeper)
+
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(nodeTabFilters.searchText == "contact")
+		#expect(contactTabFilters.debouncedSearchText == "")
+
+		sleeper.resumeNext()
+		await Task.yield()
+		#expect(nodeTabFilters.searchText == "contact")
+		#expect(contactTabFilters.debouncedSearchText == "contact")
 	}
 
 	@Test("Boolean filters persist across instances")


### PR DESCRIPTION
## What changed?

- Debounce the shared node/contact search input by 150 ms.
- Keep draft text synchronized immediately across tabs while publishing only committed text to expensive filters.
- Keep Nodes, Contacts, and Map filtering on the same committed query.
- Apply clears and filter resets immediately.
- Add lifecycle and matching tests for coalescing, stale completions, hidden-tab updates, and filtering work.

## Why did it change?

With 5,000 stored nodes, filtering on every keystroke repeatedly invalidates both the node and contact lists. Profiling showed roughly 1 second of cumulative filtering while entering a query. A 150 ms commit boundary reduced that work by about 65% while preserving the shared search experience.

This complements #2472, which addresses periodic node-list refreshes rather than search input.

## How is this tested?

- `NodeFilterParametersTests` and `NodeFilterParametersMatchesTests`: 40/40 passed.
- SwiftLint: no new violations; `MeshMapMK` retains its pre-existing `type_body_length` warning.
- iOS Simulator with 5,000 nodes and 4,733 contacts: searched for `Perf Node 4999` in Nodes, verified the result, switched to Direct Messages, and verified the shared query and matching contact.
- Clear, reset, map consistency, and stale-promotion behavior covered by tests.
- Debug simulator build succeeded.

## Screenshots/Videos (when applicable)

No visual changes.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have conducted a self-review of my code.
- [x] I have commented my code, particularly in complex areas.
- [x] I have verified whether these changes require updates to the in-app documentation under `docs/user/` or `docs/developer/`, and updated accordingly (no documentation change is required).
- [x] I have tested the change to ensure that it works as intended.