### PR TITLE
Name the rest of the screens reported to RUM

### DIFF
--- a/Meshtastic/Extensions/Logger+DataDog.swift
+++ b/Meshtastic/Extensions/Logger+DataDog.swift
@@ -129,11 +129,13 @@ struct MeshtasticSwiftUIViewsPredicate: SwiftUIRUMViewsPredicate {
 		"UUID"
 	]
 
-	/// Three view types the reflection does name, but for screens that now name themselves.
-	/// `AppSettings` was the misleading one: it was reported for pushes all over the Settings
-	/// stack, not just for App Settings. Dropping these keeps one name per screen.
+	/// View types the reflection does name, but for screens that now name themselves. Two of
+	/// them stood in for more than the screen they are named after: `AppSettings` was reported
+	/// for pushes all over the Settings stack, and `DeviceOnboarding` is the sheet the setup
+	/// steps live in rather than any one step. Dropping these keeps one name per screen.
 	private static let namedElsewhere: Set<String> = [
 		"AppSettings",
+		"DeviceOnboarding",
 		"LoRaConfig",
 		"ShareChannels"
 	]

--- a/Meshtastic/Extensions/Logger+DataDog.swift
+++ b/Meshtastic/Extensions/Logger+DataDog.swift
@@ -93,6 +93,71 @@ extension os.Logger {
 	static let datadog = DatadogLogger(subsystem: "datadog", category: "🐶 DataDog")
 }
 
+/// Decides which of the SDK's auto-detected SwiftUI view names are worth reporting.
+///
+/// The SDK names a view by reflecting over the hosting controller that is appearing. When the
+/// reflection lands on something that is not a screen it reports a name anyway, and that name
+/// takes over: the `trackScreen` modifier reports from `onAppear`, the controller reports from
+/// `viewDidAppear`, and the later one sits on top of RUM's view stack for as long as the screen
+/// is up. That is why every pushed screen was filed under
+/// `NavigationStackHostingController<AnyView>` and everything at the app root under `EmptyView`
+/// (the root window's controller — the same problem the `FirmwareUpdateGameDemoHost` name had,
+/// with a different accidental type), while the screens we had named held the view for a few
+/// milliseconds each.
+///
+/// Returning nil skips the report and leaves the last real screen on top. Names that do identify
+/// a screen are passed through unchanged, so screens that reflection already names keep the name
+/// they have in Error Tracking.
+struct MeshtasticSwiftUIViewsPredicate: SwiftUIRUMViewsPredicate {
+	/// Types the reflection reaches that are not screens: SwiftUI value types and preference
+	/// keys, our own tracking modifier, and app objects that happen to sit where a view was
+	/// expected.
+	private static let notScreens: Set<String> = [
+		"AnyView",
+		"AccessoryManager",
+		"EmptyView",
+		"EnabledTextSelectability",
+		"Font",
+		"MeshMapItem",
+		"NavigationTitleKey",
+		"Never",
+		"NodeInfoEntity",
+		"PresentationOptionsPreferenceKey",
+		"RUMViewModifier",
+		"Text",
+		"TextAlignment",
+		"UUID"
+	]
+
+	/// Three view types the reflection does name, but for screens that now name themselves.
+	/// `AppSettings` was the misleading one: it was reported for pushes all over the Settings
+	/// stack, not just for App Settings. Dropping these keeps one name per screen.
+	private static let namedElsewhere: Set<String> = [
+		"AppSettings",
+		"LoRaConfig",
+		"ShareChannels"
+	]
+
+	func rumView(for extractedViewName: String) -> RUMView? {
+		// A container's own description rather than a name: `NavigationStackHostingController<AnyView>`,
+		// `UIHostingController<AnyView>`, or a half-parsed type such as `Text)`.
+		guard !extractedViewName.isEmpty,
+			  extractedViewName.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" }) else {
+			return nil
+		}
+		// SwiftUI internals (`_PaddingLayout`, `_ViewList_View`) and the SDK's own
+		// `AutoTracked_…_Fallback` placeholders.
+		guard !extractedViewName.hasPrefix("_"), !extractedViewName.hasPrefix("AutoTracked_") else {
+			return nil
+		}
+		guard !Self.notScreens.contains(extractedViewName),
+			  !Self.namedElsewhere.contains(extractedViewName) else {
+			return nil
+		}
+		return RUMView(name: extractedViewName)
+	}
+}
+
 extension View {
 	/// Names this screen for RUM, so crashes and hangs that happen on it are filed under it.
 	///
@@ -104,8 +169,9 @@ extension View {
 	/// `NavigationStackHostingController<AnyView>`, so nothing could be attributed to a
 	/// screen at all.
 	///
-	/// A name set here wins: an error is attributed to the innermost view that has started.
-	/// Keep the names stable — renaming one splits that screen's history in Error Tracking.
+	/// A name set here only wins while no hosting controller reports over it, which is what
+	/// `MeshtasticSwiftUIViewsPredicate` above is for. Keep the names stable — renaming one
+	/// splits that screen's history in Error Tracking.
 	func trackScreen(_ name: String) -> some View {
 		trackRUMView(name: name)
 	}

--- a/Meshtastic/Extensions/Logger+DataDog.swift
+++ b/Meshtastic/Extensions/Logger+DataDog.swift
@@ -170,9 +170,9 @@ extension View {
 	/// screen at all.
 	///
 	/// A name set here only wins while no hosting controller reports over it, which is what
-	/// `MeshtasticSwiftUIViewsPredicate` above is for. Keep the names stable — renaming one
-	/// splits that screen's history in Error Tracking.
-	func trackScreen(_ name: String) -> some View {
-		trackRUMView(name: name)
+	/// `MeshtasticSwiftUIViewsPredicate` above is for. The names live in `ScreenName` so that no
+	/// two screens can share one.
+	func trackScreen(_ screen: ScreenName) -> some View {
+		trackRUMView(name: screen.rawValue)
 	}
 }

--- a/Meshtastic/Extensions/ScreenName.swift
+++ b/Meshtastic/Extensions/ScreenName.swift
@@ -1,0 +1,138 @@
+//
+//  ScreenName.swift
+//  Meshtastic
+//
+//  Copyright(c) Garth Vander Houwen 9/12/26.
+//
+
+import Foundation
+
+/// Every screen name reported to RUM, in one list.
+///
+/// One list because two screens sharing a name silently merge their crashes and hangs into one
+/// bucket. Swift rejects a duplicate raw value, so that collision is a build error instead.
+///
+/// The raw values are the grouping key for a screen's history in Error Tracking — changing one
+/// splits that screen's past from its future, so treat them as fixed. They are deliberately not
+/// localized: a name that followed the device language would scatter a screen across as many
+/// buckets as there are languages.
+enum ScreenName: String, CaseIterable {
+
+	// MARK: Tabs
+
+	case messages = "Messages"
+	case nodes = "Nodes"
+	case map = "Map"
+	case settings = "Settings"
+	case connect = "Connect"
+
+	// MARK: Messages
+
+	case channelMessages = "Channel Messages"
+	case directMessages = "Direct Messages"
+	case nodeDetail = "Node Detail"
+	case channelsHelp = "Channels Help"
+	case saveChannelQRCode = "Save Channel QR Code"
+	case addContact = "Add Contact"
+
+	// MARK: App root
+
+	case lockdown = "Lockdown"
+
+	// MARK: Settings
+
+	case about = "About Meshtastic"
+	case appSettings = "App Settings"
+	case routes = "Routes"
+	case routeRecorder = "Route Recorder"
+	case lora = "LoRa Config"
+	case channels = "Channel Config"
+	case shareQRCode = "Share QR Code"
+	case user = "User Config"
+	case bluetooth = "Bluetooth Config"
+	case device = "Device Config"
+	case display = "Display Config"
+	case network = "Network Config"
+	case position = "Position Config"
+	case power = "Power Config"
+	case ambientLighting = "Ambient Lighting Config"
+	case audio = "Audio Config"
+	case cannedMessages = "Canned Messages Config"
+	case detectionSensor = "Detection Sensor Config"
+	case meshBeacon = "Mesh Beacon Config"
+	case externalNotification = "External Notification Config"
+	case mqtt = "MQTT Config"
+	case neighborInfo = "Neighbor Info Config"
+	case rangeTest = "Range Test Config"
+	case paxCounter = "PAX Counter Config"
+	case ringtone = "Ringtone Config"
+	case serial = "Serial Config"
+	case security = "Security Config"
+	case storeAndForward = "Store and Forward Config"
+	case telemetry = "Telemetry Config"
+	case trafficManagement = "Traffic Management Config"
+	case debugLogs = "Logs"
+	case traceRoutes = "Trace Routes"
+	case appFiles = "App Files"
+	case firmwareUpdates = "Firmware Updates"
+	case deviceLinks = "Device Links"
+	case tak = "TAK Server"
+	case takConfig = "TAK Module Config"
+	case tools = "Tools"
+	case coreDataBrowser = "Data Browser"
+	case localMeshDiscovery = "Local Mesh Discovery"
+	case helpDocs = "Help and Documentation"
+	case backupManagement = "Backup Management"
+
+	// MARK: Screens reached from Settings
+
+	case appIconPicker = "App Icon Picker"
+	case askChirpy = "Ask Chirpy"
+	case channelEditor = "Channel Editor"
+	case discoverySession = "Discovery Session"
+	case importDeviceProfile = "Import Device Profile"
+	case logDetail = "Log Detail"
+	case mapDataFiles = "Map Data Files"
+	case routeRecordingDetails = "Route Recording Details"
+
+	// MARK: Data browser
+
+	case dataBrowserEntities = "Data Browser Entities"
+	case dataBrowserEntity = "Data Browser Entity"
+	case dataBrowserRelationships = "Data Browser Relationships"
+
+	// MARK: Firmware
+
+	case nordicDFUUpdate = "Nordic DFU Update"
+	case esp32Update = "ESP32 Update"
+	case esp32WiFiUpdate = "ESP32 Wi-Fi Update"
+	case esp32BLEUpdate = "ESP32 BLE Update"
+	case firmwareSecurityWarning = "Firmware Security Warning"
+
+	// MARK: Provisioning
+
+	case wifiProvisioning = "Wi-Fi Provisioning"
+	case wifiPassword = "Wi-Fi Password"
+	case hiddenWiFiNetwork = "Hidden Wi-Fi Network"
+
+	// MARK: Map
+
+	case mapItemPicker = "Map Item Picker"
+	case waypoint = "Waypoint"
+	case mapLegend = "Map Legend"
+	case coverageEstimate = "Coverage Estimate"
+	case positionDetail = "Position Detail"
+
+	// MARK: Node detail
+
+	case powerChannelLabels = "Power Channel Labels"
+	case noiseFloorInfo = "Noise Floor Info"
+
+	// MARK: Onboarding
+
+	case onboardingNotifications = "Onboarding Notifications"
+	case onboardingLocation = "Onboarding Location"
+	case onboardingBluetooth = "Onboarding Bluetooth"
+	case onboardingLocalNetwork = "Onboarding Local Network"
+	case onboardingSiri = "Onboarding Siri"
+}

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -347,7 +347,7 @@ struct MeshtasticAppleApp: App {
 						channelSetLink: link.data,
 						addChannels: link.add, // <-- Uses the now reliable 'add' boolean
 						accessoryManager: accessoryManager				)
-					.trackScreen("Save Channel QR Code")
+					.trackScreen(.saveChannelQRCode)
 					.presentationDetents([.large])
 					#if !targetEnvironment(macCatalyst)
 					.presentationDragIndicator(.visible)
@@ -358,7 +358,7 @@ struct MeshtasticAppleApp: App {
 							pendingContact: pendingContact,
 							accessoryManager: accessoryManager
 						)
-						.trackScreen("Add Contact")
+						.trackScreen(.addContact)
 						.presentationDetents([.medium, .large])
 						#if !targetEnvironment(macCatalyst)
 						.presentationDragIndicator(.visible)

--- a/Meshtastic/MeshtasticApp.swift
+++ b/Meshtastic/MeshtasticApp.swift
@@ -91,7 +91,7 @@ struct MeshtasticAppleApp: App {
 
 			var rumConfig = RUM.Configuration(
 				applicationID: appID,
-				swiftUIViewsPredicate: DefaultSwiftUIRUMViewsPredicate(),
+				swiftUIViewsPredicate: MeshtasticSwiftUIViewsPredicate(),
 				swiftUIActionsPredicate: DefaultSwiftUIRUMActionsPredicate(isLegacyDetectionEnabled: true),
 				trackBackgroundEvents: true
 			)
@@ -347,6 +347,7 @@ struct MeshtasticAppleApp: App {
 						channelSetLink: link.data,
 						addChannels: link.add, // <-- Uses the now reliable 'add' boolean
 						accessoryManager: accessoryManager				)
+					.trackScreen("Save Channel QR Code")
 					.presentationDetents([.large])
 					#if !targetEnvironment(macCatalyst)
 					.presentationDragIndicator(.visible)
@@ -357,6 +358,7 @@ struct MeshtasticAppleApp: App {
 							pendingContact: pendingContact,
 							accessoryManager: accessoryManager
 						)
+						.trackScreen("Add Contact")
 						.presentationDetents([.medium, .large])
 						#if !targetEnvironment(macCatalyst)
 						.presentationDragIndicator(.visible)

--- a/Meshtastic/Router/NavigationState.swift
+++ b/Meshtastic/Router/NavigationState.swift
@@ -86,6 +86,57 @@ enum SettingsNavigationState: String {
 	case localMeshDiscovery
 	case helpDocs
 	case backupManagement
+
+	/// Screen name reported to RUM. Written out rather than derived from the raw value, for the
+	/// same reason as `NavigationState.Tab.screenName`: these are the grouping key for a screen's
+	/// crashes and hangs. Not localized — a name that changed with the device language would
+	/// scatter one screen across as many buckets as there are languages.
+	var screenName: String {
+		switch self {
+		case .about: return "About Meshtastic"
+		case .appSettings: return "App Settings"
+		case .routes: return "Routes"
+		case .routeRecorder: return "Route Recorder"
+		case .lora: return "LoRa Config"
+		case .channels: return "Channel Config"
+		case .shareQRCode: return "Share QR Code"
+		case .user: return "User Config"
+		case .bluetooth: return "Bluetooth Config"
+		case .device: return "Device Config"
+		case .display: return "Display Config"
+		case .network: return "Network Config"
+		case .position: return "Position Config"
+		case .power: return "Power Config"
+		case .ambientLighting: return "Ambient Lighting Config"
+		case .audio: return "Audio Config"
+		case .cannedMessages: return "Canned Messages Config"
+		case .detectionSensor: return "Detection Sensor Config"
+		case .meshBeacon: return "Mesh Beacon Config"
+		case .externalNotification: return "External Notification Config"
+		case .mqtt: return "MQTT Config"
+		case .neighborInfo: return "Neighbor Info Config"
+		case .rangeTest: return "Range Test Config"
+		case .paxCounter: return "PAX Counter Config"
+		case .ringtone: return "Ringtone Config"
+		case .serial: return "Serial Config"
+		case .security: return "Security Config"
+		case .storeAndForward: return "Store and Forward Config"
+		case .telemetry: return "Telemetry Config"
+		case .trafficManagement: return "Traffic Management Config"
+		case .debugLogs: return "Logs"
+		case .traceRoutes: return "Trace Routes"
+		case .appFiles: return "App Files"
+		case .firmwareUpdates: return "Firmware Updates"
+		case .deviceLinks: return "Device Links"
+		case .tak: return "TAK Server"
+		case .takConfig: return "TAK Module Config"
+		case .tools: return "Tools"
+		case .coreDataBrowser: return "Data Browser"
+		case .localMeshDiscovery: return "Local Mesh Discovery"
+		case .helpDocs: return "Help and Documentation"
+		case .backupManagement: return "Backup Management"
+		}
+	}
 }
 
 struct NavigationState: Hashable {

--- a/Meshtastic/Router/NavigationState.swift
+++ b/Meshtastic/Router/NavigationState.swift
@@ -87,54 +87,52 @@ enum SettingsNavigationState: String {
 	case helpDocs
 	case backupManagement
 
-	/// Screen name reported to RUM. Written out rather than derived from the raw value, for the
-	/// same reason as `NavigationState.Tab.screenName`: these are the grouping key for a screen's
-	/// crashes and hangs. Not localized — a name that changed with the device language would
-	/// scatter one screen across as many buckets as there are languages.
-	var screenName: String {
+	/// Screen name reported to RUM, written out rather than derived from the raw value so a
+	/// rename of the case cannot move a screen to a different bucket. See `ScreenName`.
+	var screenName: ScreenName {
 		switch self {
-		case .about: return "About Meshtastic"
-		case .appSettings: return "App Settings"
-		case .routes: return "Routes"
-		case .routeRecorder: return "Route Recorder"
-		case .lora: return "LoRa Config"
-		case .channels: return "Channel Config"
-		case .shareQRCode: return "Share QR Code"
-		case .user: return "User Config"
-		case .bluetooth: return "Bluetooth Config"
-		case .device: return "Device Config"
-		case .display: return "Display Config"
-		case .network: return "Network Config"
-		case .position: return "Position Config"
-		case .power: return "Power Config"
-		case .ambientLighting: return "Ambient Lighting Config"
-		case .audio: return "Audio Config"
-		case .cannedMessages: return "Canned Messages Config"
-		case .detectionSensor: return "Detection Sensor Config"
-		case .meshBeacon: return "Mesh Beacon Config"
-		case .externalNotification: return "External Notification Config"
-		case .mqtt: return "MQTT Config"
-		case .neighborInfo: return "Neighbor Info Config"
-		case .rangeTest: return "Range Test Config"
-		case .paxCounter: return "PAX Counter Config"
-		case .ringtone: return "Ringtone Config"
-		case .serial: return "Serial Config"
-		case .security: return "Security Config"
-		case .storeAndForward: return "Store and Forward Config"
-		case .telemetry: return "Telemetry Config"
-		case .trafficManagement: return "Traffic Management Config"
-		case .debugLogs: return "Logs"
-		case .traceRoutes: return "Trace Routes"
-		case .appFiles: return "App Files"
-		case .firmwareUpdates: return "Firmware Updates"
-		case .deviceLinks: return "Device Links"
-		case .tak: return "TAK Server"
-		case .takConfig: return "TAK Module Config"
-		case .tools: return "Tools"
-		case .coreDataBrowser: return "Data Browser"
-		case .localMeshDiscovery: return "Local Mesh Discovery"
-		case .helpDocs: return "Help and Documentation"
-		case .backupManagement: return "Backup Management"
+		case .about: return .about
+		case .appSettings: return .appSettings
+		case .routes: return .routes
+		case .routeRecorder: return .routeRecorder
+		case .lora: return .lora
+		case .channels: return .channels
+		case .shareQRCode: return .shareQRCode
+		case .user: return .user
+		case .bluetooth: return .bluetooth
+		case .device: return .device
+		case .display: return .display
+		case .network: return .network
+		case .position: return .position
+		case .power: return .power
+		case .ambientLighting: return .ambientLighting
+		case .audio: return .audio
+		case .cannedMessages: return .cannedMessages
+		case .detectionSensor: return .detectionSensor
+		case .meshBeacon: return .meshBeacon
+		case .externalNotification: return .externalNotification
+		case .mqtt: return .mqtt
+		case .neighborInfo: return .neighborInfo
+		case .rangeTest: return .rangeTest
+		case .paxCounter: return .paxCounter
+		case .ringtone: return .ringtone
+		case .serial: return .serial
+		case .security: return .security
+		case .storeAndForward: return .storeAndForward
+		case .telemetry: return .telemetry
+		case .trafficManagement: return .trafficManagement
+		case .debugLogs: return .debugLogs
+		case .traceRoutes: return .traceRoutes
+		case .appFiles: return .appFiles
+		case .firmwareUpdates: return .firmwareUpdates
+		case .deviceLinks: return .deviceLinks
+		case .tak: return .tak
+		case .takConfig: return .takConfig
+		case .tools: return .tools
+		case .coreDataBrowser: return .coreDataBrowser
+		case .localMeshDiscovery: return .localMeshDiscovery
+		case .helpDocs: return .helpDocs
+		case .backupManagement: return .backupManagement
 		}
 	}
 }
@@ -150,13 +148,13 @@ struct NavigationState: Hashable {
 		/// Screen name reported to RUM. Written out rather than derived from the raw value:
 		/// these names are the grouping key for a screen's crashes and hangs, so they need to
 		/// survive a rename of the case.
-		var screenName: String {
+		var screenName: ScreenName {
 			switch self {
-			case .messages: return "Messages"
-			case .nodes: return "Nodes"
-			case .map: return "Map"
-			case .settings: return "Settings"
-			case .connect: return "Connect"
+			case .messages: return .messages
+			case .nodes: return .nodes
+			case .map: return .map
+			case .settings: return .settings
+			case .connect: return .connect
 			}
 		}
 	}

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -85,6 +85,7 @@ struct Connect: View {
 
 	private var loRaConfigDestination: some View {
 		LoRaConfig(node: safeNode, onSuccessfulSave: handleSuccessfulLoRaSave)
+			.trackScreen(SettingsNavigationState.lora.screenName)
 	}
 
 	/// Returns `node` only while it is still a live SwiftData object (`modelContext != nil`),
@@ -576,6 +577,7 @@ struct Connect: View {
 		}
 		.sheet(isPresented: $showSecurityVersionNag) {
 			SecurityVersionNag(minimumSecureVersion: accessoryManager.securityVersion, version: accessoryManager.activeConnection?.device.firmwareVersion ?? "?.?.?")
+				.trackScreen("Firmware Security Warning")
 				.presentationDetents([.large])
 				.presentationDragIndicator(.automatic)
 		}
@@ -590,6 +592,7 @@ struct Connect: View {
 			updateNymeaDiscovery()
 		}) { device in
 			WifiProvisioningView(preselectedDevice: device)
+				.trackScreen("Wi-Fi Provisioning")
 		}
 		.onAppear {
 			updateNymeaDiscovery()

--- a/Meshtastic/Views/Connect/Connect.swift
+++ b/Meshtastic/Views/Connect/Connect.swift
@@ -577,7 +577,7 @@ struct Connect: View {
 		}
 		.sheet(isPresented: $showSecurityVersionNag) {
 			SecurityVersionNag(minimumSecureVersion: accessoryManager.securityVersion, version: accessoryManager.activeConnection?.device.firmwareVersion ?? "?.?.?")
-				.trackScreen("Firmware Security Warning")
+				.trackScreen(.firmwareSecurityWarning)
 				.presentationDetents([.large])
 				.presentationDragIndicator(.automatic)
 		}
@@ -592,7 +592,7 @@ struct Connect: View {
 			updateNymeaDiscovery()
 		}) { device in
 			WifiProvisioningView(preselectedDevice: device)
-				.trackScreen("Wi-Fi Provisioning")
+				.trackScreen(.wifiProvisioning)
 		}
 		.onAppear {
 			updateNymeaDiscovery()

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -56,6 +56,7 @@ struct ContentView: View {
 			)
 			.fullScreenCover(isPresented: $isShowingLockdownGate) {
 				LockdownSheet()
+					.trackScreen("Lockdown")
 			}
 			.fullScreenCover(isPresented: $isShowingFirmwareGate) {
 				FirmwareUpdateGate()

--- a/Meshtastic/Views/ContentView.swift
+++ b/Meshtastic/Views/ContentView.swift
@@ -56,7 +56,7 @@ struct ContentView: View {
 			)
 			.fullScreenCover(isPresented: $isShowingLockdownGate) {
 				LockdownSheet()
-					.trackScreen("Lockdown")
+					.trackScreen(.lockdown)
 			}
 			.fullScreenCover(isPresented: $isShowingFirmwareGate) {
 				FirmwareUpdateGate()

--- a/Meshtastic/Views/Debugging/CoreDataBrowser.swift
+++ b/Meshtastic/Views/Debugging/CoreDataBrowser.swift
@@ -44,7 +44,7 @@ struct CoreDataBrowser: View {
 		List {
 			Section(header: Text("Entities (\(sortedModels.count))")) {
 				ForEach(sortedModels, id: \.name) { model in
-					NavigationLink(destination: DynamicEntityListView(modelType: model.type, entityName: model.name)) {
+					NavigationLink(destination: DynamicEntityListView(modelType: model.type, entityName: model.name).trackScreen(.dataBrowserEntities)) {
 						HStack {
 							Label(model.name, systemImage: "tablecells")
 								.font(.subheadline)
@@ -72,7 +72,7 @@ struct DynamicEntityListView: View {
 	var body: some View {
 		List(objects.indices, id: \.self) { index in
 			let object = objects[index]
-			NavigationLink(destination: EntityDetailView(object: object)) {
+			NavigationLink(destination: EntityDetailView(object: object).trackScreen(.dataBrowserEntity)) {
 				VStack(alignment: .leading) {
 					Text(displayName(for: object))
 						.font(.subheadline)
@@ -172,6 +172,7 @@ struct PropertyRow: View {
 		} else if let array = unwrapped as? [any PersistentModel] {
 			NavigationLink {
 				RelationshipListView(title: key, objects: array)
+					.trackScreen(.dataBrowserRelationships)
 			} label: {
 				HStack {
 					Text("[\(array.count) items]")
@@ -184,6 +185,7 @@ struct PropertyRow: View {
 		} else if let related = unwrapped as? any PersistentModel {
 			NavigationLink {
 				EntityDetailView(object: related)
+					.trackScreen(.dataBrowserEntity)
 			} label: {
 				Text(displayName(for: related))
 					.foregroundColor(.secondary)
@@ -205,7 +207,7 @@ struct RelationshipListView: View {
 	var body: some View {
 		List(objects.indices, id: \.self) { index in
 			let object = objects[index]
-			NavigationLink(destination: EntityDetailView(object: object)) {
+			NavigationLink(destination: EntityDetailView(object: object).trackScreen(.dataBrowserEntity)) {
 				VStack(alignment: .leading) {
 					Text(displayName(for: object))
 						.font(.headline)

--- a/Meshtastic/Views/Messages/ChannelList.swift
+++ b/Meshtastic/Views/Messages/ChannelList.swift
@@ -197,6 +197,7 @@ struct ChannelList: View {
 		}
 		.sheet(isPresented: $showingHelp) {
 			ChannelsHelp()
+				.trackScreen(.channelsHelp)
 				.presentationDetents([.large])
 				#if !targetEnvironment(macCatalyst)
 				.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Messages/MessageText.swift
+++ b/Meshtastic/Views/Messages/MessageText.swift
@@ -31,6 +31,7 @@ struct MessageText: View {
 					addChannels: link.add,
 					accessoryManager: accessoryManager
 				)
+				.trackScreen(.saveChannelQRCode)
 				.presentationDetents([.large])
 				#if !targetEnvironment(macCatalyst)
 				.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Messages/Messages.swift
+++ b/Meshtastic/Views/Messages/Messages.swift
@@ -137,10 +137,10 @@ struct Messages: View {
 				Group {
 					if let myInfo = node?.myInfo, let channelSelection {
 						ChannelMessageList(myInfo: myInfo, channel: channelSelection)
-							.trackScreen("Channel Messages")
+							.trackScreen(.channelMessages)
 					} else if let userSelection {
 						UserMessageList(user: userSelection)
-							.trackScreen("Direct Messages")
+							.trackScreen(.directMessages)
 					} else if case .channels = router.messagesSection {
 						Text("Select a channel")
 					} else if case .directMessages = router.messagesSection {
@@ -150,7 +150,7 @@ struct Messages: View {
 				.navigationDestination(for: Int64.self) { nodeNum in
 					if let node = getNodeInfo(id: nodeNum, context: context) {
 						NodeDetail(node: node, nodeNum: nodeNum)
-							.trackScreen("Node Detail")
+							.trackScreen(.nodeDetail)
 					}
 				}
 			}

--- a/Meshtastic/Views/Nodes/Helpers/Map/MapContent/NodeMapContent.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/MapContent/NodeMapContent.swift
@@ -83,6 +83,7 @@ struct NodeMapContent: MapContent {
 											PositionPopover(position: selection)
 												.padding()
 												.opacity(0.8)
+												.trackScreen(.positionDetail)
 												.presentationCompactAdaptation(.popover)
 										}
 
@@ -100,6 +101,7 @@ struct NodeMapContent: MapContent {
 											PositionPopover(position: selection)
 												.padding()
 												.opacity(0.8)
+												.trackScreen(.positionDetail)
 												.presentationCompactAdaptation(.popover)
 										}
 								}

--- a/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
+++ b/Meshtastic/Views/Nodes/Helpers/Map/NodeMapSwiftUI.swift
@@ -111,6 +111,7 @@ struct NodeMapSwiftUI: View {
 			}
 			.sheet(isPresented: $isShowingLegend) {
 				MapLegend(isMeshMap: false)
+					.trackScreen(.mapLegend)
 					.presentationDetents([.medium, .large])
 					.presentationContentInteraction(.scrolls)
 					#if !targetEnvironment(macCatalyst)

--- a/Meshtastic/Views/Nodes/LocalStatsLog.swift
+++ b/Meshtastic/Views/Nodes/LocalStatsLog.swift
@@ -110,6 +110,7 @@ struct LocalStatsLog: View {
 						}
 					}
 			}
+			.trackScreen(.noiseFloorInfo)
 			.presentationDetents([.medium])
 		}
 		.fileExporter(

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -482,7 +482,7 @@ struct MeshMapMK: View {
 					if let node = getNodeInfo(id: selection.id, context: context) {
 						NavigationStack {
 							NodeDetail(node: node, nodeNum: selection.id, showMapLink: false)
-								.trackScreen("Node Detail")
+								.trackScreen(.nodeDetail)
 						}
 						#if targetEnvironment(macCatalyst)
 							.overlay(alignment: .topLeading) {
@@ -538,7 +538,7 @@ struct MeshMapMK: View {
 							}
 						}
 					}
-					.trackScreen("Map Item Picker")
+					.trackScreen(.mapItemPicker)
 					.presentationDetents([.medium, .large])
 					#if !targetEnvironment(macCatalyst)
 					.presentationDragIndicator(.visible)
@@ -547,7 +547,7 @@ struct MeshMapMK: View {
 				.sheet(item: $selectedWaypoint) { selection in
 					WaypointForm(waypoint: selection)
 						.environmentObject(accessoryManager)
-						.trackScreen("Waypoint")
+						.trackScreen(.waypoint)
 						.presentationDetents([.large]) // full screen
 						#if !targetEnvironment(macCatalyst)
 						.presentationDragIndicator(.visible)
@@ -556,7 +556,7 @@ struct MeshMapMK: View {
 				.sheet(item: $editingWaypoint) { selection in
 					WaypointForm(waypoint: selection, editMode: true)
 						.environmentObject(accessoryManager)
-						.trackScreen("Waypoint")
+						.trackScreen(.waypoint)
 						.presentationDetents([.large])
 						#if !targetEnvironment(macCatalyst)
 						.presentationDragIndicator(.visible)
@@ -595,7 +595,7 @@ struct MeshMapMK: View {
 				}
 				.sheet(isPresented: $showLegend) {
 					MapLegend(isMeshMap: true)
-						.trackScreen("Map Legend")
+						.trackScreen(.mapLegend)
 						.presentationDetents([.large])
 						.presentationContentInteraction(.scrolls)
 						#if !targetEnvironment(macCatalyst)
@@ -605,7 +605,7 @@ struct MeshMapMK: View {
 				}
 				.sheet(item: $coverageSeed) { seed in
 					CoverageEstimateForm(seed: seed, runner: coverageRunner)
-						.trackScreen("Coverage Estimate")
+						.trackScreen(.coverageEstimate)
 						.presentationDetents([.large])
 						#if !targetEnvironment(macCatalyst)
 						.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Nodes/MeshMapMK.swift
+++ b/Meshtastic/Views/Nodes/MeshMapMK.swift
@@ -538,6 +538,7 @@ struct MeshMapMK: View {
 							}
 						}
 					}
+					.trackScreen("Map Item Picker")
 					.presentationDetents([.medium, .large])
 					#if !targetEnvironment(macCatalyst)
 					.presentationDragIndicator(.visible)
@@ -546,6 +547,7 @@ struct MeshMapMK: View {
 				.sheet(item: $selectedWaypoint) { selection in
 					WaypointForm(waypoint: selection)
 						.environmentObject(accessoryManager)
+						.trackScreen("Waypoint")
 						.presentationDetents([.large]) // full screen
 						#if !targetEnvironment(macCatalyst)
 						.presentationDragIndicator(.visible)
@@ -554,6 +556,7 @@ struct MeshMapMK: View {
 				.sheet(item: $editingWaypoint) { selection in
 					WaypointForm(waypoint: selection, editMode: true)
 						.environmentObject(accessoryManager)
+						.trackScreen("Waypoint")
 						.presentationDetents([.large])
 						#if !targetEnvironment(macCatalyst)
 						.presentationDragIndicator(.visible)
@@ -592,6 +595,7 @@ struct MeshMapMK: View {
 				}
 				.sheet(isPresented: $showLegend) {
 					MapLegend(isMeshMap: true)
+						.trackScreen("Map Legend")
 						.presentationDetents([.large])
 						.presentationContentInteraction(.scrolls)
 						#if !targetEnvironment(macCatalyst)
@@ -601,6 +605,7 @@ struct MeshMapMK: View {
 				}
 				.sheet(item: $coverageSeed) { seed in
 					CoverageEstimateForm(seed: seed, runner: coverageRunner)
+						.trackScreen("Coverage Estimate")
 						.presentationDetents([.large])
 						#if !targetEnvironment(macCatalyst)
 						.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Nodes/NodeList.swift
+++ b/Meshtastic/Views/Nodes/NodeList.swift
@@ -48,7 +48,7 @@ struct NodeList: View {
 						LocalStatsLog(node: node)
 					} else {
 						NodeDetail(node: node, nodeNum: selectedNum)
-							.trackScreen("Node Detail")
+							.trackScreen(.nodeDetail)
 					}
 				} else {
 					ContentUnavailableView("Select a Node", systemImage: "flipphone")

--- a/Meshtastic/Views/Nodes/PowerMetricsLog.swift
+++ b/Meshtastic/Views/Nodes/PowerMetricsLog.swift
@@ -333,6 +333,7 @@ struct PowerMetricsLog: View {
 					}
 				}
 			}
+			.trackScreen(.powerChannelLabels)
 		}
 		.fileExporter(
 			isPresented: $isExporting,

--- a/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
+++ b/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
@@ -356,7 +356,10 @@ struct DeviceOnboarding: View {
 	
 	var body: some View {
 		NavigationStack(path: $navigationPath) {
+			// The Bluetooth step is the stack's root rather than a pushed destination, so it
+			// needs the name here; the rest get it below.
 			bluetoothView
+				.trackScreen(SetupGuide.bluetooth.screenName)
 				.navigationDestination(for: SetupGuide.self) { guide in
 					Group {
 						switch guide {

--- a/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
+++ b/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
@@ -12,6 +12,17 @@ struct DeviceOnboarding: View {
 		case bluetooth
 		case localNetwork
 		case siri
+
+		/// Screen name reported to RUM. Not localized — see `SettingsNavigationState.screenName`.
+		var screenName: String {
+			switch self {
+			case .notifications: return "Onboarding Notifications"
+			case .location: return "Onboarding Location"
+			case .bluetooth: return "Onboarding Bluetooth"
+			case .localNetwork: return "Onboarding Local Network"
+			case .siri: return "Onboarding Siri"
+			}
+		}
 	}
 	
 	@EnvironmentObject var accessoryManager: AccessoryManager
@@ -347,18 +358,21 @@ struct DeviceOnboarding: View {
 		NavigationStack(path: $navigationPath) {
 			bluetoothView
 				.navigationDestination(for: SetupGuide.self) { guide in
-					switch guide {
-					case .notifications:
-						notificationView
-					case .location:
-						locationView
-					case .bluetooth:
-						bluetoothView
-					case .localNetwork:
-						localNetworkView
-					case .siri:
-						siriView
+					Group {
+						switch guide {
+						case .notifications:
+							notificationView
+						case .location:
+							locationView
+						case .bluetooth:
+							bluetoothView
+						case .localNetwork:
+							localNetworkView
+						case .siri:
+							siriView
+						}
 					}
+					.trackScreen(guide.screenName)
 				}
 		}
 		.interactiveDismissDisabled()

--- a/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
+++ b/Meshtastic/Views/Onboarding/DeviceOnboarding.swift
@@ -13,14 +13,14 @@ struct DeviceOnboarding: View {
 		case localNetwork
 		case siri
 
-		/// Screen name reported to RUM. Not localized — see `SettingsNavigationState.screenName`.
-		var screenName: String {
+		/// Screen name reported to RUM. See `ScreenName`.
+		var screenName: ScreenName {
 			switch self {
-			case .notifications: return "Onboarding Notifications"
-			case .location: return "Onboarding Location"
-			case .bluetooth: return "Onboarding Bluetooth"
-			case .localNetwork: return "Onboarding Local Network"
-			case .siri: return "Onboarding Siri"
+			case .notifications: return .onboardingNotifications
+			case .location: return .onboardingLocation
+			case .bluetooth: return .onboardingBluetooth
+			case .localNetwork: return .onboardingLocalNetwork
+			case .siri: return .onboardingSiri
 			}
 		}
 	}

--- a/Meshtastic/Views/Provisioning/WifiNetworkListView.swift
+++ b/Meshtastic/Views/Provisioning/WifiNetworkListView.swift
@@ -57,6 +57,7 @@ private struct NetworkRow: View {
 				},
 				onCancel: { showPasswordSheet = false }
 			)
+			.trackScreen(.wifiPassword)
 			.presentationDetents([.medium])
 			.presentationBackground(.regularMaterial)
 			#if !targetEnvironment(macCatalyst)
@@ -163,6 +164,7 @@ struct WifiNetworkListView: View {
 				},
 				onCancel: { showOtherSheet = false }
 			)
+			.trackScreen(.hiddenWiFiNetwork)
 			.presentationDetents([.medium])
 			.presentationBackground(.regularMaterial)
 			#if !targetEnvironment(macCatalyst)

--- a/Meshtastic/Views/Settings/AppData.swift
+++ b/Meshtastic/Views/Settings/AppData.swift
@@ -45,7 +45,7 @@ struct AppData: View {
 
 			// Map Data Section
 			Section(header: Text("Map Data")) {
-				NavigationLink(destination: MapDataFiles()) {
+				NavigationLink(destination: MapDataFiles().trackScreen(.mapDataFiles)) {
 					HStack {
 						Image(systemName: "map")
 							.symbolRenderingMode(.hierarchical)

--- a/Meshtastic/Views/Settings/AppLog.swift
+++ b/Meshtastic/Views/Settings/AppLog.swift
@@ -93,6 +93,7 @@ struct AppLog: View {
 		.sheet(item: $selectedLog, onDismiss: didDismiss) { log in
 			LogDetail(log: log)
 				.padding()
+				.trackScreen(.logDetail)
 		}
 		.task {
 			logs = await searchAppLogs()

--- a/Meshtastic/Views/Settings/AppSettings.swift
+++ b/Meshtastic/Views/Settings/AppSettings.swift
@@ -75,6 +75,7 @@ struct AppSettings: View {
 					}
 					.sheet(isPresented: $isPresentingAppIconSheet) {
 						AppIconPicker(isPresenting: self.$isPresentingAppIconSheet)
+							.trackScreen(.appIconPicker)
 							.presentationDetents([.medium])
 					}
 #endif

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -262,6 +262,7 @@ struct Channels: View {
 					.padding()
 				#endif
 				ChannelForm(channelIndex: $channelIndex, channelName: $channelName, channelKeySize: $channelKeySize, channelKey: $channelKey, channelRole: $channelRole, uplink: $uplink, downlink: $downlink, positionPrecision: $positionPrecision, preciseLocation: $preciseLocation, positionsEnabled: $positionsEnabled, hasChanges: $hasChanges, hasValidKey: $hasValidKey, supportedVersion: $supportedVersion)
+					.trackScreen("Channel Editor")
 					.presentationDetents([.large])
 					#if !targetEnvironment(macCatalyst)
 					.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Settings/Channels.swift
+++ b/Meshtastic/Views/Settings/Channels.swift
@@ -262,7 +262,7 @@ struct Channels: View {
 					.padding()
 				#endif
 				ChannelForm(channelIndex: $channelIndex, channelName: $channelName, channelKeySize: $channelKeySize, channelKey: $channelKey, channelRole: $channelRole, uplink: $uplink, downlink: $downlink, positionPrecision: $positionPrecision, preciseLocation: $preciseLocation, positionsEnabled: $positionsEnabled, hasChanges: $hasChanges, hasValidKey: $hasValidKey, supportedVersion: $supportedVersion)
-					.trackScreen("Channel Editor")
+					.trackScreen(.channelEditor)
 					.presentationDetents([.large])
 					#if !targetEnvironment(macCatalyst)
 					.presentationDragIndicator(.visible)
@@ -372,6 +372,7 @@ struct Channels: View {
 		}
 		.sheet(isPresented: $showingHelp) {
 			ChannelsHelp()
+				.trackScreen(.channelsHelp)
 				.presentationDetents([.large])
 				#if !targetEnvironment(macCatalyst)
 				.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Settings/Discovery/DiscoveryHistoryView.swift
+++ b/Meshtastic/Views/Settings/Discovery/DiscoveryHistoryView.swift
@@ -39,6 +39,7 @@ struct DiscoveryHistoryView: View {
 				ForEach(sessions, id: \.timestamp) { session in
 					NavigationLink {
 						sessionDetailView(session)
+							.trackScreen(.discoverySession)
 					} label: {
 						sessionRow(session)
 					}

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/ESP32OTAIntroSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/ESP32OTAIntroSheet.swift
@@ -194,11 +194,13 @@ struct ESP32OTAIntroSheet: View {
 				let _ = Logger.services.info("📡 [ESP32 OTA] Wi-Fi path, file \(binFileURL.lastPathComponent, privacy: .public)")
 				ESP32WifiOTASheet(binFileURL: binFileURL, host: theHost, onUpdateComplete: { dismiss() })
 					.environmentObject(accessoryManager)
+					.trackScreen("ESP32 Wi-Fi Update")
 			}
 			.sheet(isPresented: $showBLEUpdater) {
 				let _ = Logger.services.info("📡 [ESP32 OTA] BLE path, file \(binFileURL.lastPathComponent, privacy: .public)")
 				ESP32BLEOTASheet(binFileURL: binFileURL, onUpdateComplete: { dismiss() })
 					.environmentObject(accessoryManager)
+					.trackScreen("ESP32 BLE Update")
 			}
 			.navigationTitle("ESP32 Update")
 			.navigationBarTitleDisplayMode(.inline)

--- a/Meshtastic/Views/Settings/Firmware/ESP32 OTA/ESP32OTAIntroSheet.swift
+++ b/Meshtastic/Views/Settings/Firmware/ESP32 OTA/ESP32OTAIntroSheet.swift
@@ -194,13 +194,13 @@ struct ESP32OTAIntroSheet: View {
 				let _ = Logger.services.info("📡 [ESP32 OTA] Wi-Fi path, file \(binFileURL.lastPathComponent, privacy: .public)")
 				ESP32WifiOTASheet(binFileURL: binFileURL, host: theHost, onUpdateComplete: { dismiss() })
 					.environmentObject(accessoryManager)
-					.trackScreen("ESP32 Wi-Fi Update")
+					.trackScreen(.esp32WiFiUpdate)
 			}
 			.sheet(isPresented: $showBLEUpdater) {
 				let _ = Logger.services.info("📡 [ESP32 OTA] BLE path, file \(binFileURL.lastPathComponent, privacy: .public)")
 				ESP32BLEOTASheet(binFileURL: binFileURL, onUpdateComplete: { dismiss() })
 					.environmentObject(accessoryManager)
-					.trackScreen("ESP32 BLE Update")
+					.trackScreen(.esp32BLEUpdate)
 			}
 			.navigationTitle("ESP32 Update")
 			.navigationBarTitleDisplayMode(.inline)

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -319,13 +319,17 @@ private struct FirmwareContentView: View {
 			FactoryEraseView()
 		}
 		.sheet(item: $rowInstallation) { installation in
+			// UF2MassStorageView is left unnamed here and below: reflection already names it,
+			// and a second name would split its history in Error Tracking.
 			switch installation.type {
 			case .otaZip:
 				NRFDFUSheet(firmwareToFlash: installation.url)
+					.trackScreen("Nordic DFU Update")
 			case .uf2:
 				UF2MassStorageView(fileURL: installation.url)
 			case .bin:
 				ESP32OTAIntroSheet(binFileURL: installation.url)
+					.trackScreen("ESP32 Update")
 			}
 		}
 	}
@@ -504,10 +508,12 @@ private struct FirmwareContentView: View {
 					switch type {
 					case .otaZip:
 						NRFDFUSheet(firmwareToFlash: locallyChosenFirmwareFile)
+							.trackScreen("Nordic DFU Update")
 					case .uf2:
 						UF2MassStorageView(fileURL: locallyChosenFirmwareFile)
 					case .bin:
 						ESP32OTAIntroSheet(binFileURL: locallyChosenFirmwareFile)
+							.trackScreen("ESP32 Update")
 					}
 				}
 			}

--- a/Meshtastic/Views/Settings/Firmware/Firmware.swift
+++ b/Meshtastic/Views/Settings/Firmware/Firmware.swift
@@ -324,12 +324,12 @@ private struct FirmwareContentView: View {
 			switch installation.type {
 			case .otaZip:
 				NRFDFUSheet(firmwareToFlash: installation.url)
-					.trackScreen("Nordic DFU Update")
+					.trackScreen(.nordicDFUUpdate)
 			case .uf2:
 				UF2MassStorageView(fileURL: installation.url)
 			case .bin:
 				ESP32OTAIntroSheet(binFileURL: installation.url)
-					.trackScreen("ESP32 Update")
+					.trackScreen(.esp32Update)
 			}
 		}
 	}
@@ -508,12 +508,12 @@ private struct FirmwareContentView: View {
 					switch type {
 					case .otaZip:
 						NRFDFUSheet(firmwareToFlash: locallyChosenFirmwareFile)
-							.trackScreen("Nordic DFU Update")
+							.trackScreen(.nordicDFUUpdate)
 					case .uf2:
 						UF2MassStorageView(fileURL: locallyChosenFirmwareFile)
 					case .bin:
 						ESP32OTAIntroSheet(binFileURL: locallyChosenFirmwareFile)
-							.trackScreen("ESP32 Update")
+							.trackScreen(.esp32Update)
 					}
 				}
 			}

--- a/Meshtastic/Views/Settings/HelpAndDocumentation/DocPageView.swift
+++ b/Meshtastic/Views/Settings/HelpAndDocumentation/DocPageView.swift
@@ -260,6 +260,7 @@ struct AskChirpyToolbar: ViewModifier {
 			.sheet(isPresented: $isAIPresented) {
 				if #available(iOS 26, *) {
 					AIDocAssistantView()
+						.trackScreen(.askChirpy)
 				}
 			}
 	}

--- a/Meshtastic/Views/Settings/RouteRecorder.swift
+++ b/Meshtastic/Views/Settings/RouteRecorder.swift
@@ -286,6 +286,7 @@ struct RouteRecorder: View {
 						.padding(.leading, 14)
 					}
 #endif
+				.trackScreen(.routeRecordingDetails)
 				.presentationDetents([.fraction(0.45), .fraction(0.65)])
 				.presentationDetents([.fraction(0.45), .fraction(0.65)])
 				.presentationDragIndicator(.hidden)

--- a/Meshtastic/Views/Settings/Settings.swift
+++ b/Meshtastic/Views/Settings/Settings.swift
@@ -747,98 +747,101 @@ struct Settings: View {
 			.navigationDestination(for: SettingsNavigationState.self) { destination in
 				let node = liveNode(for: preferredNodeNum)
 				let configNode = liveNode(for: selectedNode)
-				switch destination {
-				case .about:
-					AboutMeshtastic()
-				case .appSettings:
-					AppSettings()
-				case .routes:
-					Routes()
-				case .routeRecorder:
-					RouteRecorder()
-				case .lora:
-					LoRaConfig(node: configNode)
-				case .channels:
-					if let node = node {
-						Channels(node: node)
-					} else {
-						Text("Loading...")
+				Group {
+					switch destination {
+					case .about:
+						AboutMeshtastic()
+					case .appSettings:
+						AppSettings()
+					case .routes:
+						Routes()
+					case .routeRecorder:
+						RouteRecorder()
+					case .lora:
+						LoRaConfig(node: configNode)
+					case .channels:
+						if let node = node {
+							Channels(node: node)
+						} else {
+							Text("Loading...")
+						}
+					case .shareQRCode:
+						ShareChannels(node: node)
+					case .user:
+						UserConfig(node: configNode)
+					case .bluetooth:
+						BluetoothConfig(node: configNode)
+					case .device:
+						DeviceConfig(node: configNode)
+					case .display:
+						DisplayConfig(node: configNode)
+					case .network:
+						NetworkConfig(node: configNode)
+					case .position:
+						PositionConfig(node: configNode)
+					case .power:
+						PowerConfig(node: configNode)
+					case .ambientLighting:
+						AmbientLightingConfig(node: configNode)
+					case .audio:
+						AudioConfig(node: configNode)
+					case .cannedMessages:
+						CannedMessagesConfig(node: configNode)
+					case .detectionSensor:
+						DetectionSensorConfig(node: configNode)
+					case .meshBeacon:
+						MeshBeaconConfig(node: configNode)
+					case .externalNotification:
+						ExternalNotificationConfig(node: configNode)
+					case .mqtt:
+						MQTTConfig(node: configNode)
+					case .neighborInfo:
+						NeighborInfoConfig(node: configNode)
+					case .rangeTest:
+						RangeTestConfig(node: configNode)
+					case .paxCounter:
+						PaxCounterConfig(node: configNode)
+					case .ringtone:
+						RtttlConfig(node: configNode)
+					case .security:
+						SecurityConfig(node: configNode)
+					case .serial:
+						SerialConfig(node: configNode)
+					case .storeAndForward:
+						StoreForwardConfig(node: configNode)
+					case .telemetry:
+						TelemetryConfig(node: configNode)
+					case .trafficManagement:
+						TrafficManagementConfig(node: configNode)
+					case .debugLogs:
+						AppLog()
+					case .traceRoutes:
+						AllTraceRoutesLog()
+					case .appFiles:
+						AppData()
+					case .firmwareUpdates:
+						Firmware(node: node)
+					case .deviceLinks:
+						DeviceLinkDirectory()
+					case .tools:
+						if #available(iOS 18, *) {
+							Tools()
+						}
+					case .tak:
+						TAKServerConfig()
+					case .takConfig:
+						TAKModuleConfig(node: configNode)
+					case .coreDataBrowser:
+						CoreDataBrowser()
+					case .localMeshDiscovery:
+						DiscoveryScanView()
+					case .helpDocs:
+						DocBrowserView()
+					case .backupManagement:
+						BackupManagement()
 					}
-				case .shareQRCode:
-					ShareChannels(node: node)
-				case .user:
-					UserConfig(node: configNode)
-				case .bluetooth:
-					BluetoothConfig(node: configNode)
-				case .device:
-					DeviceConfig(node: configNode)
-				case .display:
-					DisplayConfig(node: configNode)
-				case .network:
-					NetworkConfig(node: configNode)
-				case .position:
-					PositionConfig(node: configNode)
-				case .power:
-					PowerConfig(node: configNode)
-				case .ambientLighting:
-					AmbientLightingConfig(node: configNode)
-				case .audio:
-					AudioConfig(node: configNode)
-				case .cannedMessages:
-					CannedMessagesConfig(node: configNode)
-				case .detectionSensor:
-					DetectionSensorConfig(node: configNode)
-				case .meshBeacon:
-					MeshBeaconConfig(node: configNode)
-				case .externalNotification:
-					ExternalNotificationConfig(node: configNode)
-				case .mqtt:
-					MQTTConfig(node: configNode)
-				case .neighborInfo:
-					NeighborInfoConfig(node: configNode)
-				case .rangeTest:
-					RangeTestConfig(node: configNode)
-				case .paxCounter:
-					PaxCounterConfig(node: configNode)
-				case .ringtone:
-					RtttlConfig(node: configNode)
-				case .security:
-					SecurityConfig(node: configNode)
-				case .serial:
-					SerialConfig(node: configNode)
-				case .storeAndForward:
-					StoreForwardConfig(node: configNode)
-				case .telemetry:
-					TelemetryConfig(node: configNode)
-				case .trafficManagement:
-					TrafficManagementConfig(node: configNode)
-				case .debugLogs:
-					AppLog()
-				case .traceRoutes:
-					AllTraceRoutesLog()
-				case .appFiles:
-					AppData()
-				case .firmwareUpdates:
-					Firmware(node: node)
-				case .deviceLinks:
-					DeviceLinkDirectory()
-				case .tools:
-					if #available(iOS 18, *) {
-						Tools()
-					}
-				case .tak:
-					TAKServerConfig()
-				case .takConfig:
-					TAKModuleConfig(node: configNode)
-				case .coreDataBrowser:
-					CoreDataBrowser()
-				case .localMeshDiscovery:
-					DiscoveryScanView()
-				case .helpDocs:
-					DocBrowserView()
-				case .backupManagement:
-					BackupManagement()
 				}
+				.trackScreen(destination.screenName)
 			}
 			.onChange(of: UserDefaults.preferredPeripheralNum ) { _, newConnectedNode in
 				// If the preferred node changes, then select the newly preferred node

--- a/Meshtastic/Views/Settings/ShareChannels.swift
+++ b/Meshtastic/Views/Settings/ShareChannels.swift
@@ -169,6 +169,7 @@ struct ShareChannels: View {
 			}
 			.sheet(isPresented: $showingHelp) {
 				ChannelsHelp()
+					.trackScreen(.channelsHelp)
 					.presentationDetents([.large])
 					#if !targetEnvironment(macCatalyst)
 					.presentationDragIndicator(.visible)

--- a/Meshtastic/Views/Settings/TAKServerConfig.swift
+++ b/Meshtastic/Views/Settings/TAKServerConfig.swift
@@ -129,6 +129,7 @@ struct TAKServerConfig: View {
 		.navigationDestination(isPresented: $showShareChannels) {
 			if let node = connectedNode {
 				ShareChannels(node: node)
+					.trackScreen(SettingsNavigationState.shareQRCode.screenName)
 			}
 		}
 	}

--- a/Meshtastic/Views/Settings/Tools.swift
+++ b/Meshtastic/Views/Settings/Tools.swift
@@ -142,6 +142,7 @@ struct Tools: View {
 				addChannels: link.add,
 				accessoryManager: accessoryManager
 			)
+			.trackScreen(.saveChannelQRCode)
 			.presentationDetents([.large])
 			#if !targetEnvironment(macCatalyst)
 			.presentationDragIndicator(.visible)
@@ -201,6 +202,7 @@ struct Tools: View {
 		.sheet(item: $pendingImport) { pending in
 			ImportDeviceProfileView(plan: pending.plan)
 				.environmentObject(accessoryManager)
+				.trackScreen(.importDeviceProfile)
 		}
 		.alert("Import Failed", isPresented: $isPresentingImportFailedAlert) {
 			Button("OK") { }.keyboardShortcut(.defaultAction)

--- a/MeshtasticTests/RUMScreenNameTests.swift
+++ b/MeshtasticTests/RUMScreenNameTests.swift
@@ -48,8 +48,25 @@ struct RUMScreenNameTests {
 		}
 	}
 
-	@Test("Every settings destination has a name, and no two share one")
-	func settingsNamesAreUniqueAndPresent() {
+	/// Swift already rejects a duplicate raw value, so this can only fail if `ScreenName` stops
+	/// being the single source of names. It is here to say that out loud.
+	@Test("No two screens share a name")
+	func namesAreUnique() {
+		let names = ScreenName.allCases.map(\.rawValue)
+		#expect(Set(names).count == names.count)
+	}
+
+	@Test("Every name reads as a name, not as a type")
+	func namesAreReadable() {
+		for name in ScreenName.allCases.map(\.rawValue) {
+			#expect(!name.isEmpty)
+			#expect(name.trimmingCharacters(in: .whitespaces) == name)
+			#expect(!name.contains(where: { "_<>().".contains($0) }), "\(name) looks like a type description")
+		}
+	}
+
+	@Test("Every settings destination resolves to a name")
+	func settingsDestinationsAreNamed() {
 		let destinations: [SettingsNavigationState] = [
 			.about, .appSettings, .routes, .routeRecorder, .lora, .channels, .shareQRCode, .user,
 			.bluetooth, .device, .display, .network, .position, .power, .ambientLighting, .audio,
@@ -60,7 +77,6 @@ struct RUMScreenNameTests {
 			.helpDocs, .backupManagement
 		]
 		let names = destinations.map(\.screenName)
-		#expect(names.allSatisfy { !$0.isEmpty })
 		#expect(Set(names).count == names.count)
 	}
 }

--- a/MeshtasticTests/RUMScreenNameTests.swift
+++ b/MeshtasticTests/RUMScreenNameTests.swift
@@ -17,7 +17,7 @@ struct RUMScreenNameTests {
 
 	@Test("A view type the reflection resolved is reported under its own name")
 	func keepsRealScreenNames() {
-		for name in ["TraceRouteLog", "DeviceMetricsLog", "NodeListFilter", "MapSettingsForm", "DeviceOnboarding"] {
+		for name in ["TraceRouteLog", "DeviceMetricsLog", "NodeListFilter", "MapSettingsForm", "CompassView"] {
 			#expect(predicate.rumView(for: name)?.name == name)
 		}
 	}
@@ -43,7 +43,7 @@ struct RUMScreenNameTests {
 
 	@Test("Screens that name themselves are not also reported under a reflected name")
 	func dropsNamesSetElsewhere() {
-		for name in ["AppSettings", "LoRaConfig", "ShareChannels"] {
+		for name in ["AppSettings", "DeviceOnboarding", "LoRaConfig", "ShareChannels"] {
 			#expect(predicate.rumView(for: name) == nil)
 		}
 	}

--- a/MeshtasticTests/RUMScreenNameTests.swift
+++ b/MeshtasticTests/RUMScreenNameTests.swift
@@ -1,0 +1,66 @@
+//
+//  RUMScreenNameTests.swift
+//  MeshtasticTests
+//
+//  Copyright(c) Garth Vander Houwen 9/12/26.
+//
+
+import Testing
+import DatadogRUM
+@testable import Meshtastic
+
+/// The predicate decides what a crash or hang gets filed under, so the cases it has to reject are
+/// worth pinning down. Every rejected name here was a real bucket in RUM.
+@Suite("RUM screen names")
+struct RUMScreenNameTests {
+	private let predicate = MeshtasticSwiftUIViewsPredicate()
+
+	@Test("A view type the reflection resolved is reported under its own name")
+	func keepsRealScreenNames() {
+		for name in ["TraceRouteLog", "DeviceMetricsLog", "NodeListFilter", "MapSettingsForm", "DeviceOnboarding"] {
+			#expect(predicate.rumView(for: name)?.name == name)
+		}
+	}
+
+	@Test("A hosting controller's own description is not a screen")
+	func dropsContainerDescriptions() {
+		for name in ["NavigationStackHostingController<AnyView>", "UIHostingController<AnyView>", "Text)"] {
+			#expect(predicate.rumView(for: name) == nil)
+		}
+	}
+
+	@Test("SwiftUI internals and the SDK's placeholders are not screens")
+	func dropsInternals() {
+		for name in ["_PaddingLayout", "_ViewList_View", "AutoTracked_HostingController_Fallback"] {
+			#expect(predicate.rumView(for: name) == nil)
+		}
+	}
+
+	@Test("EmptyView, the app root's reflected type, is not a screen")
+	func dropsAppRoot() {
+		#expect(predicate.rumView(for: "EmptyView") == nil)
+	}
+
+	@Test("Screens that name themselves are not also reported under a reflected name")
+	func dropsNamesSetElsewhere() {
+		for name in ["AppSettings", "LoRaConfig", "ShareChannels"] {
+			#expect(predicate.rumView(for: name) == nil)
+		}
+	}
+
+	@Test("Every settings destination has a name, and no two share one")
+	func settingsNamesAreUniqueAndPresent() {
+		let destinations: [SettingsNavigationState] = [
+			.about, .appSettings, .routes, .routeRecorder, .lora, .channels, .shareQRCode, .user,
+			.bluetooth, .device, .display, .network, .position, .power, .ambientLighting, .audio,
+			.cannedMessages, .detectionSensor, .meshBeacon, .externalNotification, .mqtt,
+			.neighborInfo, .rangeTest, .paxCounter, .ringtone, .serial, .security, .storeAndForward,
+			.telemetry, .trafficManagement, .debugLogs, .traceRoutes, .appFiles, .firmwareUpdates,
+			.deviceLinks, .tak, .takConfig, .tools, .coreDataBrowser, .localMeshDiscovery,
+			.helpDocs, .backupManagement
+		]
+		let names = destinations.map(\.screenName)
+		#expect(names.allSatisfy { !$0.isEmpty })
+		#expect(Set(names).count == names.count)
+	}
+}


### PR DESCRIPTION
## Summary

`1379d0ab` named the five tabs and a few screens, but most of the app still
reports to Datadog under a name that means nothing. In the shipped build the
two biggest buckets are `NavigationStackHostingController<AnyView>` (every
pushed screen) and `EmptyView`, and most app hangs land in one of them.

`EmptyView` is the app root. The view URL on every one of those events is
`UIHostingController<ModifiedContent<AnyView, RootModifier>>` — the WindowGroup's
own controller. It is the same problem `FirmwareUpdateGameDemoHost` had before:
the SDK reflects over the root view's type and reports whatever it lands on.
With the demo host now behind `#if DEBUG`, the release branch it used to sit in
is empty, so the reflection resolves to `EmptyView` instead.

The naming itself was also being overridden. The SDK reports from the hosting
controller's `viewDidAppear`; `trackScreen` reports from SwiftUI's `onAppear`,
which runs first. The later report wins, so the reflected name held the screen
for its whole visit and the name we set held it for a few milliseconds. Adding
more `trackScreen` calls on their own would not have changed where a hang is
filed.

## What changed

- A `SwiftUIRUMViewsPredicate` that drops auto-detected names that are not
  screens: container descriptions (`NavigationStackHostingController<AnyView>`,
  `UIHostingController<AnyView>`), SwiftUI internals (`_PaddingLayout`,
  `_ViewList_View`), the SDK's `AutoTracked_…_Fallback` placeholders, our own
  `RUMViewModifier`, and the value types the reflection reaches (`EmptyView`,
  `TextAlignment`, `PresentationOptionsPreferenceKey`, and friends). Nothing is
  reported for those, so the last real screen stays current.
- A name on every `navigationDestination`, `.sheet`, `.fullScreenCover`,
  `.popover` and pushed screen that had none: all 42 Settings destinations, the
  five onboarding guides, the lockdown gate, the app-root save-channel and
  add-contact sheets, the map's waypoint / legend / coverage / item-picker /
  position sheets, the channel editor and channels help, the firmware update
  sheets, the Wi-Fi provisioning screens, the app-icon picker, the log detail,
  the device-profile import, Ask Chirpy, the route-recording details, the map
  data files, the discovery session detail, the power channel labels, the noise
  floor info, and the three data browser screens.
- The names live in one `ScreenName` enum and `trackScreen` takes that rather
  than a string. Two screens sharing a name would merge their crashes into one
  bucket; a `String`-backed enum makes that a build error.

Screens that reflection already names are left alone so their history in Error
Tracking is not split — `TraceRouteLog`, `DeviceMetricsLog`, `PositionLog`,
`LocalStatsLog`, `NodeListFilter`, `ChannelList`, `UserList`, `MapSettingsForm`,
`NodeMapSwiftUI`, the node-detail log screens, the discovery and offline-map
screens, `UF2MassStorageView`, and the rest.

Four are the exception. `AppSettings`, `DeviceOnboarding`, `LoRaConfig` and
`ShareChannels` now have explicit names and their reflected names are dropped, so
each screen has one name rather than two that alternate. Two of them were worth
dropping on their own: `AppSettings` was being reported for pushes all over the
Settings stack rather than for App Settings, and `DeviceOnboarding` is the sheet
the five setup steps live in, so it stood in for whichever step was showing.

## Deliberately not named

- The popovers on the RX/TX indicator, the MQTT icon and the air quality legend.
  They are small overlays on the screen behind them, not screens, and giving them
  a name would take the hang off whatever is actually on screen.
- The OTA simulator control drawer in `FirmwareOTAUpdateSheet`, which only exists
  in `#if DEBUG` builds.

## Testing

- Builds for the simulator and for Mac Catalyst.
- `xcodebuild test -only-testing:MeshtasticTests` — 3125 tests in 539 suites pass,
  including eight new ones covering the predicate, name uniqueness, and that no
  name reads like a type description.
- swiftlint on the touched files reports only violations that are already on `main`.
